### PR TITLE
Update translations for 0.36.0

### DIFF
--- a/locales/ca.po
+++ b/locales/ca.po
@@ -29,13 +29,14 @@ msgid "Select a database type"
 msgstr "Selecciona un tipus de base de dades"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:411
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:154
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -48,7 +49,7 @@ msgstr "Desa"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "Metabase necessita analitzar la teva base de dades. S'analitzarà periòdicament per tal de mantenir actualizades les metadades. A continuació, pots definir la periodicitat dels anàlisis."
 
-#: frontend/src/metabase/entities/databases/forms.js:221
+#: frontend/src/metabase/entities/databases/forms.js:290
 msgid "Database syncing"
 msgstr "S'està sincronitzant"
 
@@ -63,7 +64,7 @@ msgstr "Això es un procès simple que busca actualitzacions a l'esquema de la b
 msgid "Scan"
 msgstr "Escaneja"
 
-#: frontend/src/metabase/entities/databases/forms.js:228
+#: frontend/src/metabase/entities/databases/forms.js:297
 msgid "Scanning for Filter Values"
 msgstr "Escanejant els valors dels filtres"
 
@@ -74,7 +75,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase pot analizar els valors presents a cada camp de la base de dades, per tal d'activar filtres als quadres de comandament i les preguntes. Aquest procés pot ser intensiu, en especial si disposes d'una base de dades gran."
 
-#: frontend/src/metabase/entities/databases/forms.js:232
+#: frontend/src/metabase/entities/databases/forms.js:301
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Amb quina periodicitat Metabase ha d'analitzar i desar en memoria els valors dels camps?"
 
@@ -96,6 +97,7 @@ msgid "Never, I'll do this manually if I need to"
 msgstr "Mai. Ho faré manualment si ho necessito."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 msgid "Saving..."
@@ -132,9 +134,9 @@ msgid "in this box:"
 msgstr "en aquest camp:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:75
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
@@ -151,18 +153,18 @@ msgstr "en aquest camp:"
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:301
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:39
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:90
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:99
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:311
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:328
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "Cancel·lar"
@@ -179,7 +181,7 @@ msgstr "Eliminar"
 #: frontend/src/metabase/admin/permissions/selectors.js:323
 #: frontend/src/metabase/admin/permissions/selectors.js:330
 #: frontend/src/metabase/admin/permissions/selectors.js:441
-#: frontend/src/metabase/admin/routes.jsx:57
+#: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
@@ -199,9 +201,10 @@ msgid "Scheduling"
 msgstr "Programació"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:71
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
@@ -209,8 +212,8 @@ msgid "Save changes"
 msgstr "Desar els canvis"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:203
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:35
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
 msgstr "Accions"
 
@@ -222,8 +225,8 @@ msgstr "Sincronitzar ara l'esquema de la base de dades"
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:90
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:98
 msgid "Starting…"
 msgstr "Iniciant..."
 
@@ -241,13 +244,13 @@ msgstr "Torna a analitzar els valors dels camps ara"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
 msgstr "Error a l'iniciar l'anàlisi"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:92
 msgid "Scan triggered!"
 msgstr "Sincronització programada!"
 
@@ -270,15 +273,15 @@ msgid "Add database"
 msgstr "Afegeix base de dades"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:28
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:28
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
 #: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:195
+#: frontend/src/metabase/entities/databases/forms.js:264
 #: frontend/src/metabase/entities/questions.js:86
 #: frontend/src/metabase/entities/questions.js:102
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
@@ -318,6 +321,7 @@ msgstr "Desat correctament!"
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Edita"
@@ -360,44 +364,43 @@ msgstr "Fallit"
 msgid "Success"
 msgstr "Èxit"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:185
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Vista prèvia"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:93
 msgid "No column description yet"
 msgstr "No hi ha una descripció de la columan"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:127
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:126
 msgid "Select a field visibility"
 msgstr "Selecciona la visiblitat del camp"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:187
 msgid "No special type"
 msgstr "Sense cap tipus especial"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
 #: frontend/src/metabase/lib/core.js:275
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:44
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:37
 msgid "Other"
 msgstr "Altres"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:221
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Seleccioneu un tipus especial"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:255
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:262
 #: frontend/src/metabase/reference/components/Field.jsx:99
 msgid "Select a target"
 msgstr "Selecciona una referència"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
@@ -405,18 +408,18 @@ msgstr "Selecciona una referència"
 msgid "Columns"
 msgstr "Columnes"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Columna"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:144
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:288
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
 msgid "Visibility"
 msgstr "Visibilitat"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
 msgid "Type"
 msgstr "Tipus"
 
@@ -424,7 +427,7 @@ msgstr "Tipus"
 msgid "Current database:"
 msgstr "Base de dades actual"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
 msgid "Show original schema"
 msgstr "Mostra l'esquema original"
 
@@ -446,27 +449,27 @@ msgid_plural "{0} schemas"
 msgstr[0] "Esquema"
 msgstr[1] "Esquemes"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:99
 msgid "Why Hide?"
 msgstr "Perquè amagar-ho?"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:100
 msgid "Technical Data"
 msgstr "Informació tècnica"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
 msgstr "Irrelevant"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 msgid "Queryable"
 msgstr "Consultable"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:108
 msgid "Hidden"
 msgstr "Ocult"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136
 msgid "No table description yet"
 msgstr "No hi ha cap descripció per la taula"
 
@@ -474,32 +477,33 @@ msgstr "No hi ha cap descripció per la taula"
 msgid "Metadata Strength"
 msgstr "Força metadades"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0} taula consultable"
 msgstr[1] "{0} taules consultables"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:91
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} taula amagada"
 msgstr[1] "{0} taules amagades"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:115
 msgid "Find a table"
 msgstr "Troba una taula"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:128
 msgid "Schemas"
 msgstr "Esquemes"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:838
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:21
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:43
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:62
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 msgid "Metrics"
 msgstr "Mètriques"
@@ -508,8 +512,8 @@ msgstr "Mètriques"
 msgid "Add a Metric"
 msgstr "Afegir una mètrica"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "Definició"
@@ -518,12 +522,12 @@ msgstr "Definició"
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "Crea mètriques per afegir-les al desplegable \"Veure\" al generador de consultes"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:21
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
 #: frontend/src/metabase/home/containers/SearchApp.jsx:72
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:961
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:61
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Segments"
@@ -532,35 +536,35 @@ msgstr "Segments"
 msgid "Add a Segment"
 msgstr "Afegir un segment"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:51
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:45
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "Crea segments per afegir-los al menú de filtres del generador de consultes"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:21
 msgid "created"
 msgstr "creat"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "reverted to a previous version"
 msgstr "revertit a una versió anterior"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:30
 msgid "edited the title"
 msgstr "editat el títol"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:32
 msgid "edited the description"
 msgstr "editada la descripció"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:34
 msgid "edited the "
 msgstr "editat el"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:40
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "made some changes"
 msgstr "ha fet alguns canvis"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
 #: frontend/src/metabase/home/components/Activity.jsx:83
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
@@ -570,84 +574,84 @@ msgstr "Tu"
 msgid "Datamodel"
 msgstr "Model de dades"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:41
 msgid " History"
 msgstr " Historial"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
 msgstr "Historial de versions per"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:228
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
 msgid "{0} – Field Settings"
 msgstr "{0} - Configuració dels camps"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:289
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
 msgid "Where this field will appear throughout Metabase"
 msgstr "On es mostrara aquest camp al Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:311
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
 msgid "Filtering on this field"
 msgstr "Filtrant per aquest camp"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:312
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Quan aquest camp s'utilitza en un filtre, quins valors ha de poder introduir l'usuari?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:437
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
 msgid "No description for this field yet"
 msgstr "No existeix cap descripció per aquest camp"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
 msgid "Original value"
 msgstr "Valor Original"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:390
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
 msgid "Mapped value"
 msgstr "Valor asignat"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
 msgid "Enter value"
 msgstr "Introduïu valor"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use original value"
 msgstr "Utilitza valor original"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Use foreign key"
 msgstr "Utilitza la clau forànea"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 msgid "Custom mapping"
 msgstr "Assignació personalitzada"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
 msgid "Unrecognized mapping type"
 msgstr "Tipus d'assignació no reconeguda"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "El camp actual no es una clau forana o fan falten les metadades de la clau forana a la taula de destí"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
 msgid "The selected field isn't a foreign key"
 msgstr "El camp seleccionat no es una clau forana"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:327
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
 msgid "Display values"
 msgstr "Mostra valors"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:328
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Escull si vols mostrar el valor original de la base de dades o mostrar informació associada o personalitzada"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:278
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
 msgid "Choose a field"
 msgstr "Tria un camp"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:299
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
 msgid "Please select a column to use for display."
 msgstr "Seleccioneu una columna per mosstrar"
 
@@ -655,16 +659,16 @@ msgstr "Seleccioneu una columna per mosstrar"
 msgid "Tip:"
 msgstr "Consell:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:443
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Es possible que vulgueu actualitzar el nom del camp per assegurar-t'he que encara tinguin sentit en funció de les opcions d'assignació."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:344
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Valors del camp a la memòria cau"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:345
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "El metabase pot escanejar els valors d'aquest camp per habilitar els filtres de casella de verificació pels quadres de comandament i preguntes."
 
@@ -673,53 +677,53 @@ msgid "Re-scan this field"
 msgstr "Torna a escanejar aquest camp"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
 msgstr "Descarteu els valors de la memòria cau"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
 msgstr "Error al descartar els valors"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 msgid "Discard triggered!"
 msgstr "Neteja iniciada!"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Seleccioneu qualsevol taula per veure el seu esquema i afegir o editar les metadades."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:36
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "El nom es obligatori"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:39
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "La descripció es obligatòria"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:43
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "El missatge de revisió es obligatori"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
 msgid "Aggregation is required"
 msgstr "La agrupació es obligatòria"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Edit Your Metric"
 msgstr "Edita la teva mètrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Create Your Metric"
 msgstr "Crea la teva mètrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Feu canvis a la vostra mètrica i deixeu un nota explicativa"
 
@@ -727,62 +731,62 @@ msgstr "Feu canvis a la vostra mètrica i deixeu un nota explicativa"
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Pots crear mètriques i guardar-les com un camp calculat en aquesta taula. Les mètriques guardades inclouen el tipus d'agregat, el camp agregat i opcionalment qualsevol filtre que afegeixis. Per exemple, pots fer servir això per definir la forma oficial de calcular el \"Preu mig\" d'una taula de preus."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:180
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
 msgid "Result: "
 msgstr "Resultat: "
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
 msgid "Name Your Metric"
 msgstr "Doneu-li un nom a la vostra mètrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:190
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Give your metric a name to help others find it."
 msgstr "Doneu-li un nom a la vostra mètrica per ajudar als altres a trobar-la."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:194
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:152
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Alguna cosa descriptiva però no massa llarga"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:198
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
 msgid "Describe Your Metric"
 msgstr "Descriu la mètrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:199
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Doneu-li una descripció a la vostra mètrica per ajudar als altres a entendre de el seu contingut."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:203
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Es un bon lloc per ser més específiques sobre les regles de la mètrica no tan evidents. "
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:207
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:165
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Motiu dels canvis"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:209
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Deixeu una nota per explicar els canvis que heu fet i per a que són necessaris."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:213
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Es mostrarà al historial de revisions de la mètrica per ajudar als altres a entendre perquè han canviat les coses."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
 msgstr "Es requereix com a mínim un filtre"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
 msgstr "Edita el teu segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
 msgstr "Crear el teu segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Feu canvis al vostre segment i deixeu un nota explicativa"
 
@@ -790,33 +794,33 @@ msgstr "Feu canvis al vostre segment i deixeu un nota explicativa"
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "Seleccioneu i afegiu filtres per crear un nou segment de la taula {0}"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
 msgstr "Doneu-li un nom al vostre segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:148
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
 msgstr "Doneu un nom al vostre segment per ajudar als altres a trobar-lo."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:156
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
 msgstr "Descriu el segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Doneu una descripció al vostre segment per ajudar als altres a saber de que va."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "Aquest es un bon lloc per ser més específics sobre les regles menys obvies del segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "Això apareixerà al historial de versions d'aquest segment per ajudar a tothom a recordar perquè es va realitzar aquest canvi."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
-#: frontend/src/metabase/admin/routes.jsx:132
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:215
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
+#: frontend/src/metabase/admin/routes.jsx:137
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
@@ -824,11 +828,11 @@ msgstr "Això apareixerà al historial de versions d'aquest segment per ajudar a
 msgid "Settings"
 msgstr "Configuració"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "El Metabase pot llegir els valors d'aquesta taula per habilitar filtres de caselles de selecció als quadres de comandament i preguntes"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
 msgstr "Tornar a escanejar aquesta taula"
 
@@ -842,11 +846,11 @@ msgstr "Afegir"
 msgid "Not a valid formatted email address"
 msgstr "El format del correu electrònic no es vàlid"
 
-#: frontend/src/metabase/entities/users/forms.js:12
+#: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
 msgstr "Nom"
 
-#: frontend/src/metabase/entities/users/forms.js:18
+#: frontend/src/metabase/entities/users/forms.js:20
 msgid "Last name"
 msgstr "Cognom"
 
@@ -885,10 +889,10 @@ msgstr "Membres"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
-#: frontend/src/metabase/admin/settings/selectors.js:120
-#: frontend/src/metabase/entities/users/forms.js:24
+#: frontend/src/metabase/admin/settings/selectors.js:121
+#: frontend/src/metabase/entities/users/forms.js:26
 #: frontend/src/metabase/lib/core.js:146
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:294
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:298
 msgid "Email"
 msgstr "Correu electrònic"
 
@@ -897,14 +901,14 @@ msgid "A group is only as good as its members."
 msgstr "Un grop només val el que valen els seus membres"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
-#: frontend/src/metabase/admin/routes.jsx:52
+#: frontend/src/metabase/admin/routes.jsx:55
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Admin"
 msgstr "Administrador"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:241
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:299
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:288
 msgid "and"
 msgstr "i"
 
@@ -956,12 +960,12 @@ msgstr "Elimina el grup"
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:42
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:294
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:397
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:317
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:334
 msgid "Done"
 msgstr "Fet"
 
@@ -972,8 +976,9 @@ msgstr "Nom del grup"
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
-#: frontend/src/metabase/admin/routes.jsx:92
+#: frontend/src/metabase/admin/routes.jsx:97
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Groups"
 
@@ -1003,7 +1008,7 @@ msgstr "Desactiva"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:21
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
-#: frontend/src/metabase/admin/routes.jsx:88
+#: frontend/src/metabase/admin/routes.jsx:93
 #: frontend/src/metabase/nav/containers/Navbar.jsx:235
 msgid "People"
 msgstr "Gent"
@@ -1315,25 +1320,25 @@ msgstr "Mostrar la col·lecció"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:542
+#: frontend/src/metabase/admin/permissions/selectors.js:558
 msgid "Data Access"
 msgstr "Accedir a les dades"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:667
-#: frontend/src/metabase/admin/permissions/selectors.js:672
+#: frontend/src/metabase/admin/permissions/selectors.js:665
+#: frontend/src/metabase/admin/permissions/selectors.js:670
 msgid "View tables"
 msgstr "Mostrar taules"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:608
+#: frontend/src/metabase/admin/permissions/selectors.js:606
 msgid "SQL Queries"
 msgstr "Consultes SQL"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:678
+#: frontend/src/metabase/admin/permissions/selectors.js:676
 msgid "View schemas"
 msgstr "Mostrar esquemes"
 
-#: frontend/src/metabase/admin/routes.jsx:63
+#: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
 msgstr "Model de dades"
@@ -1363,20 +1368,24 @@ msgid "Allows users within your LDAP directory to log in to Metabase with their 
 msgstr "Permet als usuaris del teu directori LDAP iniciar sessió a Metabase amb les seves credencials LDAP i permet la assignació automàtica de grups LDAP a grups de metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:19
-#: frontend/src/metabase/admin/settings/selectors.js:167
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
+#: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
 msgstr "No es un correu electrònic vàlid"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
 msgstr "No és una enter vàlid"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
 msgstr "Canvis desats!"
 
-#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:178
+#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
 msgid "Looks like we ran into some problems"
 msgstr "Sembla que s'ha produït un error"
 
@@ -1398,7 +1407,7 @@ msgstr "Netejar"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:195
+#: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Autentificació"
 
@@ -1450,15 +1459,15 @@ msgstr "El teu ID de client de Google"
 msgid "Allow users to sign up on their own if their Google account email address is from:"
 msgstr "Permet que els usuaris es registrin per ells mateixos si la seva de compta de Google es de:"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:242
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:249
 msgid "Answers sent right to your Slack #channels"
 msgstr "Respostes enviades directament als teus #canals de Slack"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:251
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:258
 msgid "Create a Slack Bot User for MetaBot"
 msgstr "Crea un usuari de Slack BOt pel Metabot"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:261
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:268
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "Una cop arribats allí, assigna-li un nom i clica a {0}. Desprès copia i pega el token de la API del Bot al camp a continuació. Quan hagis acabat, crea un canal \"metabase_files\" en Slack. Aquest canal es necessita per pujar gràfiques."
 
@@ -1471,8 +1480,8 @@ msgid "Metabase {0} is available.  You're running {1}"
 msgstr "La versió {0} de Metabase esta disponible. Esteu fent servir la versió {1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:41
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 msgid "Update"
 msgstr "Actualitzat"
 
@@ -1499,16 +1508,16 @@ msgstr "Elimina el mapa personalitzat"
 #: frontend/src/metabase/containers/Overworld.jsx:293
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:115
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Elimina"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:165
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:141
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
 msgstr "Selecciona..."
 
@@ -1691,48 +1700,46 @@ msgid "Generate Key"
 msgstr "Genera la clau"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:87
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:18
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enabled"
 msgstr "Activat"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:92
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:19
+#: frontend/src/metabase/admin/settings/selectors.js:93
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Desactivat"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:112
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:113
 msgid "Unknown setting {0}"
 msgstr "No es coneix la configuració {0}"
 
-#: frontend/src/metabase/admin/settings/selectors.js:34
+#: frontend/src/metabase/admin/settings/selectors.js:37
 msgid "Setup"
 msgstr "Configuració"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:207
-#: frontend/src/metabase/admin/settings/selectors.js:39
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:214
+#: frontend/src/metabase/admin/settings/selectors.js:42
 msgid "General"
 msgstr "General"
 
-#: frontend/src/metabase/admin/settings/selectors.js:43
+#: frontend/src/metabase/admin/settings/selectors.js:46
 msgid "Site Name"
 msgstr "Nom del lloc"
 
-#: frontend/src/metabase/admin/settings/selectors.js:48
+#: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Site URL"
 msgstr "URL de lloc"
 
-#: frontend/src/metabase/admin/settings/selectors.js:53
+#: frontend/src/metabase/admin/settings/selectors.js:64
 msgid "Email Address for Help Requests"
 msgstr "Direcció de correu electrònic per sol·licituds d'ajuda"
 
-#: frontend/src/metabase/admin/settings/selectors.js:58
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
 msgstr "La zona horària dels informes"
 
-#: frontend/src/metabase/admin/settings/selectors.js:61
+#: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
 msgstr "La base de dades"
 
@@ -1740,11 +1747,11 @@ msgstr "La base de dades"
 msgid "Select a timezone"
 msgstr "Selecciona una zona horària"
 
-#: frontend/src/metabase/admin/settings/selectors.js:64
+#: frontend/src/metabase/admin/settings/selectors.js:75
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "No totes les bases de dades permeten zones horàries. En aquest cas aquesta configuració no tindrà efecte."
 
-#: frontend/src/metabase/admin/settings/selectors.js:69
+#: frontend/src/metabase/entities/users/forms.js:34
 msgid "Language"
 msgstr "Idioma"
 
@@ -1752,64 +1759,64 @@ msgstr "Idioma"
 msgid "Select a language"
 msgstr "Seleccioneu un idioma"
 
-#: frontend/src/metabase/admin/settings/selectors.js:79
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
 msgstr "Seguiment anònimc"
 
-#: frontend/src/metabase/admin/settings/selectors.js:84
+#: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
 msgstr "Noms de taules i camps amistosos"
 
-#: frontend/src/metabase/admin/settings/selectors.js:90
+#: frontend/src/metabase/admin/settings/selectors.js:91
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Només es reemplaçaran els guions baixos i els guions per espais"
 
-#: frontend/src/metabase/admin/settings/selectors.js:98
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Enable Nested Queries"
 msgstr "Activar consultes anidades"
 
-#: frontend/src/metabase/admin/settings/selectors.js:109
+#: frontend/src/metabase/admin/settings/selectors.js:110
 msgid "Updates"
 msgstr "Actualitzacions"
 
-#: frontend/src/metabase/admin/settings/selectors.js:114
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
 msgstr "Cerca actualitzacions"
 
-#: frontend/src/metabase/admin/settings/selectors.js:125
+#: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
 msgstr "Servidor SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:133
+#: frontend/src/metabase/admin/settings/selectors.js:134
 msgid "SMTP Port"
 msgstr "Port SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:137
+#: frontend/src/metabase/admin/settings/selectors.js:138
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:47
 msgid "That's not a valid port number"
 msgstr "El número de port és invàlid"
 
-#: frontend/src/metabase/admin/settings/selectors.js:141
+#: frontend/src/metabase/admin/settings/selectors.js:142
 msgid "SMTP Security"
 msgstr "SMTP Segur"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:150
 msgid "SMTP Username"
 msgstr "Usuari SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "SMTP Password"
 msgstr "Contrasenya SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:163
+#: frontend/src/metabase/admin/settings/selectors.js:164
 msgid "From Address"
 msgstr "Correu electrònic de"
 
-#: frontend/src/metabase/admin/settings/selectors.js:176
+#: frontend/src/metabase/admin/settings/selectors.js:178
 msgid "Slack API Token"
 msgstr "Token API Slack"
 
-#: frontend/src/metabase/admin/settings/selectors.js:178
+#: frontend/src/metabase/admin/settings/selectors.js:180
 msgid "Enter the token you received from Slack"
 msgstr "Introduïu el toquen que heu rebut de Slack"
 
@@ -1838,8 +1845,10 @@ msgid "Username or DN"
 msgstr "Nom d'usuari o DN"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:43
+#: frontend/src/metabase/entities/databases/forms.js:61
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:64
-#: frontend/src/metabase/user/components/UserSettings.jsx:65
+#: frontend/src/metabase/user/components/UserSettings.jsx:66
+#: src/metabase/driver/common.clj
 msgid "Password"
 msgstr "Contrasenya"
 
@@ -1875,79 +1884,79 @@ msgstr "Sincronitza "
 msgid "Group search base"
 msgstr "Base de cerca de grup"
 
-#: frontend/src/metabase/admin/settings/selectors.js:199
+#: frontend/src/metabase/admin/settings/selectors.js:201
 msgid "Maps"
 msgstr "Mapes"
 
-#: frontend/src/metabase/admin/settings/selectors.js:203
+#: frontend/src/metabase/admin/settings/selectors.js:205
 msgid "Map tile server URL"
 msgstr "URL del servidor de capes de mapes"
 
-#: frontend/src/metabase/admin/settings/selectors.js:204
+#: frontend/src/metabase/admin/settings/selectors.js:206
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "El Metabase fa servir OpenStretMaps per defecte"
 
-#: frontend/src/metabase/admin/settings/selectors.js:209
+#: frontend/src/metabase/admin/settings/selectors.js:211
 msgid "Custom Maps"
 msgstr "Mapes personalitzats"
 
-#: frontend/src/metabase/admin/settings/selectors.js:210
+#: frontend/src/metabase/admin/settings/selectors.js:212
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Afegeix els teus propis fitxers GeoJSON per habilitar diferents visualitzacions de mapes de regió"
 
-#: frontend/src/metabase/admin/settings/selectors.js:228
+#: frontend/src/metabase/admin/settings/selectors.js:245
 msgid "Public Sharing"
 msgstr "Compartir públicament"
 
-#: frontend/src/metabase/admin/settings/selectors.js:232
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "Enable Public Sharing"
 msgstr "Permetre compartir públicament"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:254
 msgid "Shared Dashboards"
 msgstr "Quadres de comandament compartits"
 
-#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Shared Questions"
 msgstr "Preguntes compartides"
 
-#: frontend/src/metabase/admin/settings/selectors.js:250
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Embedding in other Applications"
 msgstr "Incrustar en altres aplicacions"
 
-#: frontend/src/metabase/admin/settings/selectors.js:276
+#: frontend/src/metabase/admin/settings/selectors.js:293
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Habilitar la incrustació del Metabase a altres aplicacions"
 
-#: frontend/src/metabase/admin/settings/selectors.js:286
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Embedding secret key"
 msgstr "Clau secreta de incrustació"
 
-#: frontend/src/metabase/admin/settings/selectors.js:292
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Embedded Dashboards"
 msgstr "Quadres de comandament incrustats"
 
-#: frontend/src/metabase/admin/settings/selectors.js:298
+#: frontend/src/metabase/admin/settings/selectors.js:315
 msgid "Embedded Questions"
 msgstr "Preguntes incrustades"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:322
 msgid "Caching"
 msgstr "Memòria cau"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:326
 msgid "Enable Caching"
 msgstr "Activa la memòria cau"
 
-#: frontend/src/metabase/admin/settings/selectors.js:314
+#: frontend/src/metabase/admin/settings/selectors.js:331
 msgid "Minimum Query Duration"
 msgstr "Duració mínima de la consulta"
 
-#: frontend/src/metabase/admin/settings/selectors.js:321
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Multiplicador Temps de Vida (TTL) de la memòria cau"
 
-#: frontend/src/metabase/admin/settings/selectors.js:328
+#: frontend/src/metabase/admin/settings/selectors.js:345
 msgid "Max Cache Entry Size"
 msgstr "Mida màxima d'una entrada de la memòria cau"
 
@@ -2114,7 +2123,8 @@ msgstr "Els cuadres de comandament, les colecions i els polsos d'aquesta col·le
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/routes.jsx:205
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
+#: frontend/src/metabase/routes.jsx:196
 msgid "Archive"
 msgstr "Arxiva"
 
@@ -2130,21 +2140,21 @@ msgstr "Mostra l'arxiu"
 msgid "Unarchive this {0}"
 msgstr "Desarxiva aquest {0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:39
-#: frontend/src/metabase/components/BrowseApp.jsx:102
-#: frontend/src/metabase/components/BrowseApp.jsx:194
+#: frontend/src/metabase/components/BrowseApp.jsx:46
+#: frontend/src/metabase/components/BrowseApp.jsx:112
+#: frontend/src/metabase/components/BrowseApp.jsx:204
 #: frontend/src/metabase/containers/Overworld.jsx:270
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
 msgstr "Les nostres dades"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:146
+#: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
 msgid "X-ray this table"
 msgstr "Aplica rajos-X a aquesta taula"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:161
+#: frontend/src/metabase/components/BrowseApp.jsx:171
 msgid "Learn about this table"
 msgstr "Aprèn sobre aquesta taula"
 
@@ -2239,7 +2249,7 @@ msgstr "Contingut fixat"
 msgid "Drag something here to pin it to the top"
 msgstr "Arrasta coses aquí per fixar-les a dalt"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:755
+#: frontend/src/metabase/admin/permissions/selectors.js:753
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2293,7 +2303,7 @@ msgstr "Nova col·lecció"
 msgid "Copied!"
 msgstr "Copiat!"
 
-#: frontend/src/metabase/entities/databases/forms.js:12
+#: frontend/src/metabase/entities/databases/forms.js:14
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Utilitza un túnel SSH per a les connexions a la base de dades"
 
@@ -2305,7 +2315,7 @@ msgstr "Algunes instancies de bases de dades només es poden accedir a través d
 "Aquesta configuració també proporcionarà una cap addicional de seguretat quan no es disposi d'una VPN. \n"
 "Aquest configuració normalment es més lenta que una connexió directa."
 
-#: frontend/src/metabase/entities/databases/forms.js:212
+#: frontend/src/metabase/entities/databases/forms.js:281
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Aquesta es una base de dades gran. Deixem decidir quan el Metabase es sincronitza i escaneja les dades"
 
@@ -2315,17 +2325,17 @@ msgid "By default, Metabase does a lightweight hourly sync and an intensive dail
 msgstr "De forma predeterminada el Metabase realitzar una sincronització lleugera cada hora i un anàlisis diari intensiu dels valors dels camps.\n"
 "Si tens una base de dades gran et recomanem que activis aquesta configuració i que revisis quan i amb quina freqüència s'escanegen els valors del camp."
 
-#: frontend/src/metabase/entities/databases/forms.js:78
+#: frontend/src/metabase/entities/databases/forms.js:113
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0] per generar un ID de client i una clau secreta pel teu projecte"
 
-#: frontend/src/metabase/entities/databases/forms.js:80
-#: frontend/src/metabase/entities/databases/forms.js:95
-#: frontend/src/metabase/entities/databases/forms.js:131
+#: frontend/src/metabase/entities/databases/forms.js:115
+#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:166
 msgid "Click here"
 msgstr "Cliqueu aquí"
 
-#: frontend/src/metabase/entities/databases/forms.js:83
+#: frontend/src/metabase/entities/databases/forms.js:118
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Escul \"Un altre\" com a tipus d'aplicació. Nombra-ho com vulguis."
 
@@ -2333,19 +2343,19 @@ msgstr "Escul \"Un altre\" com a tipus d'aplicació. Nombra-ho com vulguis."
 msgid "{0} to get an auth code"
 msgstr "{0} per obtenir un codi d'autentificació"
 
-#: frontend/src/metabase/entities/databases/forms.js:107
+#: frontend/src/metabase/entities/databases/forms.js:142
 msgid "with Google Drive permissions"
 msgstr "amb permisos de Google Drive"
 
-#: frontend/src/metabase/entities/databases/forms.js:129
+#: frontend/src/metabase/entities/databases/forms.js:164
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "Per utilitzar el Metabase amb aquestes dades has d'habilitar el accés a la API a la Consola de Desenvolupadors de Googl"
 
-#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:165
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} per anar a la consola si encara no ho has fet"
 
-#: frontend/src/metabase/entities/databases/forms.js:196
+#: frontend/src/metabase/entities/databases/forms.js:265
 msgid "How would you like to refer to this database?"
 msgstr "Com t'agradaria anomenar aquesta base de dades?"
 
@@ -2354,7 +2364,8 @@ msgstr "Com t'agradaria anomenar aquesta base de dades?"
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:143
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:70
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:123
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:96
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:126
 #: frontend/src/metabase/setup/components/UserStep.jsx:93
 msgid "Next"
 msgstr "Següent"
@@ -2537,7 +2548,7 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Revertit a una revisió anterior i {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:290
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "Historial de revisións"
@@ -2583,7 +2594,7 @@ msgid "Questions"
 msgstr "Preguntes"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:320
+#: frontend/src/metabase/routes.jsx:311
 msgid "Pulses"
 msgstr "Polsos"
 
@@ -2628,15 +2639,16 @@ msgstr "Estem una mica perduts..."
 msgid "Temporary Password"
 msgstr "Contrasenya temporal"
 
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:207
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:481
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
 msgid "Hide"
 msgstr "Amaga"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:467
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:482
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:471
 msgid "Show"
 msgstr "Mostra"
 
@@ -2746,7 +2758,7 @@ msgstr "Ho sentim, no tens permisos per veure això."
 msgid "Unknown error encountered"
 msgstr "S'ha trobat un error desconegut"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/nav/containers/Navbar.jsx:373
 msgid "Create"
 msgstr "Crea"
@@ -2759,7 +2771,7 @@ msgstr "Crea un quadre de comandament"
 msgid "Table"
 msgstr "Taula"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
 msgid "Database"
 msgstr "Base de dades"
 
@@ -2779,7 +2791,7 @@ msgstr "Intenta ajustar el teu filtre per trobar el que estas buscan"
 msgid "View by"
 msgstr "Vist per"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:122
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:121
 msgid "of"
 msgstr "de"
 
@@ -2806,33 +2818,33 @@ msgstr "La nostra analítica"
 msgid "Browse all items"
 msgstr "Mostrar tots els elements"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:118
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:117
 msgid "Replace or save as new?"
 msgstr "Sobreescriure o guardar com una nova pregunta?"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:168
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace original question, \"{0}\""
 msgstr "Sobreescriure la pregunta original: \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:172
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:171
 msgid "Save as new question"
 msgstr "Guarda com una nova pregunta"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:92
 msgid "First, save your question"
 msgstr "Primer guarda la teva pregunta"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:94
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
 msgid "Save question"
 msgstr "Guardar la pregunta"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:133
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
 msgid "What is the name of your card?"
 msgstr "Quin es el nom de la teva tarjeta?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
 #: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/entities/questions.js:89
@@ -2848,15 +2860,16 @@ msgstr "Quin es el nom de la teva tarjeta?"
 msgid "Description"
 msgstr "Descripció"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
 #: frontend/src/metabase/entities/dashboards.js:150
 #: frontend/src/metabase/entities/questions.js:91
 #: frontend/src/metabase/entities/questions.js:107
+#: frontend/src/metabase/entities/snippets.js:31
 msgid "It's optional but oh, so helpful"
 msgstr "Es opcional, però va tan bé a vegades"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:148
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "A quina col·lecció vols guardar-ho?"
@@ -2873,19 +2886,19 @@ msgstr "element"
 msgid "Undo"
 msgstr "Desfer"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:266
 msgid "Applying Question"
 msgstr "Aplicant la pregunta"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:286
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "That question isn't compatible"
 msgstr "Aquesta pregunta no és compatible"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:322
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:309
 msgid "Search for a question"
 msgstr "Busca una pregunta"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:351
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:343
 msgid "We're not sure if this question is compatible"
 msgstr "No estem segurs si aquesta pregunta es compatible"
 
@@ -2934,25 +2947,23 @@ msgstr "Afegeix una pregunta"
 msgid "Add a question to this dashboard"
 msgstr "Afegiu una pregunta a aquest quadre de comandament."
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
 msgid "Add a filter"
 msgstr "Afegeix un filtre"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:256
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "Paràmetres"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:276
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:280
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
 msgid "Add a text box"
 msgstr "Afegeix una caixa de text"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:320
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:314
 msgid "Move dashboard"
 msgstr "Moure el quadre de comandament"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:303
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
 msgid "Edit dashboard"
 msgstr "Edita el quadre de comandament"
 
@@ -2960,11 +2971,11 @@ msgstr "Edita el quadre de comandament"
 msgid "Edit Dashboard Layout"
 msgstr "Editar la disposició del quadre de comandament"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:371
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:365
 msgid "You are editing a dashboard"
 msgstr "Esteu editant un quadre de comandament"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:376
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:370
 msgid "Select the field that should be filtered for each card"
 msgstr "Selecciona el camp que s'ha de filtrar per a cada targeta"
 
@@ -3052,7 +3063,7 @@ msgstr "Aquesta targeta no té camps ni paràmetres que coincideixin amb aquest 
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Els valors d'aquest camp no coincideixen amb cap altre camp que hagis escollit"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:162
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "No hi ha camps válid"
@@ -3120,7 +3131,7 @@ msgstr "ha rebut les ultimes dades de"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:329
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
 msgid "Unknown"
 msgstr "Desconegut"
 
@@ -3247,6 +3258,7 @@ msgstr "{0} elements seleccionats"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 msgid "Unarchive"
 msgstr "Desarxivar"
 
@@ -3339,7 +3351,7 @@ msgid "Longitude"
 msgstr "Longitud"
 
 #: frontend/src/metabase/lib/core.js:43
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:45
 msgid "Number"
 msgstr "Número"
@@ -3396,7 +3408,7 @@ msgid "User"
 msgstr "Usuari"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:211
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
 msgid "Source"
 msgstr "Origen"
 
@@ -3437,16 +3449,17 @@ msgid "Score"
 msgstr "Puntuació"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Títol"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
 msgid "Comment"
 msgstr "Comentari"
 
@@ -3498,9 +3511,9 @@ msgstr "Exloure"
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
 msgstr "El Metabase mai obtindrà aquesta camp. Fes-ho servir per informació sensible o irrelevant"
 
-#: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:300
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/query/description.js:77
+#: frontend/src/metabase/lib/query/description.js:262
+#: frontend/src/metabase/lib/schema_metadata.js:476
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
@@ -3515,8 +3528,7 @@ msgstr "Compta"
 msgid "CumulativeCount"
 msgstr "RecompteCumulatiu"
 
-#: frontend/src/metabase/lib/expressions/config.js:9
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:485
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3526,7 +3538,6 @@ msgstr "Suma"
 msgid "CumulativeSum"
 msgstr "SumaCumulativa"
 
-#: frontend/src/metabase/lib/expressions/config.js:11
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Distinct"
 msgstr "Diferent"
@@ -3535,25 +3546,22 @@ msgstr "Diferent"
 msgid "StandardDeviation"
 msgstr "DesviacióEstàndard"
 
-#: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:494
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Mitja"
 
-#: frontend/src/metabase/lib/expressions/config.js:14
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:539
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Mínim"
 
-#: frontend/src/metabase/lib/expressions/config.js:15
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:548
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:503
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:492
 msgid "Max"
 msgstr "Màxim"
 
@@ -3606,54 +3614,66 @@ msgstr "Que tens en ment?"
 msgid "What do you want to find out?"
 msgstr "Sobre que vols buscar?"
 
-#: frontend/src/metabase/lib/query.js:298
-#: frontend/src/metabase/lib/schema_metadata.js:466
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:250
+#: frontend/src/metabase/lib/query/description.js:75
+#: frontend/src/metabase/lib/query/description.js:260
+#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Dades brutes"
 
-#: frontend/src/metabase/lib/query.js:302
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/query/description.js:79
+#: frontend/src/metabase/lib/query/description.js:264
+#: frontend/src/metabase/lib/schema_metadata.js:521
 msgid "Cumulative count"
 msgstr "Recompte cumulatiu"
 
-#: frontend/src/metabase/lib/query.js:305
+#: frontend/src/metabase/lib/query/description.js:82
+#: frontend/src/metabase/lib/query/description.js:266
 msgid "Average of "
 msgstr "Mtija de"
 
-#: frontend/src/metabase/lib/query.js:310
+#: frontend/src/metabase/lib/query/description.js:87
+#: frontend/src/metabase/lib/query/description.js:268
 msgid "Distinct values of "
 msgstr "Valors diferents de"
 
-#: frontend/src/metabase/lib/query.js:315
+#: frontend/src/metabase/lib/query/description.js:92
+#: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
 msgstr "Desviació estàndard de "
 
-#: frontend/src/metabase/lib/query.js:320
+#: frontend/src/metabase/lib/query/description.js:97
+#: frontend/src/metabase/lib/query/description.js:272
 msgid "Sum of "
 msgstr "Suma de "
 
-#: frontend/src/metabase/lib/query.js:325
+#: frontend/src/metabase/lib/query/description.js:102
+#: frontend/src/metabase/lib/query/description.js:274
 msgid "Cumulative sum of "
 msgstr "Suma acumulativa de"
 
-#: frontend/src/metabase/lib/query.js:330
+#: frontend/src/metabase/lib/query/description.js:107
+#: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
 msgstr "Màxim de"
 
-#: frontend/src/metabase/lib/query.js:335
+#: frontend/src/metabase/lib/query/description.js:112
+#: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
 msgstr "Mínim de"
 
-#: frontend/src/metabase/lib/query.js:349
+#: frontend/src/metabase/lib/query/description.js:126
+#: frontend/src/metabase/lib/query/description.js:286
 msgid "Grouped by "
 msgstr "Agrupat per"
 
-#: frontend/src/metabase/lib/query.js:363
+#: frontend/src/metabase/lib/query/description.js:140
+#: frontend/src/metabase/lib/query/description.js:295
 msgid "Filtered by "
 msgstr "Filtrar per"
 
-#: frontend/src/metabase/lib/query.js:392
+#: frontend/src/metabase/lib/query/description.js:169
+#: frontend/src/metabase/lib/query/description.js:320
 msgid "Sorted by "
 msgstr "Ordenat per"
 
@@ -3665,55 +3685,45 @@ msgstr "Verdader"
 msgid "False"
 msgstr "Fals"
 
-#: frontend/src/metabase/lib/schema_metadata.js:321
+#: frontend/src/metabase/lib/schema_metadata.js:322
 msgid "Select longitude field"
 msgstr "Selecciona la longitud del camp"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:323
 msgid "Enter upper latitude"
 msgstr "Introdueix la latitud superior"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:324
 msgid "Enter left longitude"
 msgstr "Longitud esquerra"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:325
 msgid "Enter lower latitude"
 msgstr "Longitud inferior"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:326
 msgid "Enter right longitude"
 msgstr "Longitud dreta"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:539
 #: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:397
-#: frontend/src/metabase/lib/schema_metadata.js:405
-#: frontend/src/metabase/lib/schema_metadata.js:411
-#: frontend/src/metabase/lib/schema_metadata.js:416
-msgid "Is"
-msgstr "És"
-
 #: frontend/src/metabase/lib/schema_metadata.js:362
 #: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:398
 #: frontend/src/metabase/lib/schema_metadata.js:406
 #: frontend/src/metabase/lib/schema_metadata.js:412
-msgid "Is not"
-msgstr "No és"
+#: frontend/src/metabase/lib/schema_metadata.js:417
+msgid "Is"
+msgstr "És"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:417
-msgid "Is empty"
-msgstr "Està buit"
+#: frontend/src/metabase/lib/schema_metadata.js:413
+msgid "Is not"
+msgstr "No és"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:378
@@ -3722,109 +3732,119 @@ msgstr "Està buit"
 #: frontend/src/metabase/lib/schema_metadata.js:402
 #: frontend/src/metabase/lib/schema_metadata.js:408
 #: frontend/src/metabase/lib/schema_metadata.js:418
+msgid "Is empty"
+msgstr "Està buit"
+
+#: frontend/src/metabase/lib/schema_metadata.js:365
+#: frontend/src/metabase/lib/schema_metadata.js:379
+#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:395
+#: frontend/src/metabase/lib/schema_metadata.js:403
+#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:419
 msgid "Not empty"
 msgstr "No està buit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:371
 msgid "Equal to"
 msgstr "Igual a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:372
 msgid "Not equal to"
 msgstr "Diferent de"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Greater than"
 msgstr "Major que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Less than"
 msgstr "Menor que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Entre"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:376
 msgid "Greater than or equal to"
 msgstr "Major o igual que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Less than or equal to"
 msgstr "Menor o igual que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
+#: frontend/src/metabase/lib/schema_metadata.js:384
 msgid "Contains"
 msgstr "Conté"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:385
 msgid "Does not contain"
 msgstr "No conté"
 
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:388
 msgid "Starts with"
 msgstr "Comença amb"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:389
 msgid "Ends with"
 msgstr "Acaba amb"
 
-#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:399
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Abans"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:400
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Després"
 
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:414
 msgid "Inside"
 msgstr "Dins"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Només una taula amb files a la a resposta. Sense operacions addicionals."
 
-#: frontend/src/metabase/lib/schema_metadata.js:474
+#: frontend/src/metabase/lib/schema_metadata.js:475
 msgid "Count of rows"
 msgstr "Nombre de files"
 
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:477
 msgid "Total number of rows in the answer."
 msgstr "Nombre total de files a la resposta"
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Sum of ..."
 msgstr "Suma de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:486
 msgid "Sum of all the values of a column."
 msgstr "Suma tots els valors de una columna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:492
+#: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Average of ..."
 msgstr "Mitja de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:495
 msgid "Average of all the values of a column"
 msgstr "Mitja de tots els valors de una columna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:501
+#: frontend/src/metabase/lib/schema_metadata.js:502
 msgid "Number of distinct values of ..."
 msgstr "Nombre de valors diferents de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:504
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Nombre de valors únics de una columna entre totes les files de la resposta"
 
-#: frontend/src/metabase/lib/schema_metadata.js:510
+#: frontend/src/metabase/lib/schema_metadata.js:511
 msgid "Cumulative sum of ..."
 msgstr "Suma acumulada de ..."
 
@@ -3832,7 +3852,7 @@ msgstr "Suma acumulada de ..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Suma cumulativa de tots els valors de una columan. \\\\n Per exemple: Els ingressos totals al llarg del temps"
 
-#: frontend/src/metabase/lib/schema_metadata.js:519
+#: frontend/src/metabase/lib/schema_metadata.js:520
 msgid "Cumulative count of rows"
 msgstr "Recompte acumulat de files"
 
@@ -3840,27 +3860,27 @@ msgstr "Recompte acumulat de files"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Recompte acumulat del número de files. \\\\n Per exemple: el nombre total de vendes al llarg del temps"
 
-#: frontend/src/metabase/lib/schema_metadata.js:528
+#: frontend/src/metabase/lib/schema_metadata.js:529
 msgid "Standard deviation of ..."
 msgstr "Desviació estàndard de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:531
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Nombre que expressa com varien els valors de una columna entre totes les files de la resposta"
 
-#: frontend/src/metabase/lib/schema_metadata.js:537
+#: frontend/src/metabase/lib/schema_metadata.js:538
 msgid "Minimum of ..."
 msgstr "Mínim de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Minimum value of a column"
 msgstr "Valor mínim de una columna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:546
+#: frontend/src/metabase/lib/schema_metadata.js:547
 msgid "Maximum of ..."
 msgstr "Màxim de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:549
 msgid "Maximum value of a column"
 msgstr "Valor màxim de una columna"
 
@@ -4036,7 +4056,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Categoria"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:43
-#: frontend/src/metabase/user/components/UserSettings.jsx:55
+#: frontend/src/metabase/user/components/UserSettings.jsx:56
 msgid "Account settings"
 msgstr "Configuració del compte"
 
@@ -4048,7 +4068,7 @@ msgstr "Sortir de l'administració"
 msgid "Logs"
 msgstr "Registres"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:103
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:104
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:22
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:65
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:100
@@ -4088,9 +4108,9 @@ msgid "Metabase Admin"
 msgstr "Administració del Metabase"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:36
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:36
 msgid "Ask a question"
 msgstr "Fes una pregunta"
 
@@ -4111,7 +4131,7 @@ msgstr "Referència"
 msgid "Which metric?"
 msgstr "Quina mètrica?"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "La definició de mètriques comunes per al teu equip fa que sigui encara més fàcil crear preguntes"
 
@@ -4123,7 +4143,7 @@ msgstr "Com crear mètriques"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Consulta les dades al llarg del temps, com a mapa o en una taula pivotada per ajudar a entendre les tendències o els canvis."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:149
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
 msgid "Custom"
 msgstr "Personalitzat"
 
@@ -4136,13 +4156,13 @@ msgstr "Nova pregunta"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Utilitzeu el generador de preguntes per veure tendències, llistes de coses o les teves pròpies mètriques"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:107
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:110
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Consulta nativa"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:108
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:111
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Per a preguntes més complicades pots escriure la teva pròpia consulta SQL o nativa."
 
@@ -4247,6 +4267,7 @@ msgid "Enter a default value..."
 msgstr "Introduïu un valor predeterminat"
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
+#: frontend/src/metabase/containers/Form.jsx:307
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "S'ha produït un error"
@@ -4495,7 +4516,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "Recomanem mantenir els polsos petits i enfocats per facilitar la seva comprensió i que siguin útils per tot l'equip"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:161
-#: frontend/src/metabase/query_builder/components/view/View.jsx:131
+#: frontend/src/metabase/query_builder/components/view/View.jsx:133
 msgid "Pick your data"
 msgstr "Escull les teves dade"
 
@@ -4511,47 +4532,47 @@ msgstr "Correus electrònics"
 msgid "Slack messages"
 msgstr "Missatges de Slack"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:216
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Enviat"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:217
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} s'enviarà a la les"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:219
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Missatges"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:235
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "Envia el correu electrònic ara"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:236
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Envia a {0} ara"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:238
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Enviant..."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "S'ha produït un error al enviar"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "No s'ha enviat el pols perquè no te resultats"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Pols enviat"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:282
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} ha de ser configurat per un administrador."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:295
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:299
 msgid "Slack"
 msgstr "Slack"
 
@@ -4704,7 +4725,7 @@ msgstr "Mitja"
 msgid "Distincts"
 msgstr "Diferents"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:55
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "Veure aquest {0}"
@@ -4715,11 +4736,12 @@ msgstr[1] "Veure aquests {0}"
 msgid "Zoom in"
 msgstr "Amplia"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Expressió personalitzada"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Common Metrics"
 msgstr "Mètriques comuns"
 
@@ -4916,34 +4938,34 @@ msgstr "generalment"
 msgid "Pick a segment or table"
 msgstr "Tria un segment o taula"
 
-#: frontend/src/metabase/entities/databases/forms.js:191
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
+#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Selecciona una base de dades"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:94
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:85
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:31
 msgid "Select..."
 msgstr "Seleccionar.."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:134
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
 msgid "Select a table"
 msgstr "Selecciona una taula"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:819
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:926
 msgid "No tables found in this database."
 msgstr "No s'han trobat taules en aquesta base de dades"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:856
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:901
 msgid "Is a question missing?"
 msgstr "Falta una pregunta?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:863
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:909
 msgid "Learn more about nested queries"
 msgstr "Aconsegueix més informació sobre consultes anidades"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:898
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:951
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:40
 msgid "Fields"
 msgstr "Camps"
 
@@ -4977,11 +4999,11 @@ msgstr "Ordena"
 msgid "Row limit"
 msgstr "Límit de files"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
 msgid "Unknown Field"
 msgstr "Camp desconegut"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:75
 msgid "field"
 msgstr "camp"
 
@@ -4989,19 +5011,20 @@ msgstr "camp"
 msgid "Matches"
 msgstr "Coincidències"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:148
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:156
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:135
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Afegeix filtres per perfilar la teva resposta"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:293
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
 msgstr "Afegeix una agrupació"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:37
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:313
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
-#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:66
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:67
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:89
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:131
@@ -5017,16 +5040,16 @@ msgstr "Afegeix una agrupació"
 msgid "Data"
 msgstr "Dades"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:340
 msgid "Filtered by"
 msgstr "Filtrat per"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:376
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:357
 msgid "View"
 msgstr "Mostra"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:393
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:374
 msgid "Grouped By"
 msgstr "Agrupat per"
 
@@ -5034,7 +5057,7 @@ msgstr "Agrupat per"
 msgid "None"
 msgstr "Cap"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:471
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
 msgid "This question is written in {0}."
 msgstr "Aquesta pregunta està escrita en {0}"
 
@@ -5046,7 +5069,7 @@ msgstr "Amaga l'editor"
 msgid "Hide Query"
 msgstr "Amaga la consulta"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:481
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
 msgid "Open Editor"
 msgstr "Obrir l'editor"
 
@@ -5287,7 +5310,7 @@ msgstr "Tots els valors diferents de {0}"
 msgid "Number of {0} grouped by {1}"
 msgstr "Número de {0} agrupades per {1}"
 
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:77
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5346,32 +5369,33 @@ msgstr "Mostra les dades de {0}"
 msgid "More"
 msgstr "Més"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:194
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:216
 msgid "Invalid expression"
 msgstr "Expressió invàlida"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:269
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:282
 msgid "unknown error"
 msgstr "error desconegut"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:47
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:53
 msgid "Field formula"
 msgstr "Formula del camp"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:60
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:64
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Pensa que això es com escriure una fórmula en un full de càlcul: Pots utilitzar números, camps d'aquesta taula, símbols màtemàtics com + i algunes funcions. Pots escriure alguna cosa com: Subtotal - Cost"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:69
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:208
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
 msgid "Learn more"
 msgstr "Aprendre'n més"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:77
 msgid "Give it a name"
 msgstr "Dona-li un nom"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:79
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
 msgid "Something nice and descriptive"
 msgstr "Quelcom agradable i descriptiu"
 
@@ -5451,11 +5475,11 @@ msgid "Enter desired number"
 msgstr "Introdueix el nombre desitjat"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:154
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:161
 msgid "Empty"
 msgstr "Buit"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:119
 msgid "Find a value"
 msgstr "Cerca un valor"
 
@@ -5523,35 +5547,35 @@ msgstr "Llegeix la documentació complerta"
 msgid "Filter label"
 msgstr "Filtre d'etiqueta"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:135
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:134
 msgid "Variable type"
 msgstr "Tipus de variable"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:143
 msgid "Text"
 msgstr "Text"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
 msgid "Date"
 msgstr "Data"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:147
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
 msgid "Field Filter"
 msgstr "Filtre de camp"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Field to map to"
 msgstr "Camp per mapejar a"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:180
 msgid "Filter widget type"
 msgstr "Tipus de filtre"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:230
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
 msgid "Required?"
 msgstr "Obligatori?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:240
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
 msgid "Default filter widget value"
 msgstr "Valor per defecte el camp de filtre"
 
@@ -5563,7 +5587,7 @@ msgstr "Arxivar aquesta pregunta?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Aquesta pregunta s'eliminarà dels quadres de comandaments o polsos que la utilitzin."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:158
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
 msgid "Question"
 msgstr "Pregunta"
 
@@ -5733,7 +5757,7 @@ msgid "Details"
 msgstr "Detalls"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
-#: frontend/src/metabase/reference/databases/TableList.jsx:116
+#: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
 msgstr "Taules a {0}"
 
@@ -5814,24 +5838,24 @@ msgstr "Perquè aquesta taula es interesant"
 msgid "Things to be aware of about this table"
 msgstr "Coses a tenir en compte sobre aquesta taule"
 
-#: frontend/src/metabase/reference/databases/TableList.jsx:30
+#: frontend/src/metabase/reference/databases/TableList.jsx:29
 msgid "Tables in this database will appear here as they're added"
 msgstr "Les taules d'aquesta base de dades es mostraran aquí una vegades afegeixes"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:34
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:33
 msgid "Questions about this table will appear here as they're added"
 msgstr "Les preguntes d'aquesta taula es mostraran aquí una vegades afegeixes"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:73
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:77
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:76
 msgid "Questions about {0}"
 msgstr "Preguntes sobre {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
 msgid "Created {0} by {1}"
 msgstr "Creat fa {0} per {1}"
 
@@ -6020,19 +6044,19 @@ msgstr "Altres camps pels que es pot agrupar aquesta mètrica"
 msgid "Fields you can group this metric by"
 msgstr "Camps pels que es pot agrupar aquesta mètrica"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "Les mètriques són nombres oficials pels que el teu equip es preocupa"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Metrics will appear here once your admins have created some"
 msgstr "Les mètriques apareixeran aquí una vegada que els teus administradors n'hagin creat alguna. "
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:28
 msgid "Learn how to create metrics"
 msgstr "Aprèn com crear mètriques"
 
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:34
 msgid "Questions about this metric will appear here as they're added"
 msgstr "Les preguntes sobre aquesta mètrica apareixeran aquí quan es creïn."
 
@@ -6058,23 +6082,23 @@ msgstr "Perquè aquest segment es interessant"
 msgid "Things to be aware of about this Segment"
 msgstr "Coses a tenir en compte d'aquest segment"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
 msgid "Segments are interesting subsets of tables"
 msgstr "Els segments son subconjunts interessants de taules"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "La definició de segments comuns pel teu equip fa que encara sigui més fàcil fer preguntes"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Segments will appear here once your admins have created some"
 msgstr "Els segments apareixeran aquí una vegada que els administradors els hagin creat"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
 msgid "Learn how to create segments"
 msgstr "Aprèn a crear segments"
 
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:35
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:34
 msgid "Questions about this segment will appear here as they're added"
 msgstr "Les preguntes sobre aquest segment apareixeran aquí quan s'afegeixin"
 
@@ -6094,22 +6118,22 @@ msgstr "Preguntes sobre aquest segment"
 msgid "X-ray this segment"
 msgstr "Aplica rajos-X a aquest segment"
 
-#: frontend/src/metabase/routes.jsx:178 frontend/src/metabase/routes.jsx:179
+#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
 msgid "Login"
 msgstr "Inicia sessió"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:303
 #: frontend/src/metabase/containers/ItemPicker.jsx:115
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:204
+#: frontend/src/metabase/routes.jsx:195
 msgid "Search"
 msgstr "Cerca"
 
-#: frontend/src/metabase/routes.jsx:223
+#: frontend/src/metabase/routes.jsx:214
 msgid "Dashboard"
 msgstr "Quadre de comandament"
 
-#: frontend/src/metabase/routes.jsx:236
+#: frontend/src/metabase/routes.jsx:227
 msgid "New Question"
 msgstr "Nova pregunta"
 
@@ -6153,63 +6177,63 @@ msgstr "Gràcies per ajudar-nos a millorar"
 msgid "We won't collect any usage events"
 msgstr "No recopilarem cap esdeveniment d'ús."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:88
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Per ajudar-nos a millorar el Metabase ens agradaria recollir informació sobre el seu us a través de Google Analytics."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:90
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Here's a full list of everything we track and why."
 msgstr "Aquí hi ha una llista complerta de tota la informació que recollirem i perquè."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Permetre que el Metabase reculli esdeveniments d'ús de forma anònima"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:113
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0} recull informació sobre les teves dades o els resultats de les preguntes"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:114
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
 msgid "never"
 msgstr "mai"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:119
 msgid "All collection is completely anonymous."
 msgstr "Tota la informació obtinguda es totalment anònima"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "La recopilació es pot desactivar en qualsevol moment des de la pàgina de configuració."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:44
+#: frontend/src/metabase/setup/components/Setup.jsx:59
 msgid "If you feel stuck"
 msgstr "Si et sents abrumant"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:49
+#: frontend/src/metabase/setup/components/Setup.jsx:64
 msgid "our getting started guide"
 msgstr "la nostra guia d'iniciació"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:50
+#: frontend/src/metabase/setup/components/Setup.jsx:65
 msgid "is just a click away."
 msgstr "està a un sol click"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:92
+#: frontend/src/metabase/setup/components/Setup.jsx:111
 msgid "Welcome to Metabase"
 msgstr "Benvingut/da al Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:93
+#: frontend/src/metabase/setup/components/Setup.jsx:112
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Sembla que tot està funcionant. Ara anem a coneixe't, connectar amb les teves dades i començar a donar respostes a les teves preguntes."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:97
+#: frontend/src/metabase/setup/components/Setup.jsx:116
 msgid "Let's get started"
 msgstr "Començem"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:142
+#: frontend/src/metabase/setup/components/Setup.jsx:166
 msgid "You're all set up!"
 msgstr "Ja està tot llest!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:153
+#: frontend/src/metabase/setup/components/Setup.jsx:177
 msgid "Take me to Metabase"
 msgstr "Portam al Metabase"
 
@@ -6221,13 +6245,13 @@ msgstr "Com t'hem d'anomenar?"
 msgid "Hi, {0}. nice to meet you!"
 msgstr "Hola {0}, encantat de coneixe't"
 
-#: frontend/src/metabase/entities/users/forms.js:33
+#: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
 msgstr "Crea una contrasenya"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:44
-#: frontend/src/metabase/entities/users/forms.js:35
-#: frontend/src/metabase/entities/users/forms.js:82
+#: frontend/src/metabase/entities/users/forms.js:50
+#: frontend/src/metabase/entities/users/forms.js:97
 msgid "Shhh..."
 msgstr "Shhht..."
 
@@ -6235,11 +6259,11 @@ msgstr "Shhht..."
 msgid "Confirm password"
 msgstr "Confirma la contrasenya"
 
-#: frontend/src/metabase/entities/users/forms.js:42
+#: frontend/src/metabase/entities/users/forms.js:57
 msgid "Shhh... but one more time so we get it right"
 msgstr "Shhht... una altra vegada per assegurar-nos que ho fem bé"
 
-#: frontend/src/metabase/entities/users/forms.js:70
+#: frontend/src/metabase/entities/users/forms.js:85
 msgid "Your company or team name"
 msgstr "El nom de la teva empresa o equip"
 
@@ -6408,7 +6432,7 @@ msgstr "La contrasenya s'ha actualitzat correctament"
 msgid "Account updated successfully!"
 msgstr "El compte s'ha actualitzat amb èxit"
 
-#: frontend/src/metabase/entities/users/forms.js:81
+#: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
 msgstr "Contrasenya actual"
 
@@ -6420,7 +6444,7 @@ msgstr "Inicia sessió amb la direcció de correu electrònic de Googl"
 msgid "User Details"
 msgstr "Detalls del usuari"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:327
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:344
 msgid "Reset to defaults"
 msgstr "Restablir els valors predeterminats"
 
@@ -6445,15 +6469,15 @@ msgstr "Quins camps vols fer servir pels eixos X i Y?"
 msgid "Choose fields"
 msgstr "Escull els camps"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:217
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:234
 msgid "Save as default view"
 msgstr "Guarda com a vista per defecte"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Draw box to filter"
 msgstr "Dibuixa una caixa per filtrar"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Cancel filter"
 msgstr "Cancel·la el filtre"
 
@@ -6481,19 +6505,19 @@ msgstr "No s'ha pogut trobar la visualització"
 msgid "Could not display this chart with this data."
 msgstr "No s'ha pogut mostrar el gràfic amb aquesta informació."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:526
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
 msgid "No results!"
 msgstr "Sense resultats"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:547
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
 msgid "Still Waiting..."
 msgstr "Esperant..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:550
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
 msgid "This usually takes an average of {0}."
 msgstr "Normalment tarda una mitja de {0}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:556
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
 msgid "(This is a bit long for a dashboard)"
 msgstr "(es una mica llarg per a un quadre de comandament)"
 
@@ -6652,19 +6676,19 @@ msgstr "Afegir una regla"
 msgid "Update rule"
 msgstr "Actualitzar la regla"
 
-#: frontend/src/metabase/visualizations/index.js:32
+#: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
 msgstr "La visualització es buida"
 
-#: frontend/src/metabase/visualizations/index.js:37
+#: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
 msgstr "La visualització ha de definir una variable 'identificadora' estàtica: "
 
-#: frontend/src/metabase/visualizations/index.js:43
+#: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
 msgstr "Ja s'ha registrat una visualització amb aquesta identificació:"
 
-#: frontend/src/metabase/visualizations/index.js:71
+#: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
 msgstr "No hi ha visualitzacions per {0}"
 
@@ -6690,23 +6714,23 @@ msgid "Doh! The data from your query doesn't fit the chosen display choice. This
 msgstr "Les dades de la teva consulta no s'ajusten a la opció de visualització escollida. Aquesta visualització necessita com a mínim {0} {1} de dades."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:9
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:117
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:120
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:161
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:169
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:249
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:267
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "columna"
@@ -6817,83 +6841,83 @@ msgstr "Res"
 msgid "Linear Interpolated"
 msgstr "Interpolació lineal"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
 msgstr "Escala Eix-X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
 msgstr "Series de temps"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:454
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
 msgid "Linear"
 msgstr "Lineal"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
 msgid "Power"
 msgstr "Exponencial"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:428
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:445
 msgid "Log"
 msgstr "Logarítimc"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:441
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:430
 msgid "Histogram"
 msgstr "Histograma"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
 msgstr "Ordinal"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
 msgstr "Escala Eix-Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:462
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
 msgstr "Mostra lńia i marca del Eix-X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:360
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:468
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:349
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
 msgid "Compact"
 msgstr "Compacte"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:469
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
 msgid "Rotate 45°"
 msgstr "Girar 45º"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:459
 msgid "Rotate 90°"
 msgstr "Girar 90º"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
 msgid "Show y-axis line and marks"
 msgstr "Mostra ínia i marques del Eix-Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:489
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Auto y-axis range"
 msgstr "Rang del Eix-Y automàtic"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:533
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:522
 msgid "Use a split y-axis when necessary"
 msgstr "Utilitza un Eix-Y dividit quan sigui necesàri"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:540
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:529
 msgid "Show label on x-axis"
 msgstr "Mostra etiqueta en l'Eix-X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:546
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:535
 msgid "X-axis label"
 msgstr "Etiqueta Eix-X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:555
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:544
 msgid "Show label on y-axis"
 msgstr "Mostra etiqueta en l'Eix-Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:561
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:550
 msgid "Y-axis label"
 msgstr "Etiqueta Eix-Y"
 
@@ -7019,23 +7043,23 @@ msgstr "Opacitat mínima"
 msgid "Max Zoom"
 msgstr "Zoom Maxim"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:231
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:234
 msgid "No relationships found."
 msgstr "No s'han trobat relacions"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:269
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:272
 msgid "via {0}"
 msgstr "via {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:347
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
 msgid "This {0} is connected to:"
 msgstr "Està {0} està connectada a:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "Object Detail"
 msgstr "Detall del objecte"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:93
 msgid "object"
 msgstr "objecte"
 
@@ -7425,7 +7449,7 @@ msgstr "Tens moltes preguntes guardades a {0}? Crea col·leccions per gestionar-
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:149 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -8944,19 +8968,19 @@ msgstr "Pot editar aquesta col·lecció i els seus continguts"
 msgid "Can view items in this collection"
 msgstr "Pot veure el contingut d'aquesta col·lecció"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:767
+#: frontend/src/metabase/admin/permissions/selectors.js:765
 msgid "Collection Access"
 msgstr "Accés a la col·lecció"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:841
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Aquest grup té permisos per veure com a mínim una sub-col·lecció d'aquesta col·lecció"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:848
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Aquest grup té permisos per editar com a mínim una sub-col·lecció d'aquesta col·lecció"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:861
+#: frontend/src/metabase/admin/permissions/selectors.js:859
 msgid "View sub-collections"
 msgstr "Mostra sub col·leccíó"
 
@@ -8964,7 +8988,7 @@ msgstr "Mostra sub col·leccíó"
 msgid "Remember Me"
 msgstr "Recorda'm"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:63
+#: frontend/src/metabase/components/BrowseApp.jsx:73
 msgid "X-ray this schema"
 msgstr "Aplica rajos-X a aquest esquema"
 
@@ -9025,15 +9049,15 @@ msgstr "El Metabase no ha pogut trobar cap resultat per la seva cerca."
 msgid "No metrics"
 msgstr "No s'ha trobat cap mètrica"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:31
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:41
 msgid "Aggregations"
 msgstr "Agregats"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:32
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:42
 msgid "Operators"
 msgstr "Operadors"
 
-#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:30
+#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:35
 msgid "Custom fields"
 msgstr "Camps personalitzats"
 
@@ -9199,7 +9223,7 @@ msgstr "nom-del-meu-cluster.abcd1234.us-east-1.redshift.amazonaws.com"
 msgid "toucan_sightings"
 msgstr "avistament_de_tucans"
 
-#: src/metabase/driver/sparksql.clj
+#: src/metabase/models/collection.clj
 msgid "default"
 msgstr "per defecte"
 
@@ -9227,10 +9251,10 @@ msgstr "N/A"
 msgid "Windows domain"
 msgstr "Domini de Windows"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:539
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:545
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:554
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:560
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:528
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:534
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:543
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
 msgstr "Etiquetes"
 
@@ -9265,9 +9289,9 @@ msgstr "Compartir"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:286
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:294
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:302
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:319
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:324
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
@@ -9282,19 +9306,18 @@ msgstr "Compartir"
 msgid "Display"
 msgstr "Visualitza"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:461
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:476
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:502
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:532
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:402
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:465
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:483
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:521
 msgid "Axes"
 msgstr "Eixos"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:212
-#: frontend/src/metabase/admin/settings/selectors.js:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:219
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:62
 msgid "Formatting"
@@ -9328,7 +9351,7 @@ msgstr "Aplica rajos-X"
 msgid "Compare to the rest"
 msgstr "Compara amb a resta"
 
-#: frontend/src/metabase/entities/databases/forms.js:16
+#: frontend/src/metabase/entities/databases/forms.js:18
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Utilitza la zona horària de la màquina virtual de Java (JVM)"
 
@@ -9357,24 +9380,24 @@ msgstr "Utilitza la zona horària de la màquina virtual de Java (JVM)"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Estem analitzant les taules i els camps per ajudar-te a explorar les teves dades"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
 msgid "Tip: "
 msgstr "Consell: "
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:237
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
 msgstr "Selecciona un tipus de moneda"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:300
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
 msgid "Field Type"
 msgstr "Tipo de camp"
 
-#: frontend/src/metabase/admin/routes.jsx:113
+#: frontend/src/metabase/admin/routes.jsx:118
 #: frontend/src/metabase/nav/containers/Navbar.jsx:267
 msgid "Troubleshooting"
 msgstr "Solució de problemes"
 
-#: frontend/src/metabase/admin/settings/selectors.js:103
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Enable X-ray features"
 msgstr "Habilita les característiques de rajos-X"
 
@@ -9419,7 +9442,7 @@ msgstr "Duració (ms)"
 msgid "Currency"
 msgstr "Modena"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
 msgstr "Escull un usuari o canal"
 
@@ -9567,7 +9590,7 @@ msgstr "Format de la línia"
 msgid "Show dots on lines"
 msgstr "Mostrar punts a les línies"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:348
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
@@ -9581,7 +9604,7 @@ msgstr "En quin eix?"
 msgid "Line + Bar"
 msgstr "Línia + Barra"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
 msgid "line and bar chart"
 msgstr "Gràfic de línia i barra"
 
@@ -11028,7 +11051,7 @@ msgstr "Com es distribueix aquesta mètrica entre els diferents nombres."
 msgid "Sessions by page where the session began"
 msgstr "Sessions per pàgina on ha començat la sessió"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:503
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -11397,7 +11420,7 @@ msgstr "Duplica aquest ítem"
 msgid "Archive this item"
 msgstr "Arxiva aquest ítem"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:331
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:325
 msgid "Duplicate dashboard"
 msgstr "Duplica el quadre de comandaments"
 
@@ -11502,7 +11525,7 @@ msgid_plural "Quarters of year"
 msgstr[0] "Trimestre del any"
 msgstr[1] "Trimestres de l'any"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
@@ -11518,8 +11541,8 @@ msgstr "[Q]Q"
 msgid "This"
 msgstr "Aquest"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:97
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:137
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:136
 msgid "Invalid"
 msgstr "Invàlid"
 
@@ -12282,6 +12305,7 @@ msgstr "Aquí estan les teves {0} targetes més recents"
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
 msgstr "Pots ser una mica més específic o utilitzar la identificació? He trobat aquestes targetes amb noms que coincideixen:"
 
+#: src/metabase/driver/common/parameters/values.clj
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
 msgstr "No s'ha trobat la targeta {0}"
@@ -12390,11 +12414,11 @@ msgstr "Instruccions de fallada"
 msgid "Archive this?"
 msgstr "Arxivar això?"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:243
+#: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
 msgstr "Apren de les teves dades"
 
-#: frontend/src/metabase/entities/databases/forms.js:20
+#: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
 msgstr "Utilitza el DNS SRV quan et conectis"
 
@@ -12404,7 +12428,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "Aquesta opció requereis que el host sigui FQDN. Si es conecta a un clúster Atlar es possibleu que necessiteu habilitar aquesta opció. Si no sabeu el que significa deixa-ho deshbilitat."
 
-#: frontend/src/metabase/entities/databases/forms.js:204
+#: frontend/src/metabase/entities/databases/forms.js:273
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Executa les consultes automàticament quan es realitze un sumari o un filtre simple."
 
@@ -12428,11 +12452,11 @@ msgstr "Tots els resultats"
 msgid "Our Analytics"
 msgstr "Les nostres analítiques"
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:513
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
 msgstr "Suma aditiva de tots els valors d'una columna.\\n P.e: Ingresos totals al llarg dels temps."
 
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
 msgstr "Recompte aditiu del nombre de files.\\n P.e: Nombre total de vendes en el temps"
 
@@ -12442,7 +12466,7 @@ msgstr "Recompte aditiu del nombre de files.\\n P.e: Nombre total de vendes en e
 msgid "Filter"
 msgstr "Filtre"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:50
 msgid "record"
 msgid_plural "records"
 msgstr[0] "registre"
@@ -12456,27 +12480,27 @@ msgstr "Navegar"
 msgid "Write SQL"
 msgstr "Escriu SQL"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:83
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
 msgstr "Pregunta simple"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:84
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:87
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
 msgstr "Tria algunes dades, visualitza'ls i filtra'ls, resumeix-los i analitza'ls de forma senzilla."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:95
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:98
 msgid "Custom question"
 msgstr "Pregunta personalitzada"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:96
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:99
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Utilitza l'editor avançat per unir dades, crear columnes personalitzades, fer cálculs matemàtics i més."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Basic Metrics"
 msgstr "Mètriques bàsiques"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:322
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
 msgid "Custom…"
 msgstr "Personalitzada..."
 
@@ -12546,15 +12570,15 @@ msgstr "Trieu la columna per la qual agrupar"
 msgid "Pick your starting data"
 msgstr "Trieu les dades inicials"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select None"
 msgstr "Seleccionar cap"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select All"
 msgstr "Selecciona'ls tots"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:151
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:152
 msgid "Pick a table..."
 msgstr "Trieu una taula..."
 
@@ -12677,15 +12701,15 @@ msgstr "Afegeix una mètrica"
 #: frontend/src/metabase/lib/core.js:137 frontend/src/metabase/lib/core.js:142
 #: frontend/src/metabase/lib/core.js:147 frontend/src/metabase/lib/core.js:152
 #: frontend/src/metabase/lib/core.js:157 frontend/src/metabase/lib/core.js:162
-#: frontend/src/metabase/user/components/UserSettings.jsx:63
+#: frontend/src/metabase/user/components/UserSettings.jsx:64
 msgid "Profile"
 msgstr "Perfil"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:560
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "Això normalment es batant ràpid pero sembla que aquesta vegada esta tardant una mica."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
 msgid "Combo"
 msgstr "Combo"
 
@@ -12701,11 +12725,11 @@ msgstr "Tendència"
 msgid "Boolean"
 msgstr "Boleà"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:62
 msgid "Unknown Segment"
 msgstr "Segment desconegut"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:73
 msgid "Unknown Filter"
 msgstr "Filtre desconegut"
 
@@ -12835,6 +12859,7 @@ msgstr "Utilitzant la clase NEWLY CREATE com a carregardor de classes de context
 msgid "Failed to copy file"
 msgstr "No s'ha pogut copia el fitxer"
 
+#. check that the URL is valid
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
 msgstr "Url invàlida: {0}"
@@ -13109,7 +13134,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Esculleix les columnes que vols incloure"
 
-#: frontend/src/metabase/entities/databases/forms.js:205
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Al activar aquesta opció Metabase executarà automàticamente les consultes quan els usuaris realitzin exploracions simples amb els botóns Resumir i Filtra de taules i gràfiques. Pots desactivar aquesta opció si les consultes a la base de dades son lentes. Aquesta configuració no afecta als detalls ni a les consultes SQL."
 
@@ -13147,7 +13172,7 @@ msgstr "Error al determinar les columnes esperades de la consulta"
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "Excepció no controlada, s'espera un middleware `catch-exceptions` que la controli"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:125
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
 msgid "Diagnostic Info"
 msgstr "Informació diagnostic"
 
@@ -13171,11 +13196,11 @@ msgstr "S'ha product un error amb l'autentificació de Google. Si us plau, conta
 msgid "Sign in with email"
 msgstr "Registrar-se a través del correu electrònic"
 
-#: frontend/src/metabase/entities/databases/forms.js:21
+#: frontend/src/metabase/entities/databases/forms.js:23
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "Utiltizar aquesta opció requereix que la maquina contingui un FQDN. Si us conecteu a un cluster de Atlas, potseu haureu d'habilitar aquesta opció. Si no sabeu el que vol dir això, millor que ho deixeu desactivat."
 
-#: frontend/src/metabase/entities/databases/forms.js:213
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Per defecte, Metabase fa un sincronització lleujera cada hora i una sincronització intensiva cada hora dels valors dels camps. Si teniu una base de dades gran, us recomanem activar aquesta opció i revisar quan i amb quina freqüencia s'escanejen els valors dels camps."
 
@@ -13243,11 +13268,11 @@ msgstr "No ho incloguis"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "El camp no sera visible o seleccionable a les preguntes createdes amb la interface d'usuari. Si que es podrà accedir amb consultes SQL/natives."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:512
 msgid "Cumulative sum"
 msgstr "Suma acumulada"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Standard deviation"
 msgstr "Desviació estàndard"
 
@@ -13259,23 +13284,23 @@ msgstr "ha de tenir com a mínim {0} caràcters"
 msgid "Must be at least {0} characters long"
 msgstr "Ha de tenir com a mínim {0} caràcters"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:389
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:82
 msgid "Name (required)"
 msgstr "Nom (obligatori)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:556
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
 msgid "Run selected text"
 msgstr "Execut el text seleccionat"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:557
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
 msgid "Run query"
 msgstr "Executa la consulta"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(⌘ + enter)"
 msgstr "(⌘ + intro)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + intro)"
 
@@ -13287,7 +13312,7 @@ msgstr "Aquí es on apareixeran els teus resultats"
 msgid "You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question."
 msgstr "No fareu cap canvi permanent a les questions guardades sinó cliqueu \"Guarda\" i seleccioneu la opció de sobrescriure la pregunta original."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:199
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:200
 msgid "There aren't any filter widgets for this type of field yet."
 msgstr "Encara no hi ha cap tipus de giny de cerca per aquest tipus de camp."
 
@@ -13323,19 +13348,19 @@ msgstr "Línia objectiu"
 msgid "Trend line"
 msgstr "Línia de tendència"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:320
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:317
 msgid "Show values on data points"
 msgstr "Mostra els valors amb punts de dades"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:334
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:325
 msgid "Values to show"
 msgstr "Valors a mostrar"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:342
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:332
 msgid "As many as can fit nicely"
 msgstr "El màxim que es mostrin correctament"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:343
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
 msgid "All"
 msgstr "Tots"
 
@@ -13627,31 +13652,31 @@ msgstr "Nombres"
 msgid "No mappable groups"
 msgstr "No hi ha grup mapejables"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:107
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
 msgstr "Documentació de metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
 msgstr "Incloud una guia per solucionar problemes"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:112
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
 msgid "Post on the Metabase support forum"
 msgstr "Publica al fòrum de support de metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:114
 msgid "A community forum for all things Metabase"
 msgstr "Un forum comunitari per temes relacionats amb metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:117
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
 msgid "File a bug report"
 msgstr "Obriu una incidencia"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:119
 msgid "Create a GitHub issue (includes the diagnostic info below)"
 msgstr "Creu una incidència a github  (inclou la informació de diagnostic)"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:127
 msgid "Please include these details in support requests. Thank you!"
 msgstr "SI us plau, afegiu aquest detalls a les vostres peticions de suport. Gràcies"
 
@@ -13679,38 +13704,40 @@ msgstr "No s'ha trobat cap coincidencia"
 msgid "Submit"
 msgstr "Envia"
 
-#: frontend/src/metabase/entities/databases/forms.js:13
+#: frontend/src/metabase/entities/databases/forms.js:15
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host. This option also provides an extra layer of security when a VPN is not available. Enabling this is usually slower than a direct connection."
 msgstr "Algunes bases de dades només es poden accedir conectant a través d'un servidor SSH. Aquesta opció afegeix una capa de seguretat quan no es disposa de VPN. Activar aquesta opció normalment és més lent que una conexió directa."
 
-#: frontend/src/metabase/entities/databases/forms.js:17
+#: frontend/src/metabase/entities/databases/forms.js:19
 msgid "We suggest you leave this off unless you're doing manual timezone casting in many or most of your queries with this data."
 msgstr "Et sugerim que ho deixis descativat si està establint la zona horaria a la major part de les consultes d'aquestes dades."
 
-#: frontend/src/metabase/entities/databases/forms.js:93
+#: frontend/src/metabase/entities/databases/forms.js:128
 msgid "{0} to get an auth code."
 msgstr "{0} per obtenir un codi d'autentificació."
 
-#: frontend/src/metabase/entities/databases/forms.js:101
+#: frontend/src/metabase/entities/databases/forms.js:136
+#: src/metabase/models/collection.clj
 msgid "or"
 msgstr "o"
 
-#: frontend/src/metabase/entities/databases/forms.js:159
-#: frontend/src/metabase/entities/databases/forms.js:197
-#: frontend/src/metabase/entities/users/forms.js:44
+#: frontend/src/metabase/entities/databases/forms.js:39
+#: frontend/src/metabase/entities/databases/forms.js:226
+#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "obligatori"
 
-#: frontend/src/metabase/entities/databases/forms.js:188
+#: frontend/src/metabase/entities/databases/forms.js:257
 msgid "Database type"
 msgstr "Tipus de base de dades"
 
-#: frontend/src/metabase/entities/databases/forms.js:222
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Es tracta d'una process lleuger que comprava les actualitzacions del esquema d'aquesta base de dades. En la majoria de caso es suficient que es sincronitzi cada hora."
 
-#: frontend/src/metabase/entities/databases/forms.js:230
+#: frontend/src/metabase/entities/databases/forms.js:299
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "El metabase pot escanejar els valors de cada camp a la base de dades per activar els filtres de casella de verificació als cuadres de comandament i preguntes. Aquest proces pot consumir bastants recursos, especialment si teniu una base de dades gran."
 
@@ -13718,15 +13745,15 @@ msgstr "El metabase pot escanejar els valors de cada camp a la base de dades per
 msgid "Collection"
 msgstr "Col·leció"
 
-#: frontend/src/metabase/entities/users/forms.js:40
+#: frontend/src/metabase/entities/users/forms.js:55
 msgid "Confirm your password"
 msgstr "Confirmeu la vostra contrasenya"
 
-#: frontend/src/metabase/entities/users/forms.js:45
+#: frontend/src/metabase/entities/users/forms.js:60
 msgid "passwords do not match"
 msgstr "Les contrasenyes no coincideixen"
 
-#: frontend/src/metabase/entities/users/forms.js:71
+#: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
 msgstr "Departament de meravelles"
 
@@ -13766,328 +13793,324 @@ msgid "Returns the average of the values in the column."
 msgstr "Retorna la mitjana dels valors de la columna."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:18
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
 msgid "The column whose values to average."
 msgstr "La columna de valors que es vol fer la mitjana."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "start"
 msgstr "inici"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "end"
 msgstr "final"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
 msgid "Checks a date or numeric column's values to see if they're within the specified range."
 msgstr "Comproba si els valors d'una columna numerica o de tipus data estan dins d'un rang especificat."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
 msgstr "Valoració"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:24
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:98
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
 msgid "condition"
 msgstr "condició"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
 msgid "output"
 msgstr "sortida"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Comprova una llista de casos i retorna el valor corresponent al primer valor verdader amb un valor por defecte opcional per quan no es compleix cap condició."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
 msgid "Weight"
 msgstr "Pes"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
 msgid "Large"
 msgstr "Llarg"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
 msgid "Medium"
 msgstr "Mitja"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
 msgid "Small"
 msgstr "Petit"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
 msgid "Something that should evaluate to true or false."
 msgstr "Un valor que s'evalua a verdader o fals"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:54
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "El valor que es retornarà si la condició es certa."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:62
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "value1"
 msgstr "valor1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:74
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
 msgid "value2"
 msgstr "valor2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Mira els valors de cada argument en ordre i retorna el primer que no es buit de cada fila."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:56
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
 msgid "Comments"
 msgstr "Comentaris"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
 msgid "Notes"
 msgstr "Notes"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
 msgid "No comments"
 msgstr "No comentaris"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
 msgid "A column or value."
 msgstr "Una columna o valor."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:65
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:77
 msgid "If value1 is empty, value2 gets returned if it's not empty, and so on."
 msgstr "Si el valor1 es buit es retorna el valor2 si no es buit, i així succesivament."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 msgid "Combines two or more strings of text together."
 msgstr "Combina dos o més cadenes de text juntes."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
 msgid "Last Name"
 msgstr "Cognom"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 msgid "First Name"
 msgstr "Nom"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
 msgstr "El valor2 s'afegir al final d'auest."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
 msgstr "Aquest s'afegir al final del valor1."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
 msgid "string1"
 msgstr "cadena1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
 msgid "string2"
 msgstr "cadena2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:80
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Comporova si la cadena1 conté la cadena2."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:284
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
 msgid "Status"
 msgstr "Estat"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 msgid "Pass"
 msgstr "Pass"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
 msgstr "El continguts de la cadena que es comprovarà."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
 msgid "The string of text to look for."
 msgstr "El text a buscar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:90
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:116
 msgid "Returns the count of rows in the source data."
 msgstr "Retorna el nombre de files a les dades origen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Only counts rows where the condition is true."
 msgstr "Només conta les files quan la condició és verdadera."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:97
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:261
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
 msgid "Subtotal"
 msgstr "Subtotal"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
 msgid "The additive total of rows across a breakout."
 msgstr "El total additiu de les files en un conjunt."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:110
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
 msgid "The rolling sum of a column across a breakout."
 msgstr "La suma cumulativa d'una columna en un conjunt."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:113
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:268
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
 msgstr "La columna a sumar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
 msgid "The number of distinct values in this column."
 msgstr "El nombre de valors diferents d'aquesta columna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "The column whose distinct values to count."
 msgstr "La columna a comptar els valors diferents."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:128
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:145
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:153
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:201
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:274
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
 msgid "text"
 msgstr "text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:130
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:223
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
 msgid "comparison"
 msgstr "comparació"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Retorna verdader si el final de la cadena es correspon amb el text de comparació."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "Appetite"
 msgstr "Aptetit"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "hungry"
 msgstr "Gana"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 msgid "A column or string of text to check."
 msgstr "La columan o cadena a comprobar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
 msgid "The string of text that the original text should end with."
 msgstr "El text amb el que ha d'acabar el text original."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 msgid "regular_expression"
 msgstr "expresió_regular"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:136
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Extreu les subcadenes concordants segons l'expressió regular."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:137
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
 msgid "Address"
 msgstr "Adreça"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 msgid "The column or string of text to search though."
 msgstr "La columna o el text on buscar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
 msgid "The regular expression to match."
 msgstr "L'expressió regular a buscar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the string of text in all lowercase."
 msgstr "Retorna el text tot en minúscules."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:149
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to lowercase."
 msgstr "La columna amb els valors a convertir a mínuscules."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:154
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 msgid "Removes leading whitespace from a string of text."
 msgstr "Elimina els espais al inici d'un text."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:157
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column with values you want to trim."
 msgstr "La columna d'on voleu eliminar els espais."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "Returns the largest value found in the column."
 msgstr "Retorna el valor més gran que es troba a la columna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
 msgid "Age"
 msgstr "Edat"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:165
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
 msgid "The numeric column whose maximum you want to find."
 msgstr "La columna numèrica a la que voleu buscar el màxim."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:170
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "Returns the smallest value found in the column."
 msgstr "Retorna el valor més petit que es troba a la columna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
 msgid "Salary"
 msgstr "Salari"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:173
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
 msgid "The numeric column whose minimum you want to find."
 msgstr "La columna numèrica a la que voleu buscar el mínim."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:181
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:242
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
 msgid "position"
 msgstr "posició"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:194
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
 msgid "length"
 msgstr "longitud"
 
@@ -14096,7 +14119,7 @@ msgstr "longitud"
 msgid "new_text"
 msgstr "nou_text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:187
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
 msgid "Replaces a part of the input text with new text."
 msgstr "Reemplaça part del text amb el nou text."
 
@@ -14108,7 +14131,7 @@ msgstr "ID Comanda"
 msgid "Updated Part of ID"
 msgstr "S'ha actualitzat la part del ID"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
 msgid "The text that will be modified."
 msgstr "El text que serà modificcat."
 
@@ -14124,87 +14147,87 @@ msgstr "El nombre de caràcters a remplaçar."
 msgid "The text to use in the replacement."
 msgstr "El text que s'utilitzarà per remplaçar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Elimina els espais al final d'un text."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:210
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Retorna el percentatge de files que compleixen la condició en valor decimal."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:218
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Retorna verdades si l'inic del text es correspon amb el text de comparació."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Course Name"
 msgstr "Nom del curs"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Computer Science"
 msgstr "Informàtica"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
 msgid "The string of text that the original text should start with."
 msgstr "La cada amb que ha de començar el text original."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:229
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
 msgid "Calculates the standard deviation of the column."
 msgstr "Calcula la desviació estàndard de la columna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:230
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
 msgid "Population"
 msgstr "Habitants"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
 msgid "A numeric column."
 msgstr "Una columan numèrica."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
 msgid "Returns a portion of the supplied text."
 msgstr "Retorna una part del text d'entrada."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:241
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:313
 msgid "The text to return a portion of."
 msgstr "El text a retornar una part."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
 msgid "The position to start copying characters."
 msgstr "La posició on començar a copiar caràcters."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:245
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
 msgid "The number of characters to return."
 msgstr "El número de caràcters a retornar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
 msgid "Adds up all the values of the column."
 msgstr "Afegeix tots els valors de la columna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:253
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
 msgid "The numeric column to sum."
 msgstr "La columna numerica a sumar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Suma tots els valors de la columan que compleixen amb la condició."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
 msgid "Order Status"
 msgstr "Estat comanda"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
 msgid "Valid"
 msgstr "Vàlid"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Elimina els espais al inici i al final d'una text."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
 msgid "Returns the string of text in all upper case."
 msgstr "Retorna el text to amb majúscules."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
 msgid "The column with values to convert to upper case."
 msgstr "La columna amb els valors que es volen convertir a majuscules."
 
@@ -14266,39 +14289,39 @@ msgstr "Gràcies per utilitzar Metabase!"
 msgid "Powered by {0}"
 msgstr "Amb la tecnologia de {0}"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:191
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
 msgid "To:"
 msgstr "A:"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:40
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
 msgstr "No es pot utilitzar aquesta pregunta perquè esta basada en una altra base de dades"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:44
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:43
 msgid "Couldn't find a saved question with that ID number."
 msgstr "No s'ha trobat cap pregunta guardada amb aquest número de ID."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:55
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:54
 msgid "Pick a saved question"
 msgstr "Seleccioneu una pregunta guardada"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:57
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:56
 msgid "Pick a different question"
 msgstr "Seleccioneu una pregunta diferent."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:62
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:61
 msgid "Loading…"
 msgstr "Carregant..."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:79
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:78
 msgid "Question #…"
 msgstr "Pregunta #..."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:81
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
 msgstr "Pregunta #{0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:115
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
 msgstr "Ultima edició {0}"
 
@@ -14310,11 +14333,11 @@ msgstr "{0} crea una variable en aquesta consulta anomenada \"nom_variable\". Es
 msgid "Giving a variable the \"Field Filter\" type allows you to link questions to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "Seleccionant el tipus \"Filtre de camp\" per una variable us permet enllaçar preguntes amb els filtres dels quadres de comandament o utilitzar més tipus de filtres a les vostres preguntes SQL. Una variable de filtre de camp afegeix un SQL similar al que es genera amb el generador de consultes quan s'afegeix un filtre a les columnes existents."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:131
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
 msgstr "Nom de la variable"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:217
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:218
 msgid "Filter widget label"
 msgstr "Etiqueta giny de filtre"
 
@@ -14346,11 +14369,11 @@ msgstr "A la capçalera de la columna"
 msgid "In every table cell"
 msgstr "A cada cel·la de la taula"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:351
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:341
 msgid "Value formatting"
 msgstr "Format dels valors"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:361
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
 msgid "Full"
 msgstr "Ple"
 
@@ -14678,3 +14701,482 @@ msgstr "Error al generar l'informaciód de la columna:"
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandonment email!"
 msgstr "Enviant correu d'abondonament!"
+
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
+msgstr "Podeu crear mètriques guardades per afegir una opció de metrica nombrada. Les metriques guaradades inclouen el tipus d'agregació, el camp i els filtres opcionals que s'hagin afegit. Per expmle, podeu utilizar això per crear la manera oficial de calcular el \"Preu mitg\" de la taula de comandes."
+
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:105
+msgid "Select and add filters to create your new segment."
+msgstr "Seleccioneu i afegiu filtrer per crear el vostre nou segment."
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+msgid "Alphabetical"
+msgstr "Alfabètic"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+msgid "Smart"
+msgstr "Inteligent"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+msgid "Column order: {0}"
+msgstr "Ordre de la columna: {0}"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
+msgid "Unhide all"
+msgstr "Mostrar-ho tot"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:204
+msgid "Hide all"
+msgstr "Amaga-ho tot"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:206
+msgid "Unhide"
+msgstr "Mostra"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:22
+msgid "New metric"
+msgstr "Nova mètrica"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:45
+msgid "Create metrics to add them to the Summarize dropdown in the query builder"
+msgstr "Crea mètriques per afegirles al desplegable del sumari en el constructor de consultes"
+
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:22
+msgid "New segment"
+msgstr "Nou segment"
+
+#: frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx:71
+msgid "Filter by table"
+msgstr "Filtra per taula"
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:64
+msgid "Checking HTTPS..."
+msgstr "Comprobant HTTPS..."
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:66
+msgid "It looks like HTTPS is not properly configured"
+msgstr "Sembla que el HTTPS no esta configurat correctament"
+
+#: frontend/src/metabase/admin/settings/selectors.js:57
+msgid "Redirect to HTTPS"
+msgstr "Redireccionar a HTTP"
+
+#: frontend/src/metabase/admin/settings/selectors.js:219
+msgid "Localization"
+msgstr "Localització"
+
+#: frontend/src/metabase/admin/settings/selectors.js:222
+msgid "Instance language"
+msgstr "Idioma de la instància"
+
+#: frontend/src/metabase/admin/settings/selectors.js:237
+msgid "Localization options"
+msgstr "Opcions de localització"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:51
+msgid "This database doesn't have any tables."
+msgstr "Aquesta base de dades encara no te cap taula."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
+msgid "This field only accepts a single value because it's used in a SQL query."
+msgstr "Aquest camp només accepta un únic valor perquè s'utiltiza en una consulta SQL"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:17
+msgid "Service Accounts"
+msgstr "Comptes de servei"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:26
+msgid "Metabase connects to Big Query via {0}."
+msgstr "El metabase es conecta a Big Query a través de {0}."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:29
+msgid "Continue using an OAuth application to connect"
+msgstr "Continua utilizat una aplicació OAuth per conectar"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:43
+msgid "We recommend switching to use {0} instead of an OAuth application to connect to BigQuery"
+msgstr "Recomenem canviar a {0} en comptes de una aplicació OAuth conectada a BigQuery"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:48
+msgid "Connect to a Service Account instead"
+msgstr "Conecta a un compte de servei"
+
+#: frontend/src/metabase/entities/databases/forms.js:44
+msgid "invalid JSON"
+msgstr "JSON Invàlid"
+
+#: frontend/src/metabase/entities/databases/forms.js:50
+msgid "SSH private key"
+msgstr "Clau privada SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:51
+msgid "Paste the contents of your ssh private key here"
+msgstr "Copieu el contingut de la vostra clau privada aqui"
+
+#: frontend/src/metabase/entities/databases/forms.js:55
+msgid "Passphrase for the SSH private key"
+msgstr "Contrasenya per la clau privada"
+
+#: frontend/src/metabase/entities/databases/forms.js:58
+msgid "SSH Authentication"
+msgstr "Autentificació SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:60
+msgid "SSH Key"
+msgstr "Clau SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:65
+msgid "Server SSL certificate chain"
+msgstr "Cadena de certificats SSL del servidor"
+
+#: frontend/src/metabase/entities/databases/forms.js:66
+msgid "Paste the contents of the server's SSL certificate chain here"
+msgstr "Enganxeu el contingut de la cadena de certificats SSL del servidor aquí"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:11
+msgid "Paste a connection string"
+msgstr "Copieu una cadena de conexió"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:12
+msgid "Fill out individual fields"
+msgstr "Emplena els camps individuals"
+
+#: frontend/src/metabase/entities/snippets.js:14
+msgid "Enter some SQL here so you can reuse it later"
+msgstr "Introduiu text SQL per reutilitzarlo despres"
+
+#: frontend/src/metabase/entities/snippets.js:24
+msgid "Give your snippet a name"
+msgstr "Doneu un nom pel vostre pedaç de codi"
+
+#: frontend/src/metabase/entities/snippets.js:25
+msgid "Current Customers"
+msgstr "Clients actuals"
+
+#: frontend/src/metabase/entities/snippets.js:30
+msgid "Add a description"
+msgstr "Afegiu una descripció"
+
+#: frontend/src/metabase/entities/users/forms.js:37
+msgid "Use site default"
+msgstr "Utilitza el lloc per defecte"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+msgid "find"
+msgstr "cerca"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+msgid "replace"
+msgstr "remplaça"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+msgid "The text to find."
+msgstr "El text a buscar."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "The text to use as the replacement."
+msgstr "El text a utilizar com a remplaçament."
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+msgid "Editing {0}"
+msgstr "Editant {0}"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+msgid "Create your new snippet"
+msgstr "Creu un nou pedaç de codi"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+msgid "Archived snippets"
+msgstr "Pedaços de codi arxivats"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+msgid "Snippets are reusable bits of SQL"
+msgstr "Els pedaços de codi son bits de SQL reutilitzables"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+msgid "Create a snippet"
+msgstr "Crea un pedaç de codi"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+msgid "Snippets"
+msgstr "Pedaços de codi"
+
+#: frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx:15
+msgid "SQL Snippets"
+msgstr "Pedaços de codi SQL"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:38
+msgid "Your language is set to {0}"
+msgstr "El vostre idioma s'ha establert a {0}"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:50
+msgid "What's your preferred language?"
+msgstr "Quin es el vostre idioma preferit?"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:54
+msgid "This language will be used throughout Metabase and will be the default for new users."
+msgstr "Aquest idioma es farà server a través de metabase i serà l'idioma per defecte dels nous usuarios."
+
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:159
+msgid "We filtered out {0} row(s) containing null values."
+msgstr "Hem filtrat {0} files perquè contenen valors buits."
+
+#: frontend/src/metabase/visualizations/lib/settings/series.js:133
+msgid "Show values for this series"
+msgstr "Mostra els valors de la serie"
+
+#: src/metabase/api/card.clj
+msgid "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
+msgstr "La duracció mitjana de la execució de la pregunta es {0}, utilitzant el TTL 'magic' de {1}"
+
+#: src/metabase/api/native_query_snippet.clj
+msgid "A snippet with that name already exists. Please pick a different name."
+msgstr "Ja existeix un pedaç de codi amb aquest nou. Si us plau, utilitzeu-n'he un de diferent."
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Metric]"
+msgstr "[Mètrica desconeguda]"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Segment]"
+msgstr "[Segment desconegut]"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error writing error to output stream"
+msgstr "Error escribint el error al flux de sortida"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Caught unexpected Exception in streaming response body"
+msgstr "S'ha trobat una excepció inesperada al cos de resposta de streaming"
+
+#: src/metabase/async/streaming_response.clj
+msgid "bound-fn caught unexpected Exception"
+msgstr "bound-fn ha trobat una excepció inesperada."
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error determining whether HTTP request was canceled"
+msgstr "Error al determinar perquè s'ha cancel·lat la sol·licitud HTTP"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Check cancelation status timed out after {0}"
+msgstr "Compra el estat de cancel·laciód espres de {0}"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Unexpected exception in do-f-async"
+msgstr "do-f-async ha trobat una excepció inesperada"
+
+#: src/metabase/async/streaming_response.clj src/metabase/server.clj
+msgid "Unexpected exception writing error response"
+msgstr "Excepció inesperada al escriure la resposta d'error."
+
+#: src/metabase/driver/common.clj
+msgid "Server certificate not trusted - did you specify the correct SSL certificate chain?"
+msgstr "No es confia amb el certificat del servidor. Heu especificat la cadena SSL correctament?"
+
+#: src/metabase/driver/common.clj
+msgid "Server appears to require SSL - please enable SSL above"
+msgstr "Sembla que el servidor requereix SSL - activa el SSL a dalt"
+
+#: src/metabase/driver/common.clj
+msgid "Username"
+msgstr "Nom d'usuari"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Don''t know how to parse parameter of type {0}"
+msgstr "No se com llegir el paràmetre de tipus {0}"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Invalid :card parameter: missing `:card-id`"
+msgstr "Invalid :card parameter: falta `:card-id`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Unable to resolve Snippet: missing `:snippet-id`"
+msgstr "No es pot resoldre el pedaç de codi: falta el `:snippet-id`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Snippet {0} {1} not found."
+msgstr "El pedaç de codi {0} {1} no s'ha trobat"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error determining value for parameter"
+msgstr "Error al determinar el valor d'un paràmetre"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error building query parameter map"
+msgstr "Error al contruir el mapeig de paràmetres de la consulta"
+
+#: src/metabase/middleware/log.clj
+msgid "ASYNC"
+msgstr "ASÍNCRON"
+
+#: src/metabase/middleware/log.clj
+msgid "{0} ({1} DB calls)"
+msgstr "{0} ({1} consultes a la BBDD)"
+
+#: src/metabase/middleware/log.clj
+msgid "App DB connections: {0}/{1}"
+msgstr "Connexións BBDD aplicació: {0}/{1}"
+
+#: src/metabase/middleware/log.clj
+msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
+msgstr "Fils jetty: {0}/{1} ({2} en espera, {3} en cua)"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} total active threads)"
+msgstr "({0} fils actius totals)"
+
+#: src/metabase/middleware/log.clj
+msgid "Queries in flight: {0}"
+msgstr "Consultes en lluita: {0}"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} queued)"
+msgstr "({0} en cua)"
+
+#: src/metabase/models/collection.clj
+msgid "Collection must be in the same namespace as its parent"
+msgstr "Les col·leccions han d'estar al mateix espai de noms que el seu pare"
+
+#: src/metabase/models/collection.clj
+msgid "Personal Collections must be in the default namespace"
+msgstr "Les col·leccions personals han d'estar a l'espai de noms per fecte"
+
+#: src/metabase/models/collection.clj
+msgid "You cannot move a Collection to a different namespace once it has been created."
+msgstr "No podeu moure una col·lecció a un espai de noms diferent una vegada s'ha creat."
+
+#: src/metabase/models/collection.clj src/metabase/models/permissions.clj
+msgid "Collection does not exist."
+msgstr "La col·lecció no existeix."
+
+#: src/metabase/models/collection.clj
+msgid "A {0} can only go in Collections in the {1} namespace."
+msgstr "Un {0} només pot anar a una col·lecció al nom d'espais {1}."
+
+#: src/metabase/models/database.clj
+msgid "Error sending database deletion notification"
+msgstr "Error al enviar la notificació d'eliminiació de base de dades"
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "You cannot update the creator_id of a NativeQuerySnippet."
+msgstr "No es pot actualitzar el id_creador de una NativeQuerySnippet."
+
+#: src/metabase/models/setting.clj
+msgid "Error fetching value of Setting"
+msgstr "Error al obtenir el valor de la Configuració"
+
+#: src/metabase/public_settings.clj
+msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
+msgstr "El idioma que es fara servir per l'interficie d'usuari de Metabase, el sistema de correus, els pulsos i les alertes."
+
+#: src/metabase/public_settings.clj
+msgid "This is also the default language for all users, which they can change from their own account settings."
+msgstr "Aquest també es l'idoma per defecte pels usuaris, que poden canviar a els preferències del seu compte."
+
+#: src/metabase/public_settings.clj
+msgid "Invalid locale {0}"
+msgstr "Localització invàlida {0}"
+
+#: src/metabase/public_settings.clj
+msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
+msgstr "Força tot trànsit a utilitzar HTTPS mitjançant una redirecció, si l’URL del lloc és HTTPS"
+
+#: src/metabase/public_settings.clj
+msgid "Cannot redirect requests to HTTPS unless `site-url` is HTTPS."
+msgstr "No es pot redirecciona les peticions a HTTPS si el lloc web no es HTTPS."
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error registering fonts: Metabase will not be able to send Pulses."
+msgstr "Error al registrar les fonts: El metabase no podrá enviar pulsos."
+
+#: src/metabase/pulse/render/png.clj
+msgid "This is a known issue with certain JVMs. See {0} and for more details."
+msgstr "Això es una incidencia coneguda de vàries JVMs. Vegeu {0} per més detalls."
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error rendering Pulse"
+msgstr "Error al renderitzar Pulse"
+
+#: src/metabase/query_processor/context/default.clj
+msgid "Query timed out after {0}, raising timeout exception."
+msgstr "S'ha esgotat el temps d'execució de la consulta desprès de {0}. Llençant una excepció de fi de temps."
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "No fields found for table {0}."
+msgstr "No s'han trobat camps per la taula {0}."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Case"
+msgstr "Cas"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Variance of {0}"
+msgstr "Variació de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Median of {0}"
+msgstr "Mitjana de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "{0}th percentile of {1}"
+msgstr "{0}é percentil de {1}"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Not caching results: results are larger than {0} KB"
+msgstr "No es guarda una cache dels resultats perquè la mida es superior a {0} KB."
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Cannot cache results: expected byte array, got {0}"
+msgstr "No es pot guardar un cache dels resultats: S'esperava un array de bytes, s'ha obtingut {0}"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Request is closed; no one to return cached results to"
+msgstr "La peticio s'ha tancat; no es pot retornar els resultats de la cache"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Error attempting to fetch cached results for query with hash {0}"
+msgstr "Error al intentar obtenir els resultats de la cache amb hash {0}"
+
+#: src/metabase/query_processor/middleware/cache_backend/db.clj
+msgid "Error preparing statement to fetch cached query results"
+msgstr "Error al preparar la consulta per obtenir els resultats de cache"
+
+#: src/metabase/query_processor/middleware/catch_exceptions.clj
+msgid "Error processing query: {0}"
+msgstr "Error processant la commanda: {0}"
+
+#: src/metabase/server.clj
+msgid "Unexpected exception in endpoint"
+msgstr "Excepció no esperada al endpoint"
+
+#: src/metabase/server.clj
+msgid "Unexpected Exception in API request handler"
+msgstr "Excepció no esperada al API Request handler"
+
+#: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+msgid "Error reducing {0}"
+msgstr "Error al reduïr: {0}"
+
+#: src/metabase/sync/analyze/fingerprint/insights.clj
+msgid "Error generating timeseries insight keyed by: {0}"
+msgstr "Error al generar les series de dades de la clau: {0}"
+
+#: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
+msgstr "La posició de la base de dades {0} ha cambiat de \"{1}\" a \"{2}\"."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Unscheduling task for Database {0}: trigger: {1}"
+msgstr "Eliminar la programació de la tasca per la base de dades {0}: trigger: {1}"
+
+#: src/metabase/util/schema.clj
+msgid "value must be a keyword or string."
+msgstr "el valor ha de ser una clau o una cadena"
+
+#: src/metabase/util/schema.clj
+msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
+msgstr "La cadena ha de ser el codi ISO de dos lletres del idioma o el codi idioma-pais. Per exemple: 'ca' or 'ca_ES'."

--- a/locales/cs.po
+++ b/locales/cs.po
@@ -5,28 +5,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 "Project-Id-Version: Metabase\n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: cs\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:24
 msgid "Your database has been added!"
-msgstr "¡Tu base de datos ha sido añadida!"
+msgstr "Vaše databáze byla přidána!"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:28
 msgid "We took a look at your data, and we have some automated explorations that we can show you!"
-msgstr "Echamos un vistazo a tus datos y ¡tenemos algunas exploraciones automatizadas que podemos mostrarte!"
+msgstr "Prošli jsme Vaše data a vytvořili jsme nějaké automatické průzkumy, které Vám můžeme ukázat!"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:35
 msgid "I'm good thanks"
-msgstr "Está bien, gracias"
+msgstr "V pořádku, děkuji."
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:42
 msgid "Explore this data"
-msgstr "Explora estos datos"
+msgstr "Prozkoumat tyto data"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:42
 msgid "Select a database type"
-msgstr "Selecciona un tipo de base de datos"
+msgstr "Zvolte typ databáze"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
@@ -43,100 +43,95 @@ msgstr "Selecciona un tipo de base de datos"
 #: frontend/src/metabase/reference/components/EditHeader.jsx:69
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:30
 msgid "Save"
-msgstr "Guardar"
+msgstr "Uložit"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:122
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
-msgstr "Para hacer algo de magia, Metabase necesita escanear la base de datos. Lo volveremos a hacer periódicamente para mantener actualizados los metadatos. Puedes controlar cuando se realizan los repasos periódicos a continuación."
+msgstr "Aby mohl Metabase předvést svá kouzla, potřebuje si proskenovat Vaši databázi. Tento sken bude prováděn periodicky, aby byla metadata vždy aktuální. Níže můžete nastavit, kdy se budou tyto periodické skeny provádět."
 
 #: frontend/src/metabase/entities/databases/forms.js:290
 msgid "Database syncing"
-msgstr "Sincronizando base de datos"
+msgstr "Synchronizace databáze"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:128
 msgid "This is a lightweight process that checks for\n"
 "updates to this database’s schema. In most cases, you should be fine leaving this\n"
 "set to sync hourly."
-msgstr "Este es un proceso rápido que busca \n"
-"actualizaciones al esquema de esta base de datos. En la mayoría de los casos, estará bien dejar esto\n"
-"configurado para sincronizar cada hora."
+msgstr "Toto je odlehčený proces, který zjišťuje aktualizace schématu této databáze. Zpravidla by mělo vyhovovat nechat hodinovou periodu synchronizace."
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:42
 #: frontend/src/metabase/admin/databases/components/widgets/MetadataSyncScheduleWidget.jsx:22
 msgid "Scan"
-msgstr "Explorar"
+msgstr "Skenovat"
 
 #: frontend/src/metabase/entities/databases/forms.js:297
 msgid "Scanning for Filter Values"
-msgstr "Buscando valores de filtrado"
+msgstr "Hledání hodnot filtru"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:153
 msgid "Metabase can scan the values present in each\n"
 "field in this database to enable checkbox filters in dashboards and questions. This\n"
 "can be a somewhat resource-intensive process, particularly if you have a very large\n"
 "database."
-msgstr "Metabase puede escanear los valores presentes en cada \n"
-"campo en esta base de datos para habilitar filtros de casilla de verificación en cuadros de mando y preguntas. Esto \n"
-"puede ser un proceso que consume muchos recursos, particularmente si tienes una \n"
-"base de datos grande."
+msgstr "Metabase může projít hodnoty každého políčka a povolit v dotazech a nástěnkách filtrování pomocí zaškrtávacích políček. Tento proces může znatelně zatížit databázi, především, pokud je velká."
 
 #: frontend/src/metabase/entities/databases/forms.js:301
 msgid "When should Metabase automatically scan and cache field values?"
-msgstr "¿Cuándo debería Metabase escanear y almacenar automáticamente los valores de campo?"
+msgstr "Kdy má Metabase skenovat a uložit hodnoty polí do mezipaměti?"
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:25
 msgid "Regularly, on a schedule"
-msgstr "Periódicamente, siguiendo un horario"
+msgstr "Pravidelně, dle rozrvhu"
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:50
 msgid "Only when adding a new filter widget"
-msgstr "Solo cuando se añade un nuevo elemento de filtro"
+msgstr "Pouze, když přidávám nový filtrovací widget"
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:54
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
-msgstr "Cuando un usuario añade un nuevo filtro o una pregunta SQL al Dashboard Metabase escaneará los campos asignados a ese filtro para mostrar la lista de valores seleccionables."
+msgstr "Když uživatel přidá nový filtr na nástěnku nebo k SQL dotazu, Metabase projde pole související s filtrem, aby bylo možné zobrazit seznam možností."
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:62
 msgid "Never, I'll do this manually if I need to"
-msgstr "Nunca, lo haré manualmente si lo necesito"
+msgstr "Nikdy, udělám to vždy ručně, když budu potřebovat"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 msgid "Saving..."
-msgstr "Guardando..."
+msgstr "Ukládání..."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
 msgid "Server error encountered"
-msgstr "Se ha encontrado un error en el servidor"
+msgstr "Vyskytla se chyba serveru"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 msgid "Delete this database?"
-msgstr "¿Eliminar esta base de datos?"
+msgstr "Smazat tuto databázi?"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
-msgstr "Todas las preguntas, métricas y segmentos guardados que dependen de esta base de datosse perderán."
+msgstr "Všechny uložené dotazy, metriky a segmenty závisející na této databázi budou ztraceny."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
-msgstr "Esta acción no se puede deshacer."
+msgstr "Toto nelze vzít zpět."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
-msgstr "Si estás seguro, por favor teclea:"
+msgstr "V případě nejistoty, prosím napište"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
-msgstr "ELIMINAR"
+msgstr "SMAZAT"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
-msgstr "en esta casilla:"
+msgstr "v tomto boxu:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
@@ -172,14 +167,14 @@ msgstr "en esta casilla:"
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:328
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
-msgstr "Cancelar"
+msgstr "Storno"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
-msgstr "Eliminar"
+msgstr "Smazat"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
@@ -191,19 +186,19 @@ msgstr "Eliminar"
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
-msgstr "Bases de datos"
+msgstr "Databáze"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:148
 msgid "Add Database"
-msgstr "Añadir base de datos"
+msgstr "Přidat databázi"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:73
 msgid "Connection"
-msgstr "Conexión"
+msgstr "Připojení"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:77
 msgid "Scheduling"
-msgstr "Programación"
+msgstr "Plánování"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
@@ -214,17 +209,17 @@ msgstr "Programación"
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
-msgstr "Guardar cambios"
+msgstr "Uložit změny"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:203
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
-msgstr "Acciones"
+msgstr "Akce"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 msgid "Sync database schema now"
-msgstr "Sincronizar el esquema de la base de datos ahora"
+msgstr "Synchronizovat databázové schéma"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:212
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
@@ -233,49 +228,49 @@ msgstr "Sincronizar el esquema de la base de datos ahora"
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:90
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:98
 msgid "Starting…"
-msgstr "Empezando…"
+msgstr "Spouštění..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:213
 msgid "Failed to sync"
-msgstr "No se ha podido sincronizar"
+msgstr "Synchronizace selhala"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:214
 msgid "Sync triggered!"
-msgstr "¡Sincronización iniciada!"
+msgstr "Synchronizace zahájena!"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:223
 msgid "Re-scan field values now"
-msgstr "Vuelva a escanear los valores de campo ahora"
+msgstr "Prohledat hodnoty políček"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
-msgstr "No se ha podido iniciar la exploración"
+msgstr "Nelze zahájit prohledávaní"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:92
 msgid "Scan triggered!"
-msgstr "¡Exploración iniciada!"
+msgstr "Prohledávání zahájeno!"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:233
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
-msgstr "Zona Peligrosa"
+msgstr "Na vlastní nebezpečí!"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Discard saved field values"
-msgstr "Descartar valores de campos guardados"
+msgstr "Smazat nalezené hodnoty políček"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:257
 msgid "Remove this database"
-msgstr "Eliminar esta base de datos"
+msgstr "Odstranit tuto databázi"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
-msgstr "Añadir base de datos"
+msgstr "Přidat databázi"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:28
@@ -292,37 +287,36 @@ msgstr "Añadir base de datos"
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
-msgstr "Nombre"
+msgstr "Jméno"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
-msgstr "Motor"
+msgstr "Typ"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
-msgstr "Eliminando..."
+msgstr "Odstraňování..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
-msgstr "Cargando..."
+msgstr "Načítání..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
-msgstr "Recuperar la base de datos de prueba"
+msgstr "Znovu ukázat vzorovou databázi"
 
 #: frontend/src/metabase/admin/databases/database.js:167
 msgid "Couldn't connect to the database. Please check the connection details."
-msgstr "No se ha podido conectar a la base de datos. Por favor, comprueba los detalles de la conexión."
+msgstr "Nelze se připojit k databázi. Zkontrolujte parametry připojení."
 
 #: frontend/src/metabase/admin/databases/database.js:384
 msgid "Successfully created!"
-msgstr "¡Creado con éxito!"
+msgstr "Úspěšně vytvořeno!"
 
 #: frontend/src/metabase/admin/databases/database.js:394
 msgid "Successfully saved!"
-msgstr "¡Guardado con éxito!"
+msgstr "Úspěšně uloženo!"
 
-#. Editar
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
@@ -330,64 +324,64 @@ msgstr "¡Guardado con éxito!"
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
-msgstr "Editar"
+msgstr "Upravit"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:59
 msgid "Revision History"
-msgstr "Historial de Revisiones"
+msgstr "Historie revizí"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
-msgstr "¿Retirar este {0}?"
+msgstr "Odebrat {0} ?"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
-msgstr "Las preguntas guardadas y otras cosas que dependen de este {0} continuarán funcionando pero este {1} ya no se podrá seleccionar desde el generador de consultas."
+msgstr "Uložené dotazy a ostatní věci závislé na {0} budou dále fungovat, ale {1} již nebude k dispozici ve tvůrci dotazů."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
-msgstr "Si estás seguro de querer retirar este {0} escribe una explicación de por qué está siendo retirado:"
+msgstr "Pokud jste si jisti, že chcete odebrat {0}, napište krátké vysvětlení, proč k odebrání došlo:"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
-msgstr "Esto se mostrará en el resumen de actividades y en un correo electrónico que se enviará a cualquier persona de tu equipo que haya creado algo que use este {0}."
+msgstr "Toto se zobrazí v informačním kanálu aktivit a v emailu, který se pošle komukoliv ve vašem týmu, kdo vytvoří něco, co používá toto {0}."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
-msgstr "Retirar"
+msgstr "Odebrat"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
-msgstr "Retirando…"
+msgstr "Odebírání..."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 #: frontend/src/metabase/components/form/CustomForm.jsx:188
 msgid "Failed"
-msgstr "Ha fallado"
+msgstr "Chyba"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 #: frontend/src/metabase/components/form/CustomForm.jsx:189
 msgid "Success"
-msgstr "Éxito"
+msgstr "Hotovo"
 
 #: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:185
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
-msgstr "Vista preliminar"
+msgstr "Náhled"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:93
 msgid "No column description yet"
-msgstr "No hay una descripción de la columna"
+msgstr "Sloupec nemá žádný popis"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:126
 msgid "Select a field visibility"
-msgstr "Selecciona una visibilidad de campo"
+msgstr "Nastavit viditelnost pole"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:187
 msgid "No special type"
-msgstr "Sin tipo especial"
+msgstr "Obecný typ"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
 #: frontend/src/metabase/lib/core.js:275
@@ -395,16 +389,16 @@ msgstr "Sin tipo especial"
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:37
 msgid "Other"
-msgstr "Otro"
+msgstr "Ostatní"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
-msgstr "Seleccione un tipo especial"
+msgstr "Vybrat typ"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:262
 #: frontend/src/metabase/reference/components/Field.jsx:99
 msgid "Select a target"
-msgstr "Seleccione un objetivo"
+msgstr "Vybrat cíl"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
@@ -412,98 +406,99 @@ msgstr "Seleccione un objetivo"
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Columns"
-msgstr "Columnas"
+msgstr "Sloupce"
 
-#. Campo
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
-msgstr "Campo"
+msgstr "Sloupec"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
 msgid "Visibility"
-msgstr "Visibilidad"
+msgstr "Viditelnost"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
 msgid "Type"
-msgstr "Tipo"
+msgstr "Typ"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
-msgstr "Base de datos actual:"
+msgstr "Aktuální databáze:"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
 msgid "Show original schema"
-msgstr "Mostrar esquema original"
+msgstr "Ukázat původní schéma"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
-msgstr "Tipo de dato"
+msgstr "Datový typ"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
-msgstr "Información adicional"
+msgstr "Doplňkové info"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
-msgstr "Encontrar un esquema"
+msgstr "Najít schéma"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
-msgstr[0] "Ver esquema"
-msgstr[1] "Ver esquemas"
+msgstr[0] "{0} schéma"
+msgstr[1] "{0} schémata"
+msgstr[2] "{0} schémat"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:99
 msgid "Why Hide?"
-msgstr "¿Por qué esconderlo?"
+msgstr "Důvod skrytí"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:100
 msgid "Technical Data"
-msgstr "Datos Técnicos"
+msgstr "Technická data"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
-msgstr "Irrelevante"
+msgstr "Nerelevantní"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 msgid "Queryable"
-msgstr "Consultable"
+msgstr "Dotazovatelné"
 
-#. Oculto
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:108
 msgid "Hidden"
-msgstr "Oculto"
+msgstr "Skryto"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136
 msgid "No table description yet"
-msgstr "No hay una descripción de la tabla"
+msgstr "Tabulka nemá popis"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:124
 msgid "Metadata Strength"
-msgstr "Alcance Metadatos"
+msgstr "Kvalita metadat"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
-msgstr[0] "{0] Tabla Consultable"
-msgstr[1] "{0] Tablas consultables"
+msgstr[0] "{0} dotazovatelná tabulka"
+msgstr[1] "{0} dotazovatelné tabulky"
+msgstr[2] "{0} dotazovatelných tabulek"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:91
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
-msgstr[0] "{0] Tabla Escondida"
-msgstr[1] "{0] Tablas escondidas"
+msgstr[0] "{0} skrytá tabulka"
+msgstr[1] "{0} skryté tabulky"
+msgstr[2] "{0} skrytých tabulek"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:115
 msgid "Find a table"
-msgstr "Encontrar una tabla"
+msgstr "Najít tabulku"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:128
 msgid "Schemas"
-msgstr "Esquemas"
+msgstr "Schémata"
 
 #: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
@@ -514,21 +509,21 @@ msgstr "Esquemas"
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:62
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 msgid "Metrics"
-msgstr "Métricas"
+msgstr "Metriky"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:27
 msgid "Add a Metric"
-msgstr "Añadir una métrica"
+msgstr "Přidat metriku"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
-msgstr "Definición"
+msgstr "Definice"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:51
 msgid "Create metrics to add them to the View dropdown in the query builder"
-msgstr "Crea métricas para añadirlas al menú Ver en el generador de consultas"
+msgstr "Vytvořte metriky pro jejich zobrazení ve tvůrci dotazů"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
@@ -538,293 +533,293 @@ msgstr "Crea métricas para añadirlas al menú Ver en el generador de consultas
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:61
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
-msgstr "Segmentos"
+msgstr "Segmenty"
 
 #: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:27
 msgid "Add a Segment"
-msgstr "Añadir un segmento"
+msgstr "Přidat segment"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:45
 msgid "Create segments to add them to the Filter dropdown in the query builder"
-msgstr "Crea segmentos para añadirlos al menú Filtro en el generador de consultas"
+msgstr "Vytvořte segmenty pro jejich zobrazení ve tvůrci dotazů"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:21
 msgid "created"
-msgstr "creado"
+msgstr "vytvořeno"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "reverted to a previous version"
-msgstr "revertido a una versión anterior"
+msgstr "navrácena předchozí verze"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:30
 msgid "edited the title"
-msgstr "editado el título"
+msgstr "upravil název"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:32
 msgid "edited the description"
-msgstr "editado la descripción"
+msgstr "upravil popis"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:34
 msgid "edited the "
-msgstr "editado el"
+msgstr "upravil "
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "made some changes"
-msgstr "he hecho algunos cambios"
+msgstr "provedl změny"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
 #: frontend/src/metabase/home/components/Activity.jsx:83
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
-msgstr "Tu"
+msgstr "Vy jste"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
-msgstr "Modelo de datos"
+msgstr "Datový model"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:41
 msgid " History"
-msgstr "Historia"
+msgstr " historie"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
-msgstr "Historial de Revisiones para"
+msgstr "Historie revizí pro "
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
 msgid "{0} – Field Settings"
-msgstr "{0} – Configuración de campos"
+msgstr "{0} - Nastavení políčka"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
 msgid "Where this field will appear throughout Metabase"
-msgstr "Donde aparecerá este campo en Metabase"
+msgstr "Kde se toto políčko v Metabase objevi"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
 msgid "Filtering on this field"
-msgstr "Filtrando sobre este campo"
+msgstr "Filtrování nad políčkem"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
-msgstr "Cuando este campo se usa en un filtro, ¿qué valores debería aceptar?"
+msgstr "Jakým způsobem mají uživatelé podle tohoto políčka filtrovat?"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
 msgid "No description for this field yet"
-msgstr "No hay descripción para este campo todavía"
+msgstr "Toto políčko zatím nemá popis"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
 msgid "Original value"
-msgstr "Valor original"
+msgstr "Původní hodnota"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
 msgid "Mapped value"
-msgstr "Valor asignado"
+msgstr "Namapovaná hodnota"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
 msgid "Enter value"
-msgstr "Introduce un valor"
+msgstr "Vložte hodnotu"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use original value"
-msgstr "Utiliza valor original"
+msgstr "Použít původní hodnotu"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Use foreign key"
-msgstr "Utilizar clave foránea"
+msgstr "Použít cizí klíč"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 msgid "Custom mapping"
-msgstr "Mapeo personalizado"
+msgstr "Vlastní mapování"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
 msgid "Unrecognized mapping type"
-msgstr "Tipo de mapeo no reconocido"
+msgstr "Neznámý typ mapování"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
-msgstr "El campo actual no es una clave foránea o faltan los metadatos de clave foránea en la tabla de destino"
+msgstr "Toto pole buď není cizí klíč nebo chybí metadata cílové tabulky"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
 msgid "The selected field isn't a foreign key"
-msgstr "El campo seleccionado no es una clave foránea"
+msgstr "Vybrané políčko není cizí klíč"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
 msgid "Display values"
-msgstr "Valores mostrados"
+msgstr "Zobrazit hodnoty"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
-msgstr "Elige si quieres mostrar el valor original de la base de datos, o mostrar información asociada o personalizada."
+msgstr "Vyberte, zda chcete zobrazit původní hodnotu z databáze, nebo nechat tomuto poli zobrazit přiřazenou nebo vlastní informaci."
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
 msgid "Choose a field"
-msgstr "Elige un campo"
+msgstr "Vyberte políčko"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
 msgid "Please select a column to use for display."
-msgstr "Selecciona una columna para mostrar."
+msgstr "Prosím vyberte sloupec pro zobrazení."
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:771
 msgid "Tip:"
-msgstr "Consejo:"
+msgstr "Tip:"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
-msgstr "Es posible que quieras actualizar el nombre del campo para asegurarte de que todavía tenga sentidoen función de las opciones de asignación."
+msgstr "Možná budete chtít aktualizovat název pole, aby dával stále smysl podle výběru přemapování."
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
-msgstr "Valores de campo en caché"
+msgstr "Hodnoty v mezipaměti"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
-msgstr "Metabase puede escanear los valores de este campo para habilitar los filtros de casilla de verificación en cuadros de mando y preguntas."
+msgstr "Metabase může zjistit hodnoty v tomto políčku pro povolení zaškrtávacích filtrů v nástěnkách a dotazech."
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:14
 msgid "Re-scan this field"
-msgstr "Vuelve a escanear este campo"
+msgstr "Znovu skenovat"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
-msgstr "Descartar valores de campo en caché"
+msgstr "Vymazat mezipaměť hodnot"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
-msgstr "Error al descartar valores"
+msgstr "Nepodařilo se vymazat mezipaměť hodnot"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 msgid "Discard triggered!"
-msgstr "¡Limpieza iniciada!"
+msgstr "Vymazání spuštěno"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
-msgstr "Selecciona cualquier tabla para ver su esquema y añadir o editar metadatos."
+msgstr "Vyberte tabulku pro zobrazení schématu nebo editaci metadat."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
-msgstr "Nombre es obligatorio"
+msgstr "Jméno je povinné"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
-msgstr "Descripción es obligatorio"
+msgstr "Popis je povinný"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
-msgstr "Mensaje de la revisión es obligatorio"
+msgstr "Zpráva revize je povinná"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
 msgid "Aggregation is required"
-msgstr "Agregación es obligatoria"
+msgstr "Je nutné zadat agregaci"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Edit Your Metric"
-msgstr "Edita tu Métrica"
+msgstr "Upravit metriku"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Create Your Metric"
-msgstr "Crea tu Métrica"
+msgstr "Vytvořit metriku"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "Make changes to your metric and leave an explanatory note."
-msgstr "Haz cambios en tu métrica y deja una nota explicativa."
+msgstr "Proveďte změny metriky a doplňte vysvětlující poznámku."
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:145
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
-msgstr "Puedes crear métricas y guardarlas como campo calculado en esta tabla.Las métricas guardadas incluyen el tipo de agregación, el campo agregado y, opcionalmente, cualquier filtro que añadas.Por ejemplo, puedes usar esto para definir la forma oficial de calcular el \"Precio promedio\" para una tabla de Pedidos."
+msgstr "Můžete vytvořit uložené metriky a přidat je do nabídky této tabulky. Mezi uložené metriky patří typ agregace, agregované pole a případně jakýkoliv filtr, který přidáte. Například, můžete to použít k vytvoření něčeho jako oficiální způsob výpočtu \"průměrné ceny\" pro tabulku Objednávky."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
 msgid "Result: "
-msgstr "Resultado:"
+msgstr "Výsledek: "
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
 msgid "Name Your Metric"
-msgstr "Ponle nombre a tu Métrica"
+msgstr "Pojmenujte metriku"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Give your metric a name to help others find it."
-msgstr "Dale un nombre a tu métrica para ayudar a otros a encontrarla."
+msgstr "Dejte metrice jméno, aby ji ostatní nalezli."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
-msgstr "Algo descriptivo pero no demasiado largo"
+msgstr "Přidejte stručný popis."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
 msgid "Describe Your Metric"
-msgstr "Describe tu Métrica"
+msgstr "Popište metriku"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Give your metric a description to help others understand what it's about."
-msgstr "Dale una descripción a tu métrica para ayudar a otros a entender de qué se trata."
+msgstr "Díky popisu ostatní lépe porozumí, co metrika vyjadřuje."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
 msgid "This is a good place to be more specific about less obvious metric rules"
-msgstr "Este es un buen lugar para ser más específico sobre las reglas métricas menos obvias"
+msgstr "Na tomto místě popište méně zjevné aspekty metriky."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
-msgstr "Motivo de los cambios"
+msgstr "Důvod změn"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
-msgstr "Deja una nota para explicar qué cambios has hecho y por qué fueron necesarios."
+msgstr "Přidejte poznámku pro vysvětlení, jaké změny jste udělali a proč."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
-msgstr "Esto aparecerá en el historial de revisiones de esta métrica para ayudar a todos a recordar por qué se realizó el cambio"
+msgstr "Toto uvidíte v historii revizí této metriky, aby všichni věděli, proč došlo ke změnám."
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
-msgstr "Se requiere al menos un filtro"
+msgstr "Je požadován alespoň jeden filtr"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
-msgstr "Edita tu Segmento"
+msgstr "Upravte segment"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
-msgstr "Crea tu Segmento"
+msgstr "Vytvořte segment"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
-msgstr "Haz cambios en tu segmento y deja una nota explicativa."
+msgstr "Proveďte změny segmentu a doplňte vysvětlující poznámku."
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
-msgstr "Selecciona y añade filtros para crear un nuevo segmento para la tabla {0}"
+msgstr "Vyberte a přidejte filtry pro vytvoření nového segmentu pro tabulku {0}"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
-msgstr "Ponle nombre a tu segmento"
+msgstr "Pojmenujte segment"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
-msgstr "Dale un nombre a tu segmento para ayudar a otros a encontrarla."
+msgstr "Dejte segmentu jméno, aby ho ostatní snáze našli."
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
-msgstr "Describe tu Segmento"
+msgstr "Popište segment"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 msgid "Give your segment a description to help others understand what it's about."
-msgstr "Dale una descripción a tu segmento para ayudar a otros a entender de qué se trata."
+msgstr "Popište segment pro ostatní uživatele."
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
-msgstr "Este es un buen lugar para ser más específico sobre las reglas de segmentación menos obvias"
+msgstr "Vysvětlete uživatelům méně zřejmé vlastnosti segmentu."
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
-msgstr "Esto aparecerá en el historial de revisiones de este segmento para ayudar a todos a recordar por qué se realizó el cambio"
+msgstr "Toto bude vidět v historii revizí segmentu, aby každý věděl, proč došlo ke změně."
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
 #: frontend/src/metabase/admin/routes.jsx:137
@@ -834,66 +829,66 @@ msgstr "Esto aparecerá en el historial de revisiones de este segmento para ayud
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
-msgstr "Configuración"
+msgstr "Nastavení"
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
-msgstr "Metabase puede leer los valores en esta tabla para habilitar filtros de casillas de verificación en cuadros de mandos y preguntas."
+msgstr "Metabase může prohledat hodnoty v této tabulce pro povolení zaškrtávacích filtrů v nástěnkách a dotazech."
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
-msgstr "Re-Leer esta tabla"
+msgstr "Znovu prohledat tabulku"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 msgid "Add"
-msgstr "Añadir"
+msgstr "Přidat"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:103
 msgid "Not a valid formatted email address"
-msgstr "Formato de Email incorrecto"
+msgstr "Není platný formát e-mailové adresy"
 
 #: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
-msgstr "Nombre"
+msgstr "Jméno"
 
 #: frontend/src/metabase/entities/users/forms.js:20
 msgid "Last name"
-msgstr "Apellidos"
+msgstr "Příjmení"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
-msgstr "Dirección de Email"
+msgstr "E-mail"
 
 #: frontend/src/metabase/admin/people/components/EditUserForm.jsx:202
 msgid "Permission Groups"
-msgstr "Grupos de Permisos"
+msgstr "Skupiny oprávnění"
 
 #: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
 msgid "Make this user an admin"
-msgstr "Convertir a este usuario en administrador"
+msgstr "Učinit uživatele administrátorem"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
-msgstr "Todos los usuarios pertenecen al grupo {0} no se pueden eliminar. Establecer permisos para este grupo es una excelente manera de asegurarte qué podrán ver los nuevos usuarios de Metabase."
+msgstr "Všichni uživatelé patří do {0} skupiny a nelze je odebrat. Nastavením oprávnění této skupině ovládáte, co uvidí noví uživatelé."
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
-msgstr "Este es un grupo especial cuyos miembros pueden ver todo en la instancia de Metabase, y quienes pueden acceder y realizar cambios en la configuración en el Panel de administración, ¡incluyendo el cambio de permisos!Así que añade personas a este grupo con cuidado."
+msgstr "Toto je speciální skupina, jejíž členové vidí veškerý obsah této instance a mají přístup do administrátorské sekce, včetně nastavení oprávnění! Členy této skupiny vybírejte s rozmyslem."
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
-msgstr "Para asegurarte de no quedar sin acceso a Metabase, siempre debe haber al menos un usuario en este grupo."
+msgstr "Abyste neztratili přístup k Metabase, musí v této skupině být vždy alespoň jeden uživatel. "
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
-msgstr "Miembros"
+msgstr "Členové"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
@@ -902,67 +897,68 @@ msgstr "Miembros"
 #: frontend/src/metabase/lib/core.js:146
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:298
 msgid "Email"
-msgstr "Email"
+msgstr "E-mail"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
-msgstr "Un grupo solo vale lo que valen sus miembros."
+msgstr "Skupina je dobrá tak, jako jsou její členové."
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
 #: frontend/src/metabase/admin/routes.jsx:55
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Admin"
-msgstr "Admin"
+msgstr "Správce"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:288
 msgid "and"
-msgstr "y"
+msgstr "a"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:19
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:31
 msgid "{0} other group"
 msgid_plural "{0} other groups"
-msgstr[0] "{0} grupo más"
-msgstr[1] "{0} grupos más"
+msgstr[0] "{0} jiná skupina"
+msgstr[1] "{0} jiné skupiny"
+msgstr[2] "{0} jiných skupin"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:37
 msgid "Default"
-msgstr "Por defecto"
+msgstr "Výchozí"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:39
 msgid "Something like \"Marketing\""
-msgstr "Algo como \"Marketing\""
+msgstr "Například \"Marketing\""
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:58
 msgid "Remove this group?"
-msgstr "¿Eliminar este grupo?"
+msgstr "Odstranit tuto skupinu?"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:60
 msgid "Are you sure? All members of this group will lose any permissions settings they have based on this group.\n"
 "This can't be undone."
-msgstr "¿Estás seguro? Todos los miembros de este grupo perderán las configuraciones de permisos que tengan basadas en este grupo.\n"
-"Esto no puede deshacerse."
+msgstr "Opravdu? Všichni členové skupiny ztratí jakákoliv oprávnění, která z členství v této skupině plynou.\n"
+"Toto nelze odvolat."
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
-msgstr "Sí"
+msgstr "Ano"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
-msgstr "No"
+msgstr "Ne"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:92
 msgid "Edit Name"
-msgstr "Editar Nombre"
+msgstr "Upravit jméno"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:95
 msgid "Remove Group"
-msgstr "Borrar Grupo"
+msgstr "Odebrat skupinu"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:46
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:138
@@ -976,11 +972,11 @@ msgstr "Borrar Grupo"
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:334
 msgid "Done"
-msgstr "Hecho"
+msgstr "Hotovo"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Group name"
-msgstr "Nombre Grupo"
+msgstr "Název skupiny"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
@@ -989,383 +985,384 @@ msgstr "Nombre Grupo"
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
-msgstr "Grupos"
+msgstr "Skupiny"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:364
 msgid "Create a group"
-msgstr "Crear un grupo"
+msgstr "Vytvořit skupinu"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:370
 msgid "You can use groups to control your users' access to your data. Put users in groups and then go to the Permissions section to control each group's access. The Administrators and All Users groups are special default groups that can't be removed."
-msgstr "Puedes usar grupos para controlar el acceso de tus usuarios a los datos. Coloca a los usuarios en grupos y después, ves a la sección de Permisos para controlar el acceso de cada grupo. Los grupos Administradores y All Users son grupos predeterminados especiales que no se pueden eliminar."
+msgstr "Pro řízení přístupu k datům lze použít skupiny. Rozdělte uživatele do skupin a v sekci Oprávnění nastavte jejich přístup k datům. Správci a Všichni uživatelé jsou výchozí skupiny a nelze je odstranit."
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:79
 msgid "Edit Details"
-msgstr "Editar Detalles"
+msgstr "Upravit detail"
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:85
 msgid "Re-send Invite"
-msgstr "Reenviar Invitación"
+msgstr "Znovu poslat pozvánku"
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:90
 msgid "Reset Password"
-msgstr "Restablecer la contraseña"
+msgstr "Resetovat heslo"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:40
 msgid "Deactivate"
-msgstr "Desactivar"
+msgstr "Deaktivovat"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:21
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:93
 #: frontend/src/metabase/nav/containers/Navbar.jsx:235
 msgid "People"
-msgstr "Personas"
+msgstr "Lidé"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:192
 msgid "Who do you want to add?"
-msgstr "¿A quien quieres añadir?"
+msgstr "Koho chete přidat?"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:207
 msgid "Edit {0}'s details"
-msgstr "Edita los detalles de {0}"
+msgstr "Upravit detail: {0}"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:40
 msgid "{0} has been added"
-msgstr "Se ha añadido {0}"
+msgstr "přidáno: {0}"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:224
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:262
 msgid "Add another person"
-msgstr "Añade otra persona"
+msgstr "Přidat další osobu"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:231
 msgid "We couldn’t send them an email invitation,\n"
 "so make sure to tell them to log in using {0}\n"
 "and this password we’ve generated for them:"
-msgstr "No se ha podido enviarles una invitación por correo electrónico, así que asegúraste de indicarles que inicien sesión con {0} y la contraseña que les hemos generado:"
+msgstr "E-mailovou pozvánku se nepodařilo odeslat. Ukažte uživateli, jak se přihlásit pomocí {0} a tohoto vygenerovaného hesla."
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:73
 msgid "If you want to be able to send email invites, just go to the {0} page."
-msgstr "Si quieres poder enviar invitaciones por correo electrónico, simplemente ves a la página {0}."
+msgstr "Pokud chcete mít možnost posílat e-mailové pozvánky, jděte na stránku {0}."
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:55
 msgid "We’ve sent an invite to {0} with instructions to set their password."
-msgstr "Hemos enviado una invitación a {0} con instrucciones para configurar su contraseña."
+msgstr "Uživateli {0} jsme odeslali pozvánku s instrukcemi pro nastavení hesla."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:283
 msgid "We've re-sent {0}'s invite"
-msgstr "Hemos vuelto a enviar la invitación de {0}"
+msgstr "Znovu jsme poslali pozvánku uživateli {0}"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:24
 msgid "Okay"
-msgstr "Vale"
+msgstr "Dobře"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:289
 msgid "Any previous email invites they have will no longer work."
-msgstr "Cualquier invitación de correo electrónico anterior que tengan ya no funcionará."
+msgstr "Jakékoliv předcházející pozvánky zaslané na email již nebudou funkční."
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:31
 msgid "Deactivate {0}?"
-msgstr "¿Desactivar {0}?"
+msgstr "Deaktivovat {0}?"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:34
 msgid "{0} won't be able to log in anymore."
-msgstr "{0} ya no podrá iniciar sesión."
+msgstr "{0} se již nebude moci přihlásit."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:320
 msgid "Reactivate {0}'s account?"
-msgstr "¿Activar la cuenta de {0}?"
+msgstr "Znovu aktivovat účet {0}?"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:58
 msgid "Reactivate"
-msgstr "Activar"
+msgstr "Opětovně aktivovat"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:51
 msgid "They'll be able to log in again, and they'll be placed back into the groups they were in before their account was deactivated."
-msgstr "Podrán volver a iniciar sesión y se les volverá a colocar en los grupos en los que estaban antes de que se desactivara su cuenta."
+msgstr "Budou se moci přihlásit znovu a budou zařazeni zpět do skupin, ve kterých byli před deaktivací účtu."
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:51
 msgid "Reset {0}'s password?"
-msgstr "¿Restablecer la contraseña de {0}?"
+msgstr "Resetovat heslo uživatele {0}"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:76
 msgid "Reset"
-msgstr "Reiniciar"
+msgstr "Resetovat"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
 #: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
 msgid "Are you sure you want to do this?"
-msgstr "¿Seguro que quieres hacer esto?"
+msgstr "Opravdu chcete pokračovat?"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:41
 msgid "{0}'s password has been reset"
-msgstr "La contraseña de {0} ha sido restablecida"
+msgstr "Heslo uživatele {0} resetováno"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:45
 msgid "Here’s a temporary password they can use to log in and then change their password."
-msgstr "Aquí hay una contraseña temporal que pueden usar para iniciar sesión y luego cambiar su contraseña."
+msgstr "Zde je dočasné heslo, které budou moci použít pro přihlášení a následně si jej změnit."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:388
 msgid "We've sent them an email with instructions for creating a new password."
-msgstr "Les hemos enviado un correo electrónico con instrucciones para crear una nueva contraseña."
+msgstr "Zasíláme jim email s instrukcemi, jak si vytvořit nové heslo."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 #: frontend/src/metabase/admin/settings/components/widgets/AuthenticationOption.jsx:15
 msgid "Active"
-msgstr "Activo"
+msgstr "Aktivní"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
-msgstr "Desactivado"
+msgstr "Deaktivován"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
-msgstr "Añadir alguien"
+msgstr "Přidejte někoho"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
-msgstr "Ultimo acceso"
+msgstr "Poslední přihlášení"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:154
 msgid "Signed up via Google"
-msgstr "Acceso via Google"
+msgstr "Vytvořen pomocí Google"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:159
 msgid "Signed up via LDAP"
-msgstr "Acceso via LDAP"
+msgstr "Vytvořen pomocí LDAP"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:171
 msgid "Reactivate this account"
-msgstr "Activar esta cuenta"
+msgstr "Znovu aktivovat účet"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:195
 msgid "Never"
-msgstr "Nunca"
+msgstr "Nikdy"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
-msgstr[0] "{0} tabla"
-msgstr[1] "{0} tablas"
+msgstr[0] "{0} tabulka"
+msgstr[1] "{0} tabulky"
+msgstr[2] "{0} tabulek"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
-msgstr "será"
+msgstr " bude "
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
-msgstr "dado el acceso a"
+msgstr "udělen přístup k"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
-msgstr " y "
+msgstr " a "
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
-msgstr "denegado el acceso a"
+msgstr "zakázán přístup k"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
-msgstr "ya no podrá"
+msgstr " nebude nadále moct "
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
-msgstr "ahora será capaz de"
+msgstr "bude nyní moct"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
-msgstr "consultas nativas para"
+msgstr " nativní dotazy pro "
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:14
 #: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Permissions"
-msgstr "Permisos"
+msgstr "Oprávnění"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:32
 msgid "Save permissions?"
-msgstr "¿Guardar permisos?"
+msgstr "Uložit oprávnění?"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:38
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
 msgid "Save Changes"
-msgstr "Guardar Cambios"
+msgstr "Uložit změny"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:44
 msgid "Discard changes?"
-msgstr "¿Descartar los cambios?"
+msgstr "Zahodit změny?"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:46
 msgid "No changes to permissions will be made."
-msgstr "No se realizarán cambios en los permisos."
+msgstr "Nebudou provedeny žádné změny oprávnění."
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:65
 msgid "You've made changes to permissions."
-msgstr "Has realizado cambios en los permisos."
+msgstr "Provedli jste změny oprávnění."
 
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
 msgid "Permissions for this collection"
-msgstr "Permisos de esta colección"
+msgstr "Oprávnění pro tuto sbírku"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:81
 msgid "You have unsaved changes"
-msgstr "Tiene cambios sin guardar"
+msgstr "Máte neuložené změny"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:82
 msgid "Do you want to leave this page and discard your changes?"
-msgstr "¿Quieres abandonar esta página y descartar tus cambios?"
+msgstr "Chcete opustit stránku a zahodit neuložené změny?"
 
 #: frontend/src/metabase/admin/permissions/permissions.js:129
 msgid "Sorry, an error occurred."
-msgstr "Lo siento, ocurrió un error."
+msgstr "Došlo k chybě."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:71
 msgid "Administrators always have the highest level of access to everything in Metabase."
-msgstr "Los administradores siempre tienen el más alto nivel de acceso a todo en Metabase."
+msgstr "Administrátoři mají vždy nejvyšší úroveň přístupu ke všemu v Metabase."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:73
 msgid "Every Metabase user belongs to the All Users group. If you want to limit or restrict a group's access to something, make sure the All Users group has an equal or lower level of access."
-msgstr "Todos los usuarios de Metabase pertenecen al grupo All Users. Si quieres limitar o restringir el acceso de un grupo a algo, asegúrate de que el grupo All Users tenga un nivel de acceso igual o inferior."
+msgstr "Každý uživatel Metabase patří do skupiny Všichni uživatelé. Pokud chcete omezit nebo zakázat přístupy skupiny, ujistěte se, že skupina Všichni uživatelé má stejná nebo nižší oprávnění přístupu."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:75
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
-msgstr "MetaBot es el bot de Slack de Metabase. Puedes elegir a qué tiene acceso aquí."
+msgstr "MetaBot je náš bot pro Slack. Zde můžete nastavit, k čemu má přístup."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:128
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
-msgstr "El grupo \"{0}\" puede tener acceso a un conjunto diferente de {1} que este grupo, lo que puede darle a este grupo acceso adicional a algún {2}."
+msgstr "Skupina \"{0}\" může mít přístup k jiné množině {1} než má tato skupina, což může dát této skupině další přístup k některým {2}"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:131
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
-msgstr "El grupo \"{0}\" tiene un mayor nivel de acceso que este, lo que anulará esta configuración. Debes limitar o revocar el acceso del grupo \"{1}\" a este elemento."
+msgstr "Skupina \"{0}\" má vyšší úroveň přístupu než to, čím toto nastavení přepíšete. Měli by jste omezit nebo zrušit přístup skupiny \"{1}\" k této položce."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
-msgstr "¿Limitar"
+msgstr "Omezit"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
-msgstr "¿Revocar"
+msgstr "Odvolat"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
-msgstr "el acceso a pesar de que el grupo \"{0}\" tiene mayor acceso?"
+msgstr "přístup, ikdyž \"{0}\" má vyšší přístup?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
-msgstr "Limitar el acceso"
+msgstr "Omezit přístup"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
 msgid "Revoke access"
-msgstr "Revocar el acceso"
+msgstr "Odvolat přístup"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
-msgstr "¿Cambiar el acceso a esta base de datos a limitado?"
+msgstr "Změnit přístup k této databázi na omezený?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
-msgstr "Cambiar"
+msgstr "Změnit"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
-msgstr "Permitir escritura de consultas directas"
+msgstr "Povolit přímé psaní dotazů?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
-msgstr "Esto también cambiará el acceso de datos de este grupo a Sin restricciones para esta base de datos."
+msgstr "Toto změní i přístup této skupiny k datům databáze na Neomezený."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
-msgstr "Permitir"
+msgstr "Povolit"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
-msgstr "¿Revoca el acceso a todas las tablas?"
+msgstr "Chcete zrušit přístup ke všem tabulkám?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
-msgstr "Esto también revocará el acceso de este grupo a consultas sin formato para esta base de datos."
+msgstr "Tímto se také zruší přístup této skupiny k přímým dotazům pro tuto databázi."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
-msgstr "Conceder acceso sin restricciones"
+msgstr "Poskytnout neomezený přístup"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
-msgstr "Acceso no restingido"
+msgstr "Neomezený přístup"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
-msgstr "Acceso limitado"
+msgstr "Omezený přístup"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
-msgstr "Sin acceso"
+msgstr "Bez přístupu"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
-msgstr "Escribir consultas directas"
+msgstr "Psát dotazy přímo"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
-msgstr "Puede escribir consultas directas"
+msgstr "Může psát dotazy přímo"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
-msgstr "Mima la colección"
+msgstr "Uspořádat sbírku"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
-msgstr "Ver colección"
+msgstr "Zobrazit sbírku"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:445
 #: frontend/src/metabase/admin/permissions/selectors.js:558
 msgid "Data Access"
-msgstr "Acceso a Datos"
+msgstr "Přístup k datům"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:510
 #: frontend/src/metabase/admin/permissions/selectors.js:665
 #: frontend/src/metabase/admin/permissions/selectors.js:670
 msgid "View tables"
-msgstr "Ver tablas"
+msgstr "Zobrazit tabulky"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:606
 msgid "SQL Queries"
-msgstr "Consultas SQL"
+msgstr "SQL dotazy"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:676
 msgid "View schemas"
-msgstr "Ver esquemas"
+msgstr "Zobrazit schémata"
 
 #: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
-msgstr "Modelo de Datos"
+msgstr "Datový model"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:118
 #: frontend/src/metabase/plugins/builtin/auth/google.js:31
 msgid "Sign in with Google"
-msgstr "Accede con Google"
+msgstr "Přihlásit přes Google"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 #: frontend/src/metabase/plugins/builtin/auth/google.js:32
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
-msgstr "Permite a los usuarios con cuentas Metabase existentes iniciar sesión con una cuenta de Google que coincida con su dirección de correo electrónico además de su nombre de usuario y contraseña de Metabase."
+msgstr "Umožní stávajícím uživatelům přihlásit se pomocí Google účtu, který odpovídá jejich e-mailové adrese."
 
 #: frontend/src/metabase/admin/settings/components/widgets/AuthenticationOption.jsx:24
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
-msgstr "Configura"
+msgstr "Nastavit"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:20
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:15
@@ -1374,133 +1371,133 @@ msgstr "LDAP"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:16
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
-msgstr "Permite a los usuarios de tu directorio LDAP iniciar sesión en la Metabase con sus credenciales LDAP, y permite la asignación automática de grupos LDAP a grupos de metabase."
+msgstr "Umožní uživatelům ve vašem LDAP adresáři přihlásit se pomocí LDAP účtu a umožní automatické mapování LDAP skupin do Metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
 #: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
-msgstr "Esa no es una dirección de correo electrónico válida"
+msgstr "Toto není platná e-mailová adresa."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
-msgstr "Ese no es un entero válido"
+msgstr "Toto není celé číslo"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
-msgstr "¡Cambios guardados!"
+msgstr "Změny uloženy!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
 msgid "Looks like we ran into some problems"
-msgstr "Parece que nos encontramos con algunos problemas"
+msgstr "Zdá se, že jsme narazili na problém"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:19
 msgid "Send test email"
-msgstr "Enviar email de comprobación"
+msgstr "Odeslat testovací e-mail"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:20
 msgid "Sending..."
-msgstr "Enviando..."
+msgstr "Odesílám..."
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:21
 msgid "Sent!"
-msgstr "¡Enviado!"
+msgstr "Odesláno!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:93
 msgid "Clear"
-msgstr "Limpiar"
+msgstr "Vymazat"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
-msgstr "Autenticación"
+msgstr "Autentifikace"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
-msgstr "Configuración Servidor"
+msgstr "Nastavení serveru"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:36
 msgid "User Schema"
-msgstr "Esquema de Usuario"
+msgstr "Uživatelské schema"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:40
 msgid "Attributes"
-msgstr "Atributos"
+msgstr "Atributy"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
-msgstr "Esquema de Grupo"
+msgstr "Schéma skupiny"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetting.jsx:33
 msgid "Using "
-msgstr "Utilizando"
+msgstr "Používá "
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:105
 msgid "Getting set up"
-msgstr "Preparándote"
+msgstr "Připravuje se"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:106
 msgid "A few things you can do to get the most out of Metabase."
-msgstr "Algunas cosas que puedes hacer para sacar el máximo provecho de Metabase."
+msgstr "Několik věcí, které můžete udělat, abyste z Metabase vytěžili maximum."
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:115
 msgid "Recommended next step"
-msgstr "Siguiente paso recomendado"
+msgstr "Doporučený další krok"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:114
 msgid "Google Sign-In"
-msgstr "Acceso Google"
+msgstr "Přihlášení Google"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:123
 msgid "To allow users to sign in with Google you'll need to give Metabase a Google Developers console application client ID. It only takes a few steps and instructions on how to create a key can be found {0}"
-msgstr "Para permitir que los usuarios inicien sesión con Google, deberás proporcionar a Metabase un ID de cliente de aplicación de la consola de Desarrollo de Google. Solo se necesitan unos pocos pasos y se pueden encontrar instrucciones sobre cómo crear una clave {0}"
+msgstr "Chcete-li povolit uživatelům přihlásit se pomocí služby Google, musíte Metabase poskytnout klientské ID aplikace z konzoly Google Developers. Pokyny, jak vytvořit klíč, naleznete {0}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:140
 msgid "Your Google client ID"
-msgstr "Tu ID de cliente de Google"
+msgstr "Vaše Google client ID"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:145
 msgid "Allow users to sign up on their own if their Google account email address is from:"
-msgstr "Permite que los usuarios se registren solos si la dirección de correo electrónico de su cuenta de Google es de:"
+msgstr "Umožnit uživatelům přihlásit se přes vlastní Google účet, pokud je adresa: "
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:249
 msgid "Answers sent right to your Slack #channels"
-msgstr "Respuestas enviadas directamente a tus #canales Slack"
+msgstr "Odpovědi posílané rovnou do vašich kanálů na Slacku"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:258
 msgid "Create a Slack Bot User for MetaBot"
-msgstr "Crear un usuario de Slack Bot para MetaBot"
+msgstr "Vytvořit Slack Bot uživatele pro MetaBot"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:268
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
-msgstr "Una vez que estés allí, asígnele un nombre y haz clic en {0}. Luego, copia y pega el API Token del Bot en el campo a continuación. En cuanto hayas terminado, crea un canal \"metabase_files\" en Slack. Metabase necesita ese para subir gráficos."
+msgstr "Když už jste tam, pojmenujte ho a klikněte na {0}. Potom zkopírujte a vložte Bot API Token do pole níže. Po dokončení vytvořte v Slack kanálu \"metabase_files\". Metabase to potřebuje na posílání grafů."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:17
 msgid "You're running Metabase {0} which is the latest and greatest!"
-msgstr "¡Estás ejecutando Metabase {0} que es lo último y lo mejor!"
+msgstr "Provozujete Metabase {0}, jedná se o aktuální verzi!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
-msgstr "Metabase {0} está disponible.  Estás ejecutando {1}"
+msgstr "Metabase {0} je k dispozici. Provozujete {1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:41
 #: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 msgid "Update"
-msgstr "Actualiza"
+msgstr "Aktualizovat"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:46
 msgid "What's Changed:"
-msgstr "Qué ha cambiado:"
+msgstr "Co se změnilo:"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:131
 msgid "Add a map"
-msgstr "Añade un mapa"
+msgstr "Přidat mapu"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
 #: frontend/src/metabase/lib/core.js:267
@@ -1509,7 +1506,7 @@ msgstr "URL"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
-msgstr "Elimina mapa personalizado"
+msgstr "Smazat mapu"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
@@ -1520,7 +1517,7 @@ msgstr "Elimina mapa personalizado"
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
-msgstr "Borrar"
+msgstr "Odstranit"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
@@ -1528,330 +1525,331 @@ msgstr "Borrar"
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
-msgstr "Selecciona…"
+msgstr "Vybrat..."
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
-msgstr "Valores de muestra:"
+msgstr "Vzorové hodnoty:"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
-msgstr "Añade un nuevo mapa"
+msgstr "Přidat novou mapu"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
-msgstr "Editar mapa"
+msgstr "Upravit mapu"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
-msgstr "¿Cómo quieres llamar a este mapa?"
+msgstr "Jak chcete tuto mapu nazvat?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
-msgstr "e.g. United Kingdom, Brazil, Mars"
+msgstr "např. Česká republika, Evropa, Mars"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
-msgstr "URL para el archivo GeoJSON que quieres usar"
+msgstr "URL GeoJSON souboru, který chcete použít. Je potřeba aby data byly v souřadnicovém systému WGS 84 a uloženy v UTF-8."
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
-msgstr "Como https://my-mb-server.com/maps/my-map.json"
+msgstr "Například htpps://muj-server.cz/moje-mapa.json"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
-msgstr "Actualizar"
+msgstr "Obnovit"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
-msgstr "Carga"
+msgstr "Načíst"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
-msgstr "¿Qué propiedad especifica el identificador de la región?"
+msgstr "Která položka určuje identifikátor regionu?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
-msgstr "¿Qué propiedad especifica el nombre de la región?"
+msgstr "Která položka určuje zobrazovaný název regionu?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
-msgstr "Carga un archivo GeoJSON para ver una vista previa"
+msgstr "Pro zobrazení náhledu, načtěte GeoJSON soubor"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
-msgstr "Guardar mapa"
+msgstr "Uložit mapu"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
-msgstr "Añadir mapa"
+msgstr "Přidat mapu"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:7
 msgid "Using embedding"
-msgstr "Utilizando embebido"
+msgstr "Používáno vkládání"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:9
 msgid "By enabling embedding you're agreeing to the embedding license located at"
-msgstr "Al habilitar el embebido, aceptas la licencia de incorporación ubicada en"
+msgstr "Povolením vkládání souhlasíte se související licencí umístěné na "
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
-msgstr "En lenguaje sencillo, cuando insertas tablas o cuadros de mando de Metabase en tu propia aplicación, esa aplicación no está sujeta a la Licencia AGPL que cubre el resto de Metabase, siempre que mantengas el logotipo de Metabase y el \"Powered by Metabase\" visible en esas incrustaciones. Sin embargo, debes leer el texto de licencia, ya que esa es la licencia real que aceptas al habilitar esta función."
+msgstr "Jednoduše, pokud vkládáte grafy nebo nástěnky z Metabase do vaší aplikace, tato nemusí splňovat podmínky licence AGPL, pokud ve vložených částech ponecháte viditelné logo Metabase a nápis \"Powered by Metabase\". Přesto byste si měli text licence přečíst, abyste věděli, s čím souhlasíte."
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
-msgstr "Habilitar"
+msgstr "Zapnout"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:24
 msgid "Premium embedding enabled"
-msgstr "Embebido Premium habilitado"
+msgstr "Prémiové vkládání zapnuté"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:26
 msgid "Enter the token you bought from the Metabase Store"
-msgstr "Introduce el token que compraste en la Tienda Metabase"
+msgstr "Zadejte token, který jste obdrželi po zakoupení v obchodě Metabase"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:53
 msgid "Premium embedding lets you disable \"Powered by Metabase\" on your embedded dashboards and questions."
-msgstr "La incrustación Premium te permite desactivar \"Powered by Metabase\" en tus cuadros de mandos y preguntas embebidas."
+msgstr "Prémiové vkládání umožňuje zakázat zobrazení \"Powered by Metabase\" v nástěnkách a otázkách."
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:60
 msgid "Buy a token"
-msgstr "Comprar un token"
+msgstr "Koupit token"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:63
 msgid "Enter a token"
-msgstr "Introducir un token"
+msgstr "Zadejte token"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
 msgid "Edit Mappings"
-msgstr "Editar Asignaciones"
+msgstr "Upravit mapování"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
 msgid "Group Mappings"
-msgstr "Asignaciones de Grupo"
+msgstr "Skupinové mapování"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
 msgid "Create a mapping"
-msgstr "Crear una asignación"
+msgstr "Vytvořit mapování"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
-msgstr "Las asignaciones permiten que Metabase agregue y elimine automáticamente usuarios de grupos según la información de membresía proporcionada por el servidor de directorios. La membresía al grupo de administración se puede otorgar a través de asignaciones, pero no se eliminará automáticamente como una medida a prueba de fallas."
+msgstr "Mapování umožňuje Metabase automaticky přidávat a odebírat uživatele ze skupin na základě informací o členství poskytnutých adresářovým serverem. Členství ve skupině Správce lze přidat prostřednictvím mapování, ale kvůli bezpečnostní pojistce nebude automaticky odstraněno. \n"
+"Pozor: pokud skupina na serveru obsahuje jinou skupinu, její členové nemusí být správně namapováni."
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:107
 msgid "Distinguished Name"
-msgstr "Nombre Distinguido"
+msgstr "Rozlišovací jméno"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:92
 msgid "Public Link"
-msgstr "Enlace Público"
+msgstr "Veřejný odkaz"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:93
 msgid "Revoke Link"
-msgstr "Eliminar Enlace"
+msgstr "Zrušit odkaz"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
-msgstr "¿Deshabilitar este enlace?"
+msgstr "Vypnout tento odkaz?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
-msgstr "Ya no funcionarán y no se pueden restaurar, pero puedes crear nuevos enlaces."
+msgstr "Nebudou nadále fungovat a nelze je obnovit, ale můžete vytvořit nové odkazy."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 msgid "Public Dashboard Listing"
-msgstr "Listado de Cuadros de Mando Públicos"
+msgstr "Seznam veřejných nástěnek"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
-msgstr "Aún no se ha compartido públicamente ningún cuadro de mando."
+msgstr "Žádné nástěnky nejsou veřejně sdílené."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
-msgstr "Listado de tarjetas públicas"
+msgstr "Seznam veřejných karet"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
-msgstr "Aún no se ha compartido públicamente ninguna pregunta."
+msgstr "Žádné karty nejsou veřejně sdílené."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
-msgstr "Listado de cuadros de mando embebidos"
+msgstr "Seznam vložených nástěnek"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
-msgstr "No se han incrustado cuadros de mando todavía."
+msgstr "Žádné nástěnky nemají aktivní vkládání."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
-msgstr "Listado de tarjetas embebidas"
+msgstr "Seznam vložených karet"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
-msgstr "No se han incrustado preguntas todavía."
+msgstr "Žádné karty nemají aktivní vkládání."
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:35
 msgid "Regenerate embedding key?"
-msgstr "¿Regenerar la clave de inserción?"
+msgstr "Znovu vygenerovat klíč pro vkládání?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:36
 msgid "This will cause existing embeds to stop working until they are updated with the new key."
-msgstr "Esto hará que las inserciones existentes dejen de funcionar hasta que se actualicen con la nueva clave."
+msgstr "To způsobí, že stávající vložené objekty přestanou fungovat, dokud nebudou aktualizovány novým klíčem."
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:39
 msgid "Regenerate key"
-msgstr "Regenerar clave"
+msgstr "Znovu vytvořit klíč"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:47
 msgid "Generate Key"
-msgstr "Generar clave"
+msgstr "Vytvořit klíč"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
 #: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enabled"
-msgstr "Habilitado"
+msgstr "Povoleno"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
 #: frontend/src/metabase/admin/settings/selectors.js:93
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
-msgstr "Deshabilitado"
+msgstr "Zakázáno"
 
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:113
 msgid "Unknown setting {0}"
-msgstr "La directiva de configuración {0} es desconocida"
+msgstr "Neznámé nastavení {0}"
 
 #: frontend/src/metabase/admin/settings/selectors.js:37
 msgid "Setup"
-msgstr "Configura"
+msgstr "Nastavení"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:214
 #: frontend/src/metabase/admin/settings/selectors.js:42
 msgid "General"
-msgstr "General"
+msgstr "Obecné"
 
 #: frontend/src/metabase/admin/settings/selectors.js:46
 msgid "Site Name"
-msgstr "Nombre Sitio"
+msgstr "Jméno stránky"
 
 #: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Site URL"
-msgstr "URL Sitio"
+msgstr "URL stránky"
 
 #: frontend/src/metabase/admin/settings/selectors.js:64
 msgid "Email Address for Help Requests"
-msgstr "Dirección de correo electrónico para solicitudes de ayuda"
+msgstr "E-mailová adresa pro požadavky o pomoc"
 
 #: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
-msgstr "Zona horaria de los Informes"
+msgstr "Časové pásmo reportu"
 
 #: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
-msgstr "La de la base de datos"
+msgstr "Výchozí z databáze"
 
 #: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Select a timezone"
-msgstr "Selecciona una zona horaria"
+msgstr "Zvolit časovou zónu"
 
 #: frontend/src/metabase/admin/settings/selectors.js:75
 msgid "Not all databases support timezones, in which case this setting won't take effect."
-msgstr "No todas las bases de datos admiten zonas horarias, en cuyo caso esta configuración no tendrá efecto."
+msgstr "Ne všechny databáze podporují časová pásma. V takovém případě se toto nastavení neprojeví."
 
 #: frontend/src/metabase/entities/users/forms.js:34
 msgid "Language"
-msgstr "Idioma"
+msgstr "Jazyk"
 
 #: frontend/src/metabase/admin/settings/selectors.js:65
 msgid "Select a language"
-msgstr "Selecciona un idioma"
+msgstr "Zvolit jazyk"
 
 #: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
-msgstr "Seguimiento anónimo"
+msgstr "Anonymní sledování"
 
 #: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
-msgstr "Nombres de tablas y campos amistosos"
+msgstr "Snadno pochopitelné názvy tabulek a polí"
 
 #: frontend/src/metabase/admin/settings/selectors.js:91
 msgid "Only replace underscores and dashes with spaces"
-msgstr "Solo reemplaza los guiones bajos y guiones por espacios"
+msgstr "Pouze podtržítka a pomlčky nahradit za mezery"
 
 #: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Enable Nested Queries"
-msgstr "Habilitar consultas anidadas"
+msgstr "Povolit vnořené dotazy"
 
 #: frontend/src/metabase/admin/settings/selectors.js:110
 msgid "Updates"
-msgstr "Actualizaciones"
+msgstr "Aktualizace"
 
 #: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
-msgstr "Buscar actualizaciones"
+msgstr "Zkontrolovat aktualizace"
 
 #: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
-msgstr "Servidor SMTP"
+msgstr "SMTP server"
 
 #: frontend/src/metabase/admin/settings/selectors.js:134
 msgid "SMTP Port"
-msgstr "Puerto SMTP"
+msgstr "SMTP port"
 
 #: frontend/src/metabase/admin/settings/selectors.js:138
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:47
 msgid "That's not a valid port number"
-msgstr "Ese no es un número de puerto válido"
+msgstr "Toto není validní číslo portu"
 
 #: frontend/src/metabase/admin/settings/selectors.js:142
 msgid "SMTP Security"
-msgstr "Seguridad SMTP"
+msgstr "Zabezpečení SMTP"
 
 #: frontend/src/metabase/admin/settings/selectors.js:150
 msgid "SMTP Username"
-msgstr "Usuario SMTP"
+msgstr "Přihlašovací jméno SMTP"
 
 #: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "SMTP Password"
-msgstr "Contraseña SMTP"
+msgstr "Heslo SMTP"
 
 #: frontend/src/metabase/admin/settings/selectors.js:164
 msgid "From Address"
-msgstr "Email De"
+msgstr "Adresa Od"
 
 #: frontend/src/metabase/admin/settings/selectors.js:178
 msgid "Slack API Token"
-msgstr "Slack API Token"
+msgstr "API token Slacku"
 
 #: frontend/src/metabase/admin/settings/selectors.js:180
 msgid "Enter the token you received from Slack"
-msgstr "Introduce el token que has recibido de Slack"
+msgstr "Vložte token, který jste dostali od Slacku"
 
 #: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
-msgstr "Inicio de sesión único"
+msgstr "Jednotné přihlášení"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:30
 msgid "LDAP Authentication"
-msgstr "Autentificación LDAP"
+msgstr "Autentifikace LDAP"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:36
 msgid "LDAP Host"
-msgstr "Servidor LDAP"
+msgstr "LDAP server"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:44
 msgid "LDAP Port"
-msgstr "Puerto LDAP"
+msgstr "LDAP port"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:51
 msgid "LDAP Security"
-msgstr "Seguridad LDAP"
+msgstr "LDAP zabezpečení"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:59
 msgid "Username or DN"
-msgstr "Nombre de Usuario o DN"
+msgstr "Uživatel nebo DN"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:43
 #: frontend/src/metabase/entities/databases/forms.js:61
@@ -1859,250 +1857,249 @@ msgstr "Nombre de Usuario o DN"
 #: frontend/src/metabase/user/components/UserSettings.jsx:66
 #: src/metabase/driver/common.clj
 msgid "Password"
-msgstr "Contraseña"
+msgstr "Heslo"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:69
 msgid "User search base"
-msgstr "Base de búsqueda de usuario"
+msgstr "Základna pro hledání uživatelů"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:75
 msgid "User filter"
-msgstr "Filtro de usuario"
+msgstr "Filtr uživatelů"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:81
 msgid "Check your parentheses"
-msgstr "Verifica los paréntesis"
+msgstr "Zkontrolujte závorky"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
-msgstr "Atributo de Email"
+msgstr "Atribut pro e-mail"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
-msgstr "Atributo de Nombre"
+msgstr "Atribut pro jméno"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
-msgstr "Atributo de Apellidos"
+msgstr "Atribut pro příjmení"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
-msgstr "Sincronizar membresías de grupo"
+msgstr "Synchronizovat členství ve skupinách"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:113
 msgid "Group search base"
-msgstr "Base de búsqueda para Grupo"
+msgstr "Základna pro hledání skupin"
 
 #: frontend/src/metabase/admin/settings/selectors.js:201
 msgid "Maps"
-msgstr "Mapas"
+msgstr "Mapy"
 
 #: frontend/src/metabase/admin/settings/selectors.js:205
 msgid "Map tile server URL"
-msgstr "URL del servidor de capas de mapa"
+msgstr "Namapujte pole z URL serveru"
 
 #: frontend/src/metabase/admin/settings/selectors.js:206
 msgid "Metabase uses OpenStreetMaps by default."
-msgstr "Metabase usa OpenStreetMaps por defecto."
+msgstr "Metabase používá ve výchozím nastavení OpenStreetMaps."
 
 #: frontend/src/metabase/admin/settings/selectors.js:211
 msgid "Custom Maps"
-msgstr "Mapas Personalizados"
+msgstr "Vlastní mapy"
 
 #: frontend/src/metabase/admin/settings/selectors.js:212
 msgid "Add your own GeoJSON files to enable different region map visualizations"
-msgstr "Añade tus propios archivos GeoJSON para habilitar diferentes visualizaciones de mapas de región"
+msgstr "Přidejte vlastní soubory GeoJSON, abyste povolili různé vizualizace map regionů"
 
 #: frontend/src/metabase/admin/settings/selectors.js:245
 msgid "Public Sharing"
-msgstr "Uso compartido público"
+msgstr "Veřejné sdílení"
 
 #: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "Enable Public Sharing"
-msgstr "Habilitar el intercambio público"
+msgstr "Povolit veřejné sdílení"
 
 #: frontend/src/metabase/admin/settings/selectors.js:254
 msgid "Shared Dashboards"
-msgstr "Cuadros de Mando compartidos"
+msgstr "Sdílené nástěnky"
 
 #: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Shared Questions"
-msgstr "Preguntas compartidas"
+msgstr "Sdílené dotazy"
 
 #: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Embedding in other Applications"
-msgstr "Incrustar en otras aplicaciones"
+msgstr "Vkládání do ostatních aplikací"
 
 #: frontend/src/metabase/admin/settings/selectors.js:293
 msgid "Enable Embedding Metabase in other Applications"
-msgstr "Habilitar incrustación de Metabase en otras aplicaciones"
+msgstr "Povolit vkládání do ostatních aplikací"
 
 #: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Embedding secret key"
-msgstr "Clave secreta de incrustación"
+msgstr "Klíč pro vkládání"
 
 #: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Embedded Dashboards"
-msgstr "Cuadros de Mando embebidos"
+msgstr "Vložené nástěnky"
 
 #: frontend/src/metabase/admin/settings/selectors.js:315
 msgid "Embedded Questions"
-msgstr "Preguntas embebidas"
+msgstr "Vložené dotazy"
 
 #: frontend/src/metabase/admin/settings/selectors.js:322
 msgid "Caching"
-msgstr "Almacenamiento en caché"
+msgstr "Mezipaměť"
 
 #: frontend/src/metabase/admin/settings/selectors.js:326
 msgid "Enable Caching"
-msgstr "Habilitar caché"
+msgstr "Povolit mezipaměť"
 
 #: frontend/src/metabase/admin/settings/selectors.js:331
 msgid "Minimum Query Duration"
-msgstr "Duración mínima de la consulta"
+msgstr "Minimální trvání dotazu"
 
 #: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Cache Time-To-Live (TTL) multiplier"
-msgstr "Multiplicador Time-to-Live (TTL) de caché"
+msgstr "Násobitel platnosti mezipaměti"
 
 #: frontend/src/metabase/admin/settings/selectors.js:345
 msgid "Max Cache Entry Size"
-msgstr "Tamaño máximo de entrada de caché"
+msgstr "Maximální velikost mezipaměti"
 
 #: frontend/src/metabase/alert/alert.js:60
 msgid "Your alert is all set up."
-msgstr "Tu alerta está configurada."
+msgstr "Upozornění nastaveno"
 
 #: frontend/src/metabase/alert/alert.js:101
 msgid "Your alert was updated."
-msgstr "Tu alerta fue actualizada."
+msgstr "Upozornění aktualizováno"
 
 #: frontend/src/metabase/alert/alert.js:149
 msgid "The alert was successfully deleted."
-msgstr "La alerta fue eliminada correctamente."
+msgstr "Upozornění úspěšně vymazáno."
 
 #: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
-msgstr "Por favor introduce una dirección de correo electrónico con formato válido."
+msgstr "Prosím vložte platnou e-mailovou adresu."
 
 #: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
-msgstr "Las contraseñas no coinciden"
+msgstr "Hesla se neshodují"
 
 #: frontend/src/metabase/auth/components/BackToLogin.jsx:6
 msgid "Back to login"
-msgstr "Volver al inicio de sesión"
+msgstr "Zpět na přihlášení"
 
 #: frontend/src/metabase/auth/components/GoogleNoAccount.jsx:15
 msgid "No Metabase account exists for this Google account."
-msgstr "No existe una cuenta de Metabase para esta cuenta de Google."
+msgstr "Pro tento Google účet neexistuje Metabase účet."
 
 #: frontend/src/metabase/auth/components/GoogleNoAccount.jsx:17
 msgid "You'll need an administrator to create a Metabase account before you can use Google to log in."
-msgstr "Necesitará un administrador para crear una cuenta Metabase antes de poder usar Google para iniciar sesión."
+msgstr "Před přihlášením přes Google musí administrátor vytvořit odpovídající účet v Metabase."
 
 #: frontend/src/metabase/auth/components/AuthProviderButton.jsx:23
 msgid "Sign in with {0}"
-msgstr "Inicia sesión con {0}"
+msgstr "Přihlásit pomocí {0}"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
 msgid "Please contact an administrator to have them reset your password"
-msgstr "Por favor, ponte en contacto con un administrador para que restablezca tu contraseña"
+msgstr "Kontaktujte administrátora pro reset hesla."
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "Forgot password"
-msgstr "Olvidé mi contraseña"
+msgstr "Zapomenuté heslo"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "The email you use for your Metabase account"
-msgstr "El correo electrónico que utilizas para tu cuenta Metabase"
+msgstr "E-mail vašeho Metabase účtu"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
 msgid "Send password reset email"
-msgstr "Enviar correo electrónico de restablecimiento de contraseña"
+msgstr "Poslat e-mail pro reset hesla."
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
 msgid "Check your email for instructions on how to reset your password."
-msgstr "Consulta tu correo electrónico para obtener instrucciones sobre cómo restablecer tu contraseña."
+msgstr "Instrukce pro reset hesla najdete ve své e-mailové schránce."
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:44
 msgid "Sign in to Metabase"
-msgstr "Iniciar sesión en Metabase"
+msgstr "Přihlásit do Metabase"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:165
 msgid "OR"
-msgstr "O"
+msgstr "NEBO"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
 msgid "Username or email address"
-msgstr "Nombre de usuario o dirección de correo electrónico"
+msgstr "Uživatelské jméno nebo e-mailová adresa"
 
 #: frontend/src/metabase/auth/components/AuthProviderButton.jsx:23
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:56
 msgid "Sign in"
-msgstr "Acceder"
+msgstr "Přihlásit"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:79
 msgid "I seem to have forgotten my password"
-msgstr "Parece que olvidé mi contraseña"
+msgstr "Nepamatuji si své heslo"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
 msgid "request a new reset email"
-msgstr "solicitar un nuevo correo electrónico de reinicio"
+msgstr "Požádat o nový e-mail pro reset hesla"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
 msgid "Whoops, that's an expired link"
-msgstr "Vaya, ese es un enlace caducado"
+msgstr "Ajaj, tento odkaz již vypršel."
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
-msgstr "Por razones de seguridad, los enlaces de restablecimiento de contraseña caducan después de un tiempo.\n"
-"Si aún necesita restablecer tu contraseña, puedes {0}"
+msgstr "Z bezpečnostních důvodů odkazy pro reset hesla po chvíli vyprší. Pokud stále potřebujete resetovat heslo, můžete {0}"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
 msgid "New password"
-msgstr "Nueva contraseña"
+msgstr "Nové heslo"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
 msgid "To keep your data secure, passwords {0}"
-msgstr "Para mantener tus datos seguros, las contraseñas {0}"
+msgstr "Abyste udrželi svá data v bezpečí, hesla {0}"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
-msgstr "Crear una nueva contraseña"
+msgstr "Vytvořit nové heslo"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:135
 msgid "Make sure its secure like the instructions above"
-msgstr "Ha de cumplir las instrucciones anteriores"
+msgstr "Ujistěte se, že odpovídá instrukcím výše"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:186
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:143
 msgid "Confirm new password"
-msgstr "Confirmar nueva contraseña"
+msgstr "Potvrdit nové heslo"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:193
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:152
 msgid "Make sure it matches the one you just entered"
-msgstr "Tiene que coincidir con la que acabas de poner"
+msgstr "Ujistěte se, že se hesla shodují"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
 msgid "Your password has been reset."
-msgstr "Tu contraseña ha sido restablecida."
+msgstr "Vaše heslo bylo resetováno."
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
 msgid "Sign in with your new password"
-msgstr "Inicia sesión con tu nueva contraseña"
+msgstr "Přihlaste se svým novým heslem"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
-msgstr "Ha fallado"
+msgstr "Chyba ukládání"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
@@ -2110,19 +2107,19 @@ msgstr "Ha fallado"
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
-msgstr "Guardado"
+msgstr "Uloženo"
 
 #: frontend/src/metabase/components/Alert.jsx:12
 msgid "Ok"
-msgstr "Vale"
+msgstr "Ok"
 
 #: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
 msgid "Archive this collection?"
-msgstr "¿Archivar esta colección?"
+msgstr "Archivovat sbírku?"
 
 #: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
-msgstr "Los cuadros de mando, colecciones y pulsos guardados en esta colección también se archivarán."
+msgstr "Nástěnky, sbírky a pulzy v této kolekci budou také archivovány."
 
 #: frontend/src/metabase/components/ArchiveModal.jsx:38
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
@@ -2136,19 +2133,19 @@ msgstr "Los cuadros de mando, colecciones y pulsos guardados en esta colección 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
 #: frontend/src/metabase/routes.jsx:196
 msgid "Archive"
-msgstr "Archivar"
+msgstr "Archív"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:65
 msgid "This {0} has been archived"
-msgstr "Este {0} ha sido archivado"
+msgstr "{0} byla archivována"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:710
 msgid "View the archive"
-msgstr "Ver el archivo"
+msgstr "Zobrazit archiv"
 
 #: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
-msgstr "Desarchive este {0}"
+msgstr "Vrátit zpět následující {0}"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:46
 #: frontend/src/metabase/components/BrowseApp.jsx:112
@@ -2157,132 +2154,133 @@ msgstr "Desarchive este {0}"
 #: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
-msgstr "Nuestros datos"
+msgstr "Naše data"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
 msgid "X-ray this table"
-msgstr "Aplica rayos-X a esta tabla"
+msgstr "Provést průzkum tabulky"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:171
 msgid "Learn about this table"
-msgstr "Aprende sobre esta tabla"
+msgstr "Dozvědět se více o této tabulce"
 
 #: frontend/src/metabase/components/Button.info.js:11
 #: frontend/src/metabase/components/Button.info.js:12
 #: frontend/src/metabase/components/Button.info.js:13
 msgid "Clickity click"
-msgstr "Clic"
+msgstr "Klikněte"
 
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:9
 msgid "Saved!"
-msgstr "¡Guardado!"
+msgstr "Uloženo!"
 
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:10
 msgid "Saving failed."
-msgstr "No se ha podido guardar."
+msgstr "Ukládání selhalo."
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Su"
-msgstr "D"
+msgstr "Ne"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Mo"
-msgstr "L"
+msgstr "Po"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Tu"
-msgstr "M"
+msgstr "Út"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "We"
-msgstr "X"
+msgstr "St"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Th"
-msgstr "J"
+msgstr "Čt"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Fr"
-msgstr "V"
+msgstr "Pá"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Sa"
-msgstr "S"
+msgstr "So"
 
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:41
 msgid "Your admin's email address"
-msgstr "La dirección de correo electrónico de tu administrador"
+msgstr "E-mail vašeho administrátora"
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:37
 msgid "To send {0}, you'll need to set up {1} integration."
-msgstr "Para enviar {0}, tendrás que configurar la integración con {1}."
+msgstr "Pro odeslání {0} musíte nastavit integraci s {1}"
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:38
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:41
 msgid " or "
-msgstr " o "
+msgstr " nebo "
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:40
 msgid "To send {0}, an admin needs to set up {1} integration."
-msgstr "Para enviar {0}, un administrador necesita configurar la integración con {1}."
+msgstr "Pro odeslání {0} administrátor musí nastavit integraci s {1}"
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:15
 msgid "This collection is empty, like a blank canvas"
-msgstr "Esta colección está vacía, como una hoja en blanco"
+msgstr "Tato sbírka je prázdná, jako čisté plátno"
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:16
 msgid "You can use collections to organize and group dashboards, questions and pulses for your team or yourself"
-msgstr "Puedes usar colecciones para organizar y agrupar cuadros de mando, preguntas y pulsos para tu equipo o para ti"
+msgstr "Sbírka slouží vám a vašemu týmu k seskupení nástěnek, dotazů a pulzů."
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:28
 msgid "Create another collection"
-msgstr "Crea otra colección"
+msgstr "Vytvořit další sbírku"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:68
 msgid "Dashboards let you collect and share data in one place."
-msgstr "Los cuadros de mando te permiten recopilar y compartir datos en un solo lugar."
+msgstr "Nástěnky umožňují seskupit a sdílet data na jednom místě."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:77
 msgid "Pulses let you send out the latest data to your team on a schedule via email or slack."
-msgstr "Los pulsos te permiten enviar datos de Metabase a correo electrónico o Slack en el horario que deseas."
+msgstr "Pulzy umožňují na základě plánu zasílat nejnovější informace vašemu týmu  prostřednictvím emailu nebo pomocí Slack."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:86
 msgid "Questions are a saved look at your data."
-msgstr "Las preguntas son vistas guardadas de tus datos."
+msgstr "Otázky jsou uložené pohledy na vaše data."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
-msgstr "Pins"
+msgstr "Špendlíky"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
-msgstr "Arrastra algo aquí para pegarlo arriba"
+msgstr "Přetáhněte něco sem a připnete to nahoru."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:753
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
-msgstr "Colecciones"
+msgstr "Sbírky"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:431
 #: frontend/src/metabase/components/CollectionLanding.jsx:452
 msgid "Drag here to un-pin"
-msgstr "Arrastra aquí para despegarlo"
+msgstr "Přetáhněte sem pro odepnutí"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:487
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
-msgstr[0] "{0} elemento seleccionado"
-msgstr[1] "{0} elementos seleccionados"
+msgstr[0] "{0} položka vybrána"
+msgstr[1] "{0} položek vybráno"
+msgstr[2] "{0} položek vybráno"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:517
 msgid "Move {0} items?"
-msgstr "¿Mover {1} elemento(s)?"
+msgstr "Přesunout {0} položek?"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:518
 msgid "Move \"{0}\"?"
-msgstr "¿Mover \"{0}\"?"
+msgstr "Přesunout \"{0}\"?"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:623
 #: frontend/src/metabase/components/EntityMenu.info.js:29
@@ -2290,84 +2288,82 @@ msgstr "¿Mover \"{0}\"?"
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
-msgstr "Mover"
+msgstr "Přesunout"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:687
 msgid "Edit this collection"
-msgstr "Edita esta colección"
+msgstr "Upravit tuto sbírku"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:695
 msgid "Archive this collection"
-msgstr "Archivar esta colección"
+msgstr "Archivovat tuto sbírku"
 
 #: frontend/src/metabase/components/CollectionList.jsx:67
 #: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
-msgstr "Mi colección personal"
+msgstr "Moje osobní sbírka"
 
 #: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
-msgstr "Nueva colección"
+msgstr "Nová sbírka"
 
 #: frontend/src/metabase/components/CopyButton.jsx:36
 msgid "Copied!"
-msgstr "¡Copiado!"
+msgstr "Zkopírováno!"
 
 #: frontend/src/metabase/entities/databases/forms.js:14
 msgid "Use an SSH-tunnel for database connections"
-msgstr "Utiliza un túnel SSH para las conexiones a la base de datos"
+msgstr "Použít SSH-tunel pro připojení k databázi"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
-msgstr "Algunas instalaciones de bases de datos solo se pueden acceder conectándose a través de un túnel SSH.\n"
-"Esta opción también proporciona una capa adicional de seguridad cuando no dispones de una VPN.\n"
-"Esto suele ser más lento que una conexión directa."
+msgstr "Přístup k některým instalacím databáze je možný pouze připojením přes SSH prostředníka.\n"
+"Tato volba také poskytuje další úroveň zabezpečení, když není k dispozici síť VPN. Toto je obvykle pomalejší než přímé připojení."
 
 #: frontend/src/metabase/entities/databases/forms.js:281
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
-msgstr "Esta es una base de datos grande, así que déjame elegir cuándo Metabase sincroniza y escanea"
+msgstr "Tato databáze je velká, takže nastavte kdy má Metabase spustit synchronizaci a skenování"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
-msgstr "De forma predeterminada, Metabase realiza una sincronización ligera cada hora y un análisis diario intensivo de los valores de campo.\n"
-"Si tienes una base de datos grande, te recomendamos activarla y revisar cuándo y con qué frecuencia ocurren los escaneos de valores de campo."
+msgstr "Metabase standardně provádí odlehčenou hodinovou synchronizaci a intenzivní denní skenování hodnot polí. Pokud máte rozsáhlou databázi, doporučujeme zapnout skenování a zkontrolovat kdy a jak často se uskuteční kontrola hodnot polí."
 
 #: frontend/src/metabase/entities/databases/forms.js:113
 msgid "{0} to generate a Client ID and Client Secret for your project."
-msgstr "{0} para generar un ID y clave secreta de cliente para tu proyecto."
+msgstr "{0} vygeneruje ID klienta a klíč klienta pro svůj projekt."
 
 #: frontend/src/metabase/entities/databases/forms.js:115
 #: frontend/src/metabase/entities/databases/forms.js:130
 #: frontend/src/metabase/entities/databases/forms.js:166
 msgid "Click here"
-msgstr "Haz clic aquí"
+msgstr "Klikněte zde"
 
 #: frontend/src/metabase/entities/databases/forms.js:118
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
-msgstr "Elige \"Otro\" como tipo de aplicación. Llámalo como quieras"
+msgstr "Jako typ aplikace vyberte možnost \"Jiné\". Pojmenujte ho jak chcete."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:357
 msgid "{0} to get an auth code"
-msgstr "{0} para obtener un código de autenticación"
+msgstr "{0} získá autorizační kód"
 
 #: frontend/src/metabase/entities/databases/forms.js:142
 msgid "with Google Drive permissions"
-msgstr "con permisos de Google Drive"
+msgstr "s povoleními Google Drive"
 
 #: frontend/src/metabase/entities/databases/forms.js:164
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
-msgstr "Para usar Metabase con estos datos, debes habilitar el acceso a la API en Google Developers Console."
+msgstr "Pokud chcete používat Metabase s těmito daty, musíte povolit přístup přes API v konzoli Google vývojáře."
 
 #: frontend/src/metabase/entities/databases/forms.js:165
 msgid "{0} to go to the console if you haven't already done so."
-msgstr "{0} para ir a la consola si aún no lo has hecho."
+msgstr "{0} přejděte na konzoli, pokud jste tak ještě neučinili."
 
 #: frontend/src/metabase/entities/databases/forms.js:265
 msgid "How would you like to refer to this database?"
-msgstr "¿Cómo te gustaría llamar esta base de datos?"
+msgstr "Jak by jste se chtěli odkazovat na tuto databázi?"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:187
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
@@ -2378,148 +2374,148 @@ msgstr "¿Cómo te gustaría llamar esta base de datos?"
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:126
 #: frontend/src/metabase/setup/components/UserStep.jsx:93
 msgid "Next"
-msgstr "Siguiente"
+msgstr "Další"
 
 #: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
-msgstr "Elimina este {0}"
+msgstr "Toto smazat {0}"
 
 #: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
-msgstr "Fija este elemento"
+msgstr "Připnout tuto položku"
 
 #: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
-msgstr "Mueve este elemento"
+msgstr "Přesunout tuto položku"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:21
 msgid "Edit this question"
-msgstr "Editar esta pregunta"
+msgstr "Upravit otázku"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:26
 #: frontend/src/metabase/components/EntityMenu.info.js:47
 #: frontend/src/metabase/components/EntityMenu.info.js:82
 #: frontend/src/metabase/components/EntityMenu.info.js:99
 msgid "Action type"
-msgstr "Tipo acción"
+msgstr "Typ akce"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:26
 msgid "View revision history"
-msgstr "Ver el historial de revisiones"
+msgstr "Zobrazit revize"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 msgid "Move action"
-msgstr "Acción de mover"
+msgstr "Přesunout akci"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:33
 #: frontend/src/metabase/components/EntityMenu.info.js:89
 msgid "Archive action"
-msgstr "Acción de archivar"
+msgstr "Archivovat akci"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:31
 msgid "Add to dashboard"
-msgstr "Añadir a Cuadro de Mando"
+msgstr "Přidat na nástěnku"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:49
 #: frontend/src/metabase/components/EntityMenu.info.js:101
 msgid "Download results"
-msgstr "Descarga los resultados"
+msgstr "Stáhnout výsledky"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:51
 #: frontend/src/metabase/components/EntityMenu.info.js:103
 #: frontend/src/metabase/dashboard/containers/DashboardEmbedWidget.jsx:53
 msgid "Sharing and embedding"
-msgstr "Compartiendo y Incrustando"
+msgstr "Sdílení a vkládání"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:53
 #: frontend/src/metabase/components/EntityMenu.info.js:105
 msgid "Another action type"
-msgstr "Otro tipo de acción"
+msgstr "Jiný typ akce"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:65
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
 msgid "Get alerts about this"
-msgstr "Recibe alertas sobre esto"
+msgstr "Na toto získat upozornění"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
-msgstr "Ver el SQL"
+msgstr "Zobrazit SQL"
 
 #: frontend/src/metabase/components/EntitySegments.jsx:18
 msgid "Segments for this"
-msgstr "Segmentos para este"
+msgstr "Segmenty pro tento"
 
 #: frontend/src/metabase/components/ErrorDetails.jsx:20
 msgid "Show error details"
-msgstr "Mostrar detalles del error"
+msgstr "Zobrazit podrobnosti chyby"
 
 #: frontend/src/metabase/components/ErrorDetails.jsx:26
 msgid "Here's the full error message"
-msgstr "Este es el mensaje de error completo"
+msgstr "Zde je celé chybové hlášení"
 
 #: frontend/src/metabase/components/ExplorePane.jsx:19
 msgid "Hi, Metabot here."
-msgstr "Hola, soy Metabot"
+msgstr "Ahoj, já jsem Metabot."
 
 #: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
-msgstr "Basado en el esquema"
+msgstr "Založeno na schéma"
 
 #: frontend/src/metabase/components/ExplorePane.jsx:173
 msgid "A look at your"
-msgstr "Una vista a tus"
+msgstr "Podívejte se na svou"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:296
 msgid "Search the list"
-msgstr "Busca la lista"
+msgstr "Prohledat seznam"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:307
 msgid "Search by {0}"
-msgstr "Buscar por {0}"
+msgstr "Hledat podle {0}"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:309
 msgid " or enter an ID"
-msgstr "o introduce un ID"
+msgstr " a nebo zadejte ID "
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:314
 msgid "Enter an ID"
-msgstr "Introduce un ID"
+msgstr "Zadejte ID"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:316
 msgid "Enter a number"
-msgstr "Introduce un número"
+msgstr "Zadejte číslo"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:318
 msgid "Enter some text"
-msgstr "Introduce un texto"
+msgstr "Zadejte nějaký text"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:429
 msgid "No matching {0} found."
-msgstr "No se encontraron {0} coincidentes."
+msgstr "Žádná shoda pro {0} se nenašla."
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:438
 msgid "Including every option in your filter probably won’t do much…"
-msgstr "Incluir cada opción en tu filtro probablemente no hará mucho…"
+msgstr "Zahrnutí každé možnosti do filtru pravděpodobně moc nepomůže..."
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:26
 msgid "Something's gone wrong"
-msgstr "Lo siento. Algo salió mal."
+msgstr "Něco se pokazilo :("
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:27
 msgid "We've run into an error. You can try refreshing the page, or just go back."
-msgstr "Nos encontramos con un error. Puedes intentar refrescar la página, o simplemente volver atrás"
+msgstr "Došlo k chybě. Zkuste obnovit stránku, nebo stiskněte tlačítko zpět."
 
 #: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
@@ -2530,327 +2526,327 @@ msgstr "Nos encontramos con un error. Puedes intentar refrescar la página, o si
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:238
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:213
 msgid "No description yet"
-msgstr "Sin descripción todavía"
+msgstr "Zatím bez popisu"
 
 #: frontend/src/metabase/components/Header.jsx:119
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
-msgstr "Nuevo {0}"
+msgstr "Nový {0}"
 
 #: frontend/src/metabase/components/Header.jsx:130
 msgid "Asked by {0}"
-msgstr "Preguntado por {0}"
+msgstr "Ptal se {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
-msgstr "Hoy."
+msgstr "Dnes., "
 
 #: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
-msgstr "Ayer."
+msgstr "Včera, "
 
 #: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
-msgstr "Primera revisión."
+msgstr "První revize."
 
 #: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
-msgstr "Revertido a una revisión anterior y {0}"
+msgstr "Vráceno na dřívější revizi a {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
-msgstr "Historial de Revisiones"
+msgstr "Historie revizí"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
-msgstr "Cuando"
+msgstr "Kdy"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
-msgstr "Quien"
+msgstr "Kdo"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
-msgstr "Que"
+msgstr "Co"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
-msgstr "Revertir"
+msgstr "Vrátit"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
-msgstr "Revertiendo…"
+msgstr "Vracím..."
 
 #: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
-msgstr "Falló la reversión"
+msgstr "Vracení selhalo"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
-msgstr "Revertido"
+msgstr "Vráceno"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:13
 msgid "Everything"
-msgstr "Todo"
+msgstr "Všechno"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
 msgid "Dashboards"
-msgstr "Cuadros de Mando"
+msgstr "Nástěnky"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
 msgid "Questions"
-msgstr "Preguntas"
+msgstr "Otázky"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
 #: frontend/src/metabase/routes.jsx:311
 msgid "Pulses"
-msgstr "Pulsos"
+msgstr "Pulzy"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
 #: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
-msgstr "Atrás"
+msgstr "Zpět"
 
 #: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
-msgstr "Encontrar..."
+msgstr "Najít..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 msgid "An error occured"
-msgstr "Ha ocurrido un error"
+msgstr "Nastala chyba"
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:35
 msgid "Loading..."
-msgstr "Cargando..."
+msgstr "Nahrávám..."
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:71
 msgid "Metabase Newsletter"
-msgstr "Boletín Metabase"
+msgstr "Zpravodaj Metabase"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:81
 msgid "Get infrequent emails about new releases and feature updates."
-msgstr "Recibe correos electrónicos infrecuentes sobre nuevos lanzamientos y actualizaciones de funciones."
+msgstr "Získejte občasné emaily o nových vydáních a aktualizacích."
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:99
 msgid "Subscribe"
-msgstr "Suscribir"
+msgstr "Odebírat"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:106
 msgid "You're subscribed. Thanks for using Metabase!"
-msgstr "Estás suscrito. ¡Gracias por usar Metabase!"
+msgstr "Odebíráte novinky. Díky, že používáte Metabase!"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:46
 msgid "We're a little lost..."
-msgstr "Estamos un poco perdidos..."
+msgstr "Jsme trochu ztracení..."
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:27
 msgid "Temporary Password"
-msgstr "Contraseña Temporal"
+msgstr "Dočasné heslo"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:207
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:455
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:470
 msgid "Hide"
-msgstr "Esconder"
+msgstr "Skrýt"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:456
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:471
 msgid "Show"
-msgstr "Mostrar"
+msgstr "Zobrazit"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:17
 msgid "Saved! Add this to a dashboard?"
-msgstr "¡Guardado! ¿Añadir esto a un cuadro de mando?"
+msgstr "Uloženo! Přidat na nástěnku?"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:25
 msgid "Yes please!"
-msgstr "¡Sí, por favor!"
+msgstr "Ano prosím!"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:29
 msgid "Not now"
-msgstr "Ahora no"
+msgstr "Teď ne"
 
 #: frontend/src/metabase/components/SaveStatus.jsx:53
 msgid "Error:"
-msgstr "Error:"
+msgstr "Chyba:"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:23
 msgid "Sunday"
-msgstr "Domingo"
+msgstr "Neděle"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:24
 msgid "Monday"
-msgstr "Lunes"
+msgstr "Pondělí"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:25
 msgid "Tuesday"
-msgstr "Martes"
+msgstr "Úterý"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:26
 msgid "Wednesday"
-msgstr "Miércoles"
+msgstr "Středa"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:27
 msgid "Thursday"
-msgstr "Jueves"
+msgstr "Čtvrtek"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:28
 msgid "Friday"
-msgstr "Viernes"
+msgstr "Pátek"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:29
 msgid "Saturday"
-msgstr "Sábado"
+msgstr "Sobota"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:33
 msgid "First"
-msgstr "Primero"
+msgstr "První"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:34
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
 msgid "Last"
-msgstr "Ultimo"
+msgstr "Poslední"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:35
 msgid "15th (Midpoint)"
-msgstr "15to (punto medio)"
+msgstr "15. (uprostřed)"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:125
 msgid "Calendar Day"
-msgstr "Día Calendario"
+msgstr "Kalendářní den"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:205
 msgid "your Metabase timezone"
-msgstr "tu zona horaria en Metabase"
+msgstr "vaše Metabase časové pásmo"
 
 #: frontend/src/metabase/components/SearchHeader.jsx:21
 msgid "Filter this list..."
-msgstr "Filtra esta lista..."
+msgstr "Filtrovat tento seznam..."
 
 #: frontend/src/metabase/components/Select.info.js:8
 msgid "Blue"
-msgstr "Azul"
+msgstr "Modrá"
 
 #: frontend/src/metabase/components/Select.info.js:9
 msgid "Green"
-msgstr "Verde"
+msgstr "Zelená"
 
 #: frontend/src/metabase/components/Select.info.js:10
 msgid "Red"
-msgstr "Rojo"
+msgstr "Červená"
 
 #: frontend/src/metabase/components/Select.info.js:11
 msgid "Yellow"
-msgstr "Amarillo"
+msgstr "Žlutá"
 
 #: frontend/src/metabase/components/Select.info.js:7
 msgid "A component used to make a selection"
-msgstr "Un componente utilizado para hacer una selección"
+msgstr "Komponent použitý na výběr"
 
 #: frontend/src/metabase/components/Select.info.js:20
 #: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
-msgstr "Seleccionado"
+msgstr "Vybrané"
 
 #: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
-msgstr "Nada para seleccionar"
+msgstr "Nic není vybráno"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:56
 msgid "Sorry, you don’t have permission to see that."
-msgstr "Lo siento, no tienes permiso para ver eso."
+msgstr "Promiňte, ale nemáte dostatečné oprávnění k zobrazení."
 
 #: frontend/src/metabase/components/form/FormMessage.jsx:5
 msgid "Unknown error encountered"
-msgstr "Error desconocido encontrado"
+msgstr "Došlo k neznámé chybě"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/nav/containers/Navbar.jsx:373
 msgid "Create"
-msgstr "Crea"
+msgstr "Vytvořit"
 
 #: frontend/src/metabase/containers/DashboardForm.jsx:9
 msgid "Create dashboard"
-msgstr "Crea un Cuadro de Mando"
+msgstr "Vytvořit nástěnku"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
 msgid "Table"
-msgstr "Tabla"
+msgstr "Tabulka"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
 msgid "Database"
-msgstr "Base de Datos"
+msgstr "Databáze"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:49
 msgid "Creator"
-msgstr "Creador"
+msgstr "Vytvořil"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
-msgstr "No se han encontrado resultados"
+msgstr "Žádné výsledky"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
-msgstr "Intenta ajustar tu filtro para encontrar lo que estás buscando."
+msgstr "Zkuste upravit Váš filtr aby jste našli co hledáte."
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
-msgstr "Ver por"
+msgstr "Zobrazit podle"
 
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:121
 msgid "of"
-msgstr "de"
+msgstr "z"
 
 #: frontend/src/metabase/containers/Overworld.jsx:91
 msgid "Don't tell anyone, but you're my favorite."
-msgstr "No se lo digas a nadie, pero eres mi favorito."
+msgstr "Nikomu to neříkej, ale jsi můj oblíbenec."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:85
 msgid "Once you connect your own data, I can show you some automatic explorations called x-rays. Here are some examples with sample data."
-msgstr "En cuanto conectas tus propios datos, puedo mostrarte algunas exploraciones automáticas llamadas rayos-X. Aquí hay algunos ejemplos con datos de muestra."
+msgstr "Po připojení vašich dat vám ukážu několik automatických průzkumů. Zde je několik příkladů s ukázkovými daty."
 
 #: frontend/src/metabase/containers/Overworld.jsx:180
 #: frontend/src/metabase/containers/Overworld.jsx:384
 msgid "Start here"
-msgstr "Empieza aquí"
+msgstr "Začněte zde"
 
 #: frontend/src/metabase/containers/Overworld.jsx:379
 #: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
-msgstr "Nuestra Analítica"
+msgstr "Naše analytika"
 
 #: frontend/src/metabase/containers/Overworld.jsx:248
 msgid "Browse all items"
-msgstr "Ver todos los elementos"
+msgstr "Procházet všechny položky"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:117
 msgid "Replace or save as new?"
-msgstr "¿Reemplazar o guardar como nuevo?"
+msgstr "Přepsat nebo uložit jako novou?"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace original question, \"{0}\""
-msgstr "Reemplazar la pregunta original, \"{0}\""
+msgstr "Přepsat původní otázku, \"{0}\""
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:171
 msgid "Save as new question"
-msgstr "Guardar como nueva pregunta"
+msgstr "Uložit jako novou otázku"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:92
 msgid "First, save your question"
-msgstr "Primero, guarda tu pregunta"
+msgstr "Nejprve uložte vaši otázku"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
 msgid "Save question"
-msgstr "Guardar pregunta"
+msgstr "Uložit otázku"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
 msgid "What is the name of your card?"
-msgstr "¿Cuál es el nombre de tu tarjeta?"
+msgstr "Jaký je název vaší karty?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
@@ -2868,7 +2864,7 @@ msgstr "¿Cuál es el nombre de tu tarjeta?"
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:211
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:26
 msgid "Description"
-msgstr "Descripción"
+msgstr "Popis"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
@@ -2877,587 +2873,586 @@ msgstr "Descripción"
 #: frontend/src/metabase/entities/questions.js:107
 #: frontend/src/metabase/entities/snippets.js:31
 msgid "It's optional but oh, so helpful"
-msgstr "Es opcional pero, tan útil"
+msgstr "Je to nepovinné, ale užitečné"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
-msgstr "¿En qué colección debería ir esto?"
+msgstr "Do které sbírky to chcete zařadit?"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:34
 msgid "modified"
-msgstr "modificado"
+msgstr "změněno"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:34
 msgid "item"
-msgstr "elemento"
+msgstr "položka"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
-msgstr "Deshacer"
+msgstr "Vrátit změny"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:266
 msgid "Applying Question"
-msgstr "Aplicando Pregunta"
+msgstr "Aplikuji otázku"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "That question isn't compatible"
-msgstr "Esa pregunta no es compatible"
+msgstr "Tato otázka není kompatibilní"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:309
 msgid "Search for a question"
-msgstr "Busca una pregunta"
+msgstr "Hledat otázku"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:343
 msgid "We're not sure if this question is compatible"
-msgstr "No estamos seguros si esta pregunta es compatible"
+msgstr "Nejsme si jistí, že je tato otázka kompatibilní"
 
 #: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:43
 msgid "Archive Dashboard"
-msgstr "Archivar Cuadro de Mando"
+msgstr "Archivovat nástěnku"
 
 #: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
-msgstr "Asegúrate de hacer una selección para cada serie, o el filtro no funcionará en esta tarjeta."
+msgstr "Nezapomeňte udělat výběr pro každou sérii, jinak nebude filtr na této kartě fungovat."
 
 #: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
 msgid "This dashboard is looking empty."
-msgstr "Este cuadro de mando parece estar vacío."
+msgstr "Tato nástěnka vypadá prázdně."
 
 #: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
 msgid "Add a question to start making it useful!"
-msgstr "¡Añade una pregunta para hacerlo útil!"
+msgstr "Přidejte otázku a začněte ji používat!"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:38
 msgid "Daytime mode"
-msgstr "Modo Diurno"
+msgstr "Denní režim"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:38
 msgid "Nighttime mode"
-msgstr "Modo Nocturno"
+msgstr "Noční režim"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:56
 msgid "Exit fullscreen"
-msgstr "Desactivar Pantalla Completa"
+msgstr "Opustit režim celé obrazovky"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:56
 msgid "Enter fullscreen"
-msgstr "Activar Pantalla Completa"
+msgstr "Přejít do celoobrazovkového režimu"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
-msgstr "Guardando…"
+msgstr "Ukládám..."
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:220
 msgid "Add a question"
-msgstr "Añade una pregunta"
+msgstr "Vložit otázku"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:223
 msgid "Add a question to this dashboard"
-msgstr "Añade una pregunta a este cuadro de mando"
+msgstr "Vlož otázku do této nástěnky"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
 msgid "Add a filter"
-msgstr "Añadir filtro"
+msgstr "Přidat filtr"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
-msgstr "Parámetros"
+msgstr "Parametry"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
 msgid "Add a text box"
-msgstr "Añade una caja de texto"
+msgstr "Přidat textový blok"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:314
 msgid "Move dashboard"
-msgstr "Mover cuadro de mando"
+msgstr "Přesunout nástěnku"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
 msgid "Edit dashboard"
-msgstr "Editar Cuadro de Mando"
+msgstr "Upravit nástěnku"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:307
 msgid "Edit Dashboard Layout"
-msgstr "Editar Disposición del Cuadro de Mando"
+msgstr "Upravit vzhled nástěnky"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:365
 msgid "You are editing a dashboard"
-msgstr "Estás editando un cuadro de mando"
+msgstr "Upravujete nástěnku"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:370
 msgid "Select the field that should be filtered for each card"
-msgstr "Selecciona el campo que debe filtrarse para cada tarjeta"
+msgstr "Vyberte pole, které se může filtrovat v každé kartě"
 
 #: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
-msgstr "Mover cuadro de mando a..."
+msgstr "Přesuň nástěnku do..."
 
 #: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
-msgstr "Cuadro de Mando movido a {0}"
+msgstr "Nástěnka přesunuta do {0}"
 
 #: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
 msgid "What do you want to filter?"
-msgstr "¿Qué quieres filtrar?"
+msgstr "Co chcete filtrovat?"
 
 #: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
 msgid "What kind of filter?"
-msgstr "¿Qué tipo de filtro?"
+msgstr "Jaký druh filtru?"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:242
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:250
 msgid "Off"
-msgstr "Apagado"
+msgstr "Vypnuto"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:14
 msgid "1 minute"
-msgstr "1 minuto"
+msgstr "1 minuta"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:15
 msgid "5 minutes"
-msgstr "5 minutos"
+msgstr "5 minut"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:16
 msgid "10 minutes"
-msgstr "10 minutos"
+msgstr "10 minut"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:17
 msgid "15 minutes"
-msgstr "15 minutos"
+msgstr "15 minut"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:18
 msgid "30 minutes"
-msgstr "30 minutos"
+msgstr "30 minut"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:19
 msgid "60 minutes"
-msgstr "60 minutos"
+msgstr "60 minut"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:51
 msgid "Auto-refresh"
-msgstr "Auto-Refresco"
+msgstr "Automatická aktualizace"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:57
 msgid "Refreshing in"
-msgstr "Actualizando en"
+msgstr "Obnova proběhne za"
 
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:30
 msgid "Remove this question?"
-msgstr "¿Eliminar esta pregunta?"
+msgstr "Odstranit tuto otázku?"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
-msgstr "Se ha guardado tu cuadro de mando."
+msgstr "Nástěnka byla uložena"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:740
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
-msgstr "Verlo"
+msgstr "Podívejte se"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
-msgstr "Guardalo"
+msgstr "Uložit"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
-msgstr "Mostrar más sobre este/a"
+msgstr "Zobrazit více informací"
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
-msgstr "Esta tarjeta no tiene campos ni parámetros que coincidan con este tipo de parámetro."
+msgstr "Tato karta neobsahuje pole ani parametry, které lze mapovat na tento typ parametru."
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
-msgstr "Los valores en este campo no coinciden con los valores de ningún otro campo que hayas elegido."
+msgstr "Hodnoty v tomto poli se neshodují s hodnotami jiných polí, které jste vybrali."
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
-msgstr "No hay campos válidos"
+msgstr "Žádná platná pole"
 
 #: frontend/src/metabase/entities/collections.js:98
 msgid "Name must be 100 characters or less"
-msgstr "El nombre debe tener 100 caracteres o menos"
+msgstr "Jméno může mít max.100 znaků"
 
 #: frontend/src/metabase/entities/collections.js:112
 msgid "Color is required"
-msgstr "Color es obligatorio"
+msgstr "Barva je povinná"
 
 #: frontend/src/metabase/entities/dashboards.js:143
 msgid "What is the name of your dashboard?"
-msgstr "¿Cuál es el nombre de tu cuadro de mando?"
+msgstr "Jaký je název vaší nástěnky?"
 
 #: frontend/src/metabase/home/components/Activity.jsx:95
 msgid "did some super awesome stuff that's hard to describe"
-msgstr "he hecho algunas cosas geniales que son difíciles de describir"
+msgstr "bylo provedeno pár super úžasných věcí které je obtížné popsat"
 
 #: frontend/src/metabase/home/components/Activity.jsx:104
 #: frontend/src/metabase/home/components/Activity.jsx:119
 msgid "created an alert about - "
-msgstr "creado una alerta sobre - "
+msgstr "vytvořil upozornění na - "
 
 #: frontend/src/metabase/home/components/Activity.jsx:129
 #: frontend/src/metabase/home/components/Activity.jsx:144
 msgid "deleted an alert about - "
-msgstr "eliminado una alerta sobre - "
+msgstr "smazal upozornění na - "
 
 #: frontend/src/metabase/home/components/Activity.jsx:155
 msgid "saved a question about "
-msgstr "guardado una pregunta sobre"
+msgstr "uložil otázku "
 
 #: frontend/src/metabase/home/components/Activity.jsx:168
 msgid "saved a question"
-msgstr "guardado una pregunta"
+msgstr "uložil otázku"
 
 #: frontend/src/metabase/home/components/Activity.jsx:172
 msgid "deleted a question"
-msgstr "eliminado una pregunta"
+msgstr "smazal otázku"
 
 #: frontend/src/metabase/home/components/Activity.jsx:175
 msgid "created a dashboard"
-msgstr "creado un cuadro de mando"
+msgstr "vytvořil nástěnku"
 
 #: frontend/src/metabase/home/components/Activity.jsx:178
 msgid "deleted a dashboard"
-msgstr "eliminado un cuadro de mando"
+msgstr "smazal nástěnku"
 
 #: frontend/src/metabase/home/components/Activity.jsx:184
 #: frontend/src/metabase/home/components/Activity.jsx:199
 msgid "added a question to the dashboard - "
-msgstr "añadido una pregunta al cuadro de mando - "
+msgstr "přidal otázku na nástěnku - "
 
 #: frontend/src/metabase/home/components/Activity.jsx:209
 #: frontend/src/metabase/home/components/Activity.jsx:224
 msgid "removed a question from the dashboard - "
-msgstr "eliminado una pregunta del cuadro de mando - "
+msgstr "odebral otázku z nástěnky - "
 
 #: frontend/src/metabase/home/components/Activity.jsx:234
 #: frontend/src/metabase/home/components/Activity.jsx:241
 msgid "received the latest data from"
-msgstr "recibido los últimos datos de"
+msgstr "přijal nejnovější data z"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
 msgid "Unknown"
-msgstr "Desconocido"
+msgstr "Neznámý"
 
 #: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Hello World!"
-msgstr "¡Hola Mundo!"
+msgstr "Ahoj světe!"
 
 #: frontend/src/metabase/home/components/Activity.jsx:255
 msgid "Metabase is up and running."
-msgstr "Metabase está funcionando."
+msgstr "Metabase je spuštěná a funguje"
 
 #: frontend/src/metabase/home/components/Activity.jsx:261
 #: frontend/src/metabase/home/components/Activity.jsx:291
 msgid "added the metric "
-msgstr "añadido la métrica"
+msgstr "přidal metriku"
 
 #: frontend/src/metabase/home/components/Activity.jsx:275
 #: frontend/src/metabase/home/components/Activity.jsx:365
 msgid " to the "
-msgstr "a la"
+msgstr " do "
 
 #: frontend/src/metabase/home/components/Activity.jsx:285
 #: frontend/src/metabase/home/components/Activity.jsx:325
 #: frontend/src/metabase/home/components/Activity.jsx:375
 #: frontend/src/metabase/home/components/Activity.jsx:416
 msgid " table"
-msgstr "tabla"
+msgstr " tabulka"
 
 #: frontend/src/metabase/home/components/Activity.jsx:301
 #: frontend/src/metabase/home/components/Activity.jsx:331
 msgid "made changes to the metric "
-msgstr "ha hecho cambios a la métrica"
+msgstr "udělal změnu v metrice "
 
 #: frontend/src/metabase/home/components/Activity.jsx:315
 #: frontend/src/metabase/home/components/Activity.jsx:406
 msgid " in the "
-msgstr "en el"
+msgstr " v "
 
 #: frontend/src/metabase/home/components/Activity.jsx:338
 msgid "removed the metric "
-msgstr "eliminado la métrica"
+msgstr "odstranil metriku "
 
 #: frontend/src/metabase/home/components/Activity.jsx:341
 msgid "created a pulse"
-msgstr "pulso creado"
+msgstr "vytvořil pulz"
 
 #: frontend/src/metabase/home/components/Activity.jsx:344
 msgid "deleted a pulse"
-msgstr "pulso eliminado"
+msgstr "smazal pulz"
 
 #: frontend/src/metabase/home/components/Activity.jsx:350
 #: frontend/src/metabase/home/components/Activity.jsx:381
 msgid "added the filter"
-msgstr "filtro añadido"
+msgstr "přidal filtr"
 
 #: frontend/src/metabase/home/components/Activity.jsx:391
 #: frontend/src/metabase/home/components/Activity.jsx:422
 msgid "made changes to the filter"
-msgstr "ha hecho cambios al filtro"
+msgstr "změnil filtr"
 
 #: frontend/src/metabase/home/components/Activity.jsx:429
 msgid "removed the filter {0}"
-msgstr "eliminado el filtro {0}"
+msgstr "odstranil filtr {0}"
 
 #: frontend/src/metabase/home/components/Activity.jsx:432
 msgid "joined!"
-msgstr "¡se ha unido!"
+msgstr "se připojil!"
 
 #: frontend/src/metabase/home/components/Activity.jsx:532
 msgid "Hmmm, looks like nothing has happened yet."
-msgstr "Hmmm, parece que nada ha pasado aún."
+msgstr "Hmmm, vypadá to tak že se zatím nic nestalo."
 
 #: frontend/src/metabase/home/components/Activity.jsx:535
 msgid "Save a question and get this baby going!"
-msgstr "¡Guarda una pregunta y haz que esto funcione!"
+msgstr "Uložil otázku a pěkně to tu rozjel!"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:19
 msgid "Ask questions and explore"
-msgstr "Haz preguntas y explora"
+msgstr "Zadat otázku a prozkoumat"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:20
 msgid "Click on charts or tables to explore, or ask a new question using the easy interface or the powerful SQL editor."
-msgstr "Haz clic en cuadros o tablas para explorar, o haz una nueva pregunta usando el interfaz sencillo o el potente editor SQL."
+msgstr "Klikněte na grafy nebo tabulky, abyste je prozkoumali, nebo přidejte novou otázku pomocí jednoduchého rozhraní nebo výkonného SQL editoru."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:30
 msgid "Make your own charts"
-msgstr "Crea tus propios gráficos"
+msgstr "Vytvořte vlastní grafy"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:31
 msgid "Create line charts, scatter plots, maps, and more."
-msgstr "Crea gráficos de líneas, gráficos de dispersión, mapas y más."
+msgstr "Vytvářejte sloupcové, spojnicové, koláčové grafy a mnoho jiných."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:41
 msgid "Share what you find"
-msgstr "Comparte lo que encuentres"
+msgstr "Sdílejte své hledání"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:42
 msgid "Create powerful and flexible dashboards, and send regular updates via email or Slack."
-msgstr "Crea cuadros de mando potentes y flexibles, y envía actualizaciones periódicas por correo electrónico o Slack."
+msgstr "Vytvořte výkonné a flexibilní nástěnky a pravidelně posílejte aktualizace e-mailem nebo přes Slack."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
 msgid "Let's go"
-msgstr "Vamos allá"
+msgstr "Jdeme na to!"
 
 #: frontend/src/metabase/home/components/NextStep.jsx:34
 msgid "Setup Tip"
-msgstr "Consejo de configuración"
+msgstr "Nastavte tip"
 
 #: frontend/src/metabase/home/components/NextStep.jsx:40
 msgid "View all"
-msgstr "Ver todos"
+msgstr "Zobrazit vše"
 
 #: frontend/src/metabase/home/components/RecentViews.jsx:40
 msgid "Recently Viewed"
-msgstr "Visto Recientemente"
+msgstr "Nedávno zobrazené"
 
 #: frontend/src/metabase/home/components/RecentViews.jsx:77
 msgid "You haven't looked at any dashboards or questions recently"
-msgstr "No has consultado ningún cuadro de mando o pregunta recientemente"
+msgstr "Nedávno jste se nedívali na žádné nástěnky nebo otázky"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
-msgstr "{0} elemento(s) seleccionado(s)"
+msgstr "{0} položek vybráno"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 msgid "Unarchive"
-msgstr "Desarchivar"
+msgstr "Zrušit archivaci"
 
 #: frontend/src/metabase/home/containers/HomepageApp.jsx:77
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:59
 msgid "Activity"
-msgstr "Actividad"
+msgstr "Aktivita"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:31
 msgid "Results for \"{0}\""
-msgstr "Resultados de \"{0}\""
+msgstr "Výsledků pro \"{0}\""
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:138
 msgid "Pulse"
-msgstr "Pulso"
+msgstr "Pulzy"
 
 #: frontend/src/metabase/lib/core.js:8
 msgid "Entity Key"
-msgstr "Clave Entidad"
+msgstr "Primární klíč"
 
 #: frontend/src/metabase/lib/core.js:9 frontend/src/metabase/lib/core.js:15
 #: frontend/src/metabase/lib/core.js:21
 msgid "Overall Row"
-msgstr "Fila General"
+msgstr "Celkově řádků"
 
 #: frontend/src/metabase/lib/core.js:10
 msgid "The primary key for this table."
-msgstr "La clave principal para esta tabla."
+msgstr "Primární klíč pro tuto tabuli."
 
 #: frontend/src/metabase/lib/core.js:14
 msgid "Entity Name"
-msgstr "Nombre Entidad"
+msgstr "Název klíče"
 
 #: frontend/src/metabase/lib/core.js:16
 msgid "The \"name\" of each record. Usually a column called \"name\", \"title\", etc."
-msgstr "El \"nombre\" de cada registro. Por lo general, una columna llamada \"nombre\", \"título\", etc."
+msgstr "\"Název\" každého záznamu. Obvykle sloupec s názvem \"jméno\", \"nadpis\" atd."
 
 #: frontend/src/metabase/lib/core.js:20
 msgid "Foreign Key"
-msgstr "Clave Foránea"
+msgstr "Cizí klíč"
 
 #: frontend/src/metabase/lib/core.js:22
 msgid "Points to another table to make a connection."
-msgstr "Referencia otra tabla para establecer una conexión."
+msgstr "Propojení ukazuje na jinou tabulku."
 
 #: frontend/src/metabase/lib/core.js:257
 msgid "Avatar Image URL"
-msgstr "URL Avatar"
+msgstr "URL adresa k obrázku uživatele"
 
 #: frontend/src/metabase/lib/core.js:29 frontend/src/metabase/lib/core.js:34
 #: frontend/src/metabase/lib/core.js:39 frontend/src/metabase/lib/core.js:44
 #: frontend/src/metabase/lib/core.js:49
 msgid "Common"
-msgstr "Común"
+msgstr "Běžný"
 
 #: frontend/src/metabase/lib/core.js:28
 #: frontend/src/metabase/meta/Dashboard.js:86
 #: frontend/src/metabase/modes/components/drill/PivotByCategoryDrill.jsx:10
 msgid "Category"
-msgstr "Categoría"
+msgstr "Kategorie"
 
 #: frontend/src/metabase/lib/core.js:55
 #: frontend/src/metabase/meta/Dashboard.js:66
 msgid "City"
-msgstr "Ciudad"
+msgstr "Město"
 
 #: frontend/src/metabase/lib/core.js:60
 #: frontend/src/metabase/meta/Dashboard.js:78
 msgid "Country"
-msgstr "País"
+msgstr "Stát"
 
 #: frontend/src/metabase/lib/core.js:240
 msgid "Enum"
-msgstr "Enum"
+msgstr "Enumerace"
 
 #: frontend/src/metabase/lib/core.js:262
 msgid "Image URL"
-msgstr "URL Imagen"
+msgstr "URL obrázku"
 
 #: frontend/src/metabase/lib/core.js:274
 msgid "Field containing JSON"
-msgstr "Campo que contiene JSON"
+msgstr "Pole obsahující řetězec JSON"
 
 #: frontend/src/metabase/lib/core.js:65
 msgid "Latitude"
-msgstr "Latitud"
+msgstr "Zeměpisná šířka"
 
 #: frontend/src/metabase/lib/core.js:70
 msgid "Longitude"
-msgstr "Longitud"
+msgstr "Zeměpisná délka"
 
 #: frontend/src/metabase/lib/core.js:43
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:45
 msgid "Number"
-msgstr "Número"
+msgstr "Číslo"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:19
 #: frontend/src/metabase/lib/core.js:75
 #: frontend/src/metabase/meta/Dashboard.js:70
 msgid "State"
-msgstr "Provincia"
+msgstr "Stát"
 
 #: frontend/src/metabase/lib/core.js:233
 msgid "UNIX Timestamp (Seconds)"
-msgstr "Marca de tiempo UNIX (Segundos)"
+msgstr "Časová značka UNIX (sekundy)"
 
 #: frontend/src/metabase/lib/core.js:228
 msgid "UNIX Timestamp (Milliseconds)"
-msgstr "Marca de tiempo UNIX (Milisegundos)"
+msgstr "Časová značka UNIX (milisekundy)"
 
 #: frontend/src/metabase/lib/core.js:80
 msgid "Zip Code"
-msgstr "Código Postal"
+msgstr "PSČ"
 
 #: frontend/src/metabase/lib/core.js:119
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
 msgid "Quantity"
-msgstr "Cantidad"
+msgstr "Množství"
 
 #: frontend/src/metabase/lib/core.js:107
 msgid "Income"
-msgstr "Ingreso"
+msgstr "Příjem"
 
 #: frontend/src/metabase/lib/core.js:97
 msgid "Discount"
-msgstr "Descuento"
+msgstr "Sleva"
 
-#. Sé que parece una traducción muy literal, pero no sería una traducción más acertada "Sello de tiempo de creación"?
 #: frontend/src/metabase/lib/core.js:193
 msgid "Creation timestamp"
-msgstr "Fecha y Hora de Creación"
+msgstr "Zadejte časovou značku"
 
 #: frontend/src/metabase/lib/core.js:188
 msgid "Creation time"
-msgstr "Hora de Creación"
+msgstr "Čas vytvoření"
 
 #: frontend/src/metabase/lib/core.js:183
 msgid "Creation date"
-msgstr "Fecha de Creación"
+msgstr "Datum vytvoření"
 
 #: frontend/src/metabase/lib/core.js:245
 msgid "Product"
-msgstr "Producto"
+msgstr "Produkt"
 
 #: frontend/src/metabase/lib/core.js:161
 msgid "User"
-msgstr "Usuario"
+msgstr "Uživatel"
 
 #: frontend/src/metabase/lib/core.js:250
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
 msgid "Source"
-msgstr "Fuente"
+msgstr "Zdroj"
 
 #: frontend/src/metabase/lib/core.js:112
 msgid "Price"
-msgstr "Precio"
+msgstr "Cena"
 
 #: frontend/src/metabase/lib/core.js:223
 msgid "Join timestamp"
-msgstr "Unir por Tiempo"
+msgstr "Připojte časovou značku"
 
 #: frontend/src/metabase/lib/core.js:218
 msgid "Join time"
-msgstr "Unir por Tiempo"
+msgstr "Připojte čas"
 
 #: frontend/src/metabase/lib/core.js:213
 msgid "Join date"
-msgstr "Unir por Fecha"
+msgstr "Připojte datum"
 
 #: frontend/src/metabase/lib/core.js:129
 msgid "Share"
-msgstr "Compartir"
+msgstr "Sdílet"
 
 #: frontend/src/metabase/lib/core.js:151
 msgid "Owner"
-msgstr "Propietario"
+msgstr "Vlastník"
 
 #: frontend/src/metabase/lib/core.js:141
 msgid "Company"
-msgstr "Empresa"
+msgstr "Společnost"
 
 #: frontend/src/metabase/lib/core.js:156
 msgid "Subscription"
-msgstr "Suscripción"
+msgstr "Předplatné"
 
 #: frontend/src/metabase/lib/core.js:124
 msgid "Score"
-msgstr "Puntuación"
+msgstr "Skóre"
 
 #: frontend/src/metabase/lib/core.js:48
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
@@ -3465,62 +3460,62 @@ msgstr "Puntuación"
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
-msgstr "Título"
+msgstr "Nadpis"
 
 #: frontend/src/metabase/lib/core.js:33
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
 msgid "Comment"
-msgstr "Comentario"
+msgstr "Komentář"
 
 #: frontend/src/metabase/lib/core.js:87
 msgid "Cost"
-msgstr "Coste"
+msgstr "Náklady"
 
 #: frontend/src/metabase/lib/core.js:102
 msgid "Gross margin"
-msgstr "Margen Bruto"
+msgstr "Hrubá marže"
 
 #: frontend/src/metabase/lib/core.js:136
 msgid "Birthday"
-msgstr "Cumpleaños"
+msgstr "Narozeniny"
 
 #: frontend/src/metabase/lib/core.js:285
 msgid "Search box"
-msgstr "Caja de Búsqueda"
+msgstr "Vyhledávácí pole"
 
 #: frontend/src/metabase/lib/core.js:286
 msgid "A list of all values"
-msgstr "Una lista con todos los valores"
+msgstr "Seznam všech hodnot"
 
 #: frontend/src/metabase/lib/core.js:287
 msgid "Plain input box"
-msgstr "Caja de Texto"
+msgstr "Textové pole"
 
 #: frontend/src/metabase/lib/core.js:293
 msgid "Everywhere"
-msgstr "En todas partes"
+msgstr "Všude"
 
 #: frontend/src/metabase/lib/core.js:294
 msgid "The default setting. This field will be displayed normally in tables and charts."
-msgstr "La configuración predeterminada. Este campo se mostrará normalmente en tablas y gráficos."
+msgstr "Výchozí nastavení. Toto pole se bude běžně zobrazovat v tabulkách a grafech."
 
 #: frontend/src/metabase/lib/core.js:254
 msgid "Only in Detail Views"
-msgstr "Solo en vistas detalladas"
+msgstr "Pouze v detailních pohledech"
 
 #: frontend/src/metabase/lib/core.js:299
 msgid "This field will only be displayed when viewing the details of a single record. Use this for information that's lengthy or that isn't useful in a table or chart."
-msgstr "Este campo solo se mostrará cuando veas los detalles de un solo registro. Úsalo para obtener información larga o que no sea útil en una tabla o gráfico."
+msgstr "Toto pole se zobrazí pouze při prohlížení detailu jednoho záznamu. Použijte pro informace, které jsou zdlouhavé nebo které v tabulce nebo grafu nejsou užitečné."
 
 #: frontend/src/metabase/lib/core.js:259
 msgid "Do Not Include"
-msgstr "No Incluir"
+msgstr "Nezahrnout"
 
 #: frontend/src/metabase/lib/core.js:260
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
-msgstr "Metabase nunca recuperará este campo. Úsalo para información sensible o irrelevante."
+msgstr "Metabase toto pole nikdy nezíská. Použijte na citlivé nebo irelevantní informace."
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
@@ -3533,189 +3528,190 @@ msgstr "Metabase nunca recuperará este campo. Úsalo para información sensible
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "Count"
-msgstr "Contar"
+msgstr "Počet"
 
 #: frontend/src/metabase/lib/expressions/config.js:8
 msgid "CumulativeCount"
-msgstr "RecuentoAcumulativo"
+msgstr "Kumulovaný počet"
 
 #: frontend/src/metabase/lib/schema_metadata.js:485
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
-msgstr "Suma"
+msgstr "Součet"
 
 #: frontend/src/metabase/lib/expressions/config.js:10
 msgid "CumulativeSum"
-msgstr "SumaAcumulativa"
+msgstr "Kumulativní součet"
 
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Distinct"
-msgstr "Distinto"
+msgstr "Jedinečný"
 
-#. With accents a problem occured, I removed the accents (temporarily ?)
 #: frontend/src/metabase/lib/expressions/config.js:12
 msgid "StandardDeviation"
-msgstr "DesviacionEstandar"
+msgstr "Směrodatná odchylka"
 
 #: frontend/src/metabase/lib/schema_metadata.js:494
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
-msgstr "Media"
+msgstr "Průměr"
 
 #: frontend/src/metabase/lib/schema_metadata.js:539
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
-msgstr "Mín"
+msgstr "Min"
 
 #: frontend/src/metabase/lib/schema_metadata.js:548
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
 msgid "Max"
-msgstr "Máx"
+msgstr "Max"
 
 #: frontend/src/metabase/lib/expressions/parser.js:373
 msgid "sad sad panda, lexing errors detected"
-msgstr "triste panda triste, errores léxicos detectados"
+msgstr "Byla detekována slovníková chyba"
 
 #: frontend/src/metabase/lib/formatting.js:832
 msgid "{0} second"
 msgid_plural "{0} seconds"
-msgstr[0] "{0} segundo"
-msgstr[1] "{0} segundos"
+msgstr[0] "{0} sekund"
+msgstr[1] "{0} sekundy"
+msgstr[2] "{0} sekund"
 
 #: frontend/src/metabase/lib/formatting.js:835
 msgid "{0} minute"
 msgid_plural "{0} minutes"
-msgstr[0] "{0} minuto"
-msgstr[1] "{0} minutos"
+msgstr[0] "{0} minuta"
+msgstr[1] "{0} minuty"
+msgstr[2] "{0} minut"
 
 #: frontend/src/metabase/lib/greeting.js:4
 msgid "Hey there"
-msgstr "Hola"
+msgstr "Ahoj"
 
 #: frontend/src/metabase/lib/greeting.js:5
 #: frontend/src/metabase/lib/greeting.js:29
 msgid "How's it going"
-msgstr "¿Cómo te va"
+msgstr "Jak to jde?"
 
 #: frontend/src/metabase/lib/greeting.js:6
 msgid "Howdy"
-msgstr "Hola"
+msgstr "Nazdárek"
 
 #: frontend/src/metabase/lib/greeting.js:7
 msgid "Greetings"
-msgstr "Saludos"
+msgstr "Zdravím"
 
 #: frontend/src/metabase/lib/greeting.js:8
 msgid "Good to see you"
-msgstr "Que bueno verte"
+msgstr "Rád tě vidím"
 
 #: frontend/src/metabase/lib/greeting.js:12
 msgid "What do you want to know?"
-msgstr "¿Que quieres saber?"
+msgstr "Co chcete vědět?"
 
 #: frontend/src/metabase/lib/greeting.js:13
 msgid "What's on your mind?"
-msgstr "¿Qué tienes en mente?"
+msgstr "Na co myslíte?"
 
 #: frontend/src/metabase/lib/greeting.js:14
 msgid "What do you want to find out?"
-msgstr "¿Qué quieres saber?"
+msgstr "Co chcete zjistit?"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
 #: frontend/src/metabase/lib/schema_metadata.js:467
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
-msgstr "Datos brutos"
+msgstr "Surové data"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
 #: frontend/src/metabase/lib/schema_metadata.js:521
 msgid "Cumulative count"
-msgstr "Recuento acumulativo"
+msgstr "Kumulativní počet"
 
 #: frontend/src/metabase/lib/query/description.js:82
 #: frontend/src/metabase/lib/query/description.js:266
 msgid "Average of "
-msgstr "Media de"
+msgstr "Průměr z "
 
 #: frontend/src/metabase/lib/query/description.js:87
 #: frontend/src/metabase/lib/query/description.js:268
 msgid "Distinct values of "
-msgstr "Valores distintos de"
+msgstr "Jedinečné hodnoty z "
 
 #: frontend/src/metabase/lib/query/description.js:92
 #: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
-msgstr "Desviación estándar de"
+msgstr "Směrodatná odchylka z "
 
 #: frontend/src/metabase/lib/query/description.js:97
 #: frontend/src/metabase/lib/query/description.js:272
 msgid "Sum of "
-msgstr "Suma de"
+msgstr "Součet z "
 
 #: frontend/src/metabase/lib/query/description.js:102
 #: frontend/src/metabase/lib/query/description.js:274
 msgid "Cumulative sum of "
-msgstr "Suma acumulativa de"
+msgstr "Kumulativní součet z "
 
 #: frontend/src/metabase/lib/query/description.js:107
 #: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
-msgstr "Máximo de"
+msgstr "Maximum z "
 
 #: frontend/src/metabase/lib/query/description.js:112
 #: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
-msgstr "Mínimo de"
+msgstr "Minimum z "
 
 #: frontend/src/metabase/lib/query/description.js:126
 #: frontend/src/metabase/lib/query/description.js:286
 msgid "Grouped by "
-msgstr "Agrupado por"
+msgstr "Seskupené podle "
 
 #: frontend/src/metabase/lib/query/description.js:140
 #: frontend/src/metabase/lib/query/description.js:295
 msgid "Filtered by "
-msgstr "Filtrado por"
+msgstr "Filtrované podle "
 
 #: frontend/src/metabase/lib/query/description.js:169
 #: frontend/src/metabase/lib/query/description.js:320
 msgid "Sorted by "
-msgstr "Ordenado por"
+msgstr "Seřazené podle "
 
 #: frontend/src/metabase/lib/schema_metadata.js:237
 msgid "True"
-msgstr "Verdadero"
+msgstr "Pravda"
 
 #: frontend/src/metabase/lib/schema_metadata.js:237
 msgid "False"
-msgstr "Falso"
+msgstr "Nepravda"
 
 #: frontend/src/metabase/lib/schema_metadata.js:322
 msgid "Select longitude field"
-msgstr "Selecciona el campo de longitud"
+msgstr "Vyberte pole zeměpisné délky"
 
 #: frontend/src/metabase/lib/schema_metadata.js:323
 msgid "Enter upper latitude"
-msgstr "Latitud Superior"
+msgstr "Zadejte horní zeměpisnou šířku"
 
 #: frontend/src/metabase/lib/schema_metadata.js:324
 msgid "Enter left longitude"
-msgstr "Longitud Izquierda"
+msgstr "Zadejte levou zeměpisnou délku"
 
 #: frontend/src/metabase/lib/schema_metadata.js:325
 msgid "Enter lower latitude"
-msgstr "Latitud Inferior"
+msgstr "Zadejte dolní zeměpisnou šířku"
 
 #: frontend/src/metabase/lib/schema_metadata.js:326
 msgid "Enter right longitude"
-msgstr "Longitud Derecha"
+msgstr "Zadejte pravou zeměpisnou délku"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:539
 #: frontend/src/metabase-lib/lib/Dimension.js:541
@@ -3727,7 +3723,7 @@ msgstr "Longitud Derecha"
 #: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:417
 msgid "Is"
-msgstr "Es"
+msgstr "Je"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
 #: frontend/src/metabase/lib/schema_metadata.js:383
@@ -3735,7 +3731,7 @@ msgstr "Es"
 #: frontend/src/metabase/lib/schema_metadata.js:407
 #: frontend/src/metabase/lib/schema_metadata.js:413
 msgid "Is not"
-msgstr "No es"
+msgstr "Není"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:378
@@ -3745,7 +3741,7 @@ msgstr "No es"
 #: frontend/src/metabase/lib/schema_metadata.js:408
 #: frontend/src/metabase/lib/schema_metadata.js:418
 msgid "Is empty"
-msgstr "Vacío"
+msgstr "Je prázdný"
 
 #: frontend/src/metabase/lib/schema_metadata.js:365
 #: frontend/src/metabase/lib/schema_metadata.js:379
@@ -3755,281 +3751,280 @@ msgstr "Vacío"
 #: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/lib/schema_metadata.js:419
 msgid "Not empty"
-msgstr "No Vacío"
+msgstr "Není prázdné"
 
 #: frontend/src/metabase/lib/schema_metadata.js:371
 msgid "Equal to"
-msgstr "Igual a"
+msgstr "Je roven"
 
 #: frontend/src/metabase/lib/schema_metadata.js:372
 msgid "Not equal to"
-msgstr "Distinto a"
+msgstr "Není roven"
 
 #: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Greater than"
-msgstr "Mayor que"
+msgstr "Větší než"
 
 #: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Less than"
-msgstr "Menor que"
+msgstr "Méně než"
 
 #: frontend/src/metabase/lib/schema_metadata.js:375
 #: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
-msgstr "Entre"
+msgstr "Mezi"
 
 #: frontend/src/metabase/lib/schema_metadata.js:376
 msgid "Greater than or equal to"
-msgstr "Mayor o igual a"
+msgstr "Větší nebo rovno než"
 
 #: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Less than or equal to"
-msgstr "Menos o igual a"
+msgstr "Menší nebo rovno než"
 
 #: frontend/src/metabase/lib/schema_metadata.js:384
 msgid "Contains"
-msgstr "Contiene"
+msgstr "Obsahuje"
 
 #: frontend/src/metabase/lib/schema_metadata.js:385
 msgid "Does not contain"
-msgstr "No contiene"
+msgstr "Neobsahuje"
 
 #: frontend/src/metabase/lib/schema_metadata.js:388
 msgid "Starts with"
-msgstr "Empieza con"
+msgstr "Začíná na"
 
 #: frontend/src/metabase/lib/schema_metadata.js:389
 msgid "Ends with"
-msgstr "Termina en"
+msgstr "Končí na"
 
 #: frontend/src/metabase/lib/schema_metadata.js:399
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
-msgstr "Antes"
+msgstr "Před"
 
 #: frontend/src/metabase/lib/schema_metadata.js:400
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
-msgstr "Después"
+msgstr "Po"
 
 #: frontend/src/metabase/lib/schema_metadata.js:414
 msgid "Inside"
-msgstr "Dentro"
+msgstr "Uvnitř"
 
 #: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Just a table with the rows in the answer, no additional operations."
-msgstr "Solo una tabla con las filas en la respuesta, sin operaciones adicionales."
+msgstr "Pouze tabulka s řádky v odpovědi, žádné další operace."
 
 #: frontend/src/metabase/lib/schema_metadata.js:475
 msgid "Count of rows"
-msgstr "Número de filas"
+msgstr "Počet řádků"
 
 #: frontend/src/metabase/lib/schema_metadata.js:477
 msgid "Total number of rows in the answer."
-msgstr "Número total de filas en la respuesta."
+msgstr "Celkový počet řádků v odpovědi."
 
 #: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Sum of ..."
-msgstr "Suma de ..."
+msgstr "Součet z "
 
 #: frontend/src/metabase/lib/schema_metadata.js:486
 msgid "Sum of all the values of a column."
-msgstr "Suma de todos los valores de una columna."
+msgstr "Součet všech hodnot ze sloupce"
 
 #: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Average of ..."
-msgstr "Media de ..."
+msgstr "Průměr z..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:495
 msgid "Average of all the values of a column"
-msgstr "Promedio de todos los valores de una columna"
+msgstr "Průměr všech hodnot ze sloupce"
 
 #: frontend/src/metabase/lib/schema_metadata.js:502
 msgid "Number of distinct values of ..."
-msgstr "Número de valores distintos de ..."
+msgstr "Počet jedinečných hodnot z "
 
 #: frontend/src/metabase/lib/schema_metadata.js:504
 msgid "Number of unique values of a column among all the rows in the answer."
-msgstr "Número de valores únicos de una columna entre todas las filas en la respuesta."
+msgstr "Počet jedinečných hodnot ve sloupci napříč všemi řádky v odpovědi."
 
 #: frontend/src/metabase/lib/schema_metadata.js:511
 msgid "Cumulative sum of ..."
-msgstr "Suma acumulada de ..."
+msgstr "Kumulativní součet z "
 
 #: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
-msgstr "Suma aditiva de todos los valores de una columna.\n"
-" e.g. los ingresos totales a lo largo del tiempo"
+msgstr "Přídavný součet všech hodnot sloupce. .\\ne.x. celkový příjem v čase."
 
 #: frontend/src/metabase/lib/schema_metadata.js:520
 msgid "Cumulative count of rows"
-msgstr "Recuento acumulado de filas"
+msgstr "Kumulativní počet řádků"
 
+#. duplicity
 #: frontend/src/metabase/lib/schema_metadata.js:501
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
-msgstr "Recuento aditiva del número de filas.\n"
-" e.g. número total de ventas en el tiempo"
+msgstr "Přídavný počet řádků. \\ne.x. celkový počet prodejů v čase."
 
 #: frontend/src/metabase/lib/schema_metadata.js:529
 msgid "Standard deviation of ..."
-msgstr "Desviación estándar de ..."
+msgstr "Směrodatná odchylka z..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:531
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
-msgstr "Número que expresa cuánto varían los valores de una columna entre todas las filas en la respuesta."
+msgstr "Číslo, které vyjadřuje, do jaké míry se hodnoty sloupce liší mezi všemi řádky v odpovědi."
 
 #: frontend/src/metabase/lib/schema_metadata.js:538
 msgid "Minimum of ..."
-msgstr "Mínimo de ..."
+msgstr "Minimum z ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Minimum value of a column"
-msgstr "Valor mínimo de una columna"
+msgstr "Minimální hodnota sloupce"
 
 #: frontend/src/metabase/lib/schema_metadata.js:547
 msgid "Maximum of ..."
-msgstr "Máximo de ..."
+msgstr "Maximum z ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:549
 msgid "Maximum value of a column"
-msgstr "Valor máximo de una columna"
+msgstr "Maximální hodnota sloupce"
 
 #: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
-msgstr "Desglosar por dimensión"
+msgstr "Rozbor podle dimenzí"
 
 #: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
-msgstr "letra en minúsculas"
+msgstr "malé písmeno"
 
 #: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
-msgstr "letra en mayúsculas"
+msgstr "velké písmeno"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
-msgstr "número"
+msgstr "číslo"
 
 #: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
-msgstr "carácter especial"
+msgstr "speciální znak"
 
 #: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
-msgstr "debe ser"
+msgstr "musí být"
 
 #: frontend/src/metabase/lib/settings.js:120
 #: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
-msgstr "caracteres"
+msgstr "znaků dlouhé"
 
 #: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
-msgstr "Debe ser"
+msgstr "Musí být"
 
 #: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
-msgstr "e incluir"
+msgstr "a obsahuje"
 
 #: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
-msgstr "cero"
+msgstr "nula"
 
 #: frontend/src/metabase/lib/utils.js:86
 msgid "one"
-msgstr "uno"
+msgstr "jedna"
 
 #: frontend/src/metabase/lib/utils.js:87
 msgid "two"
-msgstr "dos"
+msgstr "dvě"
 
 #: frontend/src/metabase/lib/utils.js:88
 msgid "three"
-msgstr "tres"
+msgstr "tři"
 
 #: frontend/src/metabase/lib/utils.js:89
 msgid "four"
-msgstr "cuatro"
+msgstr "čtyři"
 
 #: frontend/src/metabase/lib/utils.js:90
 msgid "five"
-msgstr "cinco"
+msgstr "pět"
 
 #: frontend/src/metabase/lib/utils.js:91
 msgid "six"
-msgstr "seis"
+msgstr "šest"
 
 #: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
-msgstr "siete"
+msgstr "sedm"
 
 #: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
-msgstr "ocho"
+msgstr "osm"
 
 #: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
-msgstr "nueve"
+msgstr "devět"
 
 #: frontend/src/metabase/meta/Dashboard.js:35
 msgid "Month and Year"
-msgstr "Mes y Año"
+msgstr "Měsíc a rok"
 
 #: frontend/src/metabase/meta/Dashboard.js:36
 msgid "Like January, 2016"
-msgstr "Como Enero 2016"
+msgstr "Např. Leden, 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:40
 msgid "Quarter and Year"
-msgstr "Trimestre y Año"
+msgstr "Kvartál a rok"
 
 #: frontend/src/metabase/meta/Dashboard.js:41
 msgid "Like Q1, 2016"
-msgstr "Como T1, 2016"
+msgstr "Např. Q1, 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:45
 msgid "Single Date"
-msgstr "Fecha Unica"
+msgstr "Jedno datum"
 
 #: frontend/src/metabase/meta/Dashboard.js:46
 msgid "Like January 31, 2016"
-msgstr "Como 31 de Enero, 2016"
+msgstr "Např. Leden 31, 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:50
 msgid "Date Range"
-msgstr "Rango de Fechas"
+msgstr "Rozsah datumu"
 
 #: frontend/src/metabase/meta/Dashboard.js:51
 msgid "Like December 25, 2015 - February 14, 2016"
-msgstr "Como 25 de Diciembre, 2015 - 14 de Febrero, 2016"
+msgstr "Např. Prosinec 25, 2015 - Únor 14, 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:55
 msgid "Relative Date"
-msgstr "Fecha Relativa"
+msgstr "Relativní datum"
 
 #: frontend/src/metabase/meta/Dashboard.js:56
 msgid "Like \"the last 7 days\" or \"this month\""
-msgstr "Como \"los últimos 7 días\" o \"este mes\""
+msgstr "Např \"posledních 7 dní\" nebo \"aktuální měsíc\""
 
 #: frontend/src/metabase/meta/Dashboard.js:60
 msgid "Date Filter"
-msgstr "Filtro de Fecha"
+msgstr "Filtr datumu"
 
 #: frontend/src/metabase/meta/Dashboard.js:61
 msgid "All Options"
-msgstr "Todas las Opciones"
+msgstr "Všechny možnosti"
 
 #: frontend/src/metabase/meta/Dashboard.js:62
 msgid "Contains all of the above"
-msgstr "Contiene todo lo anterior"
+msgstr "Obsahuje všechny výše uvedené"
 
 #: frontend/src/metabase/meta/Dashboard.js:74
 msgid "ZIP or Postal Code"
-msgstr "Código Postal"
+msgstr "PSČ"
 
 #: frontend/src/metabase/meta/Dashboard.js:82
 #: frontend/src/metabase/meta/Dashboard.js:112
@@ -4039,11 +4034,11 @@ msgstr "ID"
 #: frontend/src/metabase/meta/Dashboard.js:100
 #: frontend/src/metabase/modes/components/drill/PivotByTimeDrill.jsx:9
 msgid "Time"
-msgstr "Tiempo"
+msgstr "Čas"
 
 #: frontend/src/metabase/meta/Dashboard.js:101
 msgid "Date range, relative date, time of day, etc."
-msgstr "Rango de fechas, fecha relativa, hora del día, etc."
+msgstr "Rozsah dat, relativní datum, čas z dne atd."
 
 #: frontend/src/metabase/lib/core.js:56 frontend/src/metabase/lib/core.js:61
 #: frontend/src/metabase/lib/core.js:66 frontend/src/metabase/lib/core.js:71
@@ -4051,143 +4046,143 @@ msgstr "Rango de fechas, fecha relativa, hora del día, etc."
 #: frontend/src/metabase/meta/Dashboard.js:106
 #: frontend/src/metabase/modes/components/drill/PivotByLocationDrill.jsx:9
 msgid "Location"
-msgstr "Ubicación"
+msgstr "Poloha"
 
 #: frontend/src/metabase/meta/Dashboard.js:107
 msgid "City, State, Country, ZIP code."
-msgstr "Ciudad, Provincia, País, Código Postal."
+msgstr "Město, Okres, Stát, PSČ"
 
 #: frontend/src/metabase/meta/Dashboard.js:113
 msgid "User ID, product ID, event ID, etc."
-msgstr "ID Usuario, ID Productio, ID Evento, etc."
+msgstr "ID uživatele, ID produktu, ID události, atd."
 
 #: frontend/src/metabase/meta/Dashboard.js:118
 msgid "Other Categories"
-msgstr "Otras Categorías"
+msgstr "Ostatní kategorie"
 
 #: frontend/src/metabase/meta/Dashboard.js:119
 msgid "Category, Type, Model, Rating, etc."
-msgstr "Categoría, Tipo, Modelo, Clasificación, etc."
+msgstr "Kategorie, Typ, Model, Hodnocení atd."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:43
 #: frontend/src/metabase/user/components/UserSettings.jsx:56
 msgid "Account settings"
-msgstr "Configuración de la cuenta"
+msgstr "Nastavení účtu"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Exit admin"
-msgstr "Salir de Configuración"
+msgstr "Opustit administraci"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:35
 msgid "Logs"
-msgstr "Logs"
+msgstr "Logy"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:104
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:22
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:65
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:100
 msgid "Help"
-msgstr "Ayuda"
+msgstr "Nápověda"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:72
 msgid "About Metabase"
-msgstr "Sobre Metabase"
+msgstr "O Metabase"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:78
 msgid "Sign out"
-msgstr "Salir"
+msgstr "Odhlásit se"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Thanks for using"
-msgstr "Gracias por utilizar"
+msgstr "Děkujeme za použití"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:116
 msgid "You're on version"
-msgstr "Estás en la versión"
+msgstr "Používáte verzi"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:119
 msgid "Built on"
-msgstr "Construida el"
+msgstr "Sestavený dne"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:139
 msgid "is a Trademark of"
-msgstr "es una marca registrada de"
+msgstr "je ochranná známka společnosti"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:141
 msgid "and is built with care in San Francisco, CA"
-msgstr "y está construido con cariño en San Francisco, CA"
+msgstr "a je sestavený s péčí v San Franciscu v Kalifornii"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:224
 msgid "Metabase Admin"
-msgstr "Configuración Metabase"
+msgstr "Administrace Metabase"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:36
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:36
 msgid "Ask a question"
-msgstr "Haz una pregunta"
+msgstr "Položte otázku"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:379
 msgid "New dashboard"
-msgstr "Añadir nuevo Cuadro de Mando"
+msgstr "Nová nástěnka"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:385
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
-msgstr "Nuevo pulso"
+msgstr "Nový pulz"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:323
 msgid "Reference"
-msgstr "Referencia"
+msgstr "Reference"
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
-msgstr "¿Qué Métrica?"
+msgstr "Vyberte metriku"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Defining common metrics for your team makes it even easier to ask questions"
-msgstr "La definición de métricas comunes para tu equipo hace que sea aún más fácil hacer preguntas"
+msgstr "Definováním běžných metrik pro váš tým mu usnadňuje vytváření dotazů"
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
-msgstr "Cómo crear métricas"
+msgstr "Jak vytvořit metriku"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:138
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
-msgstr "Consulta los datos a lo largo del tiempo, como un mapa, o gírelos para ayudarte a comprender las tendencias o los cambios."
+msgstr "Zobrazte data v průběhu času, aby vám to pomohlo pochopit trendy nebo změny."
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
 msgid "Custom"
-msgstr "Personalizado"
+msgstr "Volitelný"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:157
 msgid "New question"
-msgstr "Nueva pregunta"
+msgstr "Nová otázka"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:152
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
-msgstr "Utiliza el generador de preguntas para ver tendencias, listas de cosas o para crear tus propias métricas."
+msgstr "Pomocí nástroje pro jednoduchou tvorbu dotazů můžete zobrazit trendy, seznamy věcí nebo vytvořit své vlastní metriky."
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:110
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
-msgstr "Consulta nativa"
+msgstr "Nativní dotaz"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:111
 msgid "For more complicated questions, you can write your own SQL or native query."
-msgstr "Para preguntas más complicadas puedes escribir tu propia consulta SQL o nativa."
+msgstr "Pro složitější otázky můžete napsat svůj vlastní SQL nebo nativní dotaz."
 
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
 msgid "Select a default value…"
-msgstr "Selecciona un valor por defecto…"
+msgstr "Vyberte výchozí hodnotu..."
 
 #: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
 #: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
-msgstr "Actualizar filtro"
+msgstr "Aktualizovat filtr"
 
 #: frontend/src/metabase/lib/query_time.js:112
 #: frontend/src/metabase/lib/query_time.js:123
@@ -4195,22 +4190,22 @@ msgstr "Actualizar filtro"
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
 #: src/metabase/pulse/render/datetime.clj
 msgid "Today"
-msgstr "Hoy"
+msgstr "Dnes"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
 #: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
-msgstr "Ayer"
+msgstr "Včera"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:18
 msgid "Past 7 days"
-msgstr "Ultimos 7 días"
+msgstr "Posledních 7 dní"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:19
 msgid "Past 30 days"
-msgstr "Ultimos 30 días"
+msgstr "Posledních 30 dní"
 
 #: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
@@ -4218,8 +4213,9 @@ msgstr "Ultimos 30 días"
 #: src/metabase/api/table.clj
 msgid "Week"
 msgid_plural "Weeks"
-msgstr[0] "Semana"
-msgstr[1] "Semanas"
+msgstr[0] "týden"
+msgstr[1] "týdnů"
+msgstr[2] "týdny"
 
 #: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
@@ -4227,8 +4223,9 @@ msgstr[1] "Semanas"
 #: src/metabase/api/table.clj
 msgid "Month"
 msgid_plural "Months"
-msgstr[0] "Mes"
-msgstr[1] "Meses"
+msgstr[0] "měsíc"
+msgstr[1] "měsíců"
+msgstr[2] "měsíce"
 
 #: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
@@ -4236,355 +4233,357 @@ msgstr[1] "Meses"
 #: src/metabase/api/table.clj
 msgid "Year"
 msgid_plural "Years"
-msgstr[0] "Año"
-msgstr[1] "Años"
+msgstr[0] "rok"
+msgstr[1] "roků"
+msgstr[2] "roky"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:152
 msgid "Past 7 Days"
-msgstr "Ultimos 7 Días"
+msgstr "Posledních 7 dní"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:156
 msgid "Past 30 Days"
-msgstr "Ultimos 30 Días"
+msgstr "Posledních 30 dní"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:160
 msgid "Last Week"
-msgstr "Semana Pasada"
+msgstr "Minulý týden"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:164
 msgid "Last Month"
-msgstr "El mes pasado"
+msgstr "Minulý měsíc"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:168
 msgid "Last Year"
-msgstr "El año pasado"
+msgstr "Minulý rok"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:172
 msgid "This Week"
-msgstr "Esta Semana"
+msgstr "Tento týden"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:176
 msgid "This Month"
-msgstr "Este Mes"
+msgstr "Tento měsíc"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:180
 msgid "This Year"
-msgstr "Este Año"
+msgstr "Tento rok"
 
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
-msgstr "Introduce un valor..."
+msgstr "Zadejte hodnotu..."
 
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:90
 msgid "Enter a default value..."
-msgstr "Introduce un valor predeterminado..."
+msgstr "Zadejte výchozí hodnotu..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
 #: frontend/src/metabase/containers/Form.jsx:307
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
-msgstr "Ha ocurrido un error"
+msgstr "Nastala chyba"
 
 #: frontend/src/metabase/public/components/PublicNotFound.jsx:11
 msgid "Not found"
-msgstr "No encontrado"
+msgstr "Nenalezeno"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:82
 msgid "You’ve made changes that need to be published before they will be reflected in your application embed."
-msgstr "Ha realizado cambios que deben publicarse antes de que se vean reflejados en la inserción de la aplicación."
+msgstr "Provedli jste změny, které je třeba zveřejnit dříve, než se projeví vložení ve vaší aplikaci."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:83
 msgid "You will need to publish this {0} before you can embed it in another application."
-msgstr "Tendrás que publicar este {0} antes de poder incrustarlo en otra aplicación."
+msgstr "Před vložením do jiné aplikace budete muset publikovat {0}."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:92
 msgid "Discard Changes"
-msgstr "Descartar Cambios"
+msgstr "Zrušit změny"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:99
 msgid "Updating..."
-msgstr "Actualizando..."
+msgstr "Aktualizuji..."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:100
 msgid "Updated"
-msgstr "Actualizado"
+msgstr "Aktualizováno"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:101
 msgid "Failed!"
-msgstr "¡Ha fallado!"
+msgstr "Selhalo!"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:102
 msgid "Publish"
-msgstr "Publicar"
+msgstr "Publikovat"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:111
 #: frontend/src/metabase/visualizations/lib/settings/column.js:345
 msgid "Code"
-msgstr "Código"
+msgstr "Kód"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:296
 msgid "Style"
-msgstr "Estilo"
+msgstr "Styl"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
-msgstr "¿Qué parámetros pueden usar los usuarios de este embebido?"
+msgstr "Které parametry mohou uživatelé použít ve vloženém objektu?"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
-msgstr "Este {0} aún no tiene parámetros para configurar."
+msgstr "{0} zatím nemá žádné parametry na konfiguraci."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
-msgstr "Editable"
+msgstr "Editovatelné"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
-msgstr "Bloqueado"
+msgstr "Zamknuté"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:113
 msgid "Preview Locked Parameters"
-msgstr "Vista previa de los parámetros bloqueados"
+msgstr "Náhled uzamčených parametrů"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
-msgstr "Intenta pasar algunos valores a tus parámetros bloqueados aquí. Tu servidor tendrá que proporcionar los valores reales en el token firmado al usar esto de manera real."
+msgstr "Zkuste zde zadat některé hodnoty vašich uzamčených parametrů. Váš server bude muset poskytnout skutečné hodnoty v podepsaném tokenu, když se to reálně použije."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
-msgstr "Zona peligrosa"
+msgstr "Nebezpečná zóna"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
-msgstr "Esto deshabilitará la incrustación para este {0}."
+msgstr "Tímto zakážete vkládání pro toto {0}."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
-msgstr "No publicar"
+msgstr "Zrušit sdílení"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:17
 msgid "Light"
-msgstr "Claro"
+msgstr "Světlý"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:18
 msgid "Dark"
-msgstr "Oscuro"
+msgstr "Tmavý"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:37
 msgid "Border"
-msgstr "Borde"
+msgstr "Rám"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:62
 msgid "To embed this {0} in your application:"
-msgstr "Para insertar este {0} en tu aplicación"
+msgstr "Vložení objektu {0} do vaší aplikace:"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:64
 msgid "Insert this code snippet in your server code to generate the signed embedding URL "
-msgstr "Inserta este fragmento de código en tu código de servidor para generar la URL de inserción firmada"
+msgstr "Chcete-li vygenerovat podepsanou webovou adresu na vložení, vložte tuto část kódu do kódu serveru "
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:87
 msgid "Then insert this code snippet in your HTML template or single page app."
-msgstr "A continuación, inserta este fragmento de código en tu plantilla HTML o aplicación de una sola página."
+msgstr "Potom vložte tuto část kódu do HTML šablony nebo do aplikace."
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:94
 msgid "Embed code snippet for your HTML or Frontend Application"
-msgstr "Incrusta este fragmento de código en tu aplicación"
+msgstr "Vložte část kódu do HTML nebo do prezentační aplikace."
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:101
 msgid "More {0}"
-msgstr "Más {0}"
+msgstr "Více {0}"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:103
 msgid "examples on GitHub"
-msgstr "ejemplos en GitHub"
+msgstr "příklady na GitHubu"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
-msgstr "Habilitar compartir"
+msgstr "Zapnout sdílení"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
-msgstr "¿Deshabilitar este enlace público?"
+msgstr "Vypnout tento veřejný odkaz?"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
-msgstr "Esto hará que el enlace existente deje de funcionar. Puedes volver a habilitarlo, pero cuando lo hagas será un enlace diferente."
+msgstr "To způsobí, že stávající odkaz přestane fungovat. Můžete ho znovu povolit, ale když to uděláte, bude to už jiný odkaz."
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
-msgstr "Enlace público"
+msgstr "Veřejný odkaz"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
-msgstr "Comparte este {0} con personas que no tienen una cuenta de Metabase usando la siguiente URL:"
+msgstr "Sdílejte {0} s lidmi, kteří nemají účet metabase pomocí URL adresy uvedené níže:"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
-msgstr "Incrustación pública"
+msgstr "Veřejné vložení"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
-msgstr "Incrusta este {0} en publicaciones de blogs o páginas web al copiar y pegar este fragmento:"
+msgstr "Zkopírujte a vložte tuto část kódu: {0} do blogu nebo webových stránek:"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
-msgstr "Incrustar este {0} en una aplicación"
+msgstr "Vložte {0} do aplikace"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
-msgstr "Al integrar con tu servidor de aplicaciones, puedes proporcionar un/a {0} segura limitada a un usuario específico, cliente, organización, etc."
+msgstr "Integrací s kódem aplikačního serveru můžete poskytnout zabezpečené statistiky {0} omezeny na konkrétního uživatele, zákazníka, organizaci atd."
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
-msgstr "Eliminar adjunto"
+msgstr "Odstraňte přílohu"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
-msgstr "Adjuntar archivo con resultados"
+msgstr "Přiložte soubor s výsledky"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
-msgstr "Esta pregunta se añadirá como un archivo adjunto"
+msgstr "Tato otázka se přidá jako příloha k souboru"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
-msgstr "Esta pregunta no estará incluida en tu Pulso"
+msgstr "Tato otázka nebude zahrnuta do vašeho pulzu"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
-msgstr "Este pulso ya no se enviará por correo electrónico a la dirección {1}"
+msgstr "Tento pulz již nebude doručován emailem na adresu {0} {1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
-msgstr[0] "{0} dirección"
-msgstr[1] "{0} direcciones"
+msgstr[0] "{0} adresa"
+msgstr[1] "{0} adresy"
+msgstr[2] "{0} adres"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:102
 msgid "Slack channel {0} will no longer get this pulse {1}"
-msgstr "El canal Slack {0} ya no recibirá este pulso {1}"
+msgstr "Slack kanál {0} už tento pulz nedostane {1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
-msgstr "El canal {0} ya no recibirá este pulso {1}"
+msgstr "Kanál {0} už tento pulz nedostane {1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
-msgstr "Edita un pulso"
+msgstr "Upravit pulz"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
-msgstr "¿Qué es un Pulso?"
+msgstr "Co je pulz?"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
-msgstr "Lo tengo"
+msgstr "Mám to"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
-msgstr "¿A dónde deberían ir estos datos?"
+msgstr "Kam mají tyto data jít?"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
-msgstr "Desarchivando…"
+msgstr "Vracím zpět..."
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
-msgstr "Ha fallado la recuperación"
+msgstr "Vrácení zpět selhalo"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
-msgstr "Desarchivado"
+msgstr "Nearchivované"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
-msgstr "Crea un pulso"
+msgstr "Vytvořit pulz"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:91
 msgid "Attachment"
-msgstr "Adjunto"
+msgstr "Příloha"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:105
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:112
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
-msgstr "Aviso"
+msgstr "Pozor"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:106
 msgid "We'll show the first 10 columns and 20 rows of this table in your Pulse. If you email this, we'll add a file attachment with all columns and up to 2,000 rows."
-msgstr "Mostraremos las primeras 10 columnas y 20 filas de esta tabla en tu Pulso. Si lo envías por correo electrónico, añadiremos un archivo adjunto con todas las columnas y hasta 2.000 filas."
+msgstr "Ve vašem pulzu zobrazíme prvních 10 sloupců a 20 řádků této tabulky. Pokud to pošlete e-mailem, přidáme soubor jako přílohu se všemi sloupci a až 2 000 řádky."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:113
 msgid "Raw data questions can only be included as email attachments"
-msgstr "Las preguntas de datos brutos solo se pueden incluir como archivos adjuntos de correo electrónico"
+msgstr "Dotazy na surové data mohou být zahrnuty pouze jako e-mailové přílohy"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:120
 msgid "Looks like this pulse is getting big"
-msgstr "Parece que este pulso está creciendo mucho"
+msgstr "Zdá se že tento pulz narůstá"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:121
 msgid "We recommend keeping pulses small and focused to help keep them digestible and useful to the whole team."
-msgstr "Recomendamos mantener los pulsos pequeños y enfocados para ayudar a mantenerlos digeribles y útiles para todo el equipo."
+msgstr "Doporučujeme vám udržovat pulzy malé a věcné, aby snadno srozumitelné a užitečné pro celý tým."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:161
 #: frontend/src/metabase/query_builder/components/view/View.jsx:133
 msgid "Pick your data"
-msgstr "Elige tus datos"
+msgstr "Vyberte svoje data"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:163
 msgid "Choose questions you'd like to send in this pulse"
-msgstr "Elige las preguntas que te gustaría enviar en este pulso"
+msgstr "Vyberte otázky, které chcete poslat v tomto pulzu"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
 msgid "Emails"
-msgstr "Emails"
+msgstr "Emaily"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
 msgid "Slack messages"
-msgstr "Mensajes Slack"
+msgstr "Zprávy pro Slack"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
-msgstr "Enviado"
+msgstr "Odeslat"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
-msgstr "{0} se enviará a las"
+msgstr "{0} bude odeslaný na"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
-msgstr "Mensajes"
+msgstr "Zprávy"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
-msgstr "Enviar email ahora"
+msgstr "Nyní odešlete email"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
-msgstr "Enviar a {0} ahora"
+msgstr "Nyní odešlete {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
-msgstr "Enviando…"
+msgstr "Odesílám..."
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
-msgstr "Ha fallado el envío"
+msgstr "Odeslání selhalo"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
-msgstr "No se envió porque el pulso no tiene resultados."
+msgstr "Neodeslali jsme, protože pulz nemá žádné výsledky."
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
-msgstr "Pulso enviado"
+msgstr "Pulz byl odeslaný"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
-msgstr "{0} debe ser configurado por un administrador."
+msgstr "{0} musí být nastaven správcem."
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:299
 msgid "Slack"
@@ -4592,172 +4591,173 @@ msgstr "Slack"
 
 #: frontend/src/metabase/pulse/components/PulseEditCollection.jsx:12
 msgid "Which collection should this pulse live in?"
-msgstr "¿En qué colección debería estar este pulso?"
+msgstr "V které sbírce by měl tento pulz běžet?"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:35
 msgid "Name your pulse"
-msgstr "Nombra tu pulso"
+msgstr "Pojmenujte pulz"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:37
 msgid "Give your pulse a name to help others understand what it's about"
-msgstr "Dale un nombre a tu pulso para ayudar a otros a entender de qué se trata"
+msgstr "Pojmenujte svůj pulz aby ostatní věděli o čem je"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:49
 msgid "Important metrics"
-msgstr "Métricas importantes"
+msgstr "Důležité metriky"
 
 #: frontend/src/metabase/pulse/components/PulseEditSkip.jsx:22
 msgid "Skip if no results"
-msgstr "Omitir si no hay resultados"
+msgstr "Přeskočit pulz pokud nemá výsledky"
 
 #: frontend/src/metabase/pulse/components/PulseEditSkip.jsx:24
 msgid "Skip a scheduled Pulse if none of its questions have any results"
-msgstr "Omitir un pulso programado si ninguna de sus preguntas tiene resultado"
+msgstr "Přeskočit naplánovaný pulz, pokud žádná z jeho otázek nemá výsledky"
 
 #: frontend/src/metabase/pulse/components/RecipientPicker.jsx:65
 msgid "Enter email addresses you'd like this data to go to"
-msgstr "Introduce las direcciones de correo electrónico a las que quieres que vayan estos datos"
+msgstr "Zadejte emailové adresy, na které chcete tyto data poslat"
 
 #: frontend/src/metabase/pulse/components/WhatsAPulse.jsx:16
 msgid "Help everyone on your team stay in sync with your data."
-msgstr "Ayuda a todos los de tu equipo a mantenerse sincronizados con tus datos."
+msgstr "Pomozte všem v týmu aby byli synchronizováni s vašimi daty."
 
 #: frontend/src/metabase/pulse/components/WhatsAPulse.jsx:31
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
-msgstr "Los pulsos te permiten enviar datos de Metabase a correo electrónico o Slack en el horario que desees."
+msgstr "Pulzy umožňují odesílat data z Metabase na email nebo Slack na základě plánu a podle vašeho výběru."
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "After {0}"
-msgstr "Después de {0}"
+msgstr "Po {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 msgid "Before {0}"
-msgstr "Antes de {0}"
+msgstr "Před {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
-msgstr "Vacío"
+msgstr "Je prázdný"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
-msgstr "No Vacío"
+msgstr "Není prázdný"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
-msgstr "Todo el Tiempo"
+msgstr "Vždy"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
 msgid "Apply"
-msgstr "Aplicar"
+msgstr "Aplikovat"
 
 #: frontend/src/metabase/modes/components/actions/CommonMetricsAction.jsx:21
 msgid "View {0}"
-msgstr "Ver {0}"
+msgstr "Zobrazit {0}"
 
 #: frontend/src/metabase/modes/components/actions/CompareWithTable.jsx:29
 msgid "Compare this with all rows in the table"
-msgstr "Compara esto con todas las filas en la tabla"
+msgstr "Porovnejte to se všemi řádky v tabulce"
 
 #: frontend/src/metabase/modes/components/actions/CompoundQueryAction.jsx:14
 msgid "Analyze the results of this Query"
-msgstr "Analiza los resultados de esta consulta"
+msgstr "Analyzujte výsledky tohoto dotazu"
 
 #: frontend/src/metabase/modes/components/actions/CountByTimeAction.jsx:29
 msgid "Count of rows by time"
-msgstr "Número de filas por tiempo"
+msgstr "Počet řádků podle času"
 
 #: frontend/src/metabase/modes/components/drill/PivotByDrill.jsx:52
 msgid "Break out by {0}"
-msgstr "Distribuir por {0}"
+msgstr "Rozbor podle {0}"
 
 #: frontend/src/metabase/modes/components/actions/SummarizeBySegmentMetricAction.jsx:36
 msgid "Summarize this segment"
-msgstr "Resume este segmento"
+msgstr "Sumarizujte tento segment"
 
 #: frontend/src/metabase/modes/components/actions/UnderlyingDataAction.jsx:14
 msgid "View this as a table"
-msgstr "Ver esto como una tabla"
+msgstr "Zobrazit to jako tabulku"
 
 #: frontend/src/metabase/modes/components/actions/UnderlyingRecordsAction.jsx:22
 msgid "View the underlying {0} records"
-msgstr "Ver los registros subyacentes de {0}"
+msgstr "Zobrazit základní záznamy {0}"
 
 #: frontend/src/metabase/modes/components/actions/XRayCard.jsx:20
 msgid "X-Ray this question"
-msgstr "Aplica rayos-X a esta pregunta"
+msgstr "Prozkoumej tuto otázku"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 msgid "X-ray {0} {1}"
-msgstr "Rayos-X {0} {1}"
+msgstr "Průzkum {0} {1}"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "these"
-msgstr "estos"
+msgstr "tyhle"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "this"
-msgstr "este"
+msgstr "toto"
 
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "Compare {0} {1} to the rest"
-msgstr "Compara {0} {1} con el resto"
+msgstr "Porovnejte {0} {1} se zbytkem"
 
 #: frontend/src/metabase/modes/components/drill/DistributionDrill.jsx:35
 msgid "Distribution"
-msgstr "Distribución"
+msgstr "Distribuce"
 
 #: frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx:38
 msgid "View details"
-msgstr "Ver detalles"
+msgstr "Zobrazit detaily"
 
 #: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
-msgstr "Ver los {1} de {0}"
+msgstr "Zobrazit {0} {1}"
 
 #: frontend/src/metabase/modes/components/drill/SortAction.jsx:42
 msgid "Ascending"
-msgstr "Ascendente"
+msgstr "Vzestupně"
 
 #: frontend/src/metabase/modes/components/drill/SortAction.jsx:50
 msgid "Descending"
-msgstr "Descendente"
+msgstr "Sestupně"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js:43
 msgid "over time"
-msgstr "a través del tiempo."
+msgstr "v průběhu času"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:22
 msgid "Avg"
-msgstr "Media"
+msgstr "Průměr"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:34
 msgid "Distincts"
-msgstr "Distintos"
+msgstr "Jedinečné"
 
 #: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:55
 msgid "View this {0}"
 msgid_plural "View these {0}"
-msgstr[0] "Ver el {0}"
-msgstr[1] "Ver estos {0}"
+msgstr[0] "Zobrazit tento {0}"
+msgstr[1] "Zobrazit tyto {0}"
+msgstr[2] "Zobrazit těchto {0}"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
-msgstr "Ampliar"
+msgstr "přiblížit"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
-msgstr "Expresión Personalizada"
+msgstr "Vlastní výraz"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Common Metrics"
-msgstr "Métricas Comunes"
+msgstr "Běžné metriky"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:209
 msgid "Metabasics"
@@ -4765,275 +4765,275 @@ msgstr "Metabasics"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
-msgstr "Nombre (opcional)"
+msgstr "Jméno (volitelné)"
 
 #: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:156
 msgid "Choose an aggregation"
-msgstr "Elige una agregación"
+msgstr "Vyberte agregaci"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:100
 msgid "Set up your own alert"
-msgstr "Configura tu propia alerta"
+msgstr "Nastavte si vlastní upozornění"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
-msgstr "Dando de baja..."
+msgstr "Odhlašuji z odběru..."
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
-msgstr "Error al darse de baja"
+msgstr "Odhlášení odběru selhalo"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
-msgstr "Darse de baja"
+msgstr "Odhlášení odběru"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
-msgstr "Sin canal"
+msgstr "Žádný kanál"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
-msgstr "De acuerdo, has sido dado de baja"
+msgstr "Dobře, byl jste odhlášen"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
-msgstr "Estás recibiendo las alertas de {0}"
+msgstr "Dostáváte upozornění {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
-msgstr "{0} has configurado una alerta"
+msgstr "{0} nastavit upozornění"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:160
 msgid "alerts"
-msgstr "alertas"
+msgstr "upozornění"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:183
 msgid "Let's set up your alert"
-msgstr "Vamos a configurar tu alerta"
+msgstr "Vytvoříme vaše upozornění"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:214
 msgid "The wide world of alerts"
-msgstr "El amplio mundo de las alertas"
+msgstr "Široké možnosti upozornění"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:215
 msgid "There are a few different kinds of alerts you can get"
-msgstr "Hay algunos tipos diferentes de alertas que puedes obtener"
+msgstr "Existuje několik různých druhů upozornění, které můžete získat"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:229
 msgid "When a raw data question {0}"
-msgstr "Cuando una pregunta de datos {0}"
+msgstr "Kdy je dotaz na surové data {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:230
 msgid "returns any results"
-msgstr "arroja resultados"
+msgstr "vrátí nějaké výsledky"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:241
 msgid "When a line or bar {0}"
-msgstr "Cuando una línea o barra {0}"
+msgstr "Když linie nebo sloupec {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:242
 msgid "crosses a goal line"
-msgstr "supera un objetivo"
+msgstr "dosáhne cíle"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:253
 msgid "When a progress bar {0}"
-msgstr "Cuando una barra de progreso {0}"
+msgstr "Když sloupec {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:254
 msgid "reaches its goal"
-msgstr "alcanza su objetivo"
+msgstr "dosáhne svůj cíl"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:262
 msgid "Set up an alert"
-msgstr "Crea una alerta"
+msgstr "Nastavte upozornění"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:331
 msgid "Edit your alert"
-msgstr "Edita tu alerta"
+msgstr "Upravte své upozornění"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:331
 msgid "Edit alert"
-msgstr "Editar alerta"
+msgstr "Upravit upozornění"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
-msgstr "Esta alerta ya no se enviará por correo electrónico a {0}."
+msgstr "Toto upozornění již nebude odesíláno emailem na adresu {0}."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
-msgstr "El canal Slack {0} ya no recibirá esta alerta."
+msgstr "Slack kanál {0} již nebude dostávat toto upozornění."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
-msgstr "El canal {0} ya no recibirá esta alerta."
+msgstr "Kanál {0} již nebude dostávat toto upozornění."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
-msgstr "Elimina esta alerta"
+msgstr "Odstranit toto upozornění"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
-msgstr "Detener el envío y elimina esta alerta. No se puede deshacer, así que ten cuidado."
+msgstr "Zastavit odesílání upozornění a odstranit ho. Tento krok nelze vrátit zpět, takže buďte opatrní."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
-msgstr "¿Eliminar esta alerta?"
+msgstr "Smazat toto upozornění?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
-msgstr "Avísame cuando la línea…"
+msgstr "Upozornit mě, když bude linie..."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
-msgstr "Avísame cuando la barra de progreso…"
+msgstr "Upozornit mě, když bude sloupec..."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
-msgstr "Va por encima de la línea de objetivo"
+msgstr "Překročí cílovou linii"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
-msgstr "Llega al objetivo"
+msgstr "Dosáhne cíle"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
-msgstr "Va por debajo de la línea de objetivo"
+msgstr "Spadá pod cílovou linii"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
-msgstr "Va por debajo del objetivo"
+msgstr "Spadá pod cíl"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
-msgstr "¿La primera vez que cruza, o cada vez?"
+msgstr "Pouze poprvé nebo vždy?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
-msgstr "¿La primera vez que alcanza el objetivo, o cada vez?"
+msgstr "Pouze poprvé, když dosáhne cíle, nebo vždy?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
-msgstr "La primera vez"
+msgstr "Poprvé"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
-msgstr "Cada vez"
+msgstr "Vždy"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
-msgstr "¿A dónde quieres enviar estas alertas?"
+msgstr "Kam chcete poslat tato upozornění?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
-msgstr "Envía emails de alerta a:"
+msgstr "Emailové upozornění na adresu:"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
-msgstr "{0} Las alertas basadas en objetivos aún no son compatibles para gráficos con más de una línea, por lo que esta alerta se enviará siempre que el gráfico tenga {1}."
+msgstr "{0} Upozornění na základě cíle zatím nejsou podporovány pro grafy s více než jedním řádkem, takže toto upozornění se odešle vždy, když graf má {1}."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 #: src/metabase/pulse.clj
 msgid "results"
-msgstr "resultados"
+msgstr "výsledek"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
-msgstr "{0} Este tipo de alerta es más útil cuando tu pregunta {1} no arroja ningún resultado, pero quieres saber cuándo lo hace."
+msgstr "{0} Tento druh upozornění je nejužitečnější, když vaše uložená otázka nevrátí žádné výsledky, ale chcete vědět když to nastane."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
-msgstr "Consejo:"
+msgstr "Tip"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
-msgstr "generalmente"
+msgstr "obvykle"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:61
 msgid "Pick a segment or table"
-msgstr "Elige un segmento o tabla"
+msgstr "Vyberte segment nebo tabulku"
 
 #: frontend/src/metabase/entities/databases/forms.js:260
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
-msgstr "Selecciona una base de datos"
+msgstr "Vyberte databázi"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:85
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:31
 msgid "Select..."
-msgstr "Seleccionar..."
+msgstr "Vyberte..."
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
 msgid "Select a table"
-msgstr "Selecciona una tabla"
+msgstr "Vyberte tabulku"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:926
 msgid "No tables found in this database."
-msgstr "No se encontraron tablas en esta base de datos."
+msgstr "V databázi nebyly nalezeny tabulky."
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:901
 msgid "Is a question missing?"
-msgstr "¿Falta una pregunta?"
+msgstr "Chybí otázka?"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:909
 msgid "Learn more about nested queries"
-msgstr "Obtén más información sobre consultas anidadas"
+msgstr "Více informací o vnořených dotazech"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:951
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:40
 msgid "Fields"
-msgstr "Campos"
+msgstr "Pole"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:977
 msgid "No segments were found."
-msgstr "No se encontraron segmentos"
+msgstr "Nebyl nalezen žádný segment."
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:1000
 msgid "Find a segment"
-msgstr "Encuentra un segmento"
+msgstr "Najít segment"
 
 #: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
-msgstr "Ver menos"
+msgstr "Zobrazit více"
 
 #: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
-msgstr "Ver más"
+msgstr "Zobrazit méně"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:112
 msgid "Pick a field to sort by"
-msgstr "Elige un campo para ordenar por"
+msgstr "Vyberte pole podle kterého se bude řadit"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
-msgstr "Ordenar"
+msgstr "Seřadit"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
-msgstr "Límite de filas"
+msgstr "Limit řádků"
 
 #: frontend/src/metabase/query_builder/components/FieldName.jsx:72
 msgid "Unknown Field"
-msgstr "Campo Desconocido"
+msgstr "Neznámé pole"
 
 #: frontend/src/metabase/query_builder/components/FieldName.jsx:75
 msgid "field"
-msgstr "campo"
+msgstr "pole"
 
 #: frontend/src/metabase/query_builder/components/Filter.jsx:117
 msgid "Matches"
-msgstr "Conincidencias"
+msgstr "Shody"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:135
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
-msgstr "Añade filtros para limitar tu respuesta"
+msgstr "Přidejte filtry, abyste zúžily výběr"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
-msgstr "Añadir una agrupación"
+msgstr "Přidat seskupení"
 
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:37
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:313
@@ -5052,107 +5052,107 @@ msgstr "Añadir una agrupación"
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Data"
-msgstr "Datos"
+msgstr "Data"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:340
 msgid "Filtered by"
-msgstr "Filtrado por"
+msgstr "Filtrováno podle"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:357
 msgid "View"
-msgstr "Ver"
+msgstr "Zobrazit"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:374
 msgid "Grouped By"
-msgstr "Agrupado por"
+msgstr "Seskupeno podle"
 
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
-msgstr "Ninguno"
+msgstr "Žádné"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
 msgid "This question is written in {0}."
-msgstr "Esta pregunta está escrita en {0}"
+msgstr "Tato otázka je napsána v {0}."
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
-msgstr "Esconder Editor"
+msgstr "Skrýt editor"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
-msgstr "Esconder Consulta"
+msgstr "Skrýt dotaz"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
 msgid "Open Editor"
-msgstr "Abrir Editor"
+msgstr "Otevřít editor"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:482
 msgid "Show Query"
-msgstr "Mostrar Consulta"
+msgstr "Zobraz dotaz"
 
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "This metric has been retired.  It's no longer available for use."
-msgstr "Esta métrica ha sido retirada. Ya no está disponible para su uso."
+msgstr "Tato metrika již byla zrušena. Již není možno ji použít."
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:34
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:46
 msgid "Download full results"
-msgstr "Descarga los resultados completos"
+msgstr "Stáhnout všechny výsledky"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:35
 msgid "Download this data"
-msgstr "Descargar esta información"
+msgstr "Stáhnout tato data"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:46
 msgid "Warning"
-msgstr "Aviso"
+msgstr "Varování"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
-msgstr "Tu respuesta tiene una gran cantidad de filas, por lo que podría tardar un tiempo en descargarse."
+msgstr "Odpověď obsahuje velké množství řádků, takže stažení může chvíli trvat."
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
-msgstr "El tamaño máximo de descarga es de 1 millón de filas."
+msgstr "Maximální velikost souboru ke stažení je 1 milión řádků."
 
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:11
 msgid "Edit question"
-msgstr "Editar pregunta"
+msgstr "Upravit dotaz"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:249
 msgid "SAVE CHANGES"
-msgstr "GUARDAR CAMBIOS"
+msgstr "ULOŽIT ZMĚNY"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:263
 msgid "CANCEL"
-msgstr "CANCELAR"
+msgstr "ZRUŠIT"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:276
 msgid "Move question"
-msgstr "Mover pregunta"
+msgstr "Přesunout dotaz"
 
 #: frontend/src/metabase/query_builder/components/QueryModals.jsx:155
 msgid "Which collection should this be in?"
-msgstr "¿En qué colección debería estar esto?"
+msgstr "Která sbírka to obsahuje?"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:85
 #: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
-msgstr "Variables"
+msgstr "Proměnné"
 
 #: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
-msgstr "Conoce tus datos"
+msgstr "Dozvědět se více o vašich datech"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:460
 msgid "Alerts are on"
-msgstr "Las alertas están activadas"
+msgstr "Upozornění jsou zapnuté"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:522
 msgid "started from"
-msgstr "iniciado desde"
+msgstr "pochází z"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:48
 msgid "SQL"
@@ -5160,169 +5160,170 @@ msgstr "SQL"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:48
 msgid "native query"
-msgstr "consulta nativa"
+msgstr "nativní dotaz"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:52
 msgid "Not Supported"
-msgstr "No Soportado"
+msgstr "Není podporováno"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:58
 msgid "View the {0}"
-msgstr "Ver el {0}"
+msgstr "Zobrazit {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:59
 msgid "Switch to {0}"
-msgstr "Cambiar a {0}"
+msgstr "Přepnout na {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:62
 msgid "Switch to Builder"
-msgstr "Cambiar al Editor"
+msgstr "Přepnout na Builder"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:87
 msgid "{0} for this question"
-msgstr "{0} de esta pregunta"
+msgstr "{0} pro tuto otázku"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:111
 msgid "Convert this question to {0}"
-msgstr "Convertir esta pregunta en {0}"
+msgstr "Proměnit tuto otázku na {0}"
 
 #: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:16
 msgid "This question will take approximately {0} to refresh"
-msgstr "Esta pregunta se actualizará en aproximadamente {0}"
+msgstr "Aktualizace této otázky bude trvat přibližně {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
-msgstr "Actualizado hace {0}"
+msgstr "Aktualizováno {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:141
 msgid "row"
 msgid_plural "rows"
-msgstr[0] "fila"
-msgstr[1] "filas"
+msgstr[0] "řádek"
+msgstr[1] "řádky"
+msgstr[2] "řádků"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:148
 msgid "Showing first {0} {1}"
-msgstr "Mostrando primeras {0} {1}"
+msgstr "Zobrazit prvních {0} {1}"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:151
 msgid "Showing {0} {1}"
-msgstr "Mostrando {0} {1}"
+msgstr "Zobrazuji {0} {1}"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
-msgstr "Haciendo ciencia"
+msgstr "Provádím výpočty"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
-msgstr "Si me das algunos datos puedo mostrarte algo genial. ¡Ejecuta una consulta!"
+msgstr "Pokud mi dáte nějaká data, ukážu vám něco super. Spusťte dotaz!"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:299
 msgid "How do I use this thing?"
-msgstr "¿Cómo uso esta cosa?"
+msgstr "Jak mohu tuto věc použít?"
 
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:45
 msgid "Get Answer"
-msgstr "Obtener Respuesta"
+msgstr "Získat výsledek"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:12
 msgid "It's okay to play around with saved questions"
-msgstr "Puedes jugar con preguntas guardadas"
+msgstr "Je v pořádku pohrát si s uloženými dotazy"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:14
 msgid "You won't make any permanent changes to a saved question unless you click the edit icon in the top-right."
-msgstr "No harás ningún cambio permanente en una pregunta guardada a menos que hagas clic en el icono de edición en la esquina superior derecha."
+msgstr "V uložené otázce neuděláte trvalé změny, pokud nekliknete na ikonu úprav v pravém horním rohu."
 
 #: frontend/src/metabase/query_builder/components/SearchBar.jsx:28
 msgid "Search for"
-msgstr "Buscar"
+msgstr "Hledat"
 
 #: frontend/src/metabase/query_builder/components/SelectionModule.jsx:158
 msgid "Advanced..."
-msgstr "Avanzado..."
+msgstr "Pokročilé..."
 
 #: frontend/src/metabase/query_builder/components/SelectionModule.jsx:167
 msgid "Sorry. Something went wrong."
-msgstr "Lo siento. Algo salió mal."
+msgstr "Promiňte. Něco se pokazilo."
 
 #: frontend/src/metabase/query_builder/components/TimeGroupingPopover.jsx:40
 msgid "Group time by"
-msgstr "Agrupar tiempo por"
+msgstr "Sloučit čas podle"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
-msgstr "Tu pregunta tardó demasiado tiempo"
+msgstr "Vaše otázka se zpracovává příliš dlouho"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
-msgstr "No obtuvimos una respuesta de tu base de datos a tiempo, así que tuvimos que parar.Puedes volver a intentarlo en un minuto, o si el problema persiste, puedes enviar un correo electrónico a un administrador para avisarle."
+msgstr "Nedostali jsme včas odpověď z vaší databáze, takže se dotaz musel ukončit. Můžete to zkusit za minutu znovu nebo pokud problém přetrvává, můžete kontaktovat správce prostřednictvím emailu a informovat ho."
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
-msgstr "Estamos experimentando problemas con el servidor"
+msgstr "Vyskytly se problémy se serverem"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
-msgstr "Intenta actualizar la página después de esperar uno o dos minutos. Si el problema persiste, te recomendamos que te pongas en contacto con un administrador."
+msgstr "Zkuste stránku obnovit po jedné nebo dvou minutách. Pokud problém přetrvává, doporučujeme vám obrátit se na správce."
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
-msgstr "Hubo un problema con tu pregunta"
+msgstr "S vaší otázkou se vyskytl problém"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
-msgstr "La mayoría de las veces esto es causado por una selección no válida o un valor de entrada incorrecto.Revisa tus entradas y vuelva a intentar la consulta."
+msgstr "Většinou je to způsobeno neplatným výběrem nebo nesprávnou vstupní hodnotou. Zkontrolujte své vstupy a zkuste znovu zadat dotaz."
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
-msgstr "Esta puede ser la respuesta que estás buscando. De lo contrario, intenta eliminar o cambiar tus filtros para que sean menos específicos."
+msgstr "Toto může být výsledek, který hledáte. Pokud ne, zkuste filtry odstranit nebo změnit tak, aby výsledek přesnější."
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
-msgstr "También puedes {0} cuando hay algunos resultados."
+msgstr "Můžete také {0}, pokud máte nějaké výsledky."
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
-msgstr "recibir una alerta"
+msgstr "získat upozornění"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:77
 msgid "Back to last run"
-msgstr "Volver a la última ejecución"
+msgstr "Zpět na poslední spuštění"
 
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:194
 msgid "Visualization"
-msgstr "Visualización"
+msgstr "Vizualizace"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
 msgid "No description set."
-msgstr "Sin descripción"
+msgstr "Popis nenastaven."
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
 msgid "Use for current question"
-msgstr "Usar para la pregunta actual"
+msgstr "Použít pro aktuální otázku"
 
 #: frontend/src/metabase/reference/components/UsefulQuestions.jsx:14
 msgid "Potentially useful questions"
-msgstr "Preguntas potencialmente útiles"
+msgstr "Potenciálně užitečné otázky"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
-msgstr "Agrupar por {0}"
+msgstr "Seskupeno podle {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:165
 msgid "Sum of all values of {0}"
-msgstr "Suma de todos los valores de {0}"
+msgstr "Součet všech hodnot z {0}"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:63
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:51
 msgid "All distinct values of {0}"
-msgstr "Todos los valores distintos de {0}"
+msgstr "Všechny jedinečné hodnoty z {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
-msgstr "Número de {0} agrupadas por {1}"
+msgstr "Počet {0} seskupených podle {1}"
 
 #: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
@@ -5334,335 +5335,335 @@ msgstr "Número de {0} agrupadas por {1}"
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:24
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:23
 msgid "Data Reference"
-msgstr "Referencia de Datos"
+msgstr "Odkaz na data"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:13
 msgid "Learn more about your data structure to ask more useful questions"
-msgstr "Aprende más sobre tu estructura de datos para hacer preguntas más útiles"
+msgstr "Přečtěte si další informace o struktuře dat a vytvořte další užitečné otázky"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
-msgstr "No se pudieron encontrar los metadatos de la tabla antes de crear una nueva pregunta"
+msgstr "Nelze najít metadata tabulky před vytvořením nové otázky"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
-msgstr "Ver {0}"
+msgstr "Zobrazit {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
 msgid "Metric Definition"
-msgstr "Definición de Métrica"
+msgstr "Definice metriky"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
-msgstr "Filtrar por {0}"
+msgstr "Filtrované podle {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:38
 msgid "Number of {0}"
-msgstr "Número de {0}"
+msgstr "Počet {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:48
 msgid "See all {0}"
-msgstr "Ver todos los {0}"
+msgstr "Zobrazit všechny {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
 msgid "Segment Definition"
-msgstr "Definición de Segmento"
+msgstr "Definice segmentu"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
 msgid "An error occurred loading the table"
-msgstr "Se produjo un error al cargar la tabla"
+msgstr "Chyba při načítání tabulky"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:74
 msgid "See the raw data for {0}"
-msgstr "Ver los datos de {0}"
+msgstr "Ukaž surové data pro {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
 msgid "More"
-msgstr "Más"
+msgstr "Více"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:216
 msgid "Invalid expression"
-msgstr "Expresión inválida"
+msgstr "Nesprávný výraz"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:282
 msgid "unknown error"
-msgstr "error no controlado"
+msgstr "neznámá chyba"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:53
 msgid "Field formula"
-msgstr "Fórmula de campo"
+msgstr "Vzorec pole"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:64
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
-msgstr "Piensa en esto como algo parecido a escribir una fórmula en un programa de hoja de cálculo: puedes usar números, campos de esta tabla, símbolos matemáticos como + y algunas funciones. Así puedes escribir algo como Subtotal - Cost."
+msgstr "Uvažujte o tom, jakoby to bylo jako psaní vzorce v tabulkovém programu: můžete použít čísla, pole v této tabulce, matematické symboly jako + a některé funkce. Můžete tedy zadat něco jako Mezisoučet - Náklady."
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
 msgid "Learn more"
-msgstr "Aprende más"
+msgstr "Dozvědět se více"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:77
 msgid "Give it a name"
-msgstr "Dale un nombre"
+msgstr "Přidejte název"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
 msgid "Something nice and descriptive"
-msgstr "Algo agradable y descriptivo"
+msgstr "Něco pěkné a praktické"
 
 #: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:60
 msgid "Add a custom field"
-msgstr "Añadir un campo personalizado"
+msgstr "Přidejte vlastní pole"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:17
 msgid "Include {0}"
-msgstr "Incluir {0}"
+msgstr "Zahrnout {0}"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:19
 msgid "Case sensitive"
-msgstr "Distingue mayúsculas y minúsculas"
+msgstr "Rozlišují se malá a velká písmena"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:23
 msgid "today"
-msgstr "hoy"
+msgstr "dnes"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:24
 msgid "this week"
-msgstr "esta semana"
+msgstr "tento týden"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:25
 msgid "this month"
-msgstr "este mes"
+msgstr "tento měsíc"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:26
 msgid "this year"
-msgstr "este año"
+msgstr "tento rok"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:27
 msgid "this minute"
-msgstr "este minuto"
+msgstr "tuto minutu"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:28
 msgid "this hour"
-msgstr "esta hora"
+msgstr "tuto hodinu"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:290
 msgid "not implemented {0}"
-msgstr "{0} no está implementado"
+msgstr "není implementováno {0}"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:291
 msgid "true"
-msgstr "verdadero"
+msgstr "pravda"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:291
 msgid "false"
-msgstr "falso"
+msgstr "nepravda"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
-msgstr "Añadir filtro"
+msgstr "Přidat filtr"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
 msgid "Item"
-msgstr "Elemento"
+msgstr "Položka"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
-msgstr "Anterior"
+msgstr "Předchozí"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
-msgstr "Actual"
+msgstr "Aktuální"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:257
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
-msgstr "Activado"
+msgstr "Zapnuté"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx:47
 msgid "Enter desired number"
-msgstr "Introduce el número deseado"
+msgstr "Zadejte požadované číslo"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:161
 msgid "Empty"
-msgstr "Vacío"
+msgstr "Prázdné"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:119
 msgid "Find a value"
-msgstr "Encuentra un valor"
+msgstr "Najít hodnotu"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:113
 msgid "Hide calendar"
-msgstr "Esconder calendario"
+msgstr "Skrýt kalendář"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:113
 msgid "Show calendar"
-msgstr "Mostrar calendario"
+msgstr "Zobrazit kalendář"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx:97
 msgid "You can enter multiple values separated by commas"
-msgstr "Puedes introducir varios valores separados por comas"
+msgstr "Můžete zadat více hodnot oddělených čárkami"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx:38
 msgid "Enter desired text"
-msgstr "Introduce el texto deseado"
+msgstr "Zadejte požadovaný text"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:210
 msgid "Try it"
-msgstr "Pruébalo"
+msgstr "Zkuste to"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:243
 msgid "What's this for?"
-msgstr "¿Para qué sirve esto?"
+msgstr "K čemu to slouží?"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:245
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
-msgstr "Las variables en las consultas nativas te permiten reemplazar dinámicamente los valores en tus consultas utilizando elementos de filtro o a través de la URL."
+msgstr "Proměnné v nativních dotazech umožňují dynamicky nahrazovat hodnoty v dotazech za využití filtrovacích widgetů nebo prostřednictvím URL adresy."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
-msgstr "{0} crea una variable en esta plantilla SQL llamada \"nombre_variable\". Puedes asignar tipos a las variables en el panel lateral, lo que cambia su comportamiento. Todos los tipos de variables que no sean \"Filtro de Campo\" provocarán automáticamente que se coloque un elemento de filtro en esta pregunta; con Filtros de Campo, esto es opcional. Cuando se rellena este elemento de filtro, ese valor reemplaza a la variable en la plantilla SQL."
+msgstr "{0} vytvoří proměnnou v této SQL šabloně, nazvanou jako \"název proměnné\". Proměnným mohou být v postranním panelu nastaveny typy, které mění jejich chování. U všech typů proměnných, mimo \"Filtru pole\", se na otázku automaticky umístí filtrovací widget, jen u Filtru pole je toto volitelné. Po vyplnění filtrovacího widgetu jeho hodnota nahradí proměnnou v SQL šabloně."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:259
 msgid "Field Filters"
-msgstr "Filtros de Campo"
+msgstr "Filtry pole"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
-msgstr "Darle a una variable el tipo \"Filtro de campo\" te permite vincular las tarjetas SQL con los elementos de filtro en los cuadros de mando o usar más tipos de elementos de filtro en tu pregunta de SQL. Una variable de filtro de campo inserta SQL similar a la generada por el generador de consultas GUI cuando se añaden filtros en columnas existentes."
+msgstr "Poskytnutím proměnné typu \"Filtr pole\" můžete propojit SQL karty s filtrovacími widgety na nástěnce nebo použít více typů filtrovacích widgetů na svůj SQL dotaz. Proměnná Filtr pole vloží SQL podobný té, který byl vytvořen v GUI tvůrci dotazů při přidávání filtrů do stávajících sloupců."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:264
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
-msgstr "Al añadir una variable de Filtro de campo, deberás asignarla a un campo específico. A continuación, puedes optar por mostrar un elemento de filtro en tu pregunta, pero incluso si no lo haces, ahora puedes asignar tu variable de Filtro de campo a un filtro de cuadro de mando al agregar esta pregunta al mismo. Los filtros de campo deben usarse dentro de una cláusula \"WHERE\"."
+msgstr "Když přidáváte proměnnou typu Filtr pole, budete ji muset mapovat na konkrétní pole. Pak se můžete rozhodnout, zda chcete ve své otázce zobrazit filtrovací widget, ale i když tak neučiníte, můžete během přidávání této otázky na nástěnku mapovat proměnnou typu Filtr pole s filtrem nástěnky. Filtry pole by se měly používat uvnitř klauzule \"WHERE\"."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:271
 msgid "Optional Clauses"
-msgstr "Cláusulas opcionales"
+msgstr "Volitelné klauzule"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:132
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
-msgstr "los corchetes alrededor de un {0} crean una cláusula opcional en la plantilla. Si se establece la \"variable\", entonces la cláusula completa se coloca en la plantilla. Si no, entonces se ignora toda la cláusula."
+msgstr "Závorky kolem {0} vytvoří volitelnou klauzuli v šabloně. Pokud je \"proměnná\" nastavena, celá klauzule se vloží do šablony. Pokud ne, celá klauzule se ignoruje."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:283
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
-msgstr "Para utilizar varias cláusulas opcionales, puedes incluir al menos una cláusula WHERE no opcional seguida de cláusulas opcionales que comiencen con \"AND\"."
+msgstr "Chcete-li použít vícero volitelných klauzulí, musíte zahrnout alespoň jednu povinnou WHERE klauzuli následovanou volitelnými klauzulemi začínajícími na \"AND\"."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:301
 msgid "Read the full documentation"
-msgstr "Lee la documentación completa"
+msgstr "Přečíst celou dokumentaci"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:133
 msgid "Filter label"
-msgstr "Filtro de Etiqueta"
+msgstr "Popis filtru"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:134
 msgid "Variable type"
-msgstr "Tipo de Variable"
+msgstr "Typ proměnné"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:143
 msgid "Text"
-msgstr "Texto"
+msgstr "Text"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
 msgid "Date"
-msgstr "Fecha"
+msgstr "Datum"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
 msgid "Field Filter"
-msgstr "Filtro de Campo"
+msgstr "Filtr pole"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Field to map to"
-msgstr "Campo para mapear a"
+msgstr "Pole na propojení s"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:180
 msgid "Filter widget type"
-msgstr "Tipo de filtro"
+msgstr "Typ filtrovacího widgetu"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
 msgid "Required?"
-msgstr "¿Obligatorio?"
+msgstr "Povinné?"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
 msgid "Default filter widget value"
-msgstr "Valor por defecto del filtro"
+msgstr "Výchozí hodnota filtrovacího widgetu"
 
 #: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
-msgstr "¿Archivar esta pregunta?"
+msgstr "Archivovat tuto otázku?"
 
 #: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
-msgstr "Esta pregunta se eliminará de cualquier cuadro de mando o pulso que lo usen."
+msgstr "Tato otázka bude odstraněna ze všech nástěnek nebo pulzů, které ji používají."
 
 #: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
 msgid "Question"
-msgstr "Pregunta"
+msgstr "Otázka"
 
 #: frontend/src/metabase/dashboard/components/AddToDashSelectQuestionModal.jsx:31
 msgid "Pick a question to add"
-msgstr "Elige una pregunta para añadir"
+msgstr "Vyberte otázku, kterou chcete přidat"
 
 #: frontend/src/metabase/reference/components/EditHeader.jsx:19
 msgid "You are editing this page"
-msgstr "Estás editando esta página"
+msgstr "Upravujete tuto stránku"
 
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:78
 #: frontend/src/metabase/reference/components/ReferenceHeader.jsx:45
 msgid "See this {0}"
-msgstr "Ver este {0}"
+msgstr "Zobrazit {0}"
 
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
-msgstr "Un subconjunto de"
+msgstr "Podmnožina"
 
 #: frontend/src/metabase/reference/components/Field.jsx:48
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:31
 msgid "Select a field type"
-msgstr "Selecciona un tipo de campo"
+msgstr "Vyberte typ pole"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:85
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:36
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:54
 msgid "No field type"
-msgstr "Sin tipo de campo"
+msgstr "Žádný typ pole"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/SummarizeStep.jsx:26
 msgid "by"
-msgstr "por"
+msgstr "podle"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
 #: frontend/src/metabase/reference/databases/FieldList.jsx:156
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:157
 msgid "Field type"
-msgstr "Tipo campo"
+msgstr "Typ pole"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
-msgstr "Selecciona una Clabe foránea"
+msgstr "Vyberte Cizí klíč"
 
 #: frontend/src/metabase/reference/components/Formula.jsx:56
 msgid "View the {0} formula"
-msgstr "Ver la fórmula de {0}"
+msgstr "Prohlédněte si vzorec {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:80
 msgid "Why this {0} is important"
-msgstr "Por qué este {0} es importante"
+msgstr "Proč je toto {0} důležité"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:81
 msgid "Why this {0} is interesting"
-msgstr "Por qué este {0} es interesante"
+msgstr "Proč je toto {0} zajímavé"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:87
 msgid "Nothing important yet"
-msgstr "Nada importante todavía"
+msgstr "Zatím nic důležité"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:172
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:237
@@ -5671,11 +5672,11 @@ msgstr "Nada importante todavía"
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:248
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:233
 msgid "Nothing interesting yet"
-msgstr "Nada interesante todavía"
+msgstr "Zatím nic zajímavé"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:93
 msgid "Things to be aware of about this {0}"
-msgstr "Cosas a tener en cuenta acerca de este {0}"
+msgstr "Věci, které by jste měli vědět o {0}"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:182
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:247
@@ -5684,77 +5685,77 @@ msgstr "Cosas a tener en cuenta acerca de este {0}"
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:258
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:243
 msgid "Nothing to be aware of yet"
-msgstr "Nada de lo que estar enterado todavía"
+msgstr "Nic co by jste zatím měli vědět"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:103
 msgid "Explore this metric"
-msgstr "Explora esta métrica"
+msgstr "Prozkoumejte tuto metriku"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:105
 msgid "View this metric"
-msgstr "Ver esta métrica"
+msgstr "Zobrazit tuto metriku"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:112
 msgid "By {0}"
-msgstr "Por {0}"
+msgstr "Podle {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:146
 msgid "Remove item"
-msgstr "Eliminar elemento"
+msgstr "Odebrat položku"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:155
 msgid "Why is this dashboard the most important?"
-msgstr "¿Por qué este cuadro de mando es el más importante?"
+msgstr "Proč je tato nástěnka nejdůležitější?"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:156
 msgid "What is useful or interesting about this {0}?"
-msgstr "¿Qué es útil o interesante sobre este {0}?"
+msgstr "Co je na tom užitečné nebo zajímavé {0}?"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:160
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:174
 msgid "Write something helpful here"
-msgstr "Escribe algo útil aquí"
+msgstr "Sem napište něco užitečného"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:169
 msgid "Is there anything users of this dashboard should be aware of?"
-msgstr "¿Hay algo que los usuarios de este cuadro de mando deben tener en cuenta?"
+msgstr "Je něco co by měli uživatelé této nástěnky vědět?"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:170
 msgid "Anything users should be aware of about this {0}?"
-msgstr "¿Hay alguna cosa que los usuarios deben saber sobre este {0}?"
+msgstr "Je něco co by měli uživatelé vědět o {0}?"
 
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:26
 msgid "Which 2-3 fields do you usually group this metric by?"
-msgstr "¿Con qué 2-3 campos se agrupa normalmente esta métrica?"
+msgstr "Které 2-3 pole obvykle v této metrice seskupujete?"
 
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:25
 msgid "This is the perfect place to start if you’re new to your company’s data, or if you just want to check in on what’s going on."
-msgstr "Este es el lugar perfecto para comenzar si eres nuevo en los datos de tu empresa, o si solo deseas verificar lo que está sucediendo."
+msgstr "Toto je ideální místo kde začít, pokud jste ve firemních datech nováček, nebo se chcete jen podívat na to, jak to funguje."
 
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:52
 msgid "Most useful fields to group this metric by"
-msgstr "Campos más útiles para agrupar esta métrica"
+msgstr "Nejužitečnější pole na seskupení této metriky podle"
 
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:32
 msgid "Reason for changes"
-msgstr "Motivo del cambio"
+msgstr "Důvod změn"
 
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:36
 msgid "Leave a note to explain what changes you made and why they were required"
-msgstr "Deja una nota para explicar qué cambios ha realizado y por qué fueron necesarios"
+msgstr "Zanechte poznámku a vysvětlete, jaké změny jste provedli a proč byly potřebné"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:170
 msgid "Why this database is interesting"
-msgstr "Por qué esta base de datos es interesante"
+msgstr "Proč je tato databáze zajímavá"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:180
 msgid "Things to be aware of about this database"
-msgstr "Cosas a tener en cuenta acerca de esta base de datos"
+msgstr "Co by jste měli vědět o této databázi"
 
 #: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
-msgstr "Bases de datos y tablas"
+msgstr "Databáze a tabulky"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:28
@@ -5768,966 +5769,967 @@ msgstr "Bases de datos y tablas"
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:31
 msgid "Details"
-msgstr "Detalles"
+msgstr "Podrobnosti"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
 #: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
-msgstr "Tablas en {0}"
+msgstr "Tabulky v {0}"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:226
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:204
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:222
 msgid "Actual name in database"
-msgstr "Nombre real en la base de datos"
+msgstr "Skutečný název v databázi"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:235
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:231
 msgid "Why this field is interesting"
-msgstr "Por qué este campo es interesante"
+msgstr "Proč je toto pole zajímavé?"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:245
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:241
 msgid "Things to be aware of about this field"
-msgstr "Cosas a tener en cuenta sobre este campo"
+msgstr "Co by jste měli vědět o tomto poli"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:257
 #: frontend/src/metabase/reference/databases/FieldList.jsx:159
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:253
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:160
 msgid "Data type"
-msgstr "Tipo de dato"
+msgstr "Datový typ"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:39
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:39
 msgid "Fields in this table will appear here as they're added"
-msgstr "Los campos en esta tabla aparecerán aquí a medida que se añadan"
+msgstr "Pole v této tabulce se zde zobrazí, až budou přidány"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:137
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
-msgstr "Campos en {0}"
+msgstr "Pole v {0}"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:153
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:154
 msgid "Field name"
-msgstr "Nombre de campo"
+msgstr "Název pole"
 
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:46
 msgid "X-ray this field"
-msgstr "Aplica rayos-X a este campo"
+msgstr "Prozkoumat toto pole"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:8
 msgid "Metabase is no fun without any data"
-msgstr "Metabase no es divertido sin datos"
+msgstr "Metabase není bez dat zajímavá"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:9
 msgid "Your databases will appear here once you connect one"
-msgstr "Tus bases de datos aparecerán aquí una vez que conectes una"
+msgstr "Po připojení se zde zobrazí vaše databáze"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:10
 msgid "Databases will appear here once your admins have added some"
-msgstr "Las bases de datos aparecerán aquí una vez que los administradores hayan añadido algunas"
+msgstr "Zde se objeví databáze jakmile je správci přidají"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:12
 msgid "Connect a database"
-msgstr "Conecta una base de datos"
+msgstr "Připojte databázi"
 
 #. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
 #. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
-msgstr "Número de {0}"
+msgstr "Počet z {0}"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:47
 msgid "See raw data for {0}"
-msgstr "Ver datos de {0}"
+msgstr "Ukaž surové data pro {0}"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:213
 msgid "Why this table is interesting"
-msgstr "Por qué esta tabla es interesante"
+msgstr "Proč je tato tabulka zajímavá"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:223
 msgid "Things to be aware of about this table"
-msgstr "Cosas a tener en cuenta sobre esta tabla"
+msgstr "Co by jste měli vědět o této tabulce"
 
 #: frontend/src/metabase/reference/databases/TableList.jsx:29
 msgid "Tables in this database will appear here as they're added"
-msgstr "Las tablas en esta base de datos aparecerán aquí cuando se añadan"
+msgstr "Tabulky v této databázi se zde zobrazí, až budou přidány"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:33
 msgid "Questions about this table will appear here as they're added"
-msgstr "Las preguntas sobre esta tabla aparecerán aquí cuando se añadan"
+msgstr "Otázky týkající se této tabulky se zde zobrazí, až budou přidány"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:73
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:77
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:76
 msgid "Questions about {0}"
-msgstr "Preguntas sobre {0}"
+msgstr "Otázky týkající se {0}"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
 msgid "Created {0} by {1}"
-msgstr "Creado hace {0} por {1}"
+msgstr "Vytvořené {0} uživatelem {1}"
 
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:40
 msgid "Fields in this table"
-msgstr "Campos en esta tabla"
+msgstr "Pole v této tabulce"
 
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:46
 msgid "Questions about this table"
-msgstr "Preguntas sobre esta tabla"
+msgstr "Otázky týkající se této tabulky"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
-msgstr "Ayuda a tu equipo a empezar con tus datos."
+msgstr "Pomozte svému týmu začít pracovat s vašimi daty"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
-msgstr "Muestra a tu equipo lo que es más importante al elegir tu cuadro de mando, tus métricas y tus segmentos principales."
+msgstr "Vyberte svoji nástěnku, metriky a segmenty a ukažte týmu, co je nejdůležitější."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
-msgstr "Empieza"
+msgstr "Začít"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
-msgstr "Nuestro cuadro de mando más importante"
+msgstr "Naše nejdůležitější nástěnky"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
-msgstr "Números a los que prestamos atención"
+msgstr "Čísla, kterým věnujeme pozornost"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
-msgstr "Las métricas son números destacados que le importan a tu empresa. A menudo representan un indicador central de cómo está funcionando el negocio."
+msgstr "Metriky jsou důležité čísla, o které se vaše společnost zajímá. Často představují hlavní ukazatel výkonnosti byznysu."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
-msgstr "Ver todas las métricas"
+msgstr "Zobrazit všechny metriky"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
-msgstr "Segmentos y tablas"
+msgstr "Segmenty a tabulky"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:82
 msgid "Tables"
-msgstr "Tablas"
+msgstr "Tabulky"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
-msgstr "Los segmentos y tablas son los componentes básicos de los datos de tu empresa. Las tablas son colecciones de información sin formato mientras que los segmentos son trozos acotados con significados específico, como {0}"
+msgstr "Segmenty a tabulky jsou stavebními kameny dat vaší společnosti. Tabulky jsou sbírky nezpracovaných informací, zatímco segmenty jsou konkrétní části se specifickým významem, například {0}"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
-msgstr "Las tablas son los componentes básicos de los datos de tu empresa."
+msgstr "Tabulky jsou stavebními kameny dat ve vaší společnosti."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
-msgstr "Ver todos los segmentos"
+msgstr "Zobrazit všechny segmenty"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
-msgstr "Ver todas las tablas"
+msgstr "Zobrazit všechny tabulky"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
-msgstr "Otras cosas que debes saber sobre nuestros datos"
+msgstr "Další informace o vašich datech"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
-msgstr "Descubre más"
+msgstr "Zjistit více"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
-msgstr "Una buena manera de conocer tus datos es dedicarle un poco de tiempo a explorar las diferentes tablas y otra información disponible. Puedes tardar un poco, pero comenzarás a reconocer nombres y significados con el tiempo."
+msgstr "Dobrým způsobem, jak poznat své data, je strávit trochu času zkoumáním různých tabulek a dalších informací, které máte k dispozici. Může to chvíli trvat, ale časem začnete rozpoznávat jména a významy."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
-msgstr "Explora nuestros datos"
+msgstr "Prozkoumej vaše data"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
-msgstr "¿Tienes una pregunta?"
+msgstr "Máte otázky?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
-msgstr "Habla con {0}"
+msgstr "Kontakt {0}"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
-msgstr "Ayuda a los nuevos usuarios de Metabase a encontrar su camino."
+msgstr "Pomozte novým uživatelům Metabase najít cestu k poznávání dat."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
-msgstr "La guía de introducción destaca el cuadro de mando, las métricas, los segmentos y las tablas que más importan, e informa a los usuarios sobre cosas importantes que deberían saber antes de profundizar en los datos."
+msgstr "Příručka Jak začít zdůrazňuje hlavní nástěnku, metriky, segmenty a tabulky, na kterých vám nejvíce záleží a informuje Vaše uživatele o důležitých věcech, které by měli vědět předtím, než začnou prohlížet data."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
-msgstr "¿Hay un cuadro de mando importante para tu equipo?"
+msgstr "Je pro Váš tým důležitá nějaká nástěnka?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
-msgstr "Crea un cuadro de mando ahora"
+msgstr "Vytvořte nástěnku"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
-msgstr "¿Cuál es tu cuadro de mando más importante?"
+msgstr "Jaká je Vaše nejdůležitější nástěnka?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
-msgstr "¿Tienes alguna métrica comúnmente referenciada?"
+msgstr "Máte nějaké často používány metriky?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
-msgstr "Aprende a definir una métrica"
+msgstr "Naučte se, jak definovat metriku"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
-msgstr "¿Cuáles son las 3-5 métricas más comúnmente referenciadas?"
+msgstr "Jaké jsou 3-5 nejčastějších metrik?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
-msgstr "Añade otra métrica"
+msgstr "Přidejte další metriku"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
-msgstr "¿Tienes algún segmento o tabla comúnmente referenciado?"
+msgstr "Máte nějaké segmenty nebo tabulky na které často odkazujete?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
-msgstr "Aprenda a crear un segmento"
+msgstr "Naučte se, jak vytvořit segment"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
-msgstr "¿Cuáles son los 3-5 segmentos o tablas comúnmente referenciados que serían útiles paraesta audiencia?"
+msgstr "Jaké jsou 3-5 často používané segmenty nebo tabulky, které by byly užitečné pro toto publikum?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
-msgstr "Añade otro segmento o tabla"
+msgstr "Přidejte další segment nebo tabulku"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
-msgstr "¿Hay algo que tus usuarios deberían entender o saber antes de que comiencen a acceder a los datos?"
+msgstr "Existuje něco, co by vaši uživatelé měli pochopit nebo vědět dříve, než začnou přistupovat k datům?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
-msgstr "¿Qué debe saber un usuario de estos datos antes de que comiencen a acceder a ellos?"
+msgstr "Co by měl uživatel těchto údajů vědět dříve, než k nim přistoupí?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
-msgstr "Por ejemplo, las expectativas sobre la privacidad y el uso de datos, peligros comunes o malentendidos, información sobre el rendimiento del almacén de datos, avisos legales, etc."
+msgstr "Např. Očekávání týkající se ochrany osobních údajů a jejich používání, právních upozornění atd."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
-msgstr "¿Hay alguien con quien tus usuarios puedan contactar si necesitan ayuda si están confundidos acerca de esta guía?"
+msgstr "Existuje někdo, koho by vaši uživatelé mohli kontaktovat kvůli podpory, pokud by měli otázky ohledně této příručky?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
-msgstr "¿A quién deben contactar los usuarios para obtener ayuda si están confundidos acerca de esta información?"
+msgstr "Koho by měli uživatelé kontaktovat ohledně pomoci, pokud mají otázky ohledně těchto dat?"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:76
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:97
 msgid "Please enter a revision message"
-msgstr "Por favor añade un mensaje de revisión"
+msgstr "Zadejte popis změny"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
-msgstr "Por qué esta métrica es interesante"
+msgstr "Proč je tato metrika zajímavá"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
-msgstr "Cosas a tener en cuenta acerca de esta métrica"
+msgstr "Co by jste měli vědět o této metrice"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
-msgstr "Cómo se calcula esta métrica"
+msgstr "Jak se vypočítá tato metrika"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:240
 msgid "Nothing on how it's calculated yet"
-msgstr "Nada sobre cómo se calculó aún"
+msgstr "Zatím nic o tom, jak se počítá"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:297
 msgid "Other fields you can group this metric by"
-msgstr "Otros campos por los que puedes agrupar esta métrica"
+msgstr "Ostatní pole, podle kterých můžete tuto metriku seskupit"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:298
 msgid "Fields you can group this metric by"
-msgstr "Campos por los que puedes agrupar esta métrica"
+msgstr "Pole, podle kterých můžete tuto metriku seskupit"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:24
 msgid "Metrics are the official numbers that your team cares about"
-msgstr "Las métricas son los números oficiales de los que tu equipo se preocupa"
+msgstr "Metriky jsou oficiální čísla, o které se váš tým zajímá"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Metrics will appear here once your admins have created some"
-msgstr "Las métricas aparecerán aquí una vez que tus administradores hayan creado algunas"
+msgstr "Metriky se zde zobrazí, jakmile je správce vytvoří"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:28
 msgid "Learn how to create metrics"
-msgstr "Aprende cómo crear métricas"
+msgstr "Naučte se, jak vytvářet metriky"
 
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:34
 msgid "Questions about this metric will appear here as they're added"
-msgstr "Las preguntas sobre esta métrica aparecerán aquí cuando se añadan"
+msgstr "Otázky týkající se této metriky se zde zobrazí, až budou přidány"
 
 #: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:29
 msgid "There are no revisions for this metric"
-msgstr "No hay revisiones para esta métrica"
+msgstr "Pro tuto metriku neexistují žádné revize"
 
 #: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:52
 #: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:90
 msgid "Revision history for {0}"
-msgstr "Historial de revisiones de {0}"
+msgstr "Historie revizí pro {0}"
 
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:44
 msgid "X-ray this metric"
-msgstr "Aplica rayos-X a esta métrica"
+msgstr "Prozkoumat tuto metriku"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:246
 msgid "Why this Segment is interesting"
-msgstr "Por qué este segmento es interesante"
+msgstr "Proč je tento segment zajímavý?"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:256
 msgid "Things to be aware of about this Segment"
-msgstr "Cosas a tener en cuenta sobre este segmento"
+msgstr "Co by jste měli vědět o tomto segmentu"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:23
 msgid "Segments are interesting subsets of tables"
-msgstr "Los segmentos son subconjuntos interesantes de tablas"
+msgstr "Segmenty jsou zajímavé podskupiny tabulek"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Defining common segments for your team makes it even easier to ask questions"
-msgstr "La definición de segmentos comunes para tu equipo hace que sea aún más fácil hacer preguntas"
+msgstr "Definování společných segmentů pro váš tým usnadňuje klást otázky"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Segments will appear here once your admins have created some"
-msgstr "Los segmentos aparecerán aquí una vez que los administradores hayan creado algunos"
+msgstr "Segmenty se zde zobrazí, jakmile je správce vytvoří"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:27
 msgid "Learn how to create segments"
-msgstr "Aprende a crear segmentos"
+msgstr "Naučte se, jak vytvářet segmenty"
 
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:34
 msgid "Questions about this segment will appear here as they're added"
-msgstr "Las preguntas sobre este segmento aparecerán aquí cuando se añadan"
+msgstr "Otázky týkající se tohoto segmentu se zde zobrazí, až budou přidány"
 
 #: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:28
 msgid "There are no revisions for this segment"
-msgstr "No hay revisiones para este segmento"
+msgstr "Pro tento segment neexistují žádné revize"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:37
 msgid "Fields in this segment"
-msgstr "Campos en este segmento"
+msgstr "Pole v tomto segmentu"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:43
 msgid "Questions about this segment"
-msgstr "Preguntas sobre este segmento"
+msgstr "Otázky týkající se tohoto segmentu"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:50
 msgid "X-ray this segment"
-msgstr "Aplica rayos-X a este segmento"
+msgstr "Prozkoumat tento segment"
 
 #: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
 msgid "Login"
-msgstr "Iniciar sesión"
+msgstr "Přihlásit se"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:303
 #: frontend/src/metabase/containers/ItemPicker.jsx:115
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
 #: frontend/src/metabase/routes.jsx:195
 msgid "Search"
-msgstr "Buscar"
+msgstr "Hledat"
 
 #: frontend/src/metabase/routes.jsx:214
 msgid "Dashboard"
-msgstr "Cuadro de Mando"
+msgstr "Nástěnka"
 
 #: frontend/src/metabase/routes.jsx:227
 msgid "New Question"
-msgstr "Nueva Pregunta"
+msgstr "Nová otázka"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:127
 msgid "Select the type of Database you use"
-msgstr "Selecciona el tipo de base de datos que utilizas"
+msgstr "Vyberte typ používané databáze"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:103
 msgid "Add your data"
-msgstr "Añade tus datos"
+msgstr "Přidej vaše data"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:107
 msgid "I'll add my own data later"
-msgstr "Añadiré mis propios datos más tarde"
+msgstr "Své vlastní data tu přidám později"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:108
 msgid "Connecting to {0}"
-msgstr "Conectando con {0}"
+msgstr "Připojuji se k {0}"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:130
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
-msgstr "Necesitarás información sobre tu base de datos, como el nombre de usuario y la contraseña. Si no tienes eso ahora mismo, Metabase también viene con un conjunto de datos de muestra con los que puedes empezar."
+msgstr "Budete potřebovat určité informace o své databázi, například uživatelské jméno a heslo. Pokud je ještě nemáte, Metabase přichází i se vzorovou databází, se kterou si můžete pohrát."
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my data later"
-msgstr "Añadiré mis datos más tarde"
+msgstr "Své data tu přidám později"
 
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:42
 msgid "Control automatic scans"
-msgstr "Control de escaneos automáticos"
+msgstr "Ovládejte automatické skenování"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:59
 msgid "Usage data preferences"
-msgstr "Preferencias de uso de datos"
+msgstr "Předvolby o použití údajů"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:62
 msgid "Thanks for helping us improve"
-msgstr "Gracias por ayudarnos a mejorar"
+msgstr "Děkujeme, že jste nám pomohli vylepšovat"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:63
 msgid "We won't collect any usage events"
-msgstr "No recopilaremos ningún evento de uso"
+msgstr "Nebudeme shromažďovat žádné záznamy o používání"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:88
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
-msgstr "Para ayudarnos a mejorar Metabase, nos gustaría recopilar cierta información sobre el uso a través de Google Analytics."
+msgstr "Abyste nám pomohli vylepšit Metabase, chceme shromažďovat určité údaje o používání prostřednictvím služby Google Analytics."
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Here's a full list of everything we track and why."
-msgstr "Aquí hay una lista completa de todo lo que rastreamos y por qué."
+msgstr "Zde je úplný seznam všeho, co sledujeme a proč."
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
 msgid "Allow Metabase to anonymously collect usage events"
-msgstr "Permitir que Metabase recopile eventos de uso de forma anónima"
+msgstr "Povolit Metabase anonymně sbírat záznamy o používání"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
 msgid "Metabase {0} collects anything about your data or question results."
-msgstr "Metabase {0} recopila información sobre tus datos o resultados de preguntas."
+msgstr "Metabase {0} shromažďuje cokoliv o vašich datech nebo o výsledcích otázek."
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
 msgid "never"
-msgstr "nunca"
+msgstr "nikdy"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:119
 msgid "All collection is completely anonymous."
-msgstr "Toda la información obtenida es completamente anónima."
+msgstr "Celá sbírka je zcela anonymní."
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
-msgstr "La recopilación puede desactivarse en cualquier momento en la sección de configuración."
+msgstr "Sbírky můžete kdykoliv vypnout v nastaveních správce."
 
 #: frontend/src/metabase/setup/components/Setup.jsx:59
 msgid "If you feel stuck"
-msgstr "Si te sientes abrumado"
+msgstr "Pokud se cítíte zaseknutý"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:64
 msgid "our getting started guide"
-msgstr "nuestra guía de inicio"
+msgstr "náš průvodce pro začátečníky"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:65
 msgid "is just a click away."
-msgstr "esta a un solo click."
+msgstr "je vzdálen jen na jedno kliknutí."
 
 #: frontend/src/metabase/setup/components/Setup.jsx:111
 msgid "Welcome to Metabase"
-msgstr "Bienvenid@ a Metabase"
+msgstr "Vítejte v Metabase"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:112
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
-msgstr "Parece que todo está funcionando. ¡Ahora vamos a conocerte, conectarte con tus datos y comenzar a encontrarte algunas respuestas!"
+msgstr "Vypadá to, že všechno funguje. Nyní se s vámi seznámíme, připojíme se k vašim datům a začneme prohledávat data."
 
 #: frontend/src/metabase/setup/components/Setup.jsx:116
 msgid "Let's get started"
-msgstr "Empecemos"
+msgstr "Začněme"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:166
 msgid "You're all set up!"
-msgstr "¡Estás listo!"
+msgstr "Všechno je připraveno!"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:177
 msgid "Take me to Metabase"
-msgstr "Llévame a Metabase"
+msgstr "Ukažte mi Metabase"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:49
 msgid "What should we call you?"
-msgstr "¿Cómo deberíamos llamarte?"
+msgstr "Jak by jsme vám měli říkat?"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:156
 msgid "Hi, {0}. nice to meet you!"
-msgstr "Hola {0}, ¡Encantado de conocerte!"
+msgstr "Ahoj, {0}. rád tě poznávám!"
 
 #: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
-msgstr "Crea una contraseña"
+msgstr "Vytvořit heslo"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:44
 #: frontend/src/metabase/entities/users/forms.js:50
 #: frontend/src/metabase/entities/users/forms.js:97
 msgid "Shhh..."
-msgstr "Shhh..."
+msgstr "Šššš..."
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:265
 msgid "Confirm password"
-msgstr "Confirma la contraseña"
+msgstr "Potvrďte heslo"
 
 #: frontend/src/metabase/entities/users/forms.js:57
 msgid "Shhh... but one more time so we get it right"
-msgstr "Shhh... otra vez, para asegurarnos que lo hacemos bien"
+msgstr "Ticho... takže ještě jednou, ať to máme v pořádku"
 
 #: frontend/src/metabase/entities/users/forms.js:85
 msgid "Your company or team name"
-msgstr "El nombre de tu empresa o equipo"
+msgstr "Název vaší společnosti nebo týmu"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:291
 msgid "Department of awesome"
-msgstr "Departamento impresionante"
+msgstr "Oddělení"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:26
 msgid "Metabot is admiring your integers…"
-msgstr "Metabot está admirando tus enteros…"
+msgstr "Metabot obdivuje vaše čísla ..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:27
 msgid "Metabot is performing billions of differential equations…"
-msgstr "Metabot está realizando miles de millones de ecuaciones diferenciales…"
+msgstr "Metabot provádí miliardy diferenciálních rovnic..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:28
 msgid "Metabot is doing science…"
-msgstr "Metabot está haciendo ciencia…"
+msgstr "Metabot provádí výpočty..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:29
 msgid "Metabot is checking out your metrics…"
-msgstr "Metabot está revisando tus métricas…"
+msgstr "Metabot kontroluje vaše metriky..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:30
 msgid "Metabot is looking for trends and outliers…"
-msgstr "Metabot está buscando tendencias y valores atípicos…"
+msgstr "Metabot hledá trendy a odlehlé hodnoty..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:31
 msgid "Metabot is consulting the quantum abacus…"
-msgstr "Metabot está consultando el ábaco cuántico…"
+msgstr "Metabot konzultuje kvantové počítadlo..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:32
 msgid "Metabot is feeling pretty good about all this…"
-msgstr "Metabot se siente bien con todo esto…"
+msgstr "Metabot má z toho všeho dobrý pocit..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:52
 msgid "We’ll show you some interesting explorations of your data in\n"
 "just a few minutes."
-msgstr "Te mostraremos algunas exploraciones interesantes de tus datos\n"
-"en solo unos minutos."
+msgstr "Ukážeme vám několik zajímavých průzkumů vašich dat jen za pár minut."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:72
 msgid "This seems to be taking a while. In the meantime, you can check out one of these example explorations to see what Metabase can do for you."
-msgstr "Esto parece que está tardando un tiempo. Mientras tanto, puedes ver una de estas exploraciones de ejemplo para ver lo qué Metabase puede hacer por ti."
+msgstr "Zdá se, že to chvíli trvá. Mezitím si můžete prohlédnout jeden z těchto vzorových průzkumů a zjistit, co pro vás může Metabase udělat."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:86
 msgid "I took a look at the data you just connected, and I have some explorations of interesting things I found. Hope you like them!"
-msgstr "He revisado los datos que acabas de conectar, y tengo algunas exploraciones de cosas interesantes que he encontrado. ¡Espero que te gusten!"
+msgstr "Podíval jsem se na data, které jste právě připojili, a přezkoumám zajímavé věci, které jsem našel. Doufám, že se vám líbí!"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:98
 msgid "I'm done exploring for now"
-msgstr "He terminado de explorar por ahora"
+msgstr "Zatím jsem dokončil průzkum"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:20
 msgid "Welcome to the Query Builder!"
-msgstr "¡Bienvenido al Generador de Consultas!"
+msgstr "Vítejte v Tvůrci dotazů!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:22
 msgid "The Query Builder lets you assemble questions (or \"queries\") to ask about your data."
-msgstr "El generador de consultas te permite construir preguntas (o \"consultas\") para indagar sobre tus datos."
+msgstr "Tvůrce dotazů umožňuje shromažďovat otázky (nebo \"dotazy\") a prohledávat vaše data."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:26
 msgid "Tell me more"
-msgstr "Dime más"
+msgstr "Řekněte mi více"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:43
 msgid "Start by picking the table with the data that you have a question about."
-msgstr "Empieza escogiendo la tabla con los datos sobre los que tienes una pregunta."
+msgstr "Začněte výběrem tabulky s údaji, které chcete prohledávat."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:45
 msgid "Go ahead and select the \"Orders\" table from the dropdown menu."
-msgstr "Adelante y selecciona la tabla  \"Pedidos\" en el menú desplegable."
+msgstr "Pokračujte a z rozbalovací nabídky vyberte tabulku \"Orders\"."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:78
 msgid "Filter your data to get just what you want."
-msgstr "Filtra tus datos para obtener exactamente lo que quieres."
+msgstr "Filtrujte své data a získejte přesně to, co chcete."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:79
 msgid "Click the plus button and select the \"Created At\" field."
-msgstr "Haz clic en el botón más y selecciona el campo \"Created At\"."
+msgstr "Klepněte na tlačítko plus a vyberte pole \"Created At\"."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:93
 msgid "Here we can pick how many days we want to see data for, try 10"
-msgstr "Aquí podemos elegir cuántos días queremos ver los datos, intenta con 10"
+msgstr "Zde si můžeme vybrat, pro kolik dní chcete zobrazit údaje, vyzkoušejte 10"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:116
 msgid "Here's where you can choose to add or average your data, count the number of rows in the table, or just view the raw data."
-msgstr "Aquí es donde puedes elegir agregar o promediar tus datos, contar el número de filas en la tabla, o simplemente ver los datos sin procesar."
+msgstr "Zde si můžete vybrat, zda chcete přidat nebo zprůměrovat své data, spočítat počet řádků v tabulce nebo jen zobrazit surové data."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:118
 msgid "Try it: click on <strong>Raw Data</strong> to change it to <strong>Count of rows</strong> so we can count how many orders there are in this table."
-msgstr "Pruébalo: haz clic en <strong>Datos brutos</ strong> para cambiarlo a <strong>Número de filas</ strong> para que podamos contar cuántas órdenes hay en esta tabla."
+msgstr "Vyzkoušejte to: kliknutím na <strong>Surové data</strong> je změníte na <strong>Počet řádků</strong>, abychom mohli spočítat, kolik objednávek je v této tabulce."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:142
 msgid "Add a grouping to break out your results by category, day, month, and more."
-msgstr "Añade una agrupación para dividir tus resultados por categoría, día, mes y más."
+msgstr "Pokud chcete udělat rozbor svých výsledků, přidejte seskupení podle kategorie, dne, měsíce a dalších."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:144
 msgid "Let's do it: click on <strong>Add a grouping</strong>, and choose <strong>Created At: by Week</strong>."
-msgstr "Hagámoslo: haz clic en <strong>Añadir una agrupación</ strong> y elige <strong>Created At: por semana</ strong>."
+msgstr "Uděláme to: klikněte na možnost <strong>Přidat seskupení</strong> a vyberte možnost <strong>Vytvořeno: podle týdne</strong>."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:152
 msgid "Click on \"by day\" to change it to \"Week.\""
-msgstr "Haz clic en \"por día\" para cambiarlo a \"Semana\"."
+msgstr "Kliknutím na \"podle dne\" ho změňte na \"Týden\"."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:173
 msgid "Run Your Query."
-msgstr "Ejecuta tu consulta."
+msgstr "Spustit dotaz."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:175
 msgid "You're doing so well! Click <strong>Run query</strong> to get your results!"
-msgstr "¡Lo estás haciendo muy bien! Haz clic en <strong>Ejecutar consulta</ strong> para obtener tus resultados."
+msgstr "Daří se vám to dobře! Chcete-li získat výsledky, klikněte na možnost <strong> Spustit dotaz</strong>."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:192
 msgid "You can view your results as a chart instead of a table."
-msgstr "Puedes ver sus resultados como un gráfico en lugar de una tabla."
+msgstr "Výsledky můžete zobrazit jako graf namísto tabulky."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:194
 msgid "Everbody likes charts! Click the <strong>Visualization</strong> dropdown and select <strong>Line</strong>."
-msgstr "A todos nos gustan las gráficas! Haz clic en el menú desplegable <strong>Visualización</ strong> y selecciona <strong>Línea</ strong>."
+msgstr "Každý má rád grafy! Klikněte na rozbalovací nabídku <strong>Vizualizace\n"
+"</Strong> a vyberte možnost <strong>Spojnicový</strong>."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:216
 msgid "Well done!"
-msgstr "¡Muy bien!"
+msgstr "Výborně!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:218
 msgid "That's all! If you still have questions, check out our"
-msgstr "¡Eso es todo! Si aún tienes preguntas, revisas nuestra"
+msgstr "To je vše! Pokud máte další otázky, přečtěte si náš"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:223
 msgid "User's Guide"
-msgstr "Guía del Usuario"
+msgstr "Uživatelský manuál"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:223
 msgid "Have fun exploring your data!"
-msgstr "¡Diviértete explorando tus datos!"
+msgstr "Bavte se při zkoumání vašich dat!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:226
 msgid "Thanks"
-msgstr "Gracias"
+msgstr "Díky"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:235
 msgid "Save Your Questions"
-msgstr "Guarda tus preguntas"
+msgstr "Uložte svoje otázky"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:237
 msgid "By the way, you can save your questions so you can refer to them later. Saved Questions can also be put into dashboards or Pulses."
-msgstr "Por cierto, puedes guardar tus preguntas para que puedas consultarlas más tarde.Las preguntas guardadas también se pueden poner en cuadros de mando o pulsos."
+msgstr "Mimochodem, můžete své dotazy uložit, abyste na ně mohli později odvolat. Uložené dotazy lze vkládat i do nástěnek nebo do pulzů."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:241
 msgid "Sounds good"
-msgstr "Suena bien"
+msgstr "To zní dobře"
 
 #: frontend/src/metabase/tutorial/Tutorial.jsx:248
 msgid "Whoops!"
-msgstr "¡¡uy!!"
+msgstr "Hopla!"
 
 #: frontend/src/metabase/tutorial/Tutorial.jsx:249
 msgid "Sorry, it looks like something went wrong. Please try restarting the tutorial in a minute."
-msgstr "Lo siento, parece que algo salió mal. Intenta reiniciar el tutorial en un minuto."
+msgstr "Bohužel to vypadá, že se něco pokazilo. Zkuste za minutu průvodce restartovat."
 
 #: frontend/src/metabase/user/actions.js:34
 msgid "Password updated successfully!"
-msgstr "¡Contraseña actualizada correctamente!"
+msgstr "Heslo bylo úspěšně aktualizováno!"
 
 #: frontend/src/metabase/user/actions.js:53
 msgid "Account updated successfully!"
-msgstr "¡Cuenta actualizada con éxito!"
+msgstr "Účet byl úspěšně aktualizován!"
 
 #: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
-msgstr "Contraseña actual"
+msgstr "Aktuální heslo"
 
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:137
 msgid "Sign in with Google Email address"
-msgstr "Inicia sesión con la dirección de correo electrónico de Google"
+msgstr "Přihlaste se pomocí e-mailové adresy Google"
 
 #: frontend/src/metabase/user/components/UserSettings.jsx:65
 msgid "User Details"
-msgstr "Detalles Usuario"
+msgstr "Detaily uživatele"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:344
 msgid "Reset to defaults"
-msgstr "Restablecer los valores predeterminados"
+msgstr "Reset na výchozí hodnoty"
 
 #: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:167
 msgid "unknown map"
-msgstr "mapa desconocido"
+msgstr "neznámá mapa"
 
 #: frontend/src/metabase/visualizations/components/LeafletGridHeatMap.jsx:26
 msgid "Grid map requires binned longitude/latitude."
-msgstr "El mapa de cuadrícula requiere longitud/latitud agrupada."
+msgstr "Mapa mřížky vyžaduje hranice tříd pro zeměpisnou délku / šířku."
 
 #: frontend/src/metabase/visualizations/components/LegendVertical.jsx:117
 msgid "more"
-msgstr "más"
+msgstr "více"
 
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
-msgstr "¿Qué campos quieres usar para los ejes X e Y?"
+msgstr "Která pole chcete použít pro osy X a Y?"
 
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
-msgstr "Elige campos"
+msgstr "Vyberte pole"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:234
 msgid "Save as default view"
-msgstr "Guardar como vista predeterminada"
+msgstr "Uložit jako výchozí zobrazení"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Draw box to filter"
-msgstr "Dibujar cuadro para filtrar"
+msgstr "Přidat rámeček na filtrování"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Cancel filter"
-msgstr "Cancelar Filtro"
+msgstr "Zrušit filtr"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:47
 msgid "Pin Map"
-msgstr "Mapa de Pin"
+msgstr "Připnout mapu"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
 msgid "Unset"
-msgstr "Desmarcar"
+msgstr "Zrušit"
 
 #: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
 msgid "Rows {0}-{1} of {2}"
-msgstr "Filas {0}-{1} de {2}"
+msgstr "Řádky {0} - {1} z {2}"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:206
 msgid "Data truncated to {0} rows."
-msgstr "Datos truncados a {0} filas."
+msgstr "Data byly zkráceny na {0} řádky."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:403
 msgid "Could not find visualization"
-msgstr "No se pudo encontrar la visualización"
+msgstr "Nelze najít vizualizaci"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:410
 msgid "Could not display this chart with this data."
-msgstr "No se pudo mostrar este gráfico con esta información."
+msgstr "Tento graf se nedal zobrazit s těmito daty."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:533
 msgid "No results!"
-msgstr "¡Sin resultados!"
+msgstr "Žádné výsledky!"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:554
 msgid "Still Waiting..."
-msgstr "Esperando..."
+msgstr "Stále čekám..."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:557
 msgid "This usually takes an average of {0}."
-msgstr "Esto suele tardar unos {0}."
+msgstr "Obvykle to trvá průměrně {0}."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:563
 msgid "(This is a bit long for a dashboard)"
-msgstr "(Es un poco largo para un cuadro de mando)"
+msgstr "(Toto je pro nástěnku poněkud dlouhé)"
 
+#. duplicity
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:503
 msgid "This is usually pretty fast but seems to be taking awhile right now."
-msgstr "Esto suele ser bastante rápido, pero parece estar tardando en este momento."
+msgstr "To je obvykle dost rychlé, ale nyní se zdá, že to chvíli trvá."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "Select a field"
-msgstr "Selecciona un campo"
+msgstr "Vyberte pole"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:45
 msgid "error"
-msgstr "error"
+msgstr "chyba"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:117
 msgid "Click and drag to change their order"
-msgstr "Pulsa y arrastra para cambiar el orden"
+msgstr "Kliknutím a tažením změníte jejich pořadí"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:130
 msgid "Add fields from the list below"
-msgstr "Añade campos de la lista inferior"
+msgstr "Přidejte pole ze seznamu níže"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:24
 msgid "less than"
-msgstr "menor que"
+msgstr "méně než"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:25
 msgid "greater than"
-msgstr "mayor que"
+msgstr "více než"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:26
 msgid "less than or equal to"
-msgstr "menor o igual a"
+msgstr "menší nebo rovno"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:27
 msgid "greater than or equal to"
-msgstr "nayor o igual a"
+msgstr "větší nebo rovno"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:28
 msgid "equal to"
-msgstr "igual a"
+msgstr "rovná se"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:29
 msgid "not equal to"
-msgstr "distinto a"
+msgstr "nerovná se"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:191
 msgid "Conditional formatting"
-msgstr "Formato condicional"
+msgstr "Podmíněné formátování"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:193
 msgid "You can add rules to make the cells in this table change color if\n"
 "they meet certain conditions."
-msgstr "Puedes añadir reglas para hacer que las celdas de esta tabla cambien\n"
-"de color si cumplen ciertas condiciones."
+msgstr "Můžete přidat pravidla, aby buňky v této tabulce změnily barvu, pokud\n"
+"splňují určité podmínky."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:203
 msgid "Add a rule"
-msgstr "Añade una regla"
+msgstr "Přidejte pravidlo"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:208
 msgid "Rules will be applied in this order"
-msgstr "Las reglas se aplicarán en este orden"
+msgstr "Pravidla se použijí v tomto pořadí"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:209
 msgid "Click and drag to reorder."
-msgstr "Pulsa y arrastra para cambiar el orden"
+msgstr "Kliknutím a tažením změníte pořadí."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:242
 msgid "No columns selected"
-msgstr "Ninguna columna seleccionada"
+msgstr "Sloupce nevybrány"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:290
 msgid "Cells in this column will be tinted based on their values."
-msgstr "Las celdas en esta columna se colorearán según sus valores."
+msgstr "Buňky v tomto sloupci budou obarvené na základě jejich hodnot."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:279
 msgid "When a cell in these columns is {0} it will be tinted this color."
-msgstr "Cuando una celda en estas columnas es {0}, estará teñida de este color."
+msgstr "Pokud je buňka v těchto sloupcích {0}, bude tato buňka zbarvená."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:313
 msgid "Which columns should be affected?"
-msgstr "¿A qué columnas se aplica?"
+msgstr "Které sloupce by měly být ovlivněny?"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:335
 msgid "Formatting style"
-msgstr "Estilo de formato"
+msgstr "Styl formátování"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:339
 msgid "Single color"
-msgstr "Color único"
+msgstr "Jedna barva"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:340
 msgid "Color range"
-msgstr "Rango de Color"
+msgstr "Barevná škála"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:312
 msgid "When a cell in this column is…"
-msgstr "Cuando una celda en esta columna es…"
+msgstr "Když je buňka v tomto sloupci..."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:376
 msgid "…turn its background this color:"
-msgstr "…pinta el fondo de este color:"
+msgstr "...změnit pozadí na tuto barvu:"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:382
 msgid "Highlight the whole row"
-msgstr "Resalta la fila entera"
+msgstr "Zvýrazněte celý řádek"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
 msgid "Colors"
-msgstr "Colores"
+msgstr "Barvy"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:404
 msgid "Start the range at"
-msgstr "Empieza el rango en"
+msgstr "Začít rozsah na"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:409
 msgid "Smallest value in this column"
-msgstr "El valor más pequeño en esta columna"
+msgstr "Nejmenší hodnota v tomto sloupci"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:411
 msgid "Smallest value in each column"
-msgstr "El valor más pequeño en cada columna"
+msgstr "Nejmenší hodnota v každém sloupci"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:413
 msgid "Smallest value in all of these columns"
-msgstr "El valor más pequeño en todas estas columnas"
+msgstr "Nejmenší hodnota ve všech těchto sloupcích"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:417
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:441
 msgid "Custom value"
-msgstr "Valor personalizado"
+msgstr "Vlastní hodnota"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:428
 msgid "End the range at"
-msgstr "Finaliza el rango en"
+msgstr "Ukončit rozsah na"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:433
 msgid "Largest value in this column"
-msgstr "El valor más grande en esta columna"
+msgstr "Největší hodnota v tomto sloupci"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:435
 msgid "Largest value in each column"
-msgstr "El valor más grande en cada columna"
+msgstr "Největší hodnota v každém sloupci"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:437
 msgid "Largest value in all of these columns"
-msgstr "El valor más grande en todas estas columnas"
+msgstr "Největší hodnota ve všech těchto sloupcích"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:471
 msgid "Add rule"
-msgstr "Añadir regla"
+msgstr "Přidejte pravidlo"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:471
 msgid "Update rule"
-msgstr "Actualizar regla"
+msgstr "Aktualizovat pravidlo"
 
 #: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
-msgstr "Visualización Vacía"
+msgstr "Vizualizace chybí"
 
 #: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
-msgstr "La visualización debe definir una variable estática 'identificadora':"
+msgstr "Vizualizace musí definovat statickou proměnnou 'identifikátor': "
 
 #: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
-msgstr "La visualización con ese identificador ya está registrada:"
+msgstr "Vizualizace s tímto identifikátorem je již zaregistrována:"
 
 #: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
-msgstr "No hay visualización para {0}"
+msgstr "Žádná vizualizace pro {0}"
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
-msgstr "\"{0}\" es un campo no agregado: si tienes más de un valor en un punto en el eje X, los valores se sumarán."
+msgstr "\"{0}\" je neagregované pole: má-li více než jednu hodnotu v bodě na ose x, hodnoty se sečtou."
 
 #: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:93
 msgid "This chart type requires at least 2 columns."
-msgstr "Este tipo de gráfico requiere al menos 2 columnas."
+msgstr "Tento typ grafu vyžaduje nejméně 2 sloupce."
 
 #: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:98
 msgid "This chart type doesn't support more than {0} series of data."
-msgstr "Este tipo de gráfico no admite más de {0} series de datos."
+msgstr "Tento typ grafu nepodporuje více než {0} řad."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:297
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
-msgstr "Objetivo"
+msgstr "Cíl"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
-msgstr "Vaya! Los datos de tu consulta no se ajustan a la opción de visualización elegida. Esta visualización requiere al menos {0} {1} de datos."
+msgstr "Data z vašeho dotazu se neshodují s vybranou volbou zobrazení. Tato vizualizace vyžaduje nejméně {0} {1} z dat."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
@@ -6749,253 +6751,254 @@ msgstr "Vaya! Los datos de tu consulta no se ajustan a la opción de visualizaci
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
-msgstr "columna"
+msgstr "sloupec"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:23
 msgid "No dice. We have {0} data {1} to show and that's not enough for this visualization."
-msgstr "No hay suerte. Tenemos {0} datos {1} para mostrar pero no es suficiente para esta visualización."
+msgstr "Máme k dispozici {0} dat {1}, to na tuto vizualizaci nestačí."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:23
 msgid "point"
 msgid_plural "points"
-msgstr[0] "punto"
-msgstr[1] "puntos"
+msgstr[0] "bod"
+msgstr[1] "body"
+msgstr[2] "bodů"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:35
 msgid "Bummer. We can't actually do a pin map for this data because we require both a latitude and longitude column."
-msgstr "Vaya. No podemos hacer un mapa de pin para estos datos porque necesitamos una columna de latitud y longitud."
+msgstr "Ve skutečnosti nemůžeme pro tyto údaje vytvořit mapu bodů, protože vyžadujeme sloupec zeměpisné šířky a délky."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:55
 msgid "Please configure this chart in the chart settings"
-msgstr "Por favor, configura este gráfico en la configuración del gráfico"
+msgstr "Nakonfigurujte tento graf v nastavení grafu"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:57
 msgid "Edit Settings"
-msgstr "Editar Configuración"
+msgstr "Upravit nastavení"
 
 #: frontend/src/metabase/visualizations/lib/fill_data.js:39
 msgid "xValues missing!"
-msgstr "¡Faltan valores x!"
+msgstr "Chybí hodnota pro osu X"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
 msgid "X-axis"
-msgstr "Eje-X"
+msgstr "osa X"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
-msgstr "Añade un desglose de series..."
+msgstr "Přidat konec do série..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
 msgid "Y-axis"
-msgstr "Eje-Y"
+msgstr "osa Y"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
-msgstr "Añade otra serie..."
+msgstr "Přidat další sérii..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
-msgstr "Tamaño de burbuja"
+msgstr "Velikost bubliny"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
 #: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
 msgid "Line"
-msgstr "Línea"
+msgstr "Linie"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:72
 msgid "Curve"
-msgstr "Curva"
+msgstr "Křivka"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
-msgstr "Paso"
+msgstr "Skupina"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:170
 msgid "Show point markers on lines"
-msgstr "Mostrar marcadores de puntos en líneas"
+msgstr "Zobrazit značky na čáře"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
-msgstr "Apilado"
+msgstr "Skládání"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
-msgstr "No Apilado"
+msgstr "Neskládat"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
-msgstr "Apilar"
+msgstr "Skládat"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
-msgstr "Apilado - 100%"
+msgstr "Skládat - 100%"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
-msgstr "Mostrar objetivo"
+msgstr "Zobrazit cíl"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
-msgstr "Valor del Objetivo"
+msgstr "Hodnota cíle"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:103
 msgid "Replace missing values with"
-msgstr "Reemplazar los valores faltantes con"
+msgstr "Vyměňte chybějící hodnoty za"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:107
 msgid "Zero"
-msgstr "Cero"
+msgstr "Nulu"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:108
 msgid "Nothing"
-msgstr "Nada"
+msgstr "Nic"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:109
 msgid "Linear Interpolated"
-msgstr "Lineal Interpolado"
+msgstr "Lineárně interpolované"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
-msgstr "Escala Eje-X"
+msgstr "Měřítko osy X"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
-msgstr "Series de tiempo"
+msgstr "Časová série"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:425
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:443
 msgid "Linear"
-msgstr "Lineal"
+msgstr "Lineární"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:444
 msgid "Power"
-msgstr "Exponente"
+msgstr "Výkon"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:428
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:445
 msgid "Log"
-msgstr "Logarítmico"
+msgstr "Log"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:430
 msgid "Histogram"
-msgstr "Histograma"
+msgstr "Sloupcový graf"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
-msgstr "Ordinal"
+msgstr "Řadový"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
-msgstr "Escala Eje-Y"
+msgstr "Měřítko osy Y"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
-msgstr "Mostrar línea y marcas del Eje-X"
+msgstr "Zobrazit čáru a značky na ose Y"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:349
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:457
 msgid "Compact"
-msgstr "Compacto"
+msgstr "Kompaktní"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:458
 msgid "Rotate 45°"
-msgstr "Rotar 45°"
+msgstr "Otočit o 45°"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:459
 msgid "Rotate 90°"
-msgstr "Rotar 90°"
+msgstr "Otočit o 90°"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:466
 msgid "Show y-axis line and marks"
-msgstr "Mostrar línea y marcas del Eje-Y"
+msgstr "Zobrazit čáru a značky na ose Y"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Auto y-axis range"
-msgstr "Rango del Eje-Y automático"
+msgstr "Automatický rozsah osy Y"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:522
 msgid "Use a split y-axis when necessary"
-msgstr "Utiliza un Eje-Y dividido cuando sea necesario"
+msgstr "V případě potřeby použijte rozdělenou osu Y"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:529
 msgid "Show label on x-axis"
-msgstr "Mostrar etiqueta en el Eje-X"
+msgstr "Zobrazit popis na ose X"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:535
 msgid "X-axis label"
-msgstr "Etiqueta Eje-X"
+msgstr "Popis na ose X"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:544
 msgid "Show label on y-axis"
-msgstr "Mostrar etiqueta en el Eje-Y"
+msgstr "Zobrazit popis na ose Y"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:550
 msgid "Y-axis label"
-msgstr "Etiqueta Eje-Y"
+msgstr "Popis na ose Y"
 
 #: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Standard Deviation"
-msgstr "Desviación Estándar"
+msgstr "Směrodatná odchylka"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
 #: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
 msgid "Area"
-msgstr "Area"
+msgstr "Oblast"
 
 #: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
 msgid "area chart"
-msgstr "Gráfico de área"
+msgstr "plošný graf"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
 #: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
 msgid "Bar"
-msgstr "Barra"
+msgstr "Sloupec"
 
 #: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
 msgid "bar chart"
-msgstr "Gráfico de barras"
+msgstr "sloupcový graf"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
-msgstr "¿Qué campos quieres usar?"
+msgstr "Která pole chcete použít?"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
-msgstr "Embudo"
+msgstr "Trychtýř"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
 msgid "Measure"
-msgstr "Medida"
+msgstr "Hodnoty"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
-msgstr "Tipo Embudo"
+msgstr "Typ trychtýře"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
-msgstr "Gráfico de barras"
+msgstr "Sloupcový graf"
 
 #: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
 msgid "line chart"
-msgstr "Gráfico de líneas"
+msgstr "spojnicový graf"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
 msgid "Please select longitude and latitude columns in the chart settings."
-msgstr "Selecciona las columnas de longitud y latitud en la configuración del gráfico."
+msgstr "V nastavení grafu vyberte sloupce zeměpisné délky a šířky."
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
 msgid "Please select a region map."
-msgstr "Por favor, selecciona un mapa de la región."
+msgstr "Vyberte mapu regionu."
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
 msgid "Please select region and metric columns in the chart settings."
-msgstr "Selecciona las columnas de región y métricas en la configuración del gráfico."
+msgstr "V nastavení grafu vyberte sloupce regionů a metrik."
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
 msgid "Map"
@@ -7003,460 +7006,461 @@ msgstr "Mapa"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
 msgid "Map type"
-msgstr "Tipo mapa"
+msgstr "Typ mapy"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
 msgid "Region map"
-msgstr "Mapa de la región"
+msgstr "Mapa regionu"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
 msgid "Pin map"
-msgstr "Mapa de pin"
+msgstr "Připnout mapu"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
 msgid "Pin type"
-msgstr "Tipo Pin"
+msgstr "Typ špendlíku"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Tiles"
-msgstr "Baldosas"
+msgstr "Dlaždice"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
 msgid "Markers"
-msgstr "Marcadores"
+msgstr "Značky"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
 msgid "Latitude field"
-msgstr "Campo Latitud"
+msgstr "Pole zeměpisné šířky"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
 msgid "Longitude field"
-msgstr "Campo Longitud"
+msgstr "Pole zeměpisné délky"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
 msgid "Metric field"
-msgstr "Campo Métrica"
+msgstr "Pole metriky"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
 msgid "Region field"
-msgstr "Campo Región"
+msgstr "Pole regionu"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
 msgid "Radius"
-msgstr "Radio"
+msgstr "Úhel"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
 msgid "Blur"
-msgstr "Difuminar"
+msgstr "Rozmazat"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
 msgid "Min Opacity"
-msgstr "Opacidad Mínima"
+msgstr "Min. krytí"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
 msgid "Max Zoom"
-msgstr "Acercamiento Máximo"
+msgstr "Max. přiblížení"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:234
 msgid "No relationships found."
-msgstr "No se encontraron relaciones."
+msgstr "Nebyly nalezeny žádné vztahy."
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:272
 msgid "via {0}"
-msgstr "via {0}"
+msgstr "prostřednictvím {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
 msgid "This {0} is connected to:"
-msgstr "Esta {0} está conectada a:"
+msgstr "Toto {0} je spojené s:"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "Object Detail"
-msgstr "Detalle del Objeto"
+msgstr "Detail objektu"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:93
 msgid "object"
-msgstr "objeto"
+msgstr "objekt"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
 msgid "Total"
-msgstr "Total"
+msgstr "Celkem"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
 msgid "Which columns do you want to use?"
-msgstr "¿Qué columnas quieres usar?"
+msgstr "Které sloupce chcete použít?"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
 msgid "Pie"
-msgstr "Pastel"
+msgstr "Koláč"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
 msgid "Dimension"
-msgstr "Dimensión"
+msgstr "Rozměr"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
 msgid "Show legend"
-msgstr "Mostrar Leyenda"
+msgstr "Zobrazit legendu"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
 msgid "Show percentages in legend"
-msgstr "Mostrar porcentajes en la leyenda"
+msgstr "Zobrazit procenta v legendě"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
 msgid "Minimum slice percentage"
-msgstr "Porcentaje mínimo de porción"
+msgstr "Minimální procento řezů"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
-msgstr "Objetivo conseguido"
+msgstr "Cíl se splnil"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
-msgstr "Objetivo superado"
+msgstr "Cíl byl překročen"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
-msgstr "Objetivo {0}"
+msgstr "Cíl {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
-msgstr "La visualización del progreso requiere un número."
+msgstr "Vizualizace typu postup vyžaduje číslo."
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:27
 msgid "Progress"
-msgstr "Progreso"
+msgstr "Postup"
 
 #: frontend/src/metabase/entities/collections.js:109
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
-msgstr "Color"
+msgstr "Barva"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row Chart"
-msgstr "Gráfico de Filas"
+msgstr "Pruhový graf"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
 msgid "row chart"
-msgstr "gráfico de filas"
+msgstr "pruhový graf"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:381
 msgid "Separator style"
-msgstr "Estilo separador"
+msgstr "Typ oddělovače"
 
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:88
 msgid "Number of decimal places"
-msgstr "Número de decimales"
+msgstr "Počet desetinných míst"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:405
 msgid "Add a prefix"
-msgstr "Añade un prefijo"
+msgstr "Přidejte předponu"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:409
 msgid "Add a suffix"
-msgstr "Añade un sufijo"
+msgstr "Přidejte příponu"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:398
 msgid "Multiply by a number"
-msgstr "Multiplicar por un número"
+msgstr "Vynásobte číslem"
 
 #: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
 msgid "Scatter"
-msgstr "Dispersión"
+msgstr "Bodový"
 
 #: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
 msgid "scatter plot"
-msgstr "gráfico de dispersión"
+msgstr "bodový diagram"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
 msgid "Pivot the table"
-msgstr "Pivote la tabla"
+msgstr "Kontingenčně"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:73
 msgid "Visible fields"
-msgstr "Campos visibles"
+msgstr "Viditelné pole"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
 msgid "Write here, and use Markdown if you'd like"
-msgstr "Escribe aquí. Puedes utilizar Markdown"
+msgstr "Zde napište jaké značky chcete použít"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
 msgid "Vertical Alignment"
-msgstr "Alineamiento Vertical"
+msgstr "Vertikální zarovnání"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:77
 msgid "Top"
-msgstr "Arriba:"
+msgstr "Nahoru"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:78
 msgid "Middle"
-msgstr "Medio"
+msgstr "Doprostřed"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:79
 msgid "Bottom"
-msgstr "Abajo"
+msgstr "Dolů"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:86
 msgid "Horizontal Alignment"
-msgstr "Alineamiento Horizontal"
+msgstr "Horizontální zarovnání"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:126
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:90
 msgid "Left"
-msgstr "Izquierda"
+msgstr "Doleva"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:91
 msgid "Center"
-msgstr "Centro"
+msgstr "Na střed"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:127
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:92
 msgid "Right"
-msgstr "Derecho"
+msgstr "Doprava"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:99
 msgid "Show background"
-msgstr "Mostrar fondo"
+msgstr "Zobrazit pozadí"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:760
 msgid "{0} bin"
 msgid_plural "{0} bins"
-msgstr[0] "{0} agrupación"
-msgstr[1] "{0} agrupaciones"
+msgstr[0] "{0} interval"
+msgstr[1] "{0} intervaly"
+msgstr[2] "{0} intervalů"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:766
 msgid "Auto binned"
-msgstr "Agrupación Auto"
+msgstr "Auto hranice tříd"
 
 #: src/metabase/api/alert.clj
 msgid "DELETE /api/alert/:id is deprecated. Instead, change its `archived` value via PUT /api/alert/:id."
-msgstr "DELETE /api/alert/:id esta descontinuado. Cambia el valor de `archived` via PUT /api/alert/:id."
+msgstr "DELETE /api/alert/:id je zastaralé. Místo toho změňte svoji `archivovanou` hodnotu pomocí PUT /api/alert/:id."
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid show value"
-msgstr "valor no válido para el campo mostrar"
+msgstr "neplatná hodnota zobrazení"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid value for prefix"
-msgstr "valor no válido para el prefijo"
+msgstr "neplatná hodnota pro předponu"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid value for rule name"
-msgstr "valor no válido para nombre de regla"
+msgstr "neplatná hodnota pro jméno"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "value couldn''t be parsed as base64 encoded JSON"
-msgstr "valor no se pudo analizar como JSON codificado base64"
+msgstr "hodnota nemohla být ověřena jako base64 kódované JSON"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "Invalid entity type"
-msgstr "Tipo de entidad inválida"
+msgstr "Neplatný typ entity"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "Invalid comparison entity type. Can only be one of \"table\", \"segment\", or \"adhoc\""
-msgstr "Tipo de entidad de comparación inválida. Solo puede ser \"tabla\", \"segmento\" o \"adhoc\""
+msgstr "Neplatný typ srovnávací entity. Může to být pouze \"tabulka\", \"segment\" nebo \"ad hoc\""
 
 #: src/metabase/query_processor/async.clj
 msgid "Error running query to determine Card result metadata:"
-msgstr "Error determinando el tipo de resultado de la tarjeta"
+msgstr "Chyba při spouštění dotazu k určení metadat výsledku karty:"
 
 #: src/metabase/api/card.clj
 msgid "DELETE /api/card/:id is deprecated. Instead, change its `archived` value via PUT /api/card/:id."
-msgstr "DELETE /api/card/:id esta descontinuado. Cambia el valor de `archived` via PUT /api/card/:id."
+msgstr "DELETE /api/card/:id je zastaralé. Místo toho změňte svoji `archivovanou` hodnotu pomocí PUT /api/card/:id."
 
 #: src/metabase/api/common.clj src/metabase/api/common/internal.clj
 msgid "Invalid field: {0}"
-msgstr "Campo inválido: {0}"
+msgstr "Neplatné pole: {0}"
 
 #: src/metabase/api/common.clj
 msgid "Invalid value ''{0}'' for ''{1}'': {2}"
-msgstr "Valor inválido ''{0}'' para ''{1}'': {2}"
+msgstr "Neplatná hodnota ''{0}'' pro ''{1}'': {2}"
 
 #: src/metabase/api/common.clj
 msgid "must be one of: {0}"
-msgstr "debe ser uno de: {0}"
+msgstr "musí být jedním z: {0}"
 
 #: src/metabase/api/common.clj
 msgid "Invalid Request."
-msgstr "Petición inválida."
+msgstr "Neplatný požadavek."
 
 #: src/metabase/api/common.clj
 msgid "Not found."
-msgstr "No encontrado."
+msgstr "Nenalezeno."
 
 #: src/metabase/api/common.clj
 msgid "You don''t have permissions to do that."
-msgstr "Lo siento, no tienes permiso para hacer eso."
+msgstr "Nemáte na to oprávnění."
 
 #: src/metabase/api/common.clj
 msgid "Internal server error."
-msgstr "Error de servidor interno."
+msgstr "Interní chyba serveru."
 
 #: src/metabase/api/common.clj
 msgid "Warning: endpoint {0}/{1} does not have a docstring."
-msgstr "Aviso: la llamada {0}/{1} no tiene un docstring"
+msgstr "Varování: koncový bod {0} / {1} nemá popisný řetězec."
 
 #: src/metabase/api/common.clj
 msgid "starting streaming request"
-msgstr "iniciando streaming"
+msgstr "zahajuji požadavek na streamování"
 
 #: src/metabase/async/api_response.clj
 msgid "connection closed, canceling request"
-msgstr "iniciando la solicitud de transmisión"
+msgstr "připojení bylo ukončeno, ruší se požadavek"
 
 #. a newline padding character as it's harmless and will allow us to check if the client is connected. If
 #. sending this character fails because the connection is closed, the chan will then close.  Newlines are
 #. no-ops when reading JSON which this depends upon.
 #: src/metabase/async/api_response.clj
 msgid "Response not ready, writing one byte & sleeping..."
-msgstr "La respuesta no está lista, escribiendo un byte y esperando..."
+msgstr "Odpověď není připravena, zapisuji jeden bajt a spím..."
 
 #: src/metabase/api/common.clj
 msgid "Public sharing is not enabled."
-msgstr "La compartición pública no está habilitada."
+msgstr "Veřejné sdílení není povoleno."
 
 #: src/metabase/api/common.clj
 msgid "Embedding is not enabled."
-msgstr "La incrustación no está habilitada."
+msgstr "Vkládání je vypnuto."
 
 #: src/metabase/api/common.clj
 msgid "The object has been archived."
-msgstr "El objeto ha sido archivado."
+msgstr "Objekt byl archivovaný."
 
 #: src/metabase/api/common/internal.clj
 msgid "Attempted to return a boolean as an API response. This is not allowed!"
-msgstr "Se ha intentado devolver un booleano como respuesta de API. ¡Esto no esta permitido!"
+msgstr "Pokus o vrácení logického stavu jako odpověď z API. Toto není dovoleno!"
 
 #: src/metabase/api/dataset.clj
 msgid "Source query for this query is Card {0}"
-msgstr "La consulta base de esta consulta es Tarjeta {0}"
+msgstr "Zdrojovým dotazem pro tento dotaz je Karta {0}"
 
 #: src/metabase/api/dataset.clj
 msgid "Invalid export format: {0}"
-msgstr "Formato de exportación inválido: {0}"
+msgstr "Neplatný formát exportu: {0}"
 
 #: src/metabase/api/geojson.clj
 msgid "Invalid JSON URL or resource: {0}"
-msgstr "Recurso o URL JSON no válido: {0}"
+msgstr "Neplatná JSON URL nebo prostředek: {0}"
 
 #: src/metabase/api/geojson.clj
 msgid "JSON containing information about custom GeoJSON files for use in map visualizations instead of the default US State or World GeoJSON."
-msgstr "JSON que contiene información sobre archivos GeoJSON personalizados para su uso en visualizaciones de mapas en lugar del GeoJSON por defecto de EEUU o el Mundo."
+msgstr "JSON obsahující informace o vlastních GeoJSON souborech, které mají být použity na vizualizace map namísto výchozího amerického nebo světového GeoJSON."
 
 #: src/metabase/api/geojson.clj
 msgid "Invalid custom GeoJSON key: {0}"
-msgstr "Clave personalizada GeoJSON inválida: {0}"
+msgstr "Neplatný vlastní klíč GeoJSON: {0}"
 
 #. ...but if we *still* couldn't find a match, throw an Exception, because we don't want people
 #. trying to inject new params
 #: src/metabase/api/public.clj
 msgid "Invalid param: {0}"
-msgstr "Parámetro inválido: {0}"
+msgstr "Neplatný parametr: {0}"
 
 #: src/metabase/api/pulse.clj
 msgid "DELETE /api/pulse/:id is deprecated. Instead, change its `archived` value via PUT /api/pulse/:id."
-msgstr "DELETE /api/pulse/:id esta descontinuado. Cambia el valor de `archived` via PUT /api/pulse/:id."
+msgstr "DELETE /api/pulse/:id je zastaralé. Místo toho změňte svoji `archivovanou` hodnotu pomocí PUT /api/pulse/:id."
 
 #: src/metabase/api/routes.clj
 msgid "API endpoint does not exist."
-msgstr "No existe este servicio API"
+msgstr "Koncový bod API neexistuje."
 
 #: src/metabase/api/session.clj
 msgid "Password did not match stored password."
-msgstr "La contraseña no coincide con la almacenada"
+msgstr "Heslo se neshodovalo s uloženým heslem."
 
 #: src/metabase/api/session.clj
 msgid "did not match stored password"
-msgstr "no coincide con la contraseña almacenada"
+msgstr "neodpovídá uloženému heslu"
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fallback to local authentication {0}"
-msgstr "Problema al conectar con el servidor LDAP, se recurrirá a la autentificación local {0}"
+msgstr "Při připojování k serveru LDAP se vyskytl problém, vrátím se k místním účtům {0}"
 
 #: src/metabase/api/session.clj
 msgid "Invalid reset token"
-msgstr "Token de reinicio inválido"
+msgstr "Neplatný resetovací token"
 
 #: src/metabase/api/session.clj
 msgid "Client ID for Google Auth SSO. If this is set, Google Auth is considered to be enabled."
-msgstr "ID de cliente para Google Auth SSO. Si esto está configurado, Google Auth se considera habilitado."
+msgstr "ID klienta pro Google Auth SSO. Pokud je tato možnost nastavena, Google Auth se považuje za povolené."
 
 #: src/metabase/api/session.clj
 msgid "When set, allow users to sign up on their own if their Google account email address is from this domain."
-msgstr "Permite que los usuarios se registren solos si la dirección de correo electrónico de su cuenta de Google es de este dominio."
+msgstr "Pokud je nastaveno, povolí uživatelům, aby se zaregistrovali sami, pokud je jejich emailová adresa Google účtu z této domény."
 
 #: src/metabase/api/session.clj
 msgid "Invalid Google Auth token."
-msgstr "Token de autenticación de Google no válido"
+msgstr "Neplatný token pro Google Auth."
 
 #: src/metabase/api/session.clj
 msgid "Email is not verified."
-msgstr "Correo no verificado."
+msgstr "Email není ověřený."
 
 #: src/metabase/api/session.clj
 msgid "You''ll need an administrator to create a Metabase account before you can use Google to log in."
-msgstr "Necesitarás un administrador para crear una cuenta Metabase antes de poder usar Google para iniciar sesión."
+msgstr "Než se budete moci přihlásit pomocí Google, budete potřebovat správce, aby vám vytvořil účet v Metabase."
 
 #: src/metabase/api/session.clj
 msgid "Successfully authenticated Google Auth token for: {0} {1}"
-msgstr "Se ha autentificado con éxito el token de Google Auth para: {0} {1}"
+msgstr "Úspěšně ověřený token Google Auth pro: {0} {1}"
 
 #: src/metabase/api/setup.clj
 msgid "Add a database"
-msgstr "Añade una Base de Datos"
+msgstr "Přidejte databázi"
 
 #: src/metabase/api/setup.clj
 msgid "Get connected"
-msgstr "Conectarse"
+msgstr "Být ve spojení"
 
 #: src/metabase/api/setup.clj
 msgid "Connect to your data so your whole team can start to explore."
-msgstr "Conecta tus datos para que todo el equipo pueda comenzar a explorar."
+msgstr "Připojte se ke svým datům, aby je mohl celý tým začít prohledávat."
 
 #: src/metabase/api/setup.clj
 msgid "Set up email"
-msgstr "Configura el email"
+msgstr "Nastavit email"
 
 #: src/metabase/api/setup.clj
 msgid "Add email credentials so you can more easily invite team members and get updates via Pulses."
-msgstr "Añade credenciales de correo electrónico para que puedas invitar más fácilmente a los miembros del equipo y obtener actualizaciones a través de Pulsos."
+msgstr "Přidejte údaje pro email, abyste mohli snadněji pozvat členy týmu a získat aktualizace prostřednictvím pulzů."
 
 #: src/metabase/api/setup.clj
 msgid "Set Slack credentials"
-msgstr "Establecer credenciales de Slack"
+msgstr "Nastavte pověření pro Slack"
 
 #: src/metabase/api/setup.clj
 msgid "Does your team use Slack? If so, you can send automated updates via pulses and ask questions with MetaBot."
-msgstr "¿Tu equipo usa Slack? Si es así, puedes enviar actualizaciones automáticas por pulsos y hacer preguntas con MetaBot."
+msgstr "Používá Váš tým Slack? Pokud ano, můžete odesílat automatizované novinky pomocí pulzů a klást otázky pomocí MetaBot."
 
 #: src/metabase/api/setup.clj
 msgid "Invite team members"
-msgstr "Invitar a miembros del equipo"
+msgstr "Pozvěte členy týmu"
 
 #: src/metabase/api/setup.clj
 msgid "Share answers and data with the rest of your team."
-msgstr "Comparte respuestas y datos con el resto de tu equipo."
+msgstr "Sdílejte odpovědi a data se zbytkem svého týmu."
 
 #: src/metabase/api/setup.clj
 msgid "Hide irrelevant tables"
-msgstr "Ocultar tablas irrelevantes"
+msgstr "Skrýt irelevantní tabulky"
 
 #: src/metabase/api/setup.clj
 msgid "Curate your data"
-msgstr "Mima tus datos"
+msgstr "Uspořádejte své data"
 
 #: src/metabase/api/setup.clj
 msgid "If your data contains technical or irrelevant info you can hide it."
-msgstr "Si tus datos contienen información técnica o irrelevante, puedes ocultarla."
+msgstr "Pokud vaše data obsahují technické nebo irelevantní informace, můžete je skrýt."
 
 #: src/metabase/api/setup.clj
 msgid "Organize questions"
-msgstr "Organizar preguntas"
+msgstr "Uspořádejte otázky"
 
 #: src/metabase/api/setup.clj
 msgid "Have a lot of saved questions in {0}? Create collections to help manage them and add context."
-msgstr "¿Tienes muchas preguntas guardadas en {0}? Crea colecciones para ayudar a administrarlas y añadir contexto."
+msgstr "Máte spoustu uložených dotazů v {0}? Vytvořte sbírky, které je pomohou spravovat a přidat souvislosti."
 
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
@@ -7470,1683 +7474,1687 @@ msgstr "Metabase"
 
 #: src/metabase/api/setup.clj
 msgid "Create metrics"
-msgstr "Crear métricas"
+msgstr "Vytvořte metriky"
 
 #: src/metabase/api/setup.clj
 msgid "Define canonical metrics to make it easier for the rest of your team to get the right answers."
-msgstr "Define métricas canónicas para que el resto de tu equipo obtenga las respuestas correctas."
+msgstr "Definujte všeobecné metriky, abyste ostatním členům týmu usnadnili získávání správných odpovědí."
 
 #: src/metabase/api/setup.clj
 msgid "Create segments"
-msgstr "Crear segmentos"
+msgstr "Vytvořte segmenty"
 
 #: src/metabase/api/setup.clj
 msgid "Keep everyone on the same page by creating canonical sets of filters anyone can use while asking questions."
-msgstr "Mantiene a todos en la misma página mediante la creación de conjuntos canónicos de filtros que cualquier persona puede usar al hacer preguntas."
+msgstr "Vytvořte všeobecné sady filtrů, které může kdokoliv použít při kladení otázek, a udržuje každého ve stejném stylu."
 
 #: src/metabase/api/table.clj
 msgid "Table ''{0}'' is now visible. Resyncing."
-msgstr "Ha aparecido la tabla ''{0}''. Sincronizando."
+msgstr "Tabulka '' {0} '' je nyní viditelná. Opakujte synchronizaci."
 
 #: src/metabase/api/table.clj
 msgid "Auto bin"
-msgstr "Agrupación Auto"
+msgstr "Auto intervaly"
 
 #: src/metabase/api/table.clj
 msgid "Don''t bin"
-msgstr "Sin Agrupación"
+msgstr "Bez intervalů"
 
 #: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
-msgstr[0] "Día"
-msgstr[1] "Días"
+msgstr[0] "Den"
+msgstr[1] "Dny"
+msgstr[2] "Dní"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
 #: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
-msgstr[0] "Minuto"
-msgstr[1] "Minutos"
+msgstr[0] "Minuta"
+msgstr[1] "Minuty"
+msgstr[2] "Minut"
 
 #: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
-msgstr[0] "Hora"
-msgstr[1] "Horas"
+msgstr[0] "Hodina"
+msgstr[1] "Hodiny"
+msgstr[2] "Hodin"
 
 #: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
-msgstr[0] "Trimestre"
-msgstr[1] "Trimestres"
+msgstr[0] "Kvartál"
+msgstr[1] "Kvartály"
+msgstr[2] "Kvartálů"
 
 #: src/metabase/api/table.clj
 msgid "Minute of Hour"
-msgstr "Minuto de Hora"
+msgstr "Minuta v hodině"
 
 #: src/metabase/api/table.clj
 msgid "Hour of Day"
-msgstr "Hora del Día"
+msgstr "Hodina ve dni"
 
 #: src/metabase/api/table.clj
 msgid "Day of Week"
-msgstr "Día de la Semana"
+msgstr "Den v týdnu"
 
 #: src/metabase/api/table.clj
 msgid "Day of Month"
-msgstr "Día del Mes"
+msgstr "Den v měsíci"
 
 #: src/metabase/api/table.clj
 msgid "Day of Year"
-msgstr "Día del Año"
+msgstr "Den v roku"
 
 #: src/metabase/api/table.clj
 msgid "Week of Year"
-msgstr "Semana del Año"
+msgstr "Týden v roce"
 
 #: src/metabase/api/table.clj
 msgid "Month of Year"
-msgstr "Mes del Año"
+msgstr "Měsíc v roce"
 
 #: src/metabase/api/table.clj
 msgid "Quarter of Year"
-msgstr "Trimestre del Año"
+msgstr "Kvartál v roce"
 
 #: src/metabase/api/table.clj
 msgid "10 bins"
-msgstr "10 agrupaciones"
+msgstr "10 intervalů"
 
 #: src/metabase/api/table.clj
 msgid "50 bins"
-msgstr "50 agrupaciones"
+msgstr "50 intervalů"
 
 #: src/metabase/api/table.clj
 msgid "100 bins"
-msgstr "100 agrupaciones"
+msgstr "100 intervalů"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 0.1 degrees"
-msgstr "Agrupa cada 0.1 grados"
+msgstr "Interval každých 0,1 stupně"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 1 degree"
-msgstr "Agrupa cada 1 grado"
+msgstr "Interval každý 1 stupeň"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 10 degrees"
-msgstr "Agrupa cada 10 grados"
+msgstr "Interval každých 10 stupňů"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 20 degrees"
-msgstr "Agrupa cada 20 grados"
+msgstr "Interval každých 20 stupňů"
 
 #. returns `true` if successful -- see JavaDoc
 #: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
-msgstr "¡No se encontró un escritor de imágenes apropiado!"
+msgstr "Nebyl nalezen vhodný nástroj pro vytváření obrázků!"
 
 #: src/metabase/api/user.clj
 msgid "Email address already in use."
-msgstr "Dirección de Email ya en uso"
+msgstr "Emailová adresa se již používá."
 
 #: src/metabase/api/user.clj
 msgid "Email address already associated to another user."
-msgstr "Dirección de Email asociado a otro usuario"
+msgstr "Emailová adresa je již přiřazena jinému uživateli."
 
 #: src/metabase/api/user.clj
 msgid "Not able to reactivate an active user"
-msgstr "No se puede activar un usuario activo"
+msgstr "Nelze reaktivovat aktivního uživatele"
 
 #: src/metabase/api/user.clj
 msgid "Invalid password"
-msgstr "Contraseña inválida"
+msgstr "Špatné heslo"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "All {0}"
-msgstr "Todos los {0}"
+msgstr "Všechny {0}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "{0}, all {1}"
-msgstr "{0}, todos {1}"
+msgstr "{0}, všechny {1}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "Comparison of {0} and {1}"
-msgstr "Comparativa de {0} y {1}"
+msgstr "Porovnání {0} a {1}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "Automatically generated comparison dashboard comparing {0} and {1}"
-msgstr "Crea automáticamente comparativas de {0} y {1}"
+msgstr "Automaticky generované porovnání nástěnek {0} a {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "sum"
-msgstr "suma"
+msgstr "součet"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "average"
-msgstr "media"
+msgstr "průměr"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "minumum"
-msgstr "mínimo"
+msgstr "minimum"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "maximum"
-msgstr "máximo"
+msgstr "maximum"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "distinct count"
-msgstr "Cuenta distinta"
+msgstr "jedinečný počet"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "standard deviation"
-msgstr "desviación estándar"
+msgstr "směrodatná odchylka"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "cumulative count"
-msgstr "recuento acumulativo"
+msgstr "kumulativní počet"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "cumulative sum"
-msgstr "suma acumulativa"
+msgstr "kumulativní součet"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} and {1}"
-msgstr "{0} y {1}"
+msgstr "{0} a {1}"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
-msgstr "{0} de {1}"
+msgstr "{0} z {1}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
-msgstr "{0} por {1}"
+msgstr "{0} z {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} in the {1} segment"
-msgstr "{0} en el segmento {1}"
+msgstr "{0} v segmentu {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} segment"
-msgstr "{0} segmento"
+msgstr "{0} segment"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
 msgid_plural "{0} metrics"
-msgstr[0] "{0} métrica"
-msgstr[1] "{0} métricas"
+msgstr[0] "{0} metrika"
+msgstr[1] "{0} metriky"
+msgstr[2] "{0} metrik"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
-msgstr "{0} campo"
+msgstr "{0} pole"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "\"{0}\" question"
-msgstr "\"{0}\" pregunta"
+msgstr "\"{0}\" otázka"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Compare with {0}"
-msgstr "Compara con {0}"
+msgstr "Porovnat s {0}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Compare with entire dataset"
-msgstr "Compara con todos los datos"
+msgstr "Porovnat s celou skupinou dat"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Applying heuristic %s to %s."
-msgstr "Aplicando heurística %s a %s."
+msgstr "Aplikuji heuristiku %s na %s."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Dimensions bindings:n%s"
-msgstr "Enlaces de dimensiones:n%s"
+msgstr "Vazby dimenzí:n%s"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Using definitions:nMetrics:n%snFilters:n%s"
-msgstr "Usando definicioness:nMétricas:n%snFiltros:n%s"
+msgstr "Pomocí definic:nMetrics:n%snFilters:n%s"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Can''t create dashboard for {0}"
-msgstr "No se puede crear un cuadro de mando para {0}"
+msgstr "Nelze vytvořit nástěnku pro {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}st"
-msgstr "{0}º"
+msgstr "{0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}nd"
-msgstr "{0}º"
+msgstr "{0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}rd"
-msgstr "{0}º"
+msgstr "{0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}th"
-msgstr "{0}º"
+msgstr "{0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "at {0}"
-msgstr "via {0}"
+msgstr "v {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "on {0}"
-msgstr "en {0}"
+msgstr "v {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in {0} week - {1}"
-msgstr "en {0} semana - {1}"
+msgstr "v {0} týden - {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in {0}"
-msgstr "en {0}"
+msgstr "v {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in Q{0} - {1}"
-msgstr "in T{0} {1}"
+msgstr "v Q{0} - {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Q{0}"
-msgstr "T{0}"
+msgstr "Q{0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is {1}"
-msgstr "{0} es {1}"
+msgstr "{0} je {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is between {1} and {2}"
-msgstr "{0} está entre {1} y {2}"
+msgstr "{0} je mezi {1} a {2}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is between {1} and {2}; and {3} is between {4} and {5}"
-msgstr "{0} está entre {1} y {2} y {3} está entre {4} y {5}"
+msgstr "{0} je mezi {1} a {2}; a {3} je mezi {4} a {5}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "where {0}"
-msgstr "donde {0}"
+msgstr "kde {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "A closer look at {0}"
-msgstr "Ver más detalles de {0}"
+msgstr "Bližší pohled na {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "A closer look at the {0}"
-msgstr "Ver más detalles de {0}"
+msgstr "Bližší pohled na {0}"
 
 #: src/metabase/automagic_dashboards/populate.clj
 msgid "Adding %s cards to dashboard %s:n%s"
-msgstr "Añadiendo %s tarjetas al Cuadro de Mando %s:n%s"
+msgstr "Přidávám karty %s na nástěnku %s:n%s"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "0 <= score <= {0}"
-msgstr "0 <= puntuación <= {0}"
+msgstr "0 <= skóre <= {0}"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "1 <= width <= {0}"
-msgstr "1 <= anchura <= {0}"
+msgstr "1 <= šířka <= {0}"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid metrics references"
-msgstr "Referencias de métricas válidas"
+msgstr "Platné odkazy na metriky"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid filters references"
-msgstr "Referencias de filtros válidos"
+msgstr "Platné odkazy na filtry"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid group references"
-msgstr "Referencias de grupos válidos"
+msgstr "Platné odkazy na skupinu"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid order_by references"
-msgstr "Referencias de ordenación válidas"
+msgstr "Platné odkazy na třídit_podle"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid dashboard filters references"
-msgstr "Referencias de filtros de cuadros de mando válidas"
+msgstr "Platných odkazů na filtry nástěnky"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid dimension references"
-msgstr "Referencias de dimensiones válidas"
+msgstr "Platné odkazy dimenzí"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid card dimension references"
-msgstr "Referencias de dimensiones de tarjeta válidas"
+msgstr "Platné odkazy na karty dimenzí"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Error parsing %s:n%s"
-msgstr "Error procesando %s:n%s"
+msgstr "Chyba při ověření %s:n%s"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "No user found with email address ''{0}''. "
-msgstr "No se ha encontrado un usuario con email ''{0}''. "
+msgstr "S emailovou adresou ''{0}'' nebyl nalezen žádný uživatel."
 
 #: src/metabase/cmd/reset_password.clj
 msgid "Please check the spelling and try again."
-msgstr "Por favor, verifícalo e intenta de nuevo"
+msgstr "Zkontrolujte zápis a zkuste to znovu."
 
 #: src/metabase/cmd/reset_password.clj
 msgid "Resetting password for {0}..."
-msgstr "Restableciendo la contraseña de {0} ..."
+msgstr "Resetuje se heslo pro {0} ..."
 
 #: src/metabase/cmd/reset_password.clj
 msgid "OK [[[{0}]]]"
-msgstr "VALE [[[{0}]]]"
+msgstr "OK [[[{0}]]]"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "FAIL [[[{0}]]]"
-msgstr "FALLO [[[{0}]]]"
+msgstr "FAIL [[[{0}]]]"
 
 #: src/metabase/core.clj
 msgid "Please use the following URL to setup your Metabase installation:"
-msgstr "Utiliza la siguiente URL para configurar tu instalación de Metabase:"
+msgstr "Pro nastavení instalace Metabase použijte následující URL adresu:"
 
 #: src/metabase/core.clj
 msgid "Metabase Shutting Down ..."
-msgstr "Apagando Metabase ..."
+msgstr "Metabase se vypíná ..."
 
 #: src/metabase/core.clj
 msgid "Metabase Shutdown COMPLETE"
-msgstr "Metabase apagado correctamente"
+msgstr "Vypnutí Metabase bylo úspěšné"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase version {0} ..."
-msgstr "Iniciando Metabase {0} ..."
+msgstr "Spouští se metabase ve verzi {0} ..."
 
 #: src/metabase/core.clj
 msgid "System timezone is ''{0}'' ..."
-msgstr "La zona horaria del sistema es ''{0}'' ..."
+msgstr "Časové pásmo systému je ''{0}'' ..."
 
 #. startup database.  validates connection & runs any necessary migrations
 #: src/metabase/core.clj
 msgid "Setting up and migrating Metabase DB. Please sit tight, this may take a minute..."
-msgstr "Configurando y migrando la base de datos de Metabase. Por favor, siéntate, esto puede tardar unos minutos ..."
+msgstr "Nastavení a migrace databáze Metabase. Vydržte, může to chvíli trvat..."
 
 #: src/metabase/core.clj
 msgid "Looks like this is a new installation ... preparing setup wizard"
-msgstr "Parece que es una instalación nueva ... iniciando el asistente de configuración"
+msgstr "Vypadá to, že se jedná o novou instalaci ... připravuje se průvodce nastavením"
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization COMPLETE"
-msgstr "Inicialización de Metabase COMPLETADA"
+msgstr "Inicializace Metabase je HOTOVÁ"
 
 #: src/metabase/server.clj
 msgid "Launching Embedded Jetty Webserver with config:"
-msgstr "Iniciando el servidor embebido Jetty con la configuración:"
+msgstr "Spuštění vestavěného webového serveru Jetty s konfigurací:"
 
 #: src/metabase/server.clj
 msgid "Shutting Down Embedded Jetty Webserver"
-msgstr "Apagando el servidor Jetty embebido"
+msgstr "Vypíná se vestavěný webový server Jetty"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase in STANDALONE mode"
-msgstr "Iniciando Metabase en modo INDEPENDIENTE"
+msgstr "Spuštění Metabase v režimu STANDALONE"
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization FAILED"
-msgstr "La inicialización de Metabase ha FALLADO"
+msgstr "Inicializace Metabase SELHALA"
 
 #: src/metabase/db/liquibase.clj
 msgid "Database has migration lock; cannot run migrations."
-msgstr "La base de datos tiene un bloqueo de migración por lo que no podemos actualizar."
+msgstr "Databáze má migrační zámek; nelze spustit migrace."
 
 #: src/metabase/db/liquibase.clj
 msgid "You can force-release these locks by running `java -jar metabase.jar migrate release-locks`."
-msgstr "Puedes forzar la liberación de estos bloqueos ejecutando `java -jar metabase.jar migrate release-locks`."
+msgstr "Tyto zámky lze odprostit spuštěním `java -jar metabase.jar migrate release-lock`."
 
 #: src/metabase/db/liquibase.clj
 msgid "Checking if Database has unrun migrations..."
-msgstr "Comprobando si la base de datos tiene migraciones sin terminar..."
+msgstr "Probíhá kontrola, zda má databáze nespuštěné migrace..."
 
 #: src/metabase/db/liquibase.clj
 msgid "Database has unrun migrations. Waiting for migration lock to be cleared..."
-msgstr "La base de datos tiene migraciones sin terminar. Esperando a que se borre el bloqueo de migración..."
+msgstr "Databáze má nespuštěné migrace. Čeká se na zrušení zámku migrace..."
 
 #: src/metabase/db/liquibase.clj
 msgid "Migration lock is cleared. Running migrations..."
-msgstr "Se ha eliminado el bloqueo de migración. Ejecutando migraciones..."
+msgstr "Zámek migrace je zrušen. Probíhá migrace."
 
 #: src/metabase/db/liquibase.clj
 msgid "Migration lock cleared, but nothing to do here! Migrations were finished by another instance."
-msgstr "Se borró el bloqueo de migración, ¡pero no hay nada que hacer aquí! Las migraciones fueron terminadas por otra instancia."
+msgstr "Zámek migrace byl zrušen, ale tady se nedá nic dělat! Migrace byly ukončeny jinou instancí."
 
 #. Set up liquibase and let it do its thing
 #: src/metabase/db.clj
 msgid "Setting up Liquibase..."
-msgstr "Preparando Liquibase..."
+msgstr "Nastavuje se Liquibase..."
 
 #: src/metabase/db.clj
 msgid "Liquibase is ready."
-msgstr "Liquibase preparado"
+msgstr "Liquibase je připravená."
 
 #: src/metabase/db.clj
 msgid "Verifying {0} Database Connection ..."
-msgstr "Verificando la conexión a la base de datos {0} ..."
+msgstr "Ověřuje se {0} připojení k databázi..."
 
 #: src/metabase/db.clj
 msgid "Verify Database Connection ... "
-msgstr "Verifica la conexión a la base de datos ... "
+msgstr "Ověřuji připojení k databázi... "
 
 #: src/metabase/db.clj
 msgid "Running Database Migrations..."
-msgstr "Ejecutando migraciones de la base de datos..."
+msgstr "Spouštím migrace databáze..."
 
 #: src/metabase/db.clj
 msgid "Database Migrations Current ... "
-msgstr "Migraciones de la base de datos actuales ..."
+msgstr "Migrace databáze je aktuálně... "
 
 #: src/metabase/driver/common.clj
 msgid "Hmm, we couldn''t connect to the database."
-msgstr "Hmm, no he podido conectar con la base de datos."
+msgstr "Jaj, nemůžeme se k databázi připojit."
 
 #: src/metabase/driver/common.clj
 msgid "Make sure your host and port settings are correct"
-msgstr "Asegúrate de que la configuración del host y del puerto sean correctas"
+msgstr "Zkontrolujte, zda je nastavení hostitele a portu správné"
 
 #: src/metabase/driver/common.clj
 msgid "We couldn''t connect to the ssh tunnel host."
-msgstr "no he podido conectar con el servidor del tunel ssh"
+msgstr "Nemohli jsme se připojit k hostiteli s pomocí ssh tunelu."
 
 #: src/metabase/driver/common.clj
 msgid "Check the username, password."
-msgstr "Verifica el nombre de usuario/contraseña."
+msgstr "Zkontrolujte uživatelské jméno a heslo."
 
 #: src/metabase/driver/common.clj
 msgid "Check the hostname and port."
-msgstr "Verifica el servidor y puerto"
+msgstr "Zkontrolujte jméno serveru a port."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like the database name is incorrect."
-msgstr "Parece que el nombre de la base de datos es incorrecto"
+msgstr "Zdá se, že název databáze je špatný."
 
 #: src/metabase/driver/common.clj
 msgid "It looks like your host is invalid."
-msgstr "Parece que tu servidor no es válido"
+msgstr "Zdá se, že váš hostitel je špatný."
 
 #: src/metabase/driver/common.clj
 msgid "Please double-check it and try again."
-msgstr "Por favor, vuelve a verificarlo e intenta de nuevo"
+msgstr "Prosím znovu to zkontrolujte a opět to zkuste."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like your password is incorrect."
-msgstr "Parece que tu contraseña es incorrecta"
+msgstr "Zdá se, že vaše heslo je špatné."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like you forgot to enter your password."
-msgstr "Parece que olvidaste poner tu contraseña"
+msgstr "Zdá se, že jste zapomněli zadat heslo."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like your username is incorrect."
-msgstr "Parece que tu nombre de usuario es incorrecto."
+msgstr "Zdá se, že vaše uživatelské jméno je špatné."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like the username or password is incorrect."
-msgstr "Parece que el nombre de usuario o la contraseña son incorrectos."
+msgstr "Zdá se, že uživatelské jméno nebo heslo je špatné."
 
 #. ## CONFIG
 #: src/metabase/driver.clj
 msgid "Connection timezone to use when executing queries. Defaults to system timezone."
-msgstr "Zona horaria de conexión que se utilizará al ejecutar consultas. El valor predeterminado es la zona horaria del sistema."
+msgstr "Časové pásmo připojení, které se použije při provádění dotazů. Výchozí nastavení je časové pásmo systému."
 
 #: src/metabase/driver.clj
 msgid "Registered driver {0} {1}"
-msgstr "Controlador registrado {0} {1}"
+msgstr "Registrovaný ovladač {0} {1}"
 
 #: src/metabase/driver.clj
 msgid "No -init-driver function found for ''{0}''"
-msgstr "No se ha encontrado ninguna función -init-driver para ''{0}''"
+msgstr "Pro ''{0}'' se nenašla žádná funkce -init-driver"
 
 #: src/metabase/driver/common.clj
 msgid "Unable to parse date string ''{0}'' for database engine ''{1}''"
-msgstr "No se puede analizar la cadena de fecha ''{0}'' para el motor de base de datos ''{1}''"
+msgstr "Nepodařilo se ověřit řetězec datumu ''{0}'' pro databázi ''{1}''"
 
 #. all-NULL columns in DBs like Mongo w/o explicit types
 #: src/metabase/driver/common.clj
 msgid "Don''t know how to map class ''{0}'' to a Field base_type, falling back to :type/*."
-msgstr "No se cómo utilizar la clase ''{0}'' como tipo base de campo, volviendo a :type/*."
+msgstr "Nevím, jak namapovat třídu ''{0}'' na pole base_type, vracím se zpět na: :type/*."
 
 #: src/metabase/driver/util.clj
 msgid "Failed to connect to database: {0}"
-msgstr "Error al conectarse a la base de datos: {0}"
+msgstr "Nepodařilo se připojit k databázi: {0}"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Invalid BigQuery identifier: ''{0}''"
-msgstr "Identificador de BigQuery inválido: ''{0}''"
+msgstr "Neplatný identifikátor BigQuery: ''{0}''"
 
 #: src/metabase/driver/bigquery.clj
 msgid "BigQuery statements can't be parameterized!"
-msgstr "Los comandos BigQuery no soportan parámetros!"
+msgstr "Příkazy BigQuery nemohou být parametrizovány!"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone:"
-msgstr "No se pudo establecer la zona horaria:"
+msgstr "Nepodařilo se nastavit časové pásmo:"
 
 #: src/metabase/driver/googleanalytics.clj
 msgid "You must enable the Google Analytics API. Use this link to go to the Google Developers Console: {0}"
-msgstr "Debes habilitar el API de Google Analytics. Utiliza este enlace para ir a la Consola de Desarrollo de Google: {0}"
+msgstr "Musíte povolit rozhraní Google Analytics API. Tento odkaz slouží k přechodu do Konzole pro vývojáře Google: {0}"
 
 #: src/metabase/driver/h2.clj
 msgid "Running SQL queries against H2 databases using the default (admin) database user is forbidden."
-msgstr "Está prohibido ejecutar consultas SQL en bases de datos H2 utilizando el usuario de base de datos predeterminado (administrador)."
+msgstr "Spouštění SQL dotazů na H2 databáze pomocí výchozího (správcovského) uživatele databáze je zakázáno."
 
 #: src/metabase/driver/sparksql.clj
 msgid "Error: metabase.driver.FixedHiveDriver is registered, but JDBC does not seem to be using it."
-msgstr "Error: metabase.driver.FixedHiveDriver está registrado, pero parece que JDBC no lo está usando."
+msgstr "Chyba: metabase.driver.FixedHiveDriver je zaregistrován, ale zdá se, že JDBC ho nepoužívá."
 
 #: src/metabase/driver/sparksql.clj
 msgid "Found metabase.driver.FixedHiveDriver."
-msgstr "Se ha encontrado metabase.driver.FixedHiveDriver."
+msgstr "Nalezeno metabase.driver.FixedHiveDriver."
 
 #: src/metabase/driver/sparksql.clj
 msgid "Successfully registered metabase.driver.FixedHiveDriver with JDBC."
-msgstr "Se ha registrado metabase.driver.FixedHiveDriver con JDBC."
+msgstr "Úspěšně zaregistrovaný metabase.driver.FixedHiveDriver v JDBC."
 
 #. CONFIG
 #. TODO - smtp-port should be switched to type :integer
 #: src/metabase/email.clj
 msgid "Email address you want to use as the sender of Metabase."
-msgstr "Dirección de correo electrónico que quieres usar como remitente de Metabase."
+msgstr "Emailová adresa, kterou chcete použít jako odesílatele v Metabase."
 
 #: src/metabase/email.clj
 msgid "The address of the SMTP server that handles your emails."
-msgstr "La dirección del servidor SMTP que maneja tus correos electrónicos."
+msgstr "Adresa SMTP serveru, který zpracovává vaše emaily."
 
 #: src/metabase/email.clj
 msgid "SMTP username."
-msgstr "Usuario SMTP."
+msgstr "Uživatelské jméno pro SMTP."
 
 #: src/metabase/email.clj
 msgid "SMTP password."
-msgstr "Contraseña SMTP."
+msgstr "Heslo pro SMTP"
 
 #: src/metabase/email.clj
 msgid "The port your SMTP server uses for outgoing emails."
-msgstr "El puerto que usa tu servidor SMTP para los correos electrónicos salientes."
+msgstr "Port, který váš SMTP server používá  na odchozí emaily."
 
 #: src/metabase/email.clj
 msgid "SMTP secure connection protocol. (tls, ssl, starttls, or none)"
-msgstr "Protocolo de conexión segura SMTP. (tls, ssl, starttls, o ninguno)"
+msgstr "Protokol zabezpečeného připojení SMTP. (lls, ssl, starttls nebo žádný)"
 
 #: src/metabase/email.clj
 msgid "none"
-msgstr "ninguno"
+msgstr "žádný"
 
 #: src/metabase/email.clj
 msgid "SMTP host is not set."
-msgstr "El servidor SMTP no está configurado."
+msgstr "SMTP hostitel není nastaven."
 
 #: src/metabase/email.clj
 msgid "Failed to send email"
-msgstr "No se pudo enviar el correo electrónico"
+msgstr "Nepodařilo se odeslat email"
 
 #: src/metabase/email.clj
 msgid "Error testing SMTP connection"
-msgstr "Error al probar la conexión SMTP"
+msgstr "Chyba při testování SMTP připojení"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Enable LDAP authentication."
-msgstr "Habilita la autenticación LDAP."
+msgstr "Povolit LDAP autentifikaci."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Server hostname."
-msgstr "Nombre servidor"
+msgstr "Název serveru. Pokud se používá SSL, mělo by se zadat FQDN."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Server port, usually 389 or 636 if SSL is used."
-msgstr "Puerto del servidor, generalmente 389 o 636 si se usa SSL."
+msgstr "Port serveru, obvykle je 389 nebo 636 - pokud se používá SSL."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Use SSL, TLS or plain text."
-msgstr "Utiliza SSL, TLS o texto sin formato."
+msgstr "Používejte SSL, TLS nebo prostý text."
 
 #: src/metabase/integrations/ldap.clj
 msgid "The Distinguished Name to bind as (if any), this user will be used to lookup information about other users."
-msgstr "El nombre distinguido para enlazar como (si existe), este usuario se utilizará para buscar información sobre otros usuarios."
+msgstr "Rozlišující jméno použité pro dotaz (pokud jej server vyžaduje), tento uživatel bude použit k vyhledávání informací o jiných uživatelích."
 
 #: src/metabase/integrations/ldap.clj
 msgid "The password to bind with for the lookup user."
-msgstr "La contraseña para vincularse con el usuario de búsqueda."
+msgstr "Heslo, které se má použít pro hledacího uživatele."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Search base for users. (Will be searched recursively)"
-msgstr "Base de búsqueda para usuarios. (Se buscará recursivamente)"
+msgstr "Počáteční umístění pro hledání uživatelů. (budou prohledány i vnořené)"
 
 #: src/metabase/integrations/ldap.clj
 msgid "User lookup filter, the placeholder '{login}' will be replaced by the user supplied login."
-msgstr "Filtro de búsqueda de usuario, el marcador de posición '{login}' se reemplazará por el inicio de sesión proporcionado por el usuario."
+msgstr "Filtr hledávání uživatele, zastupující symbol '{login}' bude nahrazen přihlašovacím jménem zadaným uživatelem. Aby se mohl uživatel přihlásit, musím mít v atributech na serveru zadáno: Jméno, Příjmení, E-mail"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user's email. (usually ''mail'', ''email'' or ''userPrincipalName'')"
-msgstr "Atributo de correo electrónico del usuario. (generalmente ''correo'', ''correo electrónico'' o ''userPrincipalName'')"
+msgstr "Atribut, který se použije jako email uživatele. (Obvykle \"mail\", \"email\" nebo \"userPrincipalName\")"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user''s first name. (usually ''givenName'')"
-msgstr "Atributo a usar para el primer nombre del usuario. (generalmente ''givenName'')"
+msgstr "Atribut, který se použije pro křestní jméno. (Obvykle \"givenName\")"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user''s last name. (usually ''sn'')"
-msgstr "Atributo para usar para el apellido del usuario. (generalmente ''sn'')"
+msgstr "Atribut, který se použije jako příjmení uživatele. (Obvykle \"sn\")"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Enable group membership synchronization with LDAP."
-msgstr "Habilite la sincronización de membresía grupal con LDAP."
+msgstr "Povolit synchronizaci členství skupin s LDAP."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Search base for groups, not required if your LDAP directory provides a ''memberOf'' overlay. (Will be searched recursively)"
-msgstr "Base de búsqueda para grupos, no requerida si tu directorio LDAP proporciona una superposición ''memberOf''. (Se buscará recursivamente)"
+msgstr "Počáteční umístění pro skupiny se nevyžaduje, pokud váš adresář LDAP poskytuje překrytí ''memberOf''. (Bude se vyhledávat rekurzivně)"
 
 #. Should be in the form: {"cn=Some Group,dc=...": [1, 2, 3]} where keys are LDAP groups and values are lists of MB groups IDs
 #: src/metabase/integrations/ldap.clj
 msgid "JSON containing LDAP to Metabase group mappings."
-msgstr "JSON que contiene las correspondencia de LDAP a grupos de Metabase."
+msgstr "JSON obsahující mapování skupin LDAP do Metabase."
 
 #. Define a setting which captures our Slack api token
 #: src/metabase/integrations/slack.clj
 msgid "Slack API bearer token obtained from https://api.slack.com/web#authentication"
-msgstr "Slack API bearer token obtenido de https://api.slack.com/web#authentication"
+msgstr "Token Slack API získaný z https://api.slack.com/web#authentication"
 
 #: src/metabase/metabot.clj
 msgid "Enable MetaBot, which lets you search for and view your saved questions directly via Slack."
-msgstr "Habilita MetaBot, que te permite buscar y ver tus preguntas guardadas directamente a través de Slack."
+msgstr "Povolte MetaBot, který vám umožní vyhledávat a prohlížet vaše uložené otázky přímo přes Slack."
 
 #: src/metabase/metabot/instance.clj
 msgid "Last MetaBot checkin was {0} ago."
-msgstr "Ultimo acceso de MetaBot fue hace {0}"
+msgstr "Poslední kontrola MetaBot byla před {0}."
 
 #: src/metabase/metabot/instance.clj
 msgid "This instance will now handle MetaBot duties."
-msgstr "Esta instalación ahora manejará tareas de MetaBot"
+msgstr "Tato instance bude nyní řešit úlohy MetaBotu."
 
 #: src/metabase/metabot.clj
 msgid "Here''s what I can {0}:"
-msgstr "Esto es lo que puedo {0}:"
+msgstr "Zde je to, co můžu {0}:"
 
 #: src/metabase/metabot.clj
 msgid "I don''t know how to {0} `{1}`.n{2}"
-msgstr "No se como {0} `{1}`.n{2}"
+msgstr "Nevím jak na to {0} `{1}`.n{2}"
 
 #: src/metabase/metabot/slack.clj
 msgid "Uh oh! :cry:n> {0}"
-msgstr "¡Oh! :cry:n>"
+msgstr "Jejda :cry:n> {0}"
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s your {0} most recent cards:n{1}"
-msgstr "Aquí están tus {0} tarjetas más recientes: n{1}"
+msgstr "Toto jsou vaše {0} nejnovější karty: n{1}"
 
 #: src/metabase/metabot/command.clj
 msgid "Could you be a little more specific? I found these cards with names that matched:n{0}"
-msgstr "¿Podrías ser un poco más específico? He encontrado estas tarjetas con nombres que coinciden: n{0}"
+msgstr "Mohl byste být trochu konkrétnější? Našel jsem tyto karty se jmény, které se shodují: n{0}"
 
 #: src/metabase/metabot/command.clj
 msgid "I don''t know what Card `{0}` is. Give me a Card ID or name."
-msgstr "No sé lo qué es la Tarjeta `{0}`. Dame un ID o nombre de tarjeta."
+msgstr "Nevím, co je karta `{0}`. Dejte mi ID karty nebo jméno."
 
 #: src/metabase/metabot/command.clj
 msgid "Show which card? Give me a part of a card name or its ID and I can show it to you. If you don''t know which card you want, try `metabot list`."
-msgstr "¿Qué tarjeta mostrar? Dame una parte del nombre de una tarjeta o su ID y te lo puedo mostrar. Si no sabes qué tarjeta quieres, prueba con `metabot list`."
+msgstr "Kterou kartu ukázat? Dejte mi část názvu karty nebo její ID a mohu vám ji ukázat. Pokud nevíte, kterou kartu chcete, zkuste `metabot list`."
 
 #: src/metabase/metabot/command.clj
 msgid "Ok, just a second..."
-msgstr "Vale, solo un segundo..."
+msgstr "Ok, jen sekundu..."
 
 #: src/metabase/metabot/command.clj
 msgid "Not Found"
-msgstr "No Encontrado"
+msgstr "Nenalezeno"
 
 #: src/metabase/metabot/command.clj
 msgid "Loading Kanye quotes..."
-msgstr "Cargando citas de Kanye..."
+msgstr "Načítání nabídky Kanye..."
 
 #: src/metabase/metabot/events.clj
 msgid "Evaluating Metabot command:"
-msgstr "Evaluando el comando de Metabot:"
+msgstr "Vyhodnocení příkazu Metabot:"
 
 #: src/metabase/metabot.clj
 msgid "Go home websocket, you're drunk."
-msgstr "El websocket esta borracho."
+msgstr "Táhni domů webSockete, ožralo jeden."
 
 #: src/metabase/metabot/websocket.clj
 msgid "Error launching metabot:"
-msgstr "Error al iniciar metabot:"
+msgstr "Chyba při spouštění metabotu:"
 
 #: src/metabase/metabot/websocket.clj
 msgid "MetaBot WebSocket is closed. Reconnecting now."
-msgstr "MetaBot WebSocket está cerrado. Reconectando ahora."
+msgstr "MetaBot WebSocket je zavřený. Probíhá opětovné připojení."
 
 #: src/metabase/metabot/websocket.clj
 msgid "Error connecting websocket:"
-msgstr "Error al conectar websocket:"
+msgstr "Chyba při připojování k websocketu:"
 
 #: src/metabase/metabot/instance.clj
 msgid "This instance is performing MetaBot duties."
-msgstr "Esta instalación está manejando tareas de MetaBot"
+msgstr "Tato instance plní úlohy MetaBotu."
 
 #: src/metabase/metabot/instance.clj
 msgid "Another instance is already handling MetaBot duties."
-msgstr "Otra instalación está manejando las tareas de MetaBot"
+msgstr "Jiná instance už plní úlohy MetaBotu."
 
 #: src/metabase/metabot.clj
 msgid "Starting MetaBot threads..."
-msgstr "Iniciando hilos de MetaBot..."
+msgstr "Spouštějí se vlákna MetaBotu..."
 
 #: src/metabase/metabot.clj
 msgid "Stopping MetaBot...  🤖"
-msgstr "Parando MetaBot...  🤖"
+msgstr "Zastavuje se MetaBot ... 🤖"
 
 #: src/metabase/metabot.clj
 msgid "MetaBot already running. Killing the previous WebSocket listener first."
-msgstr "MetaBot ya se está ejecutando. Matando al oyente WebSocket previo primero."
+msgstr "MetaBot už běží. Zabíjím předchozí WebSocket listener."
 
 #: src/metabase/middleware/security.clj
 msgid "Base-64 encoded public key for this site's SSL certificate."
-msgstr "Clave pública codificada en Base-64 para el certificado SSL de este sitio."
+msgstr "Veřejný klíč kódovaný v Base-64 pro SSL certifikát této stránky."
 
 #: src/metabase/middleware/security.clj
 msgid "Specify this to enable HTTP Public Key Pinning."
-msgstr "Especifica esto para habilitar la fijación de clave pública HTTP."
+msgstr "Zadejte tuto možnost, abyste povolili připínání veřejných HTTP klíčů."
 
 #: src/metabase/middleware/security.clj
 msgid "See {0} for more information."
-msgstr "Ver {0} para más información."
+msgstr "Více informací naleznete v {0}."
 
 #: src/metabase/models/card.clj
 msgid "Cannot save Question: source query has circular references."
-msgstr "No se puede guardar la pregunta debido a referencias circulares."
+msgstr "Nelze uložit Otázku: zdrojový dotaz má zpětné reference."
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
-msgstr "No existe la tarjeta {0}"
+msgstr "Karta {0} neexistuje."
 
 #: src/metabase/models/card.clj
 msgid "You do not have permissions to run ad-hoc native queries against Database {0}."
-msgstr "Lo siento, no tienes permiso para ejecutar consultas directas en la base de datos {0}."
+msgstr "Nemáte oprávnění ke spuštění ad-hoc nativních dotazů oproti databázi {0}."
 
 #: src/metabase/models/collection.clj
 msgid "Invalid color"
-msgstr "Color inválido"
+msgstr "Špatná barva"
 
 #: src/metabase/models/collection.clj
 msgid "must be a valid 6-character hex color code"
-msgstr "debe ser un código de color hexadecimal válido de 6 caracteres"
+msgstr "musí být platný šestimístný hexadecimální kód barvy"
 
 #: src/metabase/models/collection.clj
 msgid "Collection name cannot be blank!"
-msgstr "¡El nombre de la colección no puede estar vacío!"
+msgstr "Název sbírky nesmí být prázdný!"
 
 #: src/metabase/models/collection.clj
 msgid "cannot be blank"
-msgstr "no puede ser vacío"
+msgstr "nemůže být prázdné"
 
 #: src/metabase/models/collection.clj
 msgid "Invalid Collection location: path is invalid."
-msgstr "Ubicación de colección inválida: la ruta no es válida."
+msgstr "Neplatné umístění sbírky: cesta je neplatná."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Personal Collection."
-msgstr "No puedes mover una Colección Personal."
+msgstr "Osobní sbírku nemůžete přesunout."
 
 #: src/metabase/models/collection.clj
 msgid "Invalid Collection location: some or all ancestors do not exist."
-msgstr "Ubicación de colección inválida: uno o más antepasados no existen."
+msgstr "Neplatné umístění sbírky: Někteří nebo všichni předkové neexistují."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot archive the Root Collection."
-msgstr "¡No puedes archivar la Colección Raíz!"
+msgstr "Kořenovou sbírku nemůžete archivovat."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot archive a Personal Collection."
-msgstr "No puedes archivar una Colección Personal."
+msgstr "Osobní sbírku nemůžete archivovat."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move the Root Collection."
-msgstr "¡No puedes mover la Colección Raíz!"
+msgstr "Kořenovou sbírku nemůžete přesunout."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection into itself or into one of its descendants."
-msgstr "No puedes mover una Colección dentro de si misma o dentro de uno de sus descendientes."
+msgstr "Sbírku nemůžete přesunout do sebe nebo do jednoho z jejích potomků."
 
 #. first move this Collection
 #: src/metabase/models/collection.clj
 msgid "Moving Collection {0} and its descendants from {1} to {2}"
-msgstr "Moviendo la Colección {0} y sus descendientes de {1} a {2}"
+msgstr "Přesunout sbírku {0} a její potomky z {1} do {2}"
 
 #: src/metabase/models/collection.clj
 msgid "You're not allowed to change the owner of a Personal Collection."
-msgstr "No está permitido cambiar el propietario de una Colección Personal."
+msgstr "Nemáte oprávnění měnit vlastníka osobní sbírky."
 
 #: src/metabase/models/collection.clj
 msgid "You're not allowed to move a Personal Collection."
-msgstr "No tienes permiso para mover una Colección Personal."
+msgstr "Nemáte oprávnění přesunout osobní sbírku."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection and archive it at the same time."
-msgstr "No puedes mover y archivar una Colección al mismo tiempo."
+msgstr "Sbírku nemůžete přesunout a zároveň ji archivovat."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot delete a Personal Collection!"
-msgstr "¡No puedes eliminar una Colección Personal!"
+msgstr "Osobní sbírku nemůžete smazat."
 
 #: src/metabase/models/collection.clj
 msgid "{0} {1}''s Personal Collection"
-msgstr "Colección Personal de {0} {1}"
+msgstr "Osobní sbírka {0} {1}"
 
 #: src/metabase/models/collection_revision.clj
 msgid "You cannot update a CollectionRevision!"
-msgstr "¡No puedes actualzar una revisión de Colección!"
+msgstr "Nemůžete aktualizovat sbírku revizí!"
 
 #: src/metabase/models/field_values.clj
 msgid "Field {0} was previously automatically set to show a list widget, but now has {1} values."
-msgstr "El campo {0} se estableció automáticamente para mostrar una lista, pero ahora tiene {1} valores."
+msgstr "Pole {0} bylo předtím automaticky nastaveno tak, aby zobrazovalo widget seznamu, ale nyní má {1} hodnoty."
 
 #: src/metabase/models/field_values.clj
 msgid "Switching Field to use a search widget instead."
-msgstr "Cambio de campo para usar un elemento de búsqueda en su lugar."
+msgstr "Přepnutí pole vede k použití vyhledávacího widgetu."
 
 #: src/metabase/models/field_values.clj
 msgid "Storing updated FieldValues for Field {0}..."
-msgstr "Almacenando Valores de Campo actualizados para el campo {0} ..."
+msgstr "Ukládám aktualizované hodnoty polí pro pole {0}..."
 
 #: src/metabase/models/field_values.clj
 msgid "Storing FieldValues for Field {0}..."
-msgstr "Almacenando Valores de Campo para el campo {0} ..."
+msgstr "Ukládám hodnoty polí pro pole {0}..."
 
 #: src/metabase/models/humanization.clj
 msgid "Metabase can attempt to transform your table and field names into more sensible, human-readable versions, e.g. \"somehorriblename\" becomes \"Some Horrible Name\"."
-msgstr "Metabase puede intentar transformar los nombres de tablas y campos en versiones más entendibles y legibles para el ser humano, p.e. \"unnombrehorrible\" se convierte en \"Un Nombre Horrible\". "
+msgstr "Metabase se může pokusit transformovat názvy tabulek a polí na rozumnější verze čitelné pro člověka. Např. z \"nějakýstašnýnázev\" se stane \"Nějaký Strašný Název\""
 
 #: src/metabase/models/humanization.clj
 msgid "This doesn’t work all that well if the names are in a language other than English, however."
-msgstr "Sin embargo, esto no funciona muy bien si los nombres están en un idioma que no sea el inglés."
+msgstr "Toto však nefunguje dobře, pokud jsou názvy v jiném jazyce než v angličtině."
 
 #: src/metabase/models/humanization.clj
 msgid "Do you want us to take a guess?"
-msgstr "¿Quieres que adivinemos?"
+msgstr "Chcete, abychom hádali?"
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot create or revoke permissions for the 'Admin' group."
-msgstr "No puedes crear o revocar permisos para el grupo 'Admin'."
+msgstr "Nelze vytvořit ani odebrat pravomoci pro skupinu \"Správce\"."
 
 #: src/metabase/models/permissions.clj
 msgid "Invalid permissions object path: ''{0}''."
-msgstr "Ruta del objeto de permisos inválido: ''{0}''."
+msgstr "Neplatná cesta k objektu pravomocí: ''{0}''."
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot update a permissions entry!"
-msgstr "¡No puedes actualizar una entrada de permisos!"
+msgstr "Nemůžete aktualizovat záznam pravomocí!"
 
 #: src/metabase/models/permissions.clj
 msgid "Delete it and create a new one."
-msgstr "Elimínalo y crear uno nuevo."
+msgstr "Odstraňte ho a vytvořte nový."
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot edit permissions for a Personal Collection or its descendants."
-msgstr "No puedes editar los permisos de una Colección personal ni sus descendientes."
+msgstr "Nemůžete upravovat oprávnění pro Osobní sbírku nebo jejích potomků."
 
 #: src/metabase/models/permissions.clj
 msgid "Looks like someone else edited the permissions and your data is out of date."
-msgstr "Parece que alguien más editó los permisos y tus datos están desactualizados."
+msgstr "Zdá se, že povolení upravil někdo jiný a vaše údaje jsou zastaralé."
 
 #: src/metabase/models/permissions.clj
 msgid "Please fetch new data and try again."
-msgstr "Por favor, obtiene nuevos datos e intenta de nuevo"
+msgstr "Načtěte nové data a zkuste to znovu."
 
 #: src/metabase/models/permissions_group.clj
 msgid "Created magic permissions group ''{0}'' (ID = {1})"
-msgstr "Creado grupo de permisos mágicos ''{0}'' (ID = {1})"
+msgstr "Vytvořená skupina pravomocí ''{0}'' (ID = {1})"
 
 #: src/metabase/models/permissions_group.clj
 msgid "A group with that name already exists."
-msgstr "Ya existe un grupo con ese nombre"
+msgstr "Skupina s tímto jménem již existuje."
 
 #: src/metabase/models/permissions_group.clj
 msgid "You cannot edit or delete the ''{0}'' permissions group!"
-msgstr "¡No puedes editar o eliminar el grupo de permisos ''{0}''!"
+msgstr "Nelze upravovat ani mazat skupinu pravomocí \"{0}\"."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the 'MetaBot' group."
-msgstr "No puedes añadir o eliminar usuarios a/del grupo 'MetaBot'."
+msgstr "Ve skupině \"MetaBot\" nemůžete přidávat ani odstraňovat uživatele."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the 'All Users' group."
-msgstr "No puedes añadir o eliminar usuarios a/del grupo 'All'."
+msgstr "Ve skupině 'Všichni uživatelé' nemůžete přidávat ani odstraňovat uživatele."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot remove the last member of the 'Admin' group!"
-msgstr "¡No puedes eliminar al último miembro del grupo 'Admin'!"
+msgstr "Posledního člena skupiny 'Správce' nemůžete odstranit!"
 
 #: src/metabase/models/permissions_revision.clj
 msgid "You cannot update a PermissionsRevision!"
-msgstr "¡No puedes actualizar una revisión de permisos!"
+msgstr "Nemůžete aktualizovat revize přístupů!"
 
 #. if there's still not a Card, throw an Exception!
 #: src/metabase/models/pulse.clj
 msgid "Invalid Alert: Alert does not have a Card assoicated with it"
-msgstr "Alerta Inválida: no tiene asociada un tarjeta"
+msgstr "Neplatné upozornění: upozornění není spojeno s kartou"
 
 #: src/metabase/models/pulse.clj
 msgid "value must be a map with the keys `{0}`, `{1}`, and `{2}`."
-msgstr "el valor debe ser un mapa con los índices `{0}`, `{1}`, and `{2}`."
+msgstr "hodnota musí být mapa s klávesami `{0}`, `{1}` a `{2}`."
 
 #: src/metabase/models/pulse.clj
 msgid "value must be a map with the following keys `({0})`"
-msgstr "el valor debe ser un mapa con los índices `({0})`."
+msgstr "hodnota musí být mapa s následujícími klávesami `({0})`"
 
 #: src/metabase/models/query/permissions.clj
 msgid "Error calculating permissions for query: {0}"
-msgstr "Error calculando los permisos para la consulta: {0}"
+msgstr "Chyba při zjišťování pravomocí pro dotaz: {0}"
 
 #: src/metabase/models/query/permissions.clj
 msgid "Invalid query type: {0}"
-msgstr "Tipo de consulta inválida: {0}"
+msgstr "Neplatný typ dotazu: {0}"
 
 #: src/metabase/models/query_execution.clj
 msgid "You cannot update a QueryExecution!"
-msgstr "¡No puedes actualizar una ejecución de consulta!"
+msgstr "Nelze aktualizovat QueryExecution!"
 
 #: src/metabase/models/revision.clj
 msgid "You cannot update a Revision!"
-msgstr "¡No puedes actualizar una revisión!"
+msgstr "Revizi nelze aktualizovat!"
 
 #: src/metabase/models/setting.clj
 msgid "Setting {0} does not exist.nFound: {1}"
-msgstr "El ajuste {0} no existe.\n"
-"Encontrado: {1}"
+msgstr "Nastavení {0} neexistuje.\n"
+"Nalezeno: {1}"
 
 #: src/metabase/models/setting/cache.clj
 msgid "Updating value of settings-last-updated in DB..."
-msgstr "Actualizando ulitmo cambio en configuración..."
+msgstr "Aktualizace hodnoty \"settings-last-updated\" v DB..."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Checking whether settings cache is out of date (requires DB call)..."
-msgstr "Comprobando si la memoria caché de configuración está desactualizada..."
+msgstr "Probíhá kontrola, zda je mezipaměť s nastavením zastaralá (vyžaduje volání DB)..."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Settings have been changed on another instance, and will be reloaded here."
-msgstr "La configuración se modificó en otra instancia y se volverá a cargar aquí."
+msgstr "Nastavení bylo změněno v jiné instanci a zde se načtou znovu."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Refreshing Settings cache..."
-msgstr "Actualizando caché de Configuración"
+msgstr "Obnovuje se mezipaměť s nastavením..."
 
 #: src/metabase/models/setting.clj
 msgid "Invalid value for string: must be either \"true\" or \"false\" (case-insensitive)."
-msgstr "Valor no válido para la cadena: debe ser \"true\" o \"false\" (no distingue entre mayúsculas y minúsculas)"
+msgstr "Neplatná hodnota pro řetězec: musí být buď \"PRAVDA\" nebo \"NEPRAVDA\" (nezáleží na velikosti)."
 
 #: src/metabase/models/setting.clj
 msgid "You cannot update `settings-last-updated` yourself! This is done automatically."
-msgstr "¡No puedes actualizar `settings-last-update` ! Esto se realiza automáticamente."
+msgstr "Nemůžete aktualizovat \"settings-last-updated\" sami! Toto se provádí automaticky."
 
 #. go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
 #: src/metabase/models/setting.clj
 msgid "Error inserting a new Setting:"
-msgstr "Error insertando nueva configuración:"
+msgstr "Chyba při vkládání nového nastavení:"
 
 #: src/metabase/models/setting.clj
 msgid "Assuming Setting already exists in DB and updating existing value."
-msgstr "￼Asumiendo que la configuración ya existe en DB y actualizando el valor existente."
+msgstr "Předpokládám, že nastavení již existuje v DB a aktualizuji existující hodnotu."
 
 #: src/metabase/models/user.clj
 msgid "value must be a map with each value either a string or number."
-msgstr "el valor debe ser un mapa con valores numéricos o de cadena."
+msgstr "hodnota musí být mapa s každou hodnotou jako řetězec nebo číslo."
 
 #: src/metabase/plugins.clj
 msgid "Loading plugins in directory {0}..."
-msgstr "Cargando complementos en el directorio {0}..."
+msgstr "Načítání doplňků ve složce {0}..."
 
 #: src/metabase/plugins.clj
 msgid "Loading plugin {0}... "
-msgstr "Cargando complemento {0}..."
+msgstr "Načítám doplněk {0}... "
 
 #: src/metabase/plugins.clj
 msgid "It looks like you have some external dependencies in your Metabase plugins directory."
-msgstr "Parece que tienes algunas dependencias externas en tu directorio de complementos de Metabase."
+msgstr "Zdá se, že ve složce doplňků Metabase máte nějaké vnější závislosti."
 
 #: src/metabase/plugins.clj
 msgid "With Java 9 or higher, Metabase cannot automatically add them to your classpath."
-msgstr "Con Java 9 o superior, Metabase no puede agregarlos automáticamente a tu classpath."
+msgstr "S Javou 9 nebo vyšší, je Metabase nemůže automaticky přidat do vaší třídy."
 
 #: src/metabase/plugins.clj
 msgid "Instead, you should include them at launch with the -cp option. For example:"
-msgstr "En su lugar, debes incluirlos en el lanzamiento con la opción -cp. Por ejemplo:"
+msgstr "Namísto toho by jste je měli zahrnout při spuštění pomocí parametru -cp. Například:"
 
 #: src/metabase/plugins.clj
 msgid "See https://metabase.com/docs/latest/operations-guide/start.html#java-versions for more details."
-msgstr "Ver https://metabase.com/docs/latest/operations-guide/start.html#java-versions para más detalles."
+msgstr "Další podrobnosti najdete na stránce https://metabase.com/docs/latest/operations-guide/start.html#java-versions."
 
 #: src/metabase/plugins.clj
 msgid "(If you're already running Metabase this way, you can ignore this message.)"
-msgstr "(Si ya estás ejecutando Metabase de esta manera, puedes ignorar este mensaje.)"
+msgstr "(Pokud již používáte Metabase tímto způsobem, můžete tuto zprávu ignorovat.)"
 
 #: src/metabase/public_settings.clj
 msgid "Identify when new versions of Metabase are available."
-msgstr "Informar cuándo hay nuevas versiones de Metabase."
+msgstr "Informuj pokud jsou k dispozici nové verze Metabase."
 
 #: src/metabase/public_settings.clj
 msgid "Information about available versions of Metabase."
-msgstr "Información sobre las versiones disponibles de Metabase."
+msgstr "Informace o dostupných verzích Metabase."
 
 #: src/metabase/public_settings.clj
 msgid "The name used for this instance of Metabase."
-msgstr "El nombre usado para esta instancia de Metabase."
+msgstr "Název používaný v této instanci Metabase."
 
 #: src/metabase/public_settings.clj
 msgid "The base URL of this Metabase instance, e.g. \"http://metabase.my-company.com\"."
-msgstr "La URL base de esta instancia de Metabase, p.e. \"http://metabase.my-company.com\"."
+msgstr "Základní URL adresa této instance Metabase, např. \"http://metabase.moje-firma.cz\"."
 
 #: src/metabase/public_settings.clj
 msgid "The default language for this Metabase instance."
-msgstr "El idioma predeterminado para esta instancia de Metabase."
+msgstr "Výchozí jazyk pro tuto instanci Metabase."
 
 #: src/metabase/public_settings.clj
 msgid "This only applies to emails, Pulses, etc. Users'' browsers will specify the language used in the user interface."
-msgstr "Esto solo se aplica a correos electrónicos, pulsos, etc. Los navegadores de los usuarios especificarán el idioma utilizado en la interfaz de usuario."
+msgstr "Platí to pouze pro e-maily, impulsy atd. Prohlížeč uživatele zvolí jazyk používaný v uživatelském rozhraní."
 
 #: src/metabase/public_settings.clj
 msgid "The email address users should be referred to if they encounter a problem."
-msgstr "La dirección de correo electrónico al que se dirigirán los usuarios si encuentran un problema."
+msgstr "E-mail, na který uživatelé mohou napsat v případě problémů."
 
 #: src/metabase/public_settings.clj
 msgid "Enable the collection of anonymous usage data in order to help Metabase improve."
-msgstr "Habilita la recopilación de datos de uso anónimos para ayudar a mejorar Metabase."
+msgstr "Povolit anonymní sběr dat o používání Metabase za účelem dalšího zlepšování."
 
 #: src/metabase/public_settings.clj
 msgid "The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox."
-msgstr "La plantilla de URL del servidor de capas de mapa utilizada en las visualizaciones de mapas, por ejemplo desde OpenStreetMaps o MapBox."
+msgstr "Šablona adresy URL serveru použitá ve vizualizacích map, například z OpenStreetMaps nebo MapBox."
 
 #: src/metabase/public_settings.clj
 msgid "Enable admins to create publicly viewable links (and embeddable iframes) for Questions and Dashboards?"
-msgstr "¿Habilita a los administradores para crear enlaces visibles públicamente (y iframes incrustados) para Preguntas y Cuadros de Mando?"
+msgstr "Povolit správcům vytváření veřejně viditelných odkazů (a vnořených prvků iframe) pro otázky a nástěnky?"
 
 #: src/metabase/public_settings.clj
 msgid "Allow admins to securely embed questions and dashboards within other applications?"
-msgstr "¿Permite a los administradores insertar preguntas y cuadros de mando de forma segura dentro de otras aplicaciones?"
+msgstr "Povolit správcům bezpečně vkládat otázky a nástěnky do jiných aplikací?"
 
 #: src/metabase/public_settings.clj
 msgid "Allow using a saved question as the source for other queries?"
-msgstr "¿Permitir usar una pregunta guardada como fuente para otras consultas?"
+msgstr "Povolit použití uloženého dotazu jako základu pro další dotazy?"
 
 #: src/metabase/public_settings.clj
 msgid "Enabling caching will save the results of queries that take a long time to run."
-msgstr "Al habilitar el almacenamiento en caché se guardan los resultados de las consultas que tardan mucho tiempo en ejecutarse."
+msgstr "Povolení použití mezipaměti uloží výsledky dotazů, které budou trvat dlouho."
 
 #: src/metabase/public_settings.clj
 msgid "The maximum size of the cache, per saved question, in kilobytes:"
-msgstr "El tamaño máximo de la memoria caché, por pregunta guardada, en kilobytes:"
+msgstr "Maximální velikost mezipaměti pro uloženou otázku v kilobajtech:"
 
 #: src/metabase/public_settings.clj
 msgid "The absolute maximum time to keep any cached query results, in seconds."
-msgstr "El tiempo máximo absoluto para mantener los resultados de las consultas en caché, en segundos."
+msgstr "Absolutní maximální čas pro uchování výsledků dotazů v paměti, v sekundách."
 
 #: src/metabase/public_settings.clj
 msgid "Metabase will cache all saved questions with an average query execution time longer than this many seconds:"
-msgstr "Metabase guardará en caché todas las preguntas guardadas con un tiempo promedio de ejecución de la consulta más largo que estos segundos:"
+msgstr "Metabase uloží všechny uložené otázky do mezipaměti s průměrným časem provedení dotazu delším než je tento počet sekund:"
 
 #: src/metabase/public_settings.clj
 msgid "To determine how long each saved question''s cached result should stick around, we take the query''s average execution time and multiply that by whatever you input here."
-msgstr "Para determinar cuánto tiempo debe permanecer el resultado guardado en la memoria de cada pregunta guardada, tomamos el tiempo de ejecución promedio de la consulta y lo multiplicamos por lo que pones aquí."
+msgstr "Abychom určili, jak dlouho by se měl výsledek mezipaměti každé uložené otázky zachovat, vezmeme průměrný čas provádění dotazu a vynásobíme ho podle toho, co zde zadáte."
 
 #: src/metabase/public_settings.clj
 msgid "So if a query takes on average 2 minutes to run, and you input 10 for your multiplier, its cache entry will persist for 20 minutes."
-msgstr "Así que, si una consulta tarda un promedio de 2 minutos en ejecutarse, e introduces 10 para su multiplicador, su entrada en la memoria caché se mantendrá por 20 minutos."
+msgstr "Pokud tedy dotaz trvá v průměru 2 minuty a do multiplikátoru zadáte 10, jeho setrvání v mezipaměti bude trvat 20 minut."
 
 #: src/metabase/public_settings.clj
 msgid "When using the default binning strategy and a number of bins is not provided, this number will be used as the default."
-msgstr "Cuando se usa la estrategia de agrupación predeterminada y no se proporciona una cantidad de tramos, este número se usará como el predeterminado."
+msgstr "Pokud nepoužíváte výchozí strategii pro hranice tříd a není zadaný určitý počet intervalů, použije se toto číslo jako výchozí."
 
 #: src/metabase/public_settings.clj
 msgid "When using the default binning strategy for a field of type Coordinate (such as Latitude and Longitude), this number will be used as the default bin width (in degrees)."
-msgstr "Cuando se utiliza la estrategia de agrupación predeterminada para un campo de tipo Coordenada (como Latitud y Longitud), este número se utilizará como el ancho predeterminado del tramo (en grados)."
+msgstr "Při použití výchozí strategie hranic tříd pro pole typu Koordináty (například zeměpisná šířka a délka) se toto číslo použije jako výchozí šířka intervalu (ve stupních)."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Unable to validate token."
-msgstr "No se puede validar el token."
+msgstr "Nelze validovat token."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error fetching token status:"
-msgstr "Error consultando el estado del Token:"
+msgstr "Chyba při zjišťování stavu tokenu:"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "There was an error checking whether this token was valid."
-msgstr "Hubo un error al verificar si este token es válido."
+msgstr "Došlo k chybě při ověřování platnosti tokenu."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token validation timed out."
-msgstr "La validación de token agotó el tiempo de espera."
+msgstr "Validace tokenu vypršela."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Invalid token: token isn't in the right format."
-msgstr "Token inválido: el token no está en el formato correcto."
+msgstr "Neplatný token: token nemá správný formát."
 
 #. attempt to query the metastore API about the status of this token. If the request doesn't complete in a
 #. reasonable amount of time throw a timeout exception
 #: src/metabase/public_settings/metastore.clj
 msgid "Checking with the MetaStore to see whether {0} is valid..."
-msgstr "Verificando en el MetaStore para ver si {0} es válido ..."
+msgstr "Ověřte si u MetaStore, zda je {0} platný..."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token for premium embedding. Go to the MetaStore to get yours!"
-msgstr "Token para incrustación premium. ¡Ve a MetaStore para obtener el tuyo!"
+msgstr "Token pro prémiové vkládání. Jděte do MetaStore a získejte svůj!"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token is valid."
-msgstr "Token válido"
+msgstr "Token je platný."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error setting premium embedding token"
-msgstr "Error al configurar el Token de inserción premium"
+msgstr "Chyba při nastavování tokenu prémiového vkládání"
 
 #: src/metabase/pulse.clj
 msgid "Unable to compare results to goal for alert."
-msgstr "No se pueden comparar los resultados con el objetivo de alerta."
+msgstr "Výsledky nelze srovnávat s cílem upozornění."
 
 #: src/metabase/pulse.clj
 msgid "Question ID is ''{0}'' with visualization settings ''{1}''"
-msgstr "El ID de la pregunta es ''{0}'' con configuración de visualización ''{1}''"
+msgstr "ID otázky je ''{0}'' s nastaveními vizualizace ''{1}''"
 
 #: src/metabase/pulse.clj
 msgid "Unrecognized alert with condition ''{0}''"
-msgstr "Alerta desconocida con condición ''{0}''"
+msgstr "Nerozpoznané upozornění s podmínkou ''{0}''"
 
 #: src/metabase/pulse.clj
 msgid "Unrecognized channel type {0}"
-msgstr "El tipo de canal {0} es desconocido"
+msgstr "Nerozpoznaný typ kanálu {0}"
 
 #: src/metabase/pulse.clj
 msgid "Error sending notification!"
-msgstr "¡Error enviando norificación!"
+msgstr "Odeslání notifikace selhalo!"
 
 #: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
-msgstr "No se ha podido encontrar selector JS en ''{0}''"
+msgstr "Nelze najít selektor barev JS na ''{0}''"
 
 #: src/metabase/pulse/render.clj
 msgid "Card has errors: {0}"
-msgstr "La tarjeta tiene errores: {0}"
+msgstr "Karta obsahuje chyby: {0}"
 
 #: src/metabase/pulse/render.clj
 msgid "Pulse card render error"
-msgstr "Error al procesar Pulso"
+msgstr "Chyba vykreslení karty s pulzem"
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Trimming trailing comment from card with id {0}"
-msgstr "Eliminando el comentario final de la tarjeta con id {0}"
+msgstr "Oříznutí komentáře z karty s ID {0}"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Can't find field with ID: {0}"
-msgstr "No se puede encontrar el campo con ID: {0}"
+msgstr "Nelze najít pole s ID: {0}"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "''{0}'' is a required param."
-msgstr "''{0}'' es un parámetro requerido"
+msgstr "''{0}'' je povinný parametr."
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Found ''{0}'' with no terminating ''{1}'' in query ''{2}''"
-msgstr "Encontrado ''{0}'' sin terminación ''{1}'' en la consulta ''{2}''"
+msgstr "Našel se ''{0}'' bez ukončení ''{1}'' v dotazu ''{2}''"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Unable to substitute ''{0}'': param not specified.nFound: {1}"
-msgstr "No se puede sustituir ''{0}'': parámetro no especificado.\n"
-"Encontrado: {1}"
+msgstr "Nepodařilo se nahradit ''{0}'': Parametr nebyl zadaný. Nalezen: {1}"
 
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "You do not have permissions to view Card {0}."
-msgstr "No tienes permiso para ver la Tarjeta {0}."
+msgstr "Nemáte oprávnění k prohlížení karty {0}."
 
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "You do not have permissions to run this query."
-msgstr "No tienes permiso para ejecutar esta consulta."
+msgstr "Nemáte oprávnění ke spuštění tohoto dotazu."
 
 #: src/metabase/sync/analyze.clj
 msgid "Fingerprint updates attempted {0}, updated {1}, no data found {2}, failed {3}"
-msgstr "Actualizaciones de huellas dactilares intentadas {0}, actualizadas {1}, no se encontraron datos {2}, fallaron {3}"
+msgstr "Pokusy o aktualizaci otisků prstů {0}, aktualizované {1}, nenašli žádné údaje {2}, neúspěšné {3}"
 
 #: src/metabase/sync/analyze.clj
 msgid "Total number of fields classified {0}, {1} failed"
-msgstr "El número total de campos clasificados {0}, {1} han fallado"
+msgstr "Celkový počet klasifikovaných polí {0}, {1} selhal"
 
 #: src/metabase/sync/analyze.clj
 msgid "Total number of tables classified {0}, {1} updated"
-msgstr "Número total de tablas clasificadas {0}, {1} actualizadas"
+msgstr "Celkový počet zařazených tabulek {0}, {1} aktualizováno"
 
 #: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
 msgid "Error generating fingerprint for {0}"
-msgstr "Error generando huella para {0}"
+msgstr "Chyba při generování otisku pro {0}"
 
 #: src/metabase/sync/field_values.clj
 msgid "Updated {0} field value sets, created {1}, deleted {2} with {3} errors"
-msgstr "Conjuntos de valores de campo actualizados {0}, creados {1}, eliminados {2} con {3} errores"
+msgstr "Aktualizovány {0} množiny hodnot polí, vytvořené {1}, odstraněny {2} s {3} chybami"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of fields sync''d {0}, number of fields updated {1}"
-msgstr "Número total de campos sincronizados {0}, número de campos actualizados {1}"
+msgstr "Celkový počet synchronizovaných polí {0}, počet aktualizovaných polí {1}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of tables sync''d {0}, number of tables updated {1}"
-msgstr "Número total de tablas sincronizados {0}, número de tablas actualizados {1}"
+msgstr "Celkový počet synchronizovaných tabulek {0}, počet aktualizovaných tabulek {1}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Found timezone id {0}"
-msgstr "Encontrado la zona horaria {0}"
+msgstr "Nalezeno ID časového pásma {0}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of foreign keys sync''d {0}, {1} updated and {2} tables failed to update"
-msgstr "El número total de claves externas sincronizadas {0}, {1} actualizadas y {2} tablas han fallado"
+msgstr "Celkový počet synchronizovaných cizích klíčů {0}, {1} aktualizovaných a {2} tabulek se nepodařilo aktualizovat"
 
 #: src/metabase/sync/util.clj
 msgid "{0} Database {1} ''{2}''"
-msgstr "{0} Base de Datos {1} ''{2}''"
+msgstr "{0} Databáze {1} ''{2}''"
 
 #: src/metabase/sync/util.clj
 msgid "Table {0} ''{1}''"
-msgstr "Tabla {0} ''{1}''"
+msgstr "Tabulka {0} ''{1}''"
 
 #: src/metabase/sync/util.clj
 msgid "Field {0} ''{1}''"
-msgstr "Campo {0} ''{1}''"
+msgstr "Pole {0} ''{1}''"
 
 #: src/metabase/sync/util.clj
 msgid "Field ''{0}''"
-msgstr "Campo ''{0}''"
+msgstr "Pole ''{0}''"
 
 #: src/metabase/sync/util.clj
 msgid "step ''{0}'' for {1}"
-msgstr "paso ''{0}'' para {1}"
+msgstr "krok ''{0}'' z {1}"
 
 #: src/metabase/sync/util.clj
 msgid "Completed {0} on {1}"
-msgstr "Realizadas {0} de {1}"
+msgstr "Dokončeno {0} dne {1}"
 
 #: src/metabase/sync/util.clj
 msgid "Start: {0}"
-msgstr "Inicio: {0}"
+msgstr "Začátek: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "End: {0}"
-msgstr "Fin: {0}"
+msgstr "Konec: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "Duration: {0}"
-msgstr "Duración: {0}"
+msgstr "Trvání: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "Completed step ''{0}''"
-msgstr "Realizado el paso ''{0}''"
+msgstr "Dokončený krok ''{0}''"
 
 #: src/metabase/task.clj
 msgid "Loading tasks namespace:"
-msgstr "Cargando espacio de nombres para las tareas:"
+msgstr "Načítám jmenný prostor úloh:"
 
 #: src/metabase/task.clj
 msgid "Starting Quartz Scheduler"
-msgstr "Iniciando Programador Quartz"
+msgstr "Spuštění plánovače"
 
 #: src/metabase/task.clj
 msgid "Stopping Quartz Scheduler"
-msgstr "Parando Programador Quartz"
+msgstr "Zastavení plánovače"
 
 #: src/metabase/task.clj
 msgid "Job already exists:"
-msgstr "Tarea ya existe:"
+msgstr "Úloha už existuje:"
 
 #. This is the very first log message that will get printed.  It's here because this is one of the very first
 #. namespaces that gets loaded, and the first that has access to the logger It shows up a solid 10-15 seconds before
 #. the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
 #: src/metabase/util.clj
 msgid "Loading Metabase..."
-msgstr "Cargando Metabase..."
+msgstr "Načítá se Metabase..."
 
 #: src/metabase/util/date.clj
 msgid "Possible timezone conflict found on database {0}."
-msgstr "Posible conflicto de zona horaria en la base de datos {0}"
+msgstr "Nalezen možný konflikt časových pásem v databázi {0}."
 
 #: src/metabase/util/date.clj
 msgid "JVM timezone is {0} and detected database timezone is {1}."
-msgstr "La zona horaria de la JVM es {0} y la zona horaria de la base de datos es {1}."
+msgstr "Časové pásmo JVM je {0} a zjištěné časové pásmo databáze je {1}."
 
 #: src/metabase/util/date.clj
 msgid "Configure a report timezone to ensure proper date and time conversions."
-msgstr "Configura una zona horaria de los informes para realizar conversiones correctas de fecha y hora."
+msgstr "Nakonfigurujte časové pásmo reportu, abyste zajistili správné konverze pro datum a čas."
 
 #: src/metabase/util/embed.clj
 msgid "Secret key used to sign JSON Web Tokens for requests to `/api/embed` endpoints."
-msgstr "Clave secreta utilizada para firmar tokens web JSON para solicitudes al API `/api/embed`."
+msgstr "Tajný klíč používaný k podepisování JSON webových tokenů pro žádosti o koncový bod `/api/embed`"
 
 #: src/metabase/util/encryption.clj
 msgid "MB_ENCRYPTION_SECRET_KEY must be at least 16 characters."
-msgstr "MB_ENCRYPTION_SECRET_KEY debe tener al menos 16 caracteres"
+msgstr "MB_ENCRYPTION_SECRET_KEY musí mít nejméně 16 znaků."
 
 #: src/metabase/util/encryption.clj
 msgid "Saved credentials encryption is ENABLED for this Metabase instance."
-msgstr "Guardar credenciales encriptadas está HABILITADO para esta instancia de Metabase."
+msgstr "Šifrování uložených pověření je pro tuto instanci Metabase ZAPNUTO."
 
 #: src/metabase/util/encryption.clj
 msgid "Saved credentials encryption is DISABLED for this Metabase instance."
-msgstr "Guardar credenciales encriptadas está DESHABILITADO para esta instancia de Metabase."
+msgstr "Šifrování uložených pověření je pro tuto instanci Metabase VYPNUTO."
 
 #: src/metabase/util/encryption.clj
 msgid "nFor more information, see"
-msgstr "Para más información, ver"
+msgstr "Další informace naleznete v části"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer."
-msgstr "el valor debe ser un entero."
+msgstr "hodnota musí být celé číslo."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a string."
-msgstr "el valor debe ser un texto."
+msgstr "hodnota musí být řetězec."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a boolean."
-msgstr "el valor debe ser un booleano"
+msgstr "hodnota musí být logická hodnota."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a string that matches the regex `{0}`."
-msgstr "el valor debe ser un texto que cumpla la expresión regular `{0}`."
+msgstr "hodnota musí být řetězec, který se shoduje s regulárním výrazem \"{0}\"."
 
 #: src/metabase/util/schema.clj
 msgid "value must satisfy one of the following requirements: "
-msgstr "el valor debe satisfacer uno de los requerimientos siguientes:"
+msgstr "hodnota musí splňovat jeden z následujících požadavků: "
 
 #: src/metabase/util/schema.clj
 msgid "value may be nil, or if non-nil, {0}"
-msgstr "el valor puede ser nulo, o si no es nulo, {0}"
+msgstr "hodnota může být nula nebo nenulová, {0}"
 
 #: src/metabase/util/schema.clj
 msgid "value must be one of: {0}."
-msgstr "el valor debe ser uno de: {0}."
+msgstr "hodnota musí být jedna z : {0}."
 
 #: src/metabase/util/schema.clj
 msgid "value must be an array."
-msgstr "el valor debe ser un conjunto"
+msgstr "hodnota musí být pole."
 
 #: src/metabase/util/schema.clj
 msgid "Each {0}"
-msgstr "Cada {0}"
+msgstr "Každý {0}"
 
 #: src/metabase/util/schema.clj
 msgid "The array cannot be empty."
-msgstr "El conjunto no puede estar vacío."
+msgstr "Pole nemůže být prázdné."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a non-blank string."
-msgstr "el valor debe ser un texto no vacío"
+msgstr "hodnota nesmí být prázdný řetězec."
 
 #: src/metabase/util/schema.clj
 msgid "Integer greater than zero"
-msgstr "Entero mayor que cero"
+msgstr "Celé číslo větší než 0"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer greater than zero."
-msgstr "el valor debe ser un entero mayor que cero."
+msgstr "hodnota musí být celé číslo větší než 0."
 
 #: src/metabase/util/schema.clj
 msgid "Number greater than zero"
-msgstr "Número mayor que cero"
+msgstr "Číslo větší než 0"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a number greater than zero."
-msgstr "el valor debe ser un número mayor que cero."
+msgstr "hodnota musí být číslo větší než 0."
 
 #: src/metabase/util/schema.clj
 msgid "Keyword or string"
-msgstr "Palabra clave o texto"
+msgstr "Slovo nebo text"
 
 #: src/metabase/util/schema.clj
 msgid "Valid field type"
-msgstr "Tipo de campo válido"
+msgstr "Platný typ pole"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid field type."
-msgstr "el valor debe ser un tipo de campo válido"
+msgstr "hodnota musí být platným typem pole."
 
 #: src/metabase/util/schema.clj
 msgid "Valid field type (keyword or string)"
-msgstr "Tipo de campo válido (palabra clave o texto)"
+msgstr "Platný typ pole (klíčové slovo nebo řetězec)"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid field type (keyword or string)."
-msgstr "el valor debe ser un tipo de campo válido (palabra clave o texto)."
+msgstr "hodnota musí být platným typem pole (klíčové slovo nebo řetězec)."
 
 #: src/metabase/util/schema.clj
 msgid "Valid entity type (keyword or string)"
-msgstr "Tipo de campo válido (palabra clave o texto)"
+msgstr "Platný typ entity (klíčové slovo nebo řetězec)"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid entity type (keyword or string)."
-msgstr "el valor debe ser un tipo de campo válido (palabra clave o texto)."
+msgstr "hodnota musí být platným typem entity (klíčové slovo nebo řetězec)."
 
 #: src/metabase/util/schema.clj
 msgid "Valid map"
-msgstr "Mapa válido"
+msgstr "Platná mapa"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a map."
-msgstr "el valor debe ser un mapa"
+msgstr "hodnota musí být mapa."
 
 #: src/metabase/util/schema.clj
 msgid "Valid email address"
-msgstr "Dirección de Email válido"
+msgstr "Platná emailová adresa"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid email address."
-msgstr "el valor debe ser una dirección de correo electrónico válida"
+msgstr "hodnota musí být platná emailová adresa."
 
 #: src/metabase/util/schema.clj
 msgid "Insufficient password strength"
-msgstr "Insuficiente complejidad de contraseña"
+msgstr "Nedostatečná síla hesla"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer."
-msgstr "el valor debe ser un entero válido"
+msgstr "hodnota musí být platné celé číslo."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer greater than zero."
-msgstr "el valor debe ser un entero válido mayor que cero."
+msgstr "hodnota musí být platné celé číslo větší než nula."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid boolean string (''true'' or ''false'')."
-msgstr "el valor debe ser un booleano válido (''true'' o ''false'')."
+msgstr "hodnota musí byť platný logický řetězec (\"PRAVDA\" nebo \"NEPRAVDA\")."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid JSON string."
-msgstr "el valor debe ser un texto JSON válido."
+msgstr "hodnota musí být platný JSON řetězec."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid embedding params map."
-msgstr "el valor debe ser un mapa de parámetros de integración válido."
+msgstr "hodnota musí být platná mapa vkládacích parametrů."
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx:12
 msgid "Data permissions"
-msgstr "Permisos de acceso de datos"
+msgstr "Oprávnění dat"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx:13
 msgid "Collection permissions"
-msgstr "Permisos de acceso de colecciones"
+msgstr "Oprávnění sbírek"
 
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
 msgid "See all collection permissions"
-msgstr "Ver todos los permisos de colecciones"
+msgstr "Zobrazit všechna oprávnění ke sbírce"
 
 #: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
 msgid "Also change sub-collections"
-msgstr "También cambiar sub-colecciones"
+msgstr "Změnit i podskupiny"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
-msgstr "Puede editar esta colección y sus contenidos"
+msgstr "Může upravovat tuto sbírku a její obsah"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
-msgstr "Puede ver artículos en esta colección"
+msgstr "Může zobrazit položky v této kolekci"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:765
 msgid "Collection Access"
-msgstr "Acceso a Colección"
+msgstr "Přístup ke sbírce"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:841
 msgid "This group has permission to view at least one subcollection of this collection."
-msgstr "Este grupo tiene permiso para ver al menos una subcolección de esta colección."
+msgstr "Tato skupina má oprávnění k zobrazení alespoň jedné podskupiny této sbírky."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "This group has permission to edit at least one subcollection of this collection."
-msgstr "Este grupo tiene permiso para editar al menos una subcolección de esta colección."
+msgstr "Tato skupina má oprávnění na úpravu alespoň jedné podskupiny této sbírky."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:859
 msgid "View sub-collections"
-msgstr "Ver subcolección"
+msgstr "Zobrazit dílčí sbírky"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:245
 msgid "Remember Me"
-msgstr "Recuerdame"
+msgstr "Pamatovat si mě"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:73
 msgid "X-ray this schema"
-msgstr "Aplica rayos-X a este esquema"
+msgstr "Prozkoumat toto schéma"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:258
 msgid "Edit the permissions for this collection"
-msgstr "Editar los permisos de acceso de esta colección"
+msgstr "Upravit oprávnění pro tuto sbírku"
 
 #: frontend/src/metabase/containers/AddToDashSelectDashModal.jsx:55
 msgid "Add this question to a dashboard"
-msgstr "Añadir esta pregunta a un cuadro de mando"
+msgstr "Přidat dotaz na nástěnku"
 
 #: frontend/src/metabase/containers/AddToDashSelectDashModal.jsx:65
 msgid "Create a new dashboard"
-msgstr "Crea un Cuadro de Mando"
+msgstr "Vytvořit novou nástěnku"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:47
 msgid "The page you asked for couldn't be found."
-msgstr "La página que pidió no ha sido encontrada."
+msgstr "Nenalezli jsme požadovanou stránku."
 
 #: frontend/src/metabase/containers/ItemSelect.jsx:30
 msgid "Select a {0}"
-msgstr "Seleccione un(a) {0}"
+msgstr "Vyber {0}"
 
 #: frontend/src/metabase/containers/Overworld.jsx:234
 msgid "Save dashboards, questions, and collections in \"{0}\""
-msgstr "Guardar cuadros de mando, preguntas, y colecciones en \"{0}\""
+msgstr "Uložte nástěnky, otázky a kolekce do složky \"{0}\""
 
 #: frontend/src/metabase/containers/Overworld.jsx:235
 msgid "Access dashboards, questions, and collections in \"{0}\""
-msgstr "Acceder cuadros de mando, preguntas, y colecciones en \"{0}\""
+msgstr "Zpřístupnit nástěnky, otázky a kolekce ve složce \"{0}\""
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
-msgstr "Compara"
+msgstr "Porovnat"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
-msgstr "Alejarse"
+msgstr "Oddálit"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
-msgstr "Relacionado"
+msgstr "Příbuzný"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
-msgstr "Más Rayos-X"
+msgstr "Více vhledů"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
-msgstr "No hay resultados"
+msgstr "Prázdný výsledek"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:42
 msgid "Metabase couldn't find any results for your search."
-msgstr "Metabase no pudo encontrar ningún resultado para su busqueda."
+msgstr "Vašemu hledání neodpovídají žádná data."
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
-msgstr "Métricas no encontradas"
+msgstr "Žádné metriky"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:41
 msgid "Aggregations"
-msgstr "Agregaciones"
+msgstr "Agregace"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:42
 msgid "Operators"
-msgstr "Operadores"
+msgstr "Operátory"
 
 #: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:35
 msgid "Custom fields"
-msgstr "Campos personalizados"
+msgstr "Vlastní pole"
 
 #. 2. Create the new collections.
 #: src/metabase/db/migrations.clj
 msgid "Migrated Dashboards"
-msgstr "Cuadros de Mando migrados"
+msgstr "Migrované nástěnky"
 
 #: src/metabase/db/migrations.clj
 msgid "Migrated Pulses"
-msgstr "Pulsos migrados"
+msgstr "Migrované pulzy"
 
 #: src/metabase/db/migrations.clj
 msgid "Migrated Questions"
-msgstr "Preguntas migradas"
+msgstr "Migrované dotazy"
 
 #. 4. move everything not in this Collection to a new Collection
 #: src/metabase/db/migrations.clj
 msgid "Moving instances of {0} that aren't in a Collection to {1} Collection {2}"
-msgstr "Moviendo instancias de {0} que no están en ninguna colección a {1} Colección {2}"
+msgstr "Přesouvám instance {0}, které nejsou ve sbírce {1} do sbírky {2}"
 
 #: src/metabase/models/permissions.clj
 msgid "Failed to grant permissions: {0}"
-msgstr "Error al conceder permisos: {0}"
+msgstr "Přidělení oprávnění selhalo: {0}"
 
 #: src/metabase/util/encryption.clj
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
-msgstr "No se ha podido desencriptar la cadena. ¿Has configurado correctamenteMB_ENCRYPTION_SECRET_KEY?"
+msgstr "Nelze dešifrovat šifrovaný řetězec. Změnili jste nebo zapomněli nastavit MB_ENCRYPTION_SECRET_KEY?"
 
 #: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
-msgstr "Todas las colecciones personales"
+msgstr "Všechny osobní sbírky"
 
 #: src/metabase/driver/common.clj
 msgid "Host"
-msgstr "Servidor"
+msgstr "Adresa"
 
 #: src/metabase/driver/common.clj
 msgid "Port"
-msgstr "Puerto"
+msgstr "Port"
 
 #: src/metabase/driver/common.clj
 msgid "Database username"
-msgstr "nombre de usuario de base de datos"
+msgstr "Login do DB"
 
 #: src/metabase/driver/common.clj
 msgid "What username do you use to login to the database?"
-msgstr "¿Qué nombre de usuario usas para iniciar sesión en la base de datos?"
+msgstr "Jaký login používáte pro přihlášení do DB?"
 
 #: src/metabase/driver/common.clj
 msgid "Database password"
-msgstr "Contraseña de la base de datos"
+msgstr "Heslo do DB"
 
 #: src/metabase/driver/common.clj
 msgid "Database name"
-msgstr "nombre de la base de datos"
+msgstr "Název DB"
 
 #: src/metabase/driver/common.clj
 msgid "birds_of_the_world"
-msgstr "aves_del_mundo"
+msgstr "birds_of_the_world"
 
 #: src/metabase/driver/common.clj
 msgid "Use a secure connection (SSL)?"
-msgstr "¿Utilizar una conexión segura (SSL)?"
+msgstr "Používáte zabezpečené připojení (SSL)?"
 
 #: src/metabase/driver/common.clj
 msgid "Additional JDBC connection string options"
-msgstr "Opciones adicionales de cadena de conexión JDBC"
+msgstr "Další možnosti připojovacího řetězce JDBC"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Project ID"
-msgstr "ID de proyecto"
+msgstr "ID projektu"
 
 #: src/metabase/driver/bigquery.clj
 msgid "praxis-beacon-120871"
@@ -9154,79 +9162,79 @@ msgstr "praxis-beacon-120871"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Dataset ID"
-msgstr "Conjunto de datos ID"
+msgstr "ID datasetu"
 
 #: src/metabase/driver/bigquery.clj
 msgid "toucanSightings"
-msgstr "avistamientosDeTucanes"
+msgstr "toucanSightings"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Client ID"
-msgstr "ID de cliente"
+msgstr "ID klienta"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Client Secret"
-msgstr "Clave secreta del cliente"
+msgstr "Skrytý klíč klienta"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Auth Code"
-msgstr "Código de Autorización"
+msgstr "Autorizační kód"
 
 #: src/metabase/driver/crate.clj
 msgid "Hosts"
-msgstr "Servidores"
+msgstr "Hostitelé"
 
 #: src/metabase/driver/druid.clj
 msgid "Broker node port"
-msgstr "Puerto de nodo intermediario"
+msgstr "Broker port"
 
 #: src/metabase/driver/googleanalytics.clj
 msgid "Google Analytics Account ID"
-msgstr "ID de cuenta de Google Analytics"
+msgstr "ID účtu Google Analytics"
 
 #: src/metabase/driver/h2.clj
 msgid "Connection String"
-msgstr "Cadena de conexión"
+msgstr "Připojovací řetězec"
 
 #: src/metabase/driver/h2.clj
 msgid "Users/camsaul/bird_sightings/toucans"
-msgstr "Users/camsaul/avistamientos_de_aves/tucanes"
+msgstr "Users/camsaul/bird_sightings/toucans"
 
 #: src/metabase/driver/mongo.clj
 msgid "carrierPigeonDeliveries"
-msgstr "entregasPorPalomasMensajeras"
+msgstr "carrierPigeonDeliveries"
 
 #: src/metabase/driver/mongo.clj
 msgid "Authentication Database"
-msgstr "base de datos para autenticación"
+msgstr "Autentizační databáze"
 
 #: src/metabase/driver/mongo.clj
 msgid "Optional database to use when authenticating"
-msgstr "base de datos opcional para la autenticación"
+msgstr "Volitelná databáze, která se použije při autentifikaci"
 
 #: src/metabase/driver/mongo.clj
 msgid "Additional Mongo connection string options"
-msgstr "Opciones adicionales de cadena de conexión Mongo"
+msgstr "Další možnosti připojovacího řetězce Mongo"
 
 #: src/metabase/driver/oracle.clj
 msgid "Oracle system ID (SID)"
-msgstr "ID del sistema Oracle (SID)"
+msgstr "Systémové ID Oracle (SID)"
 
 #: src/metabase/driver/oracle.clj
 msgid "Usually something like ORCL or XE."
-msgstr "Generalmente algo como ORCL o XE"
+msgstr "Obvykle něco jako ORCL nebo XE."
 
 #: src/metabase/driver/oracle.clj
 msgid "Optional if using service name"
-msgstr "Opcional cuando se usa nombre del servicio"
+msgstr "Volitelné, pokud používáte název služby"
 
 #: src/metabase/driver/oracle.clj
 msgid "Oracle service name"
-msgstr "Nombre del servicio Oracle"
+msgstr "Název služby Oracle"
 
 #: src/metabase/driver/oracle.clj
 msgid "Optional TNS alias"
-msgstr "Alias TNS (opcional)"
+msgstr "Volitelný TNS alias"
 
 #: src/metabase/driver/presto.clj
 msgid "hive"
@@ -9234,62 +9242,62 @@ msgstr "hive"
 
 #: src/metabase/driver/redshift.clj
 msgid "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
-msgstr "nombre-de-mi-cluster.abcd1234.us-east-1.redshift.amazonaws.com"
+msgstr "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
 
 #: src/metabase/driver/redshift.clj
 msgid "toucan_sightings"
-msgstr "avistamientos_de_tucanes"
+msgstr "toucan_sightings"
 
 #: src/metabase/models/collection.clj
 msgid "default"
-msgstr "por defecto"
+msgstr "výchozí"
 
 #: src/metabase/driver/sqlite.clj
 msgid "Filename"
-msgstr "Nombre del archivo"
+msgstr "Název souboru"
 
 #: src/metabase/driver/sqlite.clj
 msgid "/home/camsaul/toucan_sightings.sqlite 😋"
-msgstr "/home/camsaul/avistamientos_de_tucanes.sqlite"
+msgstr "/home/camsaul/toucan_sightings.sqlite 😋"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "BirdsOfTheWorld"
-msgstr "AvesDelMundo"
+msgstr "BirdsOfTheWorld"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "Database instance name"
-msgstr "Nombre de la instancia de base de datos"
+msgstr "Název instance databáze"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "N/A"
-msgstr "No aplica"
+msgstr "N/A"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "Windows domain"
-msgstr "Dominio de Windows"
+msgstr "Windows Doména"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:528
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:534
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:543
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
-msgstr "Etiquetas"
+msgstr "Štítky"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 msgid "Add members"
-msgstr "Añadir miembros"
+msgstr "Přidat členy"
 
 #: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
-msgstr "Colección que se guarda en"
+msgstr "Patří do sbírky"
 
 #: frontend/src/metabase/lib/groups.js:4
 msgid "All Users"
-msgstr "Todos los Usuarios"
+msgstr "Všichni uživatelé"
 
 #: frontend/src/metabase/lib/groups.js:5
 msgid "Administrators"
-msgstr "Administradores"
+msgstr "Administrátoři"
 
 #: frontend/src/metabase/lib/groups.js:6
 msgid "MetaBot"
@@ -9297,7 +9305,7 @@ msgstr "MetaBot"
 
 #: frontend/src/metabase/public/components/widgets/EmbedModalContent.jsx:290
 msgid "Sharing"
-msgstr "Compartir"
+msgstr "Sdílení"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:218
@@ -9321,7 +9329,7 @@ msgstr "Compartir"
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
-msgstr "Visualización"
+msgstr "Zobrazení"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:402
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:437
@@ -9332,229 +9340,228 @@ msgstr "Visualización"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:521
 msgid "Axes"
-msgstr "Ejes"
+msgstr "Osy"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:219
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:62
 msgid "Formatting"
-msgstr "Formato"
+msgstr "Formátování"
 
 #: frontend/src/metabase/containers/Overworld.jsx:121
 msgid "Try these x-rays based on your data."
-msgstr "Pruebe estos rayos-X en función de tus datos."
+msgstr "Vyzkoušejte tyto rychlé průzkumy dat."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:38
 msgid "There was a problem displaying this chart."
-msgstr "Hubo un problema al mostrar esta gráfico."
+msgstr "Nastal problém při zobrazování grafu."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:39
 msgid "Sorry, you don't have permission to see this card."
-msgstr "Lo siento, no tienes permiso para ver etsa tarjeta."
+msgstr "Na zobrazení této karty nemáte oprávnění."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:55
 msgid "Just a heads up:"
-msgstr "Solo un aviso:"
+msgstr "Jen v rychlosti:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:63
 msgid "{0} without the Sample Dataset, the Query Builder tutorial won't work. You can always restore the Sample Dataset, but any questions you've saved using this data will be lost."
-msgstr "{0} sin el conjunto de datos de muestra, el tutorial del generador de consultas no funcionará. Siempre puede restaurar el conjunto de datos de muestra, pero cualquier pregunta que haya guardado con esta información se perderá"
+msgstr "{0} bude bez vzorové databáze, průvodce na tvorbu dotazů nebude fungovat. Vzorovou databázi můžete kdykoli obnovit, ale všechny otázky, které jste pomocí těchto dat uložili, se ztratí."
 
 #: frontend/src/metabase/modes/components/drill/AutomaticDashboardDrill.jsx:33
 msgid "X-ray"
-msgstr "Aplica rayos-X"
+msgstr "Průzkum"
 
 #: frontend/src/metabase/modes/components/drill/CompareToRestDrill.js:34
 msgid "Compare to the rest"
-msgstr "Compara con el resto"
+msgstr "Porovnat s ostatními"
 
 #: frontend/src/metabase/entities/databases/forms.js:18
 msgid "Use the Java Virtual Machine (JVM) timezone"
-msgstr "Utiliza la zona horaria de la máquina virtual Java"
+msgstr "Použít timezone z Java Virtual Machine (JVM)"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
-msgstr "Te sugerimos que desactives esto a menos que estés forzando manualmente la zona horaria en\n"
-"muchas o la mayoría de tus consultas con estos datos."
+msgstr "Doporučujeme vám to nechat vypnuté, pokud u dat nevykonáváte manuální přetypování časových pásem u mnoha nebo většině otázek."
 
 #: frontend/src/metabase/containers/Overworld.jsx:395
 msgid "Your team's most important dashboards go here"
-msgstr "Los cuadros de mando más importantes van aquí"
+msgstr "Sem patří nejdůležitější nástěnky vašeho týmu."
 
 #: frontend/src/metabase/containers/Overworld.jsx:396
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
-msgstr "Fija los cuadros de mando en {0} para que aparezcan en este espacio para todos"
+msgstr "Připněte nástěnky v {0}, abyste je mohli v tomto prostoru zobrazit pro všechny"
 
 #: src/metabase/db/liquibase.clj
 msgid "Unable to release the Liquibase lock after a migration failure"
-msgstr "No se ha podido eliminar el bloqueo Liquibase tras un error en la migración"
+msgstr "Po selhání migrace není možné uvolnit zámek Liquibase"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Use JVM Time Zone"
-msgstr "Utiliza la zona horaria del JVM"
+msgstr "Použijte časové pásmo JVM"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:29
 msgid "We're currently analyzing the tables and fields to help you explore your data."
-msgstr "Estamos analizando las tablas y los campos para ayudarte a explorar tus datos."
+msgstr "Momentálně analyzujeme tabulky a pole, které vám pomohou prozkoumat vaše data."
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
 msgid "Tip: "
-msgstr "Consejo: "
+msgstr "Tip: "
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
-msgstr "Selecciona un tipo de moneda"
+msgstr "Zvol typ měny"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
 msgid "Field Type"
-msgstr "Tipo Campo"
+msgstr "Typ pole"
 
 #: frontend/src/metabase/admin/routes.jsx:118
 #: frontend/src/metabase/nav/containers/Navbar.jsx:267
 msgid "Troubleshooting"
-msgstr "Solución de problemas"
+msgstr "Řešení problémů"
 
 #: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Enable X-ray features"
-msgstr "Habilitar características de Rayos-X"
+msgstr "Povolit automatické průzkumy"
 
 #: frontend/src/metabase/admin/settings/selectors.js:220
 msgid "Formatting Options"
-msgstr "Opciones de Formato"
+msgstr "Možnosti formátovaní"
 
 #: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
-msgstr "Detalles de la tarea"
+msgstr "Podrobnosti úlohy"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:29
 msgid "Troubleshooting logs"
-msgstr "Registro de solución de problemas"
+msgstr "Diagnostické záznamy"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:31
 msgid "Trying to get to the bottom of something? This section shows logs of Metabase's background tasks, which can help shed light on what's going on."
-msgstr "¿Tratando de llegar al fondo de algo? Esta sección muestra los registros de las tareas en segundo plano de Metabase, que pueden ayudar a aclarar lo que está pasando."
+msgstr "Snažíte se něco vyřešit? Tako sekce zobrazuje Metabase logy z úloh běžících na pozadí, ty vám pomůžou objasnit si co se děje."
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:56
 msgid "Task"
-msgstr "Tarea"
+msgstr "Úloha"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:57
 msgid "DB ID"
-msgstr "ID BBDD"
+msgstr "DB ID"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:58
 msgid "Started at"
-msgstr "Iniciado a las"
+msgstr "Začala v"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:59
 msgid "Ended at"
-msgstr "Terminado a las"
+msgstr "Skončila v"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:60
 msgid "Duration (ms)"
-msgstr "Duración (ms)"
+msgstr "Trvání (ms)"
 
 #: frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx:34
 #: frontend/src/metabase/lib/core.js:92
 msgid "Currency"
-msgstr "Moneda"
+msgstr "Měna"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
-msgstr "Elige un usuario o canal..."
+msgstr "Vyberte uživatele nebo kanál ..."
 
 #: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:90
 msgid "No formatting settings"
-msgstr "Sin ajustes de formato"
+msgstr "Žádné nastavení formátování"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:81
 msgid "Label for this range (optional)"
-msgstr "Nombre para este rango (opcional)"
+msgstr "Štítek pro tento rozsah (volitelné)"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:93
 msgid "Add a range"
-msgstr "Añade un rango"
+msgstr "Přidejte rozsah"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:26
 msgid "is less than"
-msgstr "es menor que"
+msgstr "je menší než"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:27
 msgid "is greater than"
-msgstr "es mayor que"
+msgstr "je větší než"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:28
 msgid "is less than or equal to"
-msgstr "es menor o igual a"
+msgstr "je menší anebo rovno"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:29
 msgid "is greater than or equal to"
-msgstr "es mayor o igual a"
+msgstr "je větší anebo rovno"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:37
 msgid "is equal to"
-msgstr "es igual a"
+msgstr "rovná se"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:31
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:38
 msgid "is not equal to"
-msgstr "no es igual a"
+msgstr "nerovná se"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:32
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:39
 msgid "is null"
-msgstr "es nulo"
+msgstr "nemá hodnotu"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:33
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:40
 msgid "is not null"
-msgstr "no es nulo"
+msgstr "má hodnotu"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:41
 msgid "contains"
-msgstr "contiene"
+msgstr "obsahuje"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:42
 msgid "does not contain"
-msgstr "no contiene"
+msgstr "neobsahuje"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:43
 msgid "starts with"
-msgstr "empieza con"
+msgstr "začíná na"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:44
 msgid "ends with"
-msgstr "termina con"
+msgstr "končí na"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:292
 msgid "When a cell in these columns {0} it will be tinted this color."
-msgstr "Cuando una celda de estas columnas sea {0} se pintará de este color."
+msgstr "Když je buňka v těchto sloupcích {0}, bude vybarvená."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:351
 msgid "When a cell in this column…"
-msgstr "Cuando una celda en esta columna..."
+msgstr "Když je buňka v tomto sloupci..."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:42
 msgid "This visualization requires you to group by a field."
-msgstr "Esta visualización require agrupar por un campo."
+msgstr "Tato vizualizace vyžaduje seskupení podle pole."
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:184
 msgid "Date style"
-msgstr "Formato de fecha"
+msgstr "Styl datumu"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:207
 msgid "Date separators"
-msgstr "Separador de fecha"
+msgstr "Oddělovače datumu"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:226
 msgid "Abbreviate names of days and months"
-msgstr "Abreviar nombres de días y meses."
+msgstr "Zkraťte názvy dní a měsíců"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:236
 msgid "Show the time"
-msgstr "Mostrar la hora"
+msgstr "Zobrazit čas"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:243
 msgid "HH:MM"
@@ -9570,373 +9577,375 @@ msgstr "HH:MM:SS.MS"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:265
 msgid "Time style"
-msgstr "Formato de hora"
+msgstr "Typ zobrazení času"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:314
 msgid "Unit of currency"
-msgstr "Unidad de moneda"
+msgstr "Jednotka měny"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:334
 msgid "Currency label style"
-msgstr "Formato etiqueta de moneda"
+msgstr "Styl měnového označení"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:361
 msgid "Where to display the unit of currency"
-msgstr "Donde mostrar la unidad de moneda"
+msgstr "Kde zobrazit jednotku měny"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:394
 msgid "Minimum number of decimal places"
-msgstr "Número mínimo de decimales"
+msgstr "Minimální počet desetinných míst"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
-msgstr "Tipo de gráfico apilado"
+msgstr "Skládaný typ grafu"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
-msgstr "Etiqueta de Objetivo"
+msgstr "Popis cíle"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
-msgstr "Mostrar línea de tendencia"
+msgstr "Zobrazit spojnici trendu"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:67
 msgid "Line style"
-msgstr "Formato de línea"
+msgstr "Styl čáry"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:84
 msgid "Show dots on lines"
-msgstr "Mostrar puntos en las líneas"
+msgstr "Zobrazit značky na čárách"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:348
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
-msgstr "Automatico"
+msgstr "Auto"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:120
 msgid "Which axis?"
-msgstr "¿En qué eje?"
+msgstr "Která osa?"
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
 msgid "Line + Bar"
-msgstr "Línea + Barra"
+msgstr "Linie + Sloupec"
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
 msgid "line and bar chart"
-msgstr "gráfico de línea y barra"
+msgstr "lineární a sloupcový graf"
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
-msgstr "La visualización del contador requiere un número."
+msgstr "Vizualizace typu měřidlo vyžaduje číslo."
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:60
 msgid "Gauge"
-msgstr "Contador"
+msgstr "Měřidlo"
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
 msgid "Gauge ranges"
-msgstr "Rangos del contador"
+msgstr "Rozsah měřidla"
 
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:107
 msgid "Field to show"
-msgstr "Campo a mostrar"
+msgstr "Pole k zobrazení"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
 msgid "last {0}"
-msgstr "último {0}"
+msgstr "poslední {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
 msgid "{0} was {1} {2}"
-msgstr "{0} era {1} {2}"
+msgstr "{0} bylo {1} {2}"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
 msgid "Group by a time field to see how this has changed over time"
-msgstr "Agrupa por un campo temporal para ver como ha cambiado a lo largo del tiempo"
+msgstr "Seskupením podle časového pole zjistíte, jak se to časem změnilo"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:51
 msgid "Switch positive / negative colors?"
-msgstr "¿Mostrar colores positivos/negativos?"
+msgstr "Přepnout normální / inverzní barvy?"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
 msgid "Pivot column"
-msgstr "Columna pivote"
+msgstr "Do sloupce"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
 msgid "Cell column"
-msgstr "Columna celda"
+msgstr "Hodnoty sloupce"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
 msgid "Visible columns"
-msgstr "Columnas visibles"
+msgstr "Viditelné sloupce"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
 msgid "Conditional Formatting"
-msgstr "Formato condicional"
+msgstr "Podmíněné formátování"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
 msgid "Column title"
-msgstr "Título columna"
+msgstr "Popisek sloupce"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:243
 msgid "Show a mini bar chart"
-msgstr "Mostrar una gráfica de barras en miniatura"
+msgstr "Zobrazit mini sloupcový graf"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:254
 msgid "Link"
-msgstr "Enlace"
+msgstr "Odkaz"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:258
 msgid "Email link"
-msgstr "Enlace Email"
+msgstr "Odkaz na e-mail"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:262
 msgid "Image"
-msgstr "Imagen"
+msgstr "Obrázek"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:266
 msgid "Automatic"
-msgstr "Automático"
+msgstr "Automatický"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:271
 msgid "View as link or image"
-msgstr "Ver como enlace o imagen"
+msgstr "Zobrazit jako odkaz nebo obrázek"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:281
 msgid "Link text"
-msgstr "Texto del enlace"
+msgstr "Text odkazu"
 
 #: src/metabase/api/common/internal.clj
 msgid "Not a valid integer: ''{0}''"
-msgstr "No es un entero válido: \"{0}\""
+msgstr "Neplatné celé číslo: ''{0}''"
 
 #: src/metabase/api/embed.clj
 msgid "Embedding is not enabled for this object."
-msgstr "No se puede incluir este tipo de objeto."
+msgstr "Vkládání není pro tento objekt povolené."
 
+#. duplicity
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fallback to local authentication: {0}"
-msgstr "Problema al conectarse al servidor LDAP, se recurrirá a la autenticación local: {0}"
+msgstr "Při připojování k serveru LDAP se vyskytl problém, vrátím se k místním účtům {0}"
 
 #: src/metabase/api/task.clj
 msgid "When including an offset, a limit must also be included."
-msgstr "Al incluir un desplazamiento, también hay que indicar un límite."
+msgstr "Při zahrnutí offsetu musí být zahrnut i limit."
 
 #: src/metabase/api/task.clj
 msgid "When including a limit, an offset must also be included."
-msgstr "Al incluir un límite, también hay que indicar el desplazamiento."
+msgstr "Při zahrnutí limitu musí být zahrnut i offset."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Applying heuristic {0} to {1}."
-msgstr "Aplicando heurística {0} a {1}."
+msgstr "Aplikace heuristicky {0} na {1}."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Dimensions bindings:n{0}"
-msgstr "Fijaciones de dimensiones:n{0}"
+msgstr "Vazby dimenzí:n{0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Using definitions:nMetrics:n{0}nFilters:n{1}"
-msgstr "Utilizando definiciones:\\nMétricas{0}\\nFiltros:\\n{1}"
+msgstr "Pomocí definic:nMetrics:n{0}nFilters:n{1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "minute"
-msgstr "minuto"
+msgstr "minuta"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "hour"
-msgstr "hora"
+msgstr "hodina"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of week"
-msgstr "día de la semana"
+msgstr "den týdne"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of month"
-msgstr "día del mes"
+msgstr "den měsíce"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of year"
-msgstr "día del año"
+msgstr "den roku"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "week"
-msgstr "semana"
+msgstr "týden"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "month"
-msgstr "mes"
+msgstr "měsíc"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "quarter"
-msgstr "trimestre"
+msgstr "kvartál"
 
 #: src/metabase/automagic_dashboards/populate.clj
 msgid "Adding {0} cards to dashboard {1}:n{2}"
-msgstr "Añadiendo {0} tarjetas al cuadro de mando {1}:n{2}"
+msgstr "Přidávám {0} karet na nástěnku {1}:n{2}"
 
 #: src/metabase/util/yaml.clj
 msgid "Error parsing {0}:n{1}"
-msgstr "Error leyendo {0}:n{1}"
+msgstr "Chyba při ověřování {0}:n{1}"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Filtering only works on dimensions! ''{0}'' is a metric. Ignoring filter."
-msgstr "ADVERTENCIA: ¡El filtrado solo funciona sobre dimensiones! ''{0}'' es una métrica, así que será ignorado."
+msgstr "UPOZORNĚNÍ: Filtrování funguje pouze podle rozměrů! ''{0}'' je metrika. Ignoruji filtr."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: A date can't belong to multiple discrete intervals, so ANDing them together doesn't make sense."
-msgstr "ADVERTENCIA: Una fecha no puede pertenecer a múltiples intervalos discretos, por lo que el hecho de unirlos con un Y no tiene sentido."
+msgstr "UPOZORNĚNÍ: Datum nemůže patřit do více diskrétních intervalů, takže jejich spojování nedává smysl."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "Ignoring these intervals: {0}"
-msgstr "Ignorando estos intérvalos: {0}"
+msgstr "Ignorování těchto intervalů: {0}"
 
 #. We should never get to this point since the all non-string negations should get automatically rewritten
 #. by the query expander.
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Don't know how to negate: {0}"
-msgstr "ADVERTENCIA: No sé cómo negar: {0}"
+msgstr "UPOZORNĚNÍ: Nevím, jak negovat: {0}"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "Sorting with Druid is only allowed in queries that have one or more breakout columns. Ignoring :order-by clause."
-msgstr "Ordenando con Druid solo se permite en consultas que tienen una o más columnas de ruptura. Ignorando la cláusula de orden."
+msgstr "Třídění s Druidem je povoleno pouze u dotazů, které mají jeden nebo více průrazových sloupců. Ignoruje :order-by klauzuli."
 
 #. TODO - this is not really true, is it
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: It only makes sense to specify :fields for a query with no aggregation. Ignoring the clause."
-msgstr "ADVERTENCIA: Solo tiene sentido especificar campos para una consulta sin agregación. Ignorando la cláusula."
+msgstr "UPOZORNĚNÍ: Má smysl zadávat :fields pro dotaz bez agregace. Ignoruji klauzuli."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Druid doenst allow limitSpec in timeseries queries. Ignoring the LIMIT clause."
-msgstr "ADVERTENCIA: Druid no permite limitSpec en consultas de series de tiempo. Ignorando la cláusula LIMIT."
+msgstr "UPOZORNĚNÍ: Druid nepovoluje limit v časových dotazech. Ignoruji klauzuli LIMIT."
 
 #: src/metabase/driver/sql/query_processor.clj
 msgid "HoneySQL Form:"
-msgstr "Formulario HoneySQL:"
+msgstr "Formulář HoneySQL:"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Unable to parse date ''{0}''"
-msgstr "No se ha podido leer la fecha \"{0}\""
+msgstr "Nepodařilo se ověřit datum \"{0}\""
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Client closed connection, cancelling query"
-msgstr "Conecxión cerrada por el cliente, cancelando consulta"
+msgstr "Klient ukončil připojení, ruším dotaz"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Setting timezone with statement: {0}"
-msgstr "Establecer zona horaria con declaración: {0}"
+msgstr "Nastavení časového pásma s příkazem: {0}"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid "Multiple date filters are not supported"
-msgstr "No se pueden hacer filtros con varias fechas."
+msgstr "Vícenásobné filtry datumu nejsou podporovány"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid ":not is not yet implemented"
-msgstr ":no no se ha implementado aun"
+msgstr ":not ještě není implementován"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid "Only one Google Analytics segment allowed at a time."
-msgstr "Solo se permite un segmento de Google Analytics a la vez."
+msgstr "Najednou je povolen pouze jeden segment Google Analytics."
 
 #: src/metabase/driver/mongo/query_processor.clj
 msgid "MONGO AGGREGATION PIPELINE:"
-msgstr "PIPELINE DE AGREGACION DE MONGO:"
+msgstr "MONGO AGGREGATION PIPELINE:"
 
 #: src/metabase/driver/mongo/query_processor.clj
 msgid "Error: mismatched columns in results! Expected: {0} Got: {1}"
-msgstr "Error: ¡columnas no coincidentes en los resultados! Esperaba: {0} pero se ha obtenido: {1}"
+msgstr "Chyba: neshodné sloupce ve výsledcích! Očekávané: {0} Mám: {1}"
 
 #: src/metabase/email/messages.clj
 msgid "Unable to create temp file in `{0}` for email attachments "
-msgstr "No se ha podido crear fichero temporal en `{0}` para adjuntos de correo "
+msgstr "V `{0}` nelze vytvořit dočasný soubor pro emailové přílohy "
 
 #: src/metabase/events/activity_feed.clj
 msgid "Error preprocessing query:"
-msgstr "Error procesando consulta:"
+msgstr "Chyba při předběžném zpracování dotazu:"
 
 #: src/metabase/mbql/normalize.clj
 msgid "Illegal filter clause: {0}"
-msgstr "Cláusula de filtro incorrecto: {0}"
+msgstr "Neplatná klauzule pro filtrování: {0}"
 
 #: src/metabase/mbql/normalize.clj
 msgid "Invalid clause:"
-msgstr "Cláusula inválida:"
+msgstr "Neplatná klauzule:"
 
+#. duplicity string
 #: src/metabase/mbql/util.clj
 msgid "Error: query's source query has not been resolved. You probably need to `preprocess` the query first."
-msgstr "Error: la consulta fuente de la consulta no se ha resuelto. Probablemente necesite 'preprocesar' la consulta primero."
+msgstr "Chyba: zjišťování zdroje dotazu nerozpoznáno. Pravděpodobně budete muset nejprve předzpracovat dotaz."
 
 #: src/metabase/mbql/util.clj
 msgid "No expression named ''{0}''"
-msgstr "No hay ninguna expresión llamada \"{0}\""
+msgstr "Žádný výraz s názvem ''{0}''"
 
 #: src/metabase/mbql/util.clj
 msgid "No aggregation at index: {0}"
-msgstr "No hay agregación en el índice: {0}"
+msgstr "Žádná agregace v indexu: {0}"
 
 #: src/metabase/models/field_values.clj
 msgid "Field values total length is {0} (max {1})."
-msgstr "La longitud total de los valores de campo es {0} (máx {1})."
+msgstr "Celková délka hodnot polí je {0} (max {1})."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues are allowed for this Field."
-msgstr "Se permiten Valores de Campo para este Campo."
+msgstr "Hodnoty polí jsou povoleny pro toto pole."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues are NOT allowed for this Field."
-msgstr "NO se permiten Valores de Campo para este campo."
+msgstr "Hodnoty polí NEJSOU povoleny pro toto pole."
 
 #: src/metabase/models/field_values.clj
 msgid "Field {0} ''{1}'' should have FieldValues and belongs to a Database with On-Demand FieldValues updating."
-msgstr "El campo {0} ''{1}'' debe tener valores de campo y pertenece a una base de datos con la actualización de valores de campo bajo demanda."
+msgstr "Pole {0} ''{1}'' by mělo mít hodnoty pole a mělo by patřit do databáze s hodnotami polí aktualizovaných na vyžádání."
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot create or revoke permissions for the ''Admin'' group."
-msgstr "No puedes crear ni revocar permisos para el grupo ''Admin''."
+msgstr "Nelze vytvořit ani odvolat povolení pro skupinu ''Správci''."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the ''MetaBot'' group."
-msgstr "No puedes agregar o eliminar usuarios del grupo ''MetaBot''."
+msgstr "Nemůžete přidávat ani odstraňovat uživatele do / ze skupiny ''MetaBot''"
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the ''All Users'' group."
-msgstr "No puedes agregar o eliminar usuarios del grupo \"Todos los usuarios\"."
+msgstr "Ve skupině ''Všichni uživatelé'' nemůžete přidávat ani odstraňovat uživatele."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot remove the last member of the ''Admin'' group!"
-msgstr "¡No puedes eliminar al último miembro del grupo ''Admin''!"
+msgstr "Posledního člena skupiny ''Správci'' nemůžete odstranit!"
 
 #. go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
 #: src/metabase/models/setting/cache.clj
 msgid "Error inserting a new Setting: {0}"
-msgstr "Error registrando la nueva configuración: {0}"
+msgstr "Chyba při vkládání nového nastavení: {0}"
 
 #: src/metabase/models/setting.clj
 msgid "defsetting descriptions strings must be `:internal?` or internationalized, found: `{0}`"
-msgstr "las cadenas de descripciones defsetting deben ser `:internal?` o traducidas, encontradas: `{0}`"
+msgstr "řetězce popisů nastavení musí být `:internal?` nebo lokalizované, nalezeny: `{0}`"
 
 #: src/metabase/plugins.clj
 msgid "Loading plugin {0}... {1}"
-msgstr "Cargando extensión {0}... {1}"
+msgstr "Načítá se doplněk {0}... {1}"
 
 #: src/metabase/public_settings.clj
 msgid "Object keyed by type, containing formatting settings"
-msgstr "Objeto tecleado por tipo, contiene ajustes de formato"
+msgstr "Objekt provázaný podle typu, obsahující nastavení formátování"
 
 #: src/metabase/public_settings.clj
 msgid "Allow users to explore data using X-rays"
-msgstr "Permitir que los usuarios hagan uso de Rayos-X"
+msgstr "Umožněte uživatelům poznávat data za použití průzkumů"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Using this URL to check token: {0}"
-msgstr "Utilizando esta URL para validar el símbolo: {0}"
+msgstr "Pomocí této URL adresy zkontrolujte token: {0}"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Unable to validate token: 404 not found."
-msgstr "No se ha podido validar el símbolo: 404 no encontrado."
+msgstr "Nepodařilo se ověřit token: 404 nenalezeno."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "There was an error checking whether this token was valid:"
-msgstr "Se produjo un error al verificar si este token era válido:"
+msgstr "Chyba při ověřování platnosti tohoto tokenu:"
 
 #. +----------------------------------------------------------------------------------------------------------------+
 #. |                                             SETTING & RELATED FNS                                              |
@@ -9944,270 +9953,270 @@ msgstr "Se produjo un error al verificar si este token era válido:"
 #. TODO - rename this to premium-features-token?
 #: src/metabase/public_settings/metastore.clj
 msgid "Token for premium features. Go to the MetaStore to get yours!"
-msgstr "Token para características premium. ¡Ve a MetaStore para conseguir el tuyo!"
+msgstr "Token pro prémiové funkce. Jděte do MetaStore a získejte svůj token!"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token format is invalid. Token should be 64 hexadecimal characters."
-msgstr "El formato del token no es válido. El token debe tener 64 caracteres hexadecimales."
+msgstr "Formát tokenu je neplatný. Token by měl mít 64 hexadecimálních znaků."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error setting premium features token"
-msgstr "Error al configurar el token de características premium"
+msgstr "Chyba při nastavování tokenu prémiových funkcí"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error validating token:"
-msgstr "Error validando el símbolo:"
+msgstr "Chyba při ověřování tokenu:"
 
 #: src/metabase/query_processor.clj
 msgid "Error preprocessing query"
-msgstr "Error procesando la consulta"
+msgstr "Chyba při předzpracování dotazu"
 
 #: src/metabase/query_processor.clj
 msgid "No native form returned."
-msgstr "No se ha obtenido un formulario nativo."
+msgstr "Žádná nativní forma se nevrátila."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
-msgstr "Respuesta no válida del controlador de base de datos. No se ha definido el estado."
+msgstr "Neplatná odpověď z ovladače databáze. Nebyl sdělen :status."
 
 #: src/metabase/query_processor.clj
 msgid "General error"
-msgstr "Error general"
+msgstr "Všeobecná chyba"
 
 #: src/metabase/query_processor.clj
 msgid "Missing query hash!"
-msgstr "¡Falta el hash de consulta!"
+msgstr "Chybí hash dotazu!"
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Table ''{0}'' has no Fields associated with it."
-msgstr "La tabla '' {0} '' no tiene campos asociados."
+msgstr "Tabulka ''{0}'' nemá přiřazené pole."
 
 #: src/metabase/query_processor/middleware/add_query_throttle.clj
 msgid "Max concurrent query limit reached"
-msgstr "Se ha alcanzado el máximo de consultas concurrentes"
+msgstr "Byl dosažen maximální počet souběžných dotazů"
 
 #. we should never reach this if our patterns are written right so this is more to catch code mistakes than
 #. something the user should expect to see
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Don't know how to get information about Field:"
-msgstr "No se cómo obtener información del Campo:"
+msgstr "Nevím, jak získat informace o poli:"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "metabase.query-processor.interface/*driver* is unbound."
-msgstr "metabase.query-processor.interface/*driver* no está definido."
+msgstr "metabase.query-processor.interface/*driver* je uvolněný."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Query processor error: mismatched number of columns in query and results."
-msgstr "Error del procesador de consultas: número de columnas no coincidentes en la consulta y los resultados."
+msgstr "Chyba zpracovatele dotazů: neshodný počet sloupců v dotazu a výsledcích."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected {0} fields, got {1}"
-msgstr "Esperaba {0} campos pero hay {1}"
+msgstr "Očekávané {0} pole, dostali {1}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected: {0}"
-msgstr "Esperado: {0}"
+msgstr "Očekávané: {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Actual: {0}"
-msgstr "Actual: {0}"
+msgstr "Aktuálně: {0}"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Unable to bin Field without a min/max value"
-msgstr "No se puede agrupar el campo sin un valor mínimo/máximo"
+msgstr "Nelze zadat hranice pole bez minimální / maximální hodnoty"
 
 #: src/metabase/query_processor/middleware/check_features.clj
 msgid "{0} is not supported by this driver."
-msgstr "Este controlador no soporta {0}"
+msgstr "{0} tento ovladač nepodporuje."
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Segment {0} does not exist, or is invalid."
-msgstr "El segmento {0} no existe o es inválido."
+msgstr "Segment {0} neexistuje nebo je neplatný."
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Metric {0} does not exist, or is invalid."
-msgstr "La Métrica {0} no existe o es inválida."
+msgstr "Metrika {0} neexistuje nebo je neplatná."
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Missing source query in Card {0}"
-msgstr "Falta la consulta de origen en la tarjeta {0}"
+msgstr "Chybí zdrojový dotaz na kartě {0}"
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Fetched source query from Card {0}:"
-msgstr "Leído la consulta de origen de la tarjeta {0}:"
+msgstr "Načetl se zdrojový dotaz z karty {0}:"
 
 #: src/metabase/query_processor/middleware/mbql_to_native.clj
 msgid "Error transforming MBQL query to native:"
-msgstr "Error al transformar la consulta MBQL a nativo:"
+msgstr "Chyba při transformaci dotazu MBQL na nativní:"
 
 #: src/metabase/query_processor/middleware/resolve_source_table.clj
 msgid "Cannot run query: could not find source table {0}."
-msgstr "No se ha podido ejecutar la consulta: no se ha encontrado la tabla origen {0}."
+msgstr "Nelze spustit dotaz: nenašla se zdrojová tabulka {0}."
 
 #: src/metabase/query_processor/middleware/results_metadata.clj
 msgid "Error recording results metadata for query:"
-msgstr "Error al registrar los metadatos de resultados para la consulta:"
+msgstr "Chyba při zaznamenávání metadat výsledků pro dotaz:"
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Query Processor store is not initialized."
-msgstr "Error: el almacén del procesador de consultas no está inicializada."
+msgstr "Chyba: Úložiště zpracovatele dotazů není inicializováno."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Table {0} is not present in the Query Processor Store."
-msgstr "Error: la tabla {0} no está presente en el almacén del procesador de consultas."
+msgstr "Chyba: Tabulka {0} se nenachází v úložišti zpracovatele dotazů."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Field {0} is not present in the Query Processor Store."
-msgstr "Error: el campo {0} no está presente en el almacén del procesador de consultas."
+msgstr "Chyba: pole {0} se nenachází v úložišti zpracovatele dotazů."
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, rows were {0}deleted"
-msgstr "La limpieza del historial de tareas fue exitosa, {0} se eliminaron filas"
+msgstr "Čištění historie úloh bylo úspěšné, řádky byly {0} odstraněny"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "not"
-msgstr "no"
+msgstr "ne"
 
 #: src/metabase/db.clj src/metabase/util/encryption.clj
 msgid "For more information, see"
-msgstr "Para obtener más información, visita"
+msgstr "Více informací naleznete na"
 
 #: src/metabase/util/schema.clj
 msgid "Integer greater than or equal to zero"
-msgstr "Entero mayor o igual a cero"
+msgstr "Celé číslo větší nebo rovno nule"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer greater than or equal to zero."
-msgstr "valor debe ser un entero igual o superior a cero."
+msgstr "hodnota musí být celé číslo větší nebo rovno nule."
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer zero or greater."
-msgstr "valor debe ser un entero igual o superior a cero."
+msgstr "hodnota musí být celé číslo, nula nebo větší než nula."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer greater than or equal to zero."
-msgstr "valor debe ser un entero igual o superior a cero."
+msgstr "hodnota musí být platné celé číslo větší nebo rovno nule."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "New users per state in the last 30 days"
-msgstr "Nuevos usuarios por estado en los últimos 30 días"
+msgstr "Noví uživatelé v každém státě za posledních 30 dní"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by day of the week"
-msgstr "Creado por día de la semana"
+msgstr "Vytvořeno podle dne v týdnu"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by quarter of the year"
-msgstr "Creado por trimestre"
+msgstr "Vytvořeno podle kvartálu v roce"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per country"
-msgstr "[[this.short-name]] por país"
+msgstr "[[this.short-name]] podle země"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Users per source"
-msgstr "Usuarios por origen"
+msgstr "Uživatelé podle zdroje"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "The top external pages that brought users to your site"
-msgstr "Las principales páginas externas que trajeron usuarios a tu sitio."
+msgstr "Nejlepší externí stránky, které přivedly uživatele na váš web"
 
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
-msgstr "Cómo se distribuye [[this]] y algo más."
+msgstr "Jak je [[this]] distribuováno a další."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "The [[this]] over time"
-msgstr "El [[this]] a lo largo del tiempo"
+msgstr "[[this]] v průběhu času"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "User growth"
-msgstr "Crecimiendo de usuarios"
+msgstr "Růst uživatelů"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Whether or not there are any patterns to when they happen."
-msgstr "Si hay o no patrones para cuando suceden."
+msgstr "Zda existují nebo neexistují vzory a kdy k nim dojde"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Users per state"
-msgstr "Usuarios por provincia"
+msgstr "Uživatelé podle státu"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions"
-msgstr "Sesiones"
+msgstr "Relace"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "How some of the numbers in [[this]] relate to each other"
-msgstr "Cómo algunos de los números en [[this]] se relacionan entre sí"
+msgstr "Jak se některá čísla v [[this]] vztahují k sobě navzájem"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per country"
-msgstr "Ventas por país"
+msgstr "Prodeje za zemi"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by month of the year"
-msgstr "Unir fecha por el mes del año"
+msgstr "Připojte datum podle měsíce v roce"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by hour of the day"
-msgstr "[[Timestamp]] por hora del día"
+msgstr "[[Timestamp]] podle hodiny dne"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "A look at the [[this]]"
-msgstr "Un vistazo a [[this]]"
+msgstr "Pohled na [[this]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Bottom 5 per category"
-msgstr "Ultimos 5 por categoría"
+msgstr "Spodních 5 pro každou kategorii"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Number of orders"
-msgstr "Número de pedidos"
+msgstr "Počet objednávek"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Event growth"
-msgstr "Crecimiento de Eventos"
+msgstr "Růst událostí"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "Total [[GenericTable]]"
-msgstr "Total [[GenericTable]]"
+msgstr "Celkem [[GenericTable]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Income growth"
-msgstr "Crecimiento de Ingresos"
+msgstr "Růst příjmů"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top 10 countries by sales in the last 30 days"
-msgstr "Primeros 10 paises por ventas en los últimos 30 días"
+msgstr "Top 10 zemí podle tržeb za posledních 30 dní"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by month of the year"
-msgstr "[[this]] por mes del año"
+msgstr "[[this]] podle měsíce v roce"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per day of the week"
-msgstr "Transacciones por día de la semana"
+msgstr "Transakce za den v týdnu"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by device type"
-msgstr "Sesiones por dispositivo"
+msgstr "Relace podle typu zařízení"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Transactions per country"
-msgstr "Transacciones por país"
+msgstr "Transakce podle krajiny"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by quarter of the year"
-msgstr "Unir fecha por trimestre"
+msgstr "Připojte datum podle kvartálu v roce"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per hour of the day"
-msgstr "Eventos por hora del día"
+msgstr "Události za hodinu během dne"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Singleton]]"
@@ -10216,20 +10225,20 @@ msgstr "[[Singleton]]"
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Top 5 [[this]]"
-msgstr "Primeros 5 [[this]]"
+msgstr "Top 5 [[this]]"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Bottom 5 [[this]]"
-msgstr "Ultimos 5 [[this]]"
+msgstr "Spodních 5 [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by day of the month"
-msgstr "[[Timestamp]] por día del mes"
+msgstr "[[Timestamp]] podle dne v měsíci"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[GenericCategoryLarge]]"
-msgstr "Por [[GenericCategoryLarge]]"
+msgstr "Za [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10237,335 +10246,335 @@ msgstr "Por [[GenericCategoryLarge]]"
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "Null values"
-msgstr "Valores nulos"
+msgstr "Bez hodnoty"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Total events"
-msgstr "Total eventos"
+msgstr "Celkový počet událostí"
 
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "A look at [[GenericTable]] across your [[this]], and how it changes over time."
-msgstr "Una mirada a [[GenericTable]] a través de tu [[this]], y cómo cambia con el tiempo."
+msgstr "Podívejte se na [[GenericTable]] v [[this]] a jak se v průběhu času mění."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryMedium]]"
-msgstr "[[this]] por [[GenericCategoryMedium]]"
+msgstr "[[this]] podle [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] changes with time"
-msgstr "Como el [[this]] cambia con el tiempo"
+msgstr "Jak se [[this]] mění s časem"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "How they compare by seasonality"
-msgstr "Cómo se comparan por estacionalidad."
+msgstr "Jak si vedou podle sezónnosti"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average income per transaction"
-msgstr "Ingreso medio por transacción"
+msgstr "Průměrný příjem na transakci"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per country"
-msgstr "[[this]] por país"
+msgstr "[[this]] podle země"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Income per state"
-msgstr "Ingresos por provincia"
+msgstr "Příjem podle státu"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[GenericCategoryMedium]]"
-msgstr "Por [[GenericCategoryMedium]]"
+msgstr "Za [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "A closer look at your [[this]]"
-msgstr "Una mirada detallada a tus [[this]]"
+msgstr "Bližší pohled na [[this]]"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "How [[GenericNumber]] is distributed"
-msgstr "Como se distribuye [[GenericNumber]]"
+msgstr "Jak se distribuuje [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by quarter of year"
-msgstr "[[Timestamp]] por trimestre"
+msgstr "[[Timestamp]] podle čtvrtletí"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per country"
-msgstr "Eventos por país"
+msgstr "Události podle zemí"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Weekdays when [[this.short-name]] were added"
-msgstr "Días de la semana cuando se añadío [[this.short-name]]"
+msgstr "Dny, kdy byly přidány [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Months when [[this.short-name]] were added"
-msgstr "Mes cuando se añadío [[this.short-name]]"
+msgstr "Měsíce, kdy byly přidány [[this.short-name]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across different categories"
-msgstr "Cómo se comparan en diferentes categorías"
+msgstr "Jak si vedou napříč různými kategoriemi"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "New users per source in the last 30"
-msgstr "Nuevos usuarios por origen en los últimos 30 días"
+msgstr "Noví uživatelé na zdroj za posledních 30"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per quarter of the year"
-msgstr "Eventos por trimestre"
+msgstr "Události za kvartál roku"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Heres a quick look at your [[this]]"
-msgstr "Una mirada rápida a tus [[this]]"
+msgstr "Zde je rychlý pohled na vaše [[this]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryLarge]], top 5"
-msgstr "[[this]] por [[GenericCategoryLarge]], primeros 5"
+msgstr "[[this]] podle [[GenericCategoryLarge]], top 5"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Days when [[this.short-name]] were added"
-msgstr "Días en los que se añadío [[this.short-name]]"
+msgstr "Dny, kdy byly přidány [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Total orders per source"
-msgstr "Pedidos totales por origen"
+msgstr "Celkový počet objednávek podle zdroje"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by quarter of the year"
-msgstr "[[this]] por trimestre"
+msgstr "[[this]] za čtvrtletí v roce"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per [[GenericCategoryMedium]]"
-msgstr "Eventos por [[GenericCategoryMedium]]"
+msgstr "Události podle [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per state"
-msgstr "Eventos por provincia"
+msgstr "Události podle státu"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top landing pages"
-msgstr "Las mejores páginas de aterrizaje"
+msgstr "Nejlepší vstupní stránky"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Heres a closer look at your [[this]] over time"
-msgstr "Una mirada detallada a tus [[this]] a lo largo del tiempo"
+msgstr "Zde je bližší pohled na [[this]] v průběhu času"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Sum of [[this]] by [[Country]]"
-msgstr "Suma de [[this]] por [[Country]]"
+msgstr "Součet [[this]] podle [[Country]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "States that are performing best"
-msgstr "Las provincia con mejores resultados"
+msgstr "Státy, které dosahují nejlepších výsledků"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by month of the year"
-msgstr "Creado por mes del año"
+msgstr "Vytvořeno podle měsíce v roce"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Sum of [[this]] by [[State]]"
-msgstr "Suma de [[this]] por [[State]]"
+msgstr "Součet [[this]] podle [[State]]"
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "Sum of [[GenericNumber]] per [[this]]"
-msgstr "Suma de [[GenericNumber]] por [[this]]"
+msgstr "Součet [[GenericNumber]] podle [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by coordinates"
-msgstr "Eventos por coordenadas"
+msgstr "Události podle souřadnic"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top referral pages"
-msgstr "Las mejores páginas de referencia"
+msgstr "Nejlepší doporučené stránky"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "An exploration of your users to get you started."
-msgstr "Un exploración de tus usuarios para empezar."
+msgstr "Přezkoumání uživatelů, abyste mohli začít."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "An overview of your [[this]] and how its distributed across time, place, and categories."
-msgstr "Una visión general de tu [[this]] y cómo se distribuye en el tiempo, el lugar y las categorías."
+msgstr "Přehled vašeho [[this]] a jeho distribuce v čase, místě a kategoriích."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Average income per state"
-msgstr "Ingresos medios por provincia"
+msgstr "Průměrný příjem podle státu"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
-msgstr "[[this]] por [[GenericCategoryMedium]]"
+msgstr "[[this]] podle [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total transactions"
-msgstr "Total transacciones"
+msgstr "Celkem transakcí"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] that have joined over time"
-msgstr "[[this.short-name]] que se han unido a lo largo del tiempo"
+msgstr "[[this.short-name]], které se připojily v průběhu času"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "The [[this]] by location"
-msgstr "Los [[this]] por ubicación"
+msgstr "[[this]] podle lokace"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per month of the year"
-msgstr "Eventos por mes del año"
+msgstr "Události za měsíc v roce"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] by [[GenericNumber]]"
-msgstr "[[this]] por [[GenericNumber]]"
+msgstr "[[this]] podle [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Quarters when [[this.short-name]] were added"
-msgstr "Trimestres en los que se añadío [[this.short-name]]"
+msgstr "Kvartály, kdy byly přidány [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "How these [[this.short-name]] are distributed"
-msgstr "Como se distribuyen [[this.short-name]]"
+msgstr "Jak jsou distribuovány [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by [[GenericNumber]]"
-msgstr "[[this.short-name]] por [[GenericNumber]]"
+msgstr "[[this.short-name]] podle [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Where users are coming from"
-msgstr "De donde vienen los usuarios"
+msgstr "Odkud přicházejí uživatelé"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "[[this]] comparisons and correlations"
-msgstr "comparaciones y correlaciones de [[this]]"
+msgstr "[[this]] srovnání a korelace"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total income"
-msgstr "Ingreso total"
+msgstr "Celkový příjem"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total income per month"
-msgstr "Inrgeso total por mes"
+msgstr "Celkový příjem za měsíc"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Number of users per source"
-msgstr "Número de usuarios por origen"
+msgstr "Počet uživatelů podle zdroje"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Transactions per state"
-msgstr "Transacciones por provincia"
+msgstr "Transakce podle státu"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "[[this]] by [[Timestamp]]"
-msgstr "[[this]] por [[Timestamp]]"
+msgstr "[[this]] podle [[Timestamp]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "New users per source in the last 30 days"
-msgstr "Nuevos usuarios por origen en los últimos 30 días"
+msgstr "Noví uživatelé podle zdroje za posledních 30 dní"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by day of the month"
-msgstr "Unir fecha por el día del mes"
+msgstr "Připojte datum podle dle v měsíci"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average discount %"
-msgstr "Descuento medio %"
+msgstr "Průměrná sleva %"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Autogenerated metrics about [[GenericTable]]."
-msgstr "Métricas autogeneradas sobre [[GenericTable]]."
+msgstr "Automaticky generované metriky o [[GenericTable]]."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per day of the month"
-msgstr "[[this]] por día del mes"
+msgstr "[[this]] za den v měsíci"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Total sessions in each country"
-msgstr "Sesiones totales en cada país"
+msgstr "Celkový počet relací v každé zemi"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per month of the year"
-msgstr "Transacciones por mes"
+msgstr "Transakcí za měsíc v roce"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per product"
-msgstr "Ventas por producto"
+msgstr "Prodeje za výrobek"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Users in each country"
-msgstr "Usuarios en cada país"
+msgstr "Uživatelů v každé zemi"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by hour of the day"
-msgstr "[[this]] por hora del día"
+msgstr "[[this]] podle hodiny dne"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events in the last 30 days"
-msgstr "Eventos en los últimos 30 días"
+msgstr "Události za posledních 30 dní"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Transactions per source"
-msgstr "Transacciones por origen"
+msgstr "Transakce podle zdroje"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Where youve acquired your users"
-msgstr "De dónde provienen tus usuarios"
+msgstr "Kde jste získali své uživatele"
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare acrosss location"
-msgstr "Como se comparan por ubicación"
+msgstr "Jak si vedou napříč polohou"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "[[this]] per product"
-msgstr "[[this]] por producto"
+msgstr "[[this]] podle produktu"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per month of the year"
-msgstr "[[this]] por mes del año"
+msgstr "[[this]] za měsíc v roce"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per country"
-msgstr "Por país"
+msgstr "Pro každou zemi"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "A deeper look at how different countries are performing for you."
-msgstr "Una mirada más profunda al rendimiento de los diferentes países."
+msgstr "Hlubší pohled na to, jak se jednotlivým zemím daří."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per state"
-msgstr "Ventas por provincia"
+msgstr "Prodeje za stát"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by [[GenericNumber]]"
-msgstr "Eventos por [[GenericNumber]]"
+msgstr "Události podle [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales per product [[ProductCategoryMedium]]"
-msgstr "Ventas por producto [[ProductCategoryMedium]]"
+msgstr "Prodeje za produkt [[ProductCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "User acquisition by country"
-msgstr "Adquisición de usuarios por país"
+msgstr "Akvizice uživatele podle země"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "[[this]] per source"
-msgstr "[[this]] por origen"
+msgstr "[[this]] podle zdroje"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by day of the week"
-msgstr "[[this]] por día de la semana"
+msgstr "[[this]] podle dne v týdnu"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Days of the month when [[this.short-name]] joined"
-msgstr "Días del mes cuando se juntan [[this.short-name]]"
+msgstr "Dny v měsíci, kdy se připojil [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Heres an overview of the people in your [[this]]"
-msgstr "Aquí hay una visión general de las personas en tu [[this]]"
+msgstr "Zde je přehled lidí ve vašem [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "How [[GenericTable]] are distributed across this time field, and if it has any seasonal patterns."
-msgstr "Cómo [[GenericTable]] se distribuye en este campo de tiempo, y si tiene algún patrón estacional."
+msgstr "Jako jsou [[GenericTable]] distribuovány v tomto časovém poli a zda má nějaké sezónní vzorce."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10576,137 +10585,137 @@ msgstr "Cómo [[GenericTable]] se distribuye en este campo de tiempo, y si tiene
 #: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Overview"
-msgstr "Visión general"
+msgstr "Přehled"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How this metric is distributed across different categories"
-msgstr "Cómo se distribuye esta métrica en diferentes categorías."
+msgstr "Jako je tato metrika distribuována do různých kategorií"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per state"
-msgstr "[[this.short-name]] por provincia"
+msgstr "[[this.short-name]] za stát"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Weekdays when [[this.short-name]] joined"
-msgstr "Días de la semana cuando se une por [[this.short-name]]"
+msgstr "Pracovní dny v měsíci, kdy se připojil [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Hours when [[this.short-name]] joined"
-msgstr "Horas cuando se une por [[this.short-name]]"
+msgstr "Hodiny, kdy se připojil [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Total income by month"
-msgstr "Ingreso total por mes"
+msgstr "Celkový příjem podle měsíce"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "A breakdown of your [[this]] over time, and its min, max, average and more."
-msgstr "Un desglose de tu [[this]] a lo largo del tiempo, y su mínimo, máximo, promedio y más."
+msgstr "Rozbor vašeho [[this]] v čase, jeho minima, maxima, průměr a další."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Average quantity per state"
-msgstr "Cantidad media por provincia"
+msgstr "Průměrné množství podle státu"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare by across different numbers"
-msgstr "Cómo se comparan por diferentes números"
+msgstr "Jak si vedou napříč různými čísli"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "New users per country in the last 30 days"
-msgstr "Nuevos usuarios por país en los últimos 30 días"
+msgstr "Noví uživatelé podle zemí za posledních 30 dní"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions over time"
-msgstr "Transacciones a lo largo del tiempo."
+msgstr "Transakce v průběhu času"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategorySmall]]"
-msgstr "[[this]] por [[GenericCategorySmall]]"
+msgstr "[[this]] za [[GenericCategorySmall]]"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Some breakdown"
-msgstr "Algún desglose"
+msgstr "Nějaké rozbory"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Average of [[this]] by [[State]]"
-msgstr "Media de [[this]] por [[State]]"
+msgstr "Průměr z [[this]] na [[State]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per quarter of the year"
-msgstr "Transacciones por trimestre"
+msgstr "Transakce za čtvrt roku"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "By coordinates"
-msgstr "Por coordenadas"
+msgstr "Podle souřadnic"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Heres a closer look at your [[this]] by products"
-msgstr "Una mirada detallada de tus [[this]] por productos"
+msgstr "Zde je bližší pohled na vaše [[this]] produkty"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per quarter of the year"
-msgstr "[[this]] por trimestre"
+msgstr "[[this]] za kvartál roku"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Heres an overview of your [[this]] data from Google Analytics"
-msgstr "Aquí hay un resumen de tus datos [[this]] de Google Analytics"
+msgstr "Zde je přehled vašich [[this]] dat ze služby Google Analytics"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Quarters when [[this.short-name]] joined"
-msgstr "Trimestres cuando se une por [[this.short-name]]"
+msgstr "Kvartály, kdy se připojil [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "New [[this.short-name]] in the last 30 days"
-msgstr "Nuevo [[this.short-name]] en los últimos 30 días"
+msgstr "Nové [[this.short-name]] za posledních 30 dní"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Total sessions by desktop, mobile, or tablet"
-msgstr "Sesiones totales por ordenador, móvil o tablet"
+msgstr "Celkový počet relací podle počítače, mobilu nebo tabletu"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "Indepth example"
-msgstr "Ejemplo en profundidad"
+msgstr "Podrobnější příklad"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average income per source"
-msgstr "Ingreso medio por origen"
+msgstr "Průměrný příjem podle zdroje"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by day of week"
-msgstr "[[Timestamp]] por día de la semana"
+msgstr "[[Timestamp]] podle dne v týdnu"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "Heres a closer look at your [[this]]"
-msgstr "Aquí hay una mirada más detallada a tus [[this]]"
+msgstr "Zde je bližší pohled na vaše [[this]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Heres a closer look at your [[this]] field"
-msgstr "Una mirada detallada de tu campo [[this]]"
+msgstr "Zde je bližší pohled na vaše [[this]] pole"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Summary"
-msgstr "Resumen"
+msgstr "Souhrn"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] is distributed geographically"
-msgstr "Cómo se distribuye geográficamente el [[this]]"
+msgstr "Jak je [[this]] geograficky distribuované"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "The pages with the most pageviews"
-msgstr "Las páginas con más visitas"
+msgstr "Stránky s největším počtem zobrazení"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "How [[Number1]] is correlated with [[Number2]]"
-msgstr "La correlación entre [[Number1]] y [[Number2]]"
+msgstr "Jak koreluje [[Number1]] s [[Number2]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Top 10 states by sales in the last 30 days"
-msgstr "Primeras 10 provincias por venta en los últimos 30 días"
+msgstr "Top 10 států podle tržeb za posledních 30 dní"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Top 10 states by sales"
-msgstr "Primeras 10 provincia por ventas"
+msgstr "Top 10 států podle tržeb"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Timestamp]]"
@@ -10714,62 +10723,62 @@ msgstr "[[Timestamp]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Where these transactions happened"
-msgstr "Donde occurrieron estas transacciones"
+msgstr "Kde se transakce udály"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top 10 countries by sales"
-msgstr "Primeros 10 paises por ventas"
+msgstr "Top 10 zemí podle prodejů"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by state"
-msgstr "Ventas por provincia"
+msgstr "Prodeje podle státu"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Where most of your sessions originate from"
-msgstr "De donde provienen la mayoría de las sesiones"
+msgstr "Odkud většina vašich relací pochází"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top acquisition channels"
-msgstr "Los mejores canales de adquisición"
+msgstr "Nejlepší akviziční kanály"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "These [[this.short-name]] across time"
-msgstr "Estos [[this.short-name]] a lo largo del tiempo"
+msgstr "Tyto [[this.short-name]] v průběhu času"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average quantity"
-msgstr "Cantidad media"
+msgstr "Průměrné množství"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per source"
-msgstr "Ventas por origen"
+msgstr "Prodeje za jednotlivé zdrojů"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Average income per country"
-msgstr "Ingreso medio por país"
+msgstr "Průměrný příjem podle země"
 
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
-msgstr "Como se distribuye [[this]]"
+msgstr "Jako je [[this]] distribuované"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Distinct [[FK]]"
-msgstr "[[FK]] distintos"
+msgstr "Jedinečný [[FK]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "How these transactions are distributed"
-msgstr "Como se distribuyen estas transacciones"
+msgstr "Jak jsou tyto transakce distribuovány"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per state"
-msgstr "Por provincias"
+msgstr "Podle státu"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "Count of [[GenericCategoryMedium]] by [[this]]"
-msgstr "Cuenta de [[GenericCategoryMedium]] por [[this]]"
+msgstr "Počet [[Generic Category Medium]] podle [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10784,68 +10793,68 @@ msgstr "Cuenta de [[GenericCategoryMedium]] por [[this]]"
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "A look at your [[this]]"
-msgstr "Una mirada a tus [[this]]"
+msgstr "Podívejte se na [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "[[GenericNumber]] by [[this]]"
-msgstr "[[GenericNumber]] por [[this]]"
+msgstr "[[GenericNumber]] podle [[this]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Sum of [[GenericNumber]] by [[this]]"
-msgstr "Suma de [[GenericNumber]] por [[this]]"
+msgstr "Součet [[GenericNumber]] podle [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A look at your [[this]] table"
-msgstr "Una mirada a tu tabla [[this]]"
+msgstr "Podívejte se na vaši [[this]] tabulku"
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "How many [[GenericTable]] there are per state, and how each state is represented across other categories."
-msgstr "Cuántos [[GenericTable]] hay por provincia y cómo se representa cada estado en otras categorías."
+msgstr "Kolik [[GenericTable]] je v jednotlivých státech a jak je každý stát zastoupen v jiných kategoriích."
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Most-viewed pages"
-msgstr "Páginas más vistas"
+msgstr "Nejsledovanější stránky"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Example exploration"
-msgstr "Exploración de ejemplo"
+msgstr "Příklad průzkumu"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales vs. rating"
-msgstr "Ventas vs. Clasificación"
+msgstr "Prodej vs. hodnocení"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per hour of the day"
-msgstr "[[this]] por hora del día"
+msgstr "[[this]] za hodinu dne"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Where your [[this.short-name]] are"
-msgstr "Donde están tus [[this.short-name]]"
+msgstr "Kde jsou [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "These are the same for all your [[this.short-name]]"
-msgstr "Estos son los mismos para todos los [[this.short-name]]"
+msgstr "Jsou stejné pro všechny vaše [[this.short-name]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by different categories"
-msgstr "Eventos por diferentes categorías"
+msgstr "Události podle různých kategorií"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Where these [[this.short-name]] are"
-msgstr "Donde están estos [[this.short-name]]"
+msgstr "Kde jsou [[this.short-name]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Over time"
-msgstr "A lo largo del tiempo"
+msgstr "Postupem času"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A summary of the events in your [[this]] table"
-msgstr "Un resumen de los eventos en tu tabla [[this]]"
+msgstr "Souhrn událostí v [[this]] tabulce"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Transactions per source over time"
-msgstr "Transacciones por origen a lo largo del tiempo."
+msgstr "Transakcí podle zdroje v průběhu času"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10853,221 +10862,222 @@ msgstr "Transacciones por origen a lo largo del tiempo."
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "How the [[this]] is distributed"
-msgstr "Como se distribuye el [[this]]"
+msgstr "Jako je [[this]] distribuovaný"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Total income per source"
-msgstr "Ingreso total por origen"
+msgstr "Celkový příjem podle zdroje"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Total [[this.short-name]]"
-msgstr "Total [[this.short-name]]"
+msgstr "Celkově [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Some metrics we found about your transactions."
-msgstr "Algunas métricas que encontramos sobre tus transacciones."
+msgstr "Některé metriky o vašich transakcích jsme našli."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "How your different products are performing."
-msgstr "Rendimiento de tus productos."
+msgstr "Jak si vedou různé produkty"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Where these events are happening"
-msgstr "Donde occuren estos eventos"
+msgstr "Kde se tyto události dějí"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Which US states are bringing you the most business."
-msgstr "Qué estados de los EEUU te están dando más negocio"
+msgstr "Které státy USA vám přinášejí nejvíce do vašeho podnikání."
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
-msgstr "Como se comparan a lo largo del tiempo"
+msgstr "Jak si vedou v průběhu času"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average transaction income per month"
-msgstr "Ingreso medio de transacción por mes"
+msgstr "Průměrný příjem z transakce za měsíc"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average quantity per month"
-msgstr "Cantidad media por mes"
+msgstr "Průměrné množství za měsíc"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "Seasonal patterns in the [[this]]"
-msgstr "Patrones estacionales en [[this]]"
+msgstr "Sezónní vzorce v [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events over time"
-msgstr "Eventos a lo largo del tiempo"
+msgstr "Události v průběhu času"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Orders and income per source"
-msgstr "Pedidos e ingresos por origen"
+msgstr "Objednávky a příjmy podle zdroje"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per hour of the day"
-msgstr "Transacciones por hora del día"
+msgstr "Transakcí za hodinu ve dni"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Where most of your traffic is coming from."
-msgstr "De donde proviene la mayoría de tu tráfico"
+msgstr "Odkud pochází většina vaší návštěvnosti."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Heres a quick look at the [[this]]"
-msgstr "Aquí hay un vistazo rápido a [[this]]"
+msgstr "Zde je rychlý pohled na [[this]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "It looks like your [[this]] has transactions, so heres a look at them"
-msgstr "Parece que tu [[this]] tiene transacciones, así que aquí hay información"
+msgstr "Vypadá to, že vaše [[this]] obsahuje transakce, takže se na ně podívejte"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average discount per month"
-msgstr "Descuento medio por mes"
+msgstr "Průměrná sleva za měsíc"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by month of the year"
-msgstr "[[Timestamp]] por mes del año"
+msgstr "[[Timestamp]] podle měsíce v roce"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategorySmall]] over time"
-msgstr "[[this]] por [[GenericCategorySmall]] a lo largo del tiempo"
+msgstr "[[this]] za [[GenericCategorySmall]] v průběhu času"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Distribution by coordinates"
-msgstr "Distribución por coordenadas"
+msgstr "Distribuce podle souřadnic"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by source"
-msgstr "Ventas por origen"
+msgstr "Prodeje podle zdroje"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales for each product category"
-msgstr "Ventas por cada categoría de producto"
+msgstr "Prodeje pro každou kategorii produktu"
 
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "A closer look at the metrics and dimensions used in this saved question."
-msgstr "Una mirada detallada a las métricas y dimensiones utilizadas en esta pregunta guardada."
+msgstr "Bližší pohled na metriky a dimenze použité v této uložené otázce."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per [[GenericCategoryMedium]]"
-msgstr "[[this.short-name]] por [[GenericCategoryMedium]]"
+msgstr "[[this.short-name]] z [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales per product [[ProductCategoryLarge]]"
-msgstr "Ventas por producto [[ProductCategoryLarge]]"
+msgstr "Prodeje za produkt [[ProductCategoryLarge]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Average quantity per country"
-msgstr "Cantidad media por país"
+msgstr "Průměrné množství podle země"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per [[GenericCategoryLarge]]"
-msgstr "[[this.short-name]] por [[GenericCategoryLarge]]"
+msgstr "[[this.short-name]] z [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Heres a closer look at your [[this]] per source"
-msgstr "Aquí hay una mirada detallada a tu [[this]] por origen"
+msgstr "Zde je bližší pohled na váš [[this]] zdroj"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per day of the month"
-msgstr "Eventos por día del mes"
+msgstr "Události za den v měsíci"
 
+#. duplicity
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "If youre into correlations, this is the x-ray for you."
-msgstr "Si te interesan las correlaciones, esta es la radiografía para ti."
+msgstr "Pokud máte rádi souvislosti, toto je to průzkum pro vás."
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by Country"
-msgstr "Sesiones por País"
+msgstr "Relace podle zemí"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Some interesting metrics about your GA stats to get you started."
-msgstr "Algunas métricas interesantes sobre tus estadísticas de GA para empezar."
+msgstr "Několik zajímavých metrik o vašich GA statistikách, které vám pomohou začít."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per state"
-msgstr "[[this]] por provincia"
+msgstr "[[this]] na stát"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by quarter of the year"
-msgstr "[[Timestamp]] por trimestre"
+msgstr "[[Timestamp]] podle kvartálu roku"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How its distributed across time and other categories."
-msgstr "Cómo se distribuye a través del tiempo y otras categorías."
+msgstr "Jak se distribuuje v čase a jiných kategoriích."
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A look at your events over time and by several categories."
-msgstr "Una mirada a tus eventos a lo largo del tiempo y por varias categorías."
+msgstr "Prohlédněte si své události v průběhu času a podle několika kategorií."
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "[[GenericTable]] per [[this]]"
-msgstr "[[GenericTable]] por [[this]]"
+msgstr "[[GenericTable]] z [[this]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average quantity per source"
-msgstr "Cantidad media por origen"
+msgstr "Průměrné množství podle zdroj"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Top 5 per category"
-msgstr "Primeros 5 por categoría"
+msgstr "5 nejlepších v kategorii"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per day of the week"
-msgstr "Eventos por día de la semana"
+msgstr "Události za den v týdnu"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "New [[this.short-name]] per month"
-msgstr "Nuevos [[this.short-name]] por mes"
+msgstr "Nový [[this.short-name]] za měsíc"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top performers"
-msgstr "Mejor desempeño"
+msgstr "Nejlepší hráči"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Transactions in the last 30 days"
-msgstr "Transacciones en los últimos 30 días"
+msgstr "Transakce za posledních 30 dní"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[GenericTable]] by [[this]]"
-msgstr "[[GenericTable]] por [[this]]"
+msgstr "[[GenericTable]] podle [[this]]"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Overview of your [[this]] data from Google Analytics"
-msgstr "Visión general de tus datos [[this]] de Google Analytics"
+msgstr "Přehled vašich [[this]] dat ze služby Google Analytics"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by hour of the day"
-msgstr "Creado por hora del día"
+msgstr "Vytvořeno za hodinu ve dni"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by month"
-msgstr "Ventas por mes"
+msgstr "Prodeje podle měsíce"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] is distributed across categories"
-msgstr "Cómo se distribuye [[this]] entre categorías"
+msgstr "Jak je [[this]] distribuován do různých kategorií"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by month of year"
-msgstr "[[Timestamp]] por mes del año"
+msgstr "[[Timestamp]] podle měsíce v roce"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "How many total sessions vs. how many individual users you had each day."
-msgstr "Cuántas sesiones en total vs. cuántos usuarios individuales has tenido cada día."
+msgstr "Celkový počet relací v porovnání s počtem jednotlivých uživatelů, které jste měli každý den."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How this metric is distributed across different numbers"
-msgstr "Cómo se distribuye esta métrica entre diferentes números."
+msgstr "Jak je tato metrika rozdělena mezi různá čísla"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by page where the session began"
-msgstr "Sesiones por página donde comenzó la sesión."
+msgstr "Relace podle stránky, kde se relace začala"
 
 #: frontend/src/metabase/lib/schema_metadata.js:503
 #: resources/automagic_dashboards/field/DateTime.yaml
@@ -11076,20 +11086,20 @@ msgstr "Sesiones por página donde comenzó la sesión."
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "Distinct values"
-msgstr "Valores distintos"
+msgstr "Jedinečné hodnoty"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Hours when [[this.short-name]] were added"
-msgstr "Horas en las que se añadío [[this.short-name]]"
+msgstr "Hodiny, kdy byly přidány [[this.short-name]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by day of the week"
-msgstr "[[Timestamp]] por día de la semana"
+msgstr "[[Timestamp]] podle dne v týdnu"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[GenericNumber]] over time"
-msgstr "[[GenericNumber]] a lo largo del tiempo"
+msgstr "[[GenericNumber]] v průběhu času"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
@@ -11098,43 +11108,43 @@ msgstr "[[GenericNumber]] a lo largo del tiempo"
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Heres an overview of your [[this]]"
-msgstr "Aquí hay una visión general de tu [[this]]"
+msgstr "Zde je přehled vašich [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by coordinates"
-msgstr "[[this.short-name]] por coordenadas"
+msgstr "[[this.short-name]] podle souřadnic"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Heres a closer look at your [[this]] per state"
-msgstr "Una mirada detallada a los [[this]] por provincia"
+msgstr "Zde je bližší pohled na váš [[this]] podle státu"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by day of the month"
-msgstr "Creado por día del mes"
+msgstr "Vytvořeno dne v měsíci"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales by coordinates"
-msgstr "Ventas por coordenadas"
+msgstr "Prodej podle souřadnic"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "New [[this.short-name]] over time"
-msgstr "Nuevos [[this.short-name]] a lo largo del tiempo"
+msgstr "Nové [[this.short-name]] v průběhu času"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by hour of the day"
-msgstr "Unir fecha por hora del día"
+msgstr "Připojte datum podle hodiny ve dni"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by hour of day"
-msgstr "[[Timestamp]] por hora del día"
+msgstr "[[Timestamp]] podle hodiny ve dni"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions and unique users per day"
-msgstr "Sesiones y usuarios únicos por día."
+msgstr "Relace a jedineční uživatelé denně"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per [[GenericCategoryLarge]]"
-msgstr "Eventos por [[GenericCategoryLarge]]"
+msgstr "Události za [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -11143,413 +11153,425 @@ msgstr "Eventos por [[GenericCategoryLarge]]"
 #: resources/automagic_dashboards/field/GenericField.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
-msgstr "Cómo se comparan por distribución"
+msgstr "Jak si vedou podle distribuce"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Income per country"
-msgstr "Ingreso por país"
+msgstr "Příjem podle země"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Heres a closer look at your [[this]] per country"
-msgstr "Una mirada detallada de tus [[this]] por país"
+msgstr "Zde je bližší pohled na vaši [[this]] zemi"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by product [[ProductCategory]]"
-msgstr "Ventas por producto [[ProductCategory]]"
+msgstr "Prodeje podle produktu [[ProductCategory]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryLarge]], bottom 5"
-msgstr "[[this]] por [[GenericCategoryLarge]], últimos 5"
+msgstr "[[this]] z [[GenericCategoryLarge]], posledních 5"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] added in the last 30 days"
-msgstr "[[this.short-name]] añadidos en los últimos 30 días"
+msgstr "[[this.short-name]] přidáno za posledních 30 dní"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[Source]]"
-msgstr "Por [[Source]]"
+msgstr "Na [[Source]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average item quantity per month"
-msgstr "Cantidad media por mes"
+msgstr "Průměrné množství položek za měsíc"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "The number of [[GenericTable]] per country, and how each country is represented in different categories."
-msgstr "El número de [[GenericTable]] por país, y cómo cada país está representado en diferentes categorías."
+msgstr "Počet [[GenericTable]] na zemi a jak je každá země zastoupena v různých kategoriích."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per day of the week"
-msgstr "[[this]] por día de la semana"
+msgstr "[[this]] za den v týdnu"
 
+#. typo error in english source
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average qunatity per source"
-msgstr "Cantidad media por origen"
+msgstr "Průměrná kvantita podle zdroje"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by [[Timestamp]]"
-msgstr "[[this.short-name]] por [[Timestamp]]"
+msgstr "[[this.short-name]] z [[Timestamp]]"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Summary statistics"
-msgstr "Resumen Estadístico"
+msgstr "Souhrnná statistika"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per month"
-msgstr "Ventas por mes"
+msgstr "Prodeje za měsíc"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[GenericNumber]] by join date"
-msgstr "[[GenericNumber]] por unión de fecha"
+msgstr "[[GenericNumber]] podle data připojení"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Average of [[this]] by [[Country]]"
-msgstr "Media de[[this]] por [[Country]]"
+msgstr "Průměr z [[this]] na [[Country]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[this]] over time"
-msgstr "[[this]] a lo largo del tiempo"
+msgstr "[[this]] v průběhu času"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by day of the week"
-msgstr "Unir fecha por día de la semana"
+msgstr "Připojte datum podle dne v týdnu"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "We crunched the numbers for your [[this]]"
-msgstr "Hemos procesado los números de tu [[this]]"
+msgstr "Přechroustali jsme čísla pro vaše [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Months when [[this.short-name]] joined"
-msgstr "Meses cuando se une por [[this.short-name]]"
+msgstr "Měsíce, kdy se připojil [[this.short-name]]"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to parse resource `{0}` as JSON"
-msgstr "Respuesta JSON incorrecta: `{0}`"
+msgstr "Nepodařilo se ověřit prostředek \"{0}\" jako JSON"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to find JSON via relative path `{0}`"
-msgstr "No se puede encontrar JSON a través de la ruta relativa `{0}`"
+msgstr "Nemůžeme najít JSON prostřednictvím relativní cesty `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Connection to host timed out for URL `{0}`"
-msgstr "La conexión con el host ha caducado para la URL `{0}`"
+msgstr "Vypršel časový limit připojení k hostiteli pro URL adresu `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to connect to unknown host at URL `{0}`"
-msgstr "No se puede conectar a un host desconocido en la URL `{0}`"
+msgstr "Nelze se spojit s neznámým hostitelem na URL adrese `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to connect to host at URL `{0}`"
-msgstr "No se puede conectar con el host en la URL `{0}`"
+msgstr "Nelze se spojit s hostitelem na URL adrese `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Connection refused by host at for URL `{0}`"
-msgstr "Conexión rechazada por el host en la URL `{0}`"
+msgstr "Hostitel odmítl připojení na URL adrese `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to retrieve resource at URL `{0}`"
-msgstr "No se puede recuperar el recurso en la URL `{0}`"
+msgstr "Zdroj nelze načíst z URL `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to parse resource at URL `{0}` as JSON"
-msgstr "No se puede analizar el recurso en la URL `{0}` como JSON"
+msgstr "Nepodařilo se ověřit prostředek z URL \"{0}\" jako JSON"
 
+#. duplicity
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fall back to local authentication: {0}"
-msgstr "Problema al conectarse al servidor LDAP, se volverá a la autenticación local: {0}"
+msgstr "Při připojování k serveru LDAP se vyskytl problém, vrátím se k místním účtům {0}"
 
 #: src/metabase/driver/bigquery.clj
 msgid "BigQuery statements can''t be parameterized!"
-msgstr "¡Las consultas BigQuery no se pueden parametrizar!"
+msgstr "Příkazy BigQuery nemohou být parametrizovány!"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Druid does not allow limitSpec in time series queries. Ignoring the LIMIT clause."
-msgstr "ADVERTENCIA: Druid no permite limitSpec en consultas de series de tiempo. Ignorando la cláusula LIMIT."
+msgstr "UPOZORNĚNÍ: Druid nepovoluje limitSpec v dotazech časových řad. Ignoruji vlastnost LIMIT"
 
 #: src/metabase/driver/snowflake.clj
 msgid "Invalid Snowflake connection details: missing DB name."
-msgstr "Valores de conexión a SnowFlake inválidas: falta el nombre de la BBDD"
+msgstr "Neplatné podrobnosti o připojení k Snowflake: chybí název DB."
 
 #: src/metabase/email/messages.clj
 msgid "We’d love your feedback."
-msgstr "Nos encantaría tus comentarios."
+msgstr "Byli bychom rádi, pokud byste nám poslali vaši zpětnou vazbu."
 
 #: src/metabase/email/messages.clj
 msgid "It looks like Metabase wasn’t quite a match for you."
-msgstr "Parece que Metabase no se ha ajustado a tus expectativas."
+msgstr "Vypadá to, že pro vás Metabase nebyla nejlepší volba."
 
 #: src/metabase/email/messages.clj
 msgid "Would you mind taking a fast 5 question survey to help the Metabase team understand why and make things better in the future?"
-msgstr "¿Te importaría realizar una encuesta rápida de 5 preguntas para ayudar al equipo de Metabase a comprender por qué y mejorar las cosas en el futuro?"
+msgstr "Mohl byste vyplnit 5 rychlých otázek, abyste pomohli týmu Metabase do budoucna pár věcí pochopit a vylepšit?"
 
 #: src/metabase/email/messages.clj
 msgid "We hope you''ve been enjoying Metabase."
-msgstr "Esperamos que hayas estado disfrutando de Metabase."
+msgstr "Doufáme, že se vám Metabase líbil."
 
 #: src/metabase/email/messages.clj
 msgid "Would you mind taking a fast 6 question survey to tell us how it’s going?"
-msgstr "¿Te importaría hacer una encuesta rápida de 6 preguntas para decirnos cómo va?"
+msgstr "Nevadilo by vám odpovědět na 6 rychlých otázek, aby jste nám řekli, jak se vám Metabase používá ?"
 
 #: src/metabase/email/messages.clj
 msgid "{0} created a Metabase account"
-msgstr "{0} ha creado una cuenta en Metabase"
+msgstr "{0} vytvořil účet Metabase"
 
 #: src/metabase/email/messages.clj
 msgid "{0} accepted their Metabase invite"
-msgstr "{0} ha aceptado su invitación a Metabase"
+msgstr "{0} přijal pozvání do Metabase"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Password Reset Request"
-msgstr "[Metabase] Solicitud Reestablecer Contraseña"
+msgstr "[Metabase] Žádost o reset hesla"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Notification"
-msgstr "[Metabase] Notificación"
+msgstr "[Metabase] Oznámení"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Help make Metabase better."
-msgstr "[Metabase] Ayuda a mejorar Metabase."
+msgstr "[Metabase] Pomozte vylepšit Metabase."
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Tell us how things are going."
-msgstr "[Metabase] Dinos como van las cosas."
+msgstr "[Metabase] Řekněte nám, jak se Metabase používá."
 
 #: src/metabase/mbql/util.clj
 msgid "Error: query''s source query has not been resolved. You probably need to `preprocess` the query first."
-msgstr "Error: la consulta fuente de la consulta no se ha resuelto. Probablemente necesites 'preprocesar' la consulta primero."
+msgstr "Chyba: zjišťování zdroje dotazu nerozpoznáno. Pravděpodobně budete muset nejprve předzpracovat dotaz."
 
 #: src/metabase/models/params.clj
 msgid "Don't know what to do with:"
-msgstr "No se que hacer con:"
+msgstr "Nevím, co dělat s:"
 
 #: src/metabase/models/params.clj
 msgid "Don't know how to wrap:"
-msgstr "No se como envolver:"
+msgstr "Nevím, jak obalit:"
 
 #: src/metabase/public_settings.clj
 msgid "Failed setting `query-caching-max-kb` to {0}."
-msgstr "No se ha podido establecer `query-caching-max-kb` a {0}"
+msgstr "Nelze nastavit `query-caching-max-kb` na {0}."
 
 #: src/metabase/public_settings.clj
 msgid "Values greater than {1} are not allowed."
-msgstr "No se permiten valores superiores a {1}"
+msgstr "Hodnoty větší než {1} nejsou povoleny."
 
 #: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
-msgstr "La base de datos {0} no existe."
+msgstr "Databáze {0} neexistuje."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Database is not present in the Query Processor Store."
-msgstr "Error: La base de datos no está presente en el procesador de consultas."
+msgstr "Chyba: Databáze se nenachází v úložišti zpracovatele dotazů."
 
 #: src/metabase/util/embed.clj
 msgid "Invalid embedding-secret-key! Secret key must be a hexadecimal-encoded 256-bit key (i.e., a 64-character string)."
-msgstr "¡Clave secreta no válida! La clave secreta debe ser una clave de 256 bits codificada en hexadecimal (es decir, una cadena de 64 caracteres)."
+msgstr "Neplatný embedding-secret-key! Tajný klíč musí být hexadecimálně kódováný 256-bitový klíč (tj 64-znakový řetězec)."
 
 #: src/metabase/util/embed.clj
 msgid "JWT is missing `alg`."
-msgstr "Falta el JWT `alg`."
+msgstr "JWT chybí `alg`."
 
 #: src/metabase/util/embed.clj
 msgid "JWT `alg` cannot be `none`."
-msgstr "JWT `alg` no puede ser `none`."
+msgstr "JWT `alg` nemůže byť `žádný`."
 
 #: src/metabase/util/embed.clj
 msgid "The embedding secret key has not been set."
-msgstr "No se ha establecido la clave secreta embebida."
+msgstr "Klíč na vkládání nebyl nastaven."
 
 #: src/metabase/util/embed.clj
 msgid "Token is missing value for keypath"
-msgstr "Falta el valor de keypath en el token."
+msgstr "Tokenu chybí hodnota pro cestu ke klíči"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "In-depth example"
-msgstr "Ejemplo avanzado"
+msgstr "Podrobný příklad"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:29
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:17
 msgid "Key"
-msgstr "Clave"
+msgstr "Klíč"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:30
 msgid "Class"
-msgstr "Clase"
+msgstr "Třída"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:32
 msgid "Triggers"
-msgstr "Disparadores"
+msgstr "Spouštěč"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:48
 msgid "View triggers"
-msgstr "Ver disparadores"
+msgstr "Zobrazit spouštěče"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
-msgstr "Información del Programador"
+msgstr "Informace o plánovači"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:20
 msgid "Priority"
-msgstr "Prioridad"
+msgstr "Priorita"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:21
 msgid "Last Fired"
-msgstr "Última vez ejecutada"
+msgstr "Naposledy spuštěn"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:22
 msgid "Next Fire Time"
-msgstr "Próxima vez que se ejecuta"
+msgstr "Nejbližší spuštění"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:23
 msgid "Start Time"
-msgstr "Hora Inicial"
+msgstr "Čas zahájení"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:24
 msgid "End Time"
-msgstr "Hora Final"
+msgstr "Čas ukončení"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:25
 msgid "Final Fire Time"
-msgstr "Ultima Ejecución"
+msgstr "Konečný čas spuštění"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:26
 msgid "May Fire Again?"
-msgstr "¿Puede ejecutarse de nuevo?"
+msgstr "Může znovu spustit?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
-msgstr "Disparadores para {0}"
+msgstr "Spouštěče pro {0}"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:26
 msgid "Tasks"
-msgstr "Tareas"
+msgstr "Úlohy"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:31
 msgid "Jobs"
-msgstr "Trabajos"
+msgstr "Úlohy"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:735
 msgid "Duplicated {0}"
-msgstr "Duplicado {0}"
+msgstr "Duplicitní {0}"
 
 #: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
-msgstr "Duplica este ítem"
+msgstr "Duplikuj tuto položku"
 
 #: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
-msgstr "Archiva este ítem"
+msgstr "Archivuj tuto položku"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:325
 msgid "Duplicate dashboard"
-msgstr "Duplicar Cuadro de Mando"
+msgstr "Duplikovat nástěnku"
 
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:16
 msgid "Duplicate \"{0}\""
-msgstr "Duplicar \"{0}\""
+msgstr "Duplikát \"{0}\""
 
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
-msgstr "Duplicar"
+msgstr "Duplikát"
 
 #: frontend/src/metabase/lib/query_time.js:115
 msgid "Tomorrow"
-msgstr "Mañana"
+msgstr "Zítra"
 
 #: frontend/src/metabase/lib/query_time.js:129
 #: frontend/src/metabase/lib/query_time.js:143
 msgid "This {0}"
-msgstr "Este {0}"
+msgstr "Toto {0}"
 
 #: frontend/src/metabase/lib/query_time.js:132
 msgid "Next {0}"
-msgstr "Siguiente {0}"
+msgstr "Dalších {0}"
 
 #: frontend/src/metabase/lib/query_time.js:135
 #: src/metabase/pulse/render/datetime.clj
 msgid "Previous {0}"
-msgstr "Anterior {0}"
+msgstr "Předchozí {0}"
 
 #: frontend/src/metabase/lib/query_time.js:139
 msgid "Previous {0} {1}"
-msgstr "Anterior {0} {1}"
+msgstr "Předchozí {0} {1}"
 
 #: frontend/src/metabase/lib/query_time.js:141
 msgid "Next {0} {1}"
-msgstr "Siguiente {0} {1}"
+msgstr "Dalších {0} {1}"
 
 #: frontend/src/metabase/lib/query_time.js:171
 msgid "Now"
-msgstr "Ahora"
+msgstr "Nyní"
 
 #: frontend/src/metabase/lib/query_time.js:174
 msgid "{0} {1} ago"
-msgstr "hace {0} {1}"
+msgstr "Před {0} {1}"
 
 #: frontend/src/metabase/lib/query_time.js:175
 msgid "{0} {1} from now"
-msgstr "{0} {1} desde ahora"
+msgstr "{0} {1} odteď"
 
 #: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
-msgstr[0] "Periodo por defecto"
-msgstr[1] "Periodos por defecto"
+msgstr[0] "Výchozí období"
+msgstr[1] "Výchozí období"
+msgstr[2] "Výchozích období"
 
 #: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
-msgstr[0] "Minuto de la hora"
-msgstr[1] "Minutos de la hora"
+msgstr[0] "Minuta z hodiny"
+msgstr[1] "Minuty z hodiny"
+msgstr[2] "Minut z hodiny"
 
 #: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
-msgstr[0] "Hora del día"
-msgstr[1] "Horas del día"
+msgstr[0] "Hodina ze dne"
+msgstr[1] "Hodiny ze dne"
+msgstr[2] "Hodin ze dne"
 
 #: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
-msgstr[0] "Día de la semana"
-msgstr[1] "Días de la semana"
+msgstr[0] "Den z týdne"
+msgstr[1] "Dny z týdne"
+msgstr[2] "Dní z týdne"
 
 #: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
-msgstr[0] "Día del mes"
-msgstr[1] "Días del mes"
+msgstr[0] "Den z měsíce"
+msgstr[1] "Dny z měsíce"
+msgstr[2] "Dní z měsíce"
 
 #: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
-msgstr[0] "Día del año"
-msgstr[1] "Días del año"
+msgstr[0] "Den z roku"
+msgstr[1] "Dny z roku"
+msgstr[2] "Dní z roku"
 
 #: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
-msgstr[0] "Semana del año"
-msgstr[1] "Semanas del año"
+msgstr[0] "Týden z roku"
+msgstr[1] "Týdny z roku"
+msgstr[2] "Týdnů z roku"
 
 #: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
-msgstr[0] "Mes del año"
-msgstr[1] "Meses del año"
+msgstr[0] "Měsíc z roku"
+msgstr[1] "Měsíce z roku"
+msgstr[2] "Měsíců z roku"
 
 #: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
-msgstr[0] "Trimestre del año"
-msgstr[1] "Trimestres del año"
+msgstr[0] "Kvartál z roku"
+msgstr[1] "Kvartály z roku"
+msgstr[2] "Kvartálů z roku"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
 msgid_plural "{0} selections"
-msgstr[0] "{0} seleccionado"
-msgstr[1] "{0} seleccionados"
+msgstr[0] "{0} vybraný"
+msgstr[1] "{0} vybrané"
+msgstr[2] "{0} vybraných"
 
 #: frontend/src/metabase/parameters/components/widgets/DateQuarterYearWidget.jsx:11
 msgid "[Q]Q"
@@ -11557,220 +11579,220 @@ msgstr "[Q]Q"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:28
 msgid "This"
-msgstr "Este"
+msgstr "Toto"
 
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:136
 msgid "Invalid"
-msgstr "Inválido"
+msgstr "Neplatný"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
-msgstr "Añade una hora"
+msgstr "Přidat čas"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
 msgid "Nothing to compare for the previous {0}."
-msgstr "Nada que comparar en el {0} anterior."
+msgstr "Nic pro srovnání z předchozím {0}."
 
 #: frontend/src/metabase-lib/lib/Dimension.js:712
 msgid "by {0}"
-msgstr "por {0}."
+msgstr "do {0}"
 
 #: src/metabase/api/database.clj
 msgid "value must be a valid database engine."
-msgstr "el valor debe ser un motor de base de datos válido."
+msgstr "hodnota musí být platný databázový engine."
 
 #: src/metabase/api/geojson.clj
 msgid "Connection refused by host for URL `{0}`"
-msgstr "La conexión ha sido rechazada por el host a través de la URL  `{0}`"
+msgstr "Host odmítl připojení pro URL adresu `{0}`"
 
 #: src/metabase/db.clj
 msgid "Warning: Postgres connection string with `ssl=true` detected."
-msgstr "Advertencia: Una conexión a Postgres con 'ssl=true' ha sido detectada."
+msgstr "Upozornění: Zjištěn spojovací řetězec Postgres obsahující `ssl = true`."
 
 #: src/metabase/db.clj
 msgid "You may need to add `?sslmode=require` to your application DB connection string."
-msgstr "Puedes requerir agregar `?sslmode=require` a la cadena de conexión a la BD."
+msgstr "Možná budete muset do připojovacího řetězce k aplikační DB přidat `?sslmode=require`."
 
 #: src/metabase/db.clj
 msgid "If Metabase fails to launch, please add it and try again."
-msgstr "Si Metabase falla al arrancar, por favor agréguelo e intente de nuevo."
+msgstr "Pokud se Metabase nespustí, zkuste to znovu."
 
 #: src/metabase/db.clj
 msgid "See https://github.com/metabase/metabase/issues/8908 for more details."
-msgstr "Consultar https://github.com/metabase/metabase/issues/8908 para más detalles."
+msgstr "Více informací naleznete na stránce https://github.com/metabase/metabase/issues/8908."
 
 #: src/metabase/db.clj
 msgid "WARNING: Using Metabase with an H2 application database is not recomended for production deployments."
-msgstr "ADVERTENCIA: el uso de Metabase con una base de datos de aplicaciones H2 no se recomienda para implementaciones de producción."
+msgstr "UPOZORNĚNÍ: Používání Metabase běžící na H2 databázi se nedoporučuje v produkčním prostředí."
 
 #: src/metabase/db.clj
 msgid "For production deployments, we highly recommend using Postgres, MySQL, or MariaDB instead."
-msgstr "Para las implementaciones de producción, te recomendamos que utilices Postgres, MySQL o MariaDB."
+msgstr "V produkčním prostředí se důrazně doporučuje používat Postgres, MySQL nebo MariaDB."
 
 #: src/metabase/db.clj
 msgid "If you decide to continue to use H2, please be sure to back up the database file regularly."
-msgstr "Si decides continuar usando H2, asegúrate de hacer una copia de seguridad del archivo de la base de datos con regularidad."
+msgstr "Pokud se rozhodnete pokračovat v používání H2, nezapomeňte pravidelně zálohovat databázový soubor."
 
 #: src/metabase/db.clj
 msgid "See https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres for more information."
-msgstr "Para obtener más información, consulta https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres."
+msgstr "Více informací naleznete na stránce https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-orgres."
 
 #: src/metabase/db.clj
 msgid "Unable to connect to Metabase {0} DB."
-msgstr "No se ha podido conectar a la base de datos {0} de Metabase."
+msgstr "Nelze se připojit k Metabase {0} DB."
 
 #: src/metabase/db/migrations.clj
 msgid "Error adding legacy SQL directive to BigQuery saved Question"
-msgstr "Error al agregar la directiva SQL a la pregunta guardada de BigQuery"
+msgstr "Chyba při přidávání starší SQL direktivy do BigQuery uložené otázky."
 
 #: src/metabase/driver.clj
 msgid "Failed to notify {0} Database {1} updated"
-msgstr "Error al notificar {0} Base de datos {1} actualizada"
+msgstr "Aktualizace {0} databáze {1} selhala"
 
 #: src/metabase/driver/impl.clj
 msgid "Loading driver {0} {1}"
-msgstr "Cargando controlador {0} {1}"
+msgstr "Načítám ovladač {0} {1}"
 
 #: src/metabase/driver/impl.clj
 msgid "Load driver {0}"
-msgstr "Cargar controlador {0}"
+msgstr "Načíst ovladač {0} "
 
 #: src/metabase/driver/impl.clj
 msgid "Driver not registered after loading: {0}"
-msgstr "Controlador no registrado después de la carga: {0}"
+msgstr "Ovladač není zaregistrován po načtení: {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Error: attempting to change {0} property `:abstract?` from {1} to {2}."
-msgstr "Error: al intentar cambiar la propiedad {0} `:abstract?` de {1} a {2}."
+msgstr "Chyba: pokus o změnu vlastnosti {0} `:abstract?` z {1} na {2}."
 
 #: src/metabase/driver/impl.clj
 msgid "Registered abstract driver {0}"
-msgstr "Controlador {0} abstracto registrado"
+msgstr "Registrovaný abstraktní ovladač {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Registered driver {0}"
-msgstr "Controlador {0} registrado"
+msgstr "Registrovaný ovladač {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "(parents: {0})"
-msgstr "(superiores: {0})"
+msgstr "(rodiče: {0})"
 
 #: src/metabase/driver/impl.clj
 msgid "Initializing driver {0}..."
-msgstr "Inicializando controlador {0}"
+msgstr "Inicializace ovladače {0}..."
 
 #: src/metabase/driver/impl.clj
 msgid "Reason:"
-msgstr "Razón:"
+msgstr "Důvod:"
 
 #: src/metabase/driver.clj
 msgid "Invalid driver feature: {0}"
-msgstr "Característica de controlador inválida: {0}"
+msgstr "Neplatná funkce ovladače: {0}"
 
 #: src/metabase/driver/sql/query_processor.clj
 msgid "Invalid HoneySQL form:"
-msgstr "Formulario HoneySQL inválido:"
+msgstr "Neplatný formulář HoneySQL:"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Closing connection pool for database {0} ..."
-msgstr "Cerrando el pool de conexiones para la base de datos {0} ..."
+msgstr "Zavírá se sdružování připojení pro databázi {0} ..."
 
 #: src/metabase/driver/util.clj
 msgid "Error loading namespace"
-msgstr "Error cargando el espacio de nombres"
+msgstr "Chyba při načítání jmenného prostoru"
 
 #: src/metabase/events.clj
 msgid "Starting events listener:"
-msgstr "Inicializando controlador de eventos:"
+msgstr "Spouštím naslouhač událostí:"
 
 #: src/metabase/events.clj
 msgid "Unexpected error listening on events"
-msgstr "Error no esperado escuchando eventos:"
+msgstr "Neočekávaná chyba při odposlechu událostí"
 
 #: src/metabase/events/sync_database.clj
 msgid "Error syncing Database {0}"
-msgstr "Error sincronizando la base de datos {0}"
+msgstr "Chyba při synchronizaci databáze {0}"
 
 #: src/metabase/events/sync_database.clj
 msgid "Failed to process sync-database event."
-msgstr "Error al procesar el evento de sincronización de la base de datos."
+msgstr "Nepodařilo se zpracovat událost pro synchronizaci databáze."
 
 #: src/metabase/mbql/util.clj
 msgid "Bad nested-query-level: query does not have a source query"
-msgstr "Nivel de consulta anidado incorrecto: la consulta no tiene una consulta de origen"
+msgstr "Chybná vnořená úroveň dotazu: dotaz nemá zdrojový dotaz"
 
 #: src/metabase/metabot/command.clj
 msgid "I don''t know how to `{0}`."
-msgstr "No se como `{0}`."
+msgstr "Nevím jak to udělat `{0}`."
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s what I can do: "
-msgstr "Esto es lo que puedo hacer: "
+msgstr "Zde je to, co mohu udělat: "
 
 #: src/metabase/metabot/slack.clj
 msgid "Error in Metabot command"
-msgstr "Error en el comando de Metabot"
+msgstr "Chyba v Metabot příkazu"
 
 #: src/metabase/metabot/websocket.clj
 msgid "Websocket associated with this Slack event is different from the websocket we're currently using."
-msgstr "El Websocket asociado con este evento Slack es diferente del websocket que estamos usando actualmente."
+msgstr "WebSocket spojený s touto událostí Slack se liší od WebSocketu, který momentálně používáme."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues for Field {0} remain unchanged. Skipping..."
-msgstr "Los valores para el campo {0} permanecen sin cambios. Saltando..."
+msgstr "Hodnoty pole {0} zůstávají nezměněny. Přeskakuji..."
 
 #: src/metabase/models/interface.clj
 msgid "Unable to normalize:"
-msgstr "No se ha podido normalizar:"
+msgstr "Nelze normalizovat:"
 
 #: src/metabase/models/params.clj
 msgid "Could not find matching Field ID for target:"
-msgstr "No se pudo encontrar el ID de campo coincidente para el destino:"
+msgstr "Nelze najít odpovídající ID pole pro cíl:"
 
 #: src/metabase/plugins.clj
 msgid "Metabase does not have permissions to write to plugins directory {0}"
-msgstr "Metabase no tiene permisos para escribir en el directorio de extensiones {0}"
+msgstr "Metabase nemá oprávnění k zápisu do adresáře s pluginy {0}"
 
 #: src/metabase/plugins.clj
 msgid "Metabase cannot use the plugins directory {0}"
-msgstr "Metabase no puede utilizar el directorio de extensiones {0}"
+msgstr "Metabase nemůže používat adresář zásuvných modulů {0}"
 
 #: src/metabase/plugins.clj
 msgid "Please make sure the directory exists and that Metabase has permission to write to it."
-msgstr "Asegúrate de que el directorio existe y que Metabase tiene permiso para escribir en él."
+msgstr "Zkontrolujte, zda adresář existuje a zda má metabase oprávnění k zápisu do tohoto adresáře."
 
 #: src/metabase/plugins.clj
 msgid "You can change the directory Metabase uses for modules by setting the environment variable MB_PLUGINS_DIR."
-msgstr "Puedes cambiar el directorio que utiliza Metabase para los módulos configurando la variable de entorno MB_PLUGINS_DIR."
+msgstr "Adresář, který metabase používá pro moduly, můžete změnit nastavením proměnné prostředí MB_PLUGINS_DIR."
 
 #: src/metabase/plugins.clj
 msgid "Falling back to a temporary directory for now."
-msgstr "Volviendo a un directorio temporal por ahora."
+msgstr "Prozatím se vracím zpět do dočasného adresáře."
 
 #: src/metabase/plugins.clj
 msgid "Metabase cannot write to temporary directory. Please set MB_PLUGINS_DIR to a writable directory and restart Metabase."
-msgstr "Metabase no puede escribir en el directorio temporal. Configura MB_PLUGINS_DIR en un directorio escribible y reinicia Metabase."
+msgstr "Metabase nemůže zapisovat do dočasného adresáře. Prosím, nastavte MB_PLUGINS_DIR na zapisovatelný adresář a restartujte Metabase."
 
 #: src/metabase/plugins.clj
 msgid "spark-deps.jar is no longer needed by Metabase 1.0+. You can delete it from the plugins directory."
-msgstr "Metabase 1.0+ ya no necesita spark-deps.jar. Puedes eliminarlo del directorio de extensiones."
+msgstr "Metabase 1.0+ už nepotřebuje spark-deps.jar. Můžete ho odstranit z adresáře doplňků."
 
 #: src/metabase/plugins.clj
 msgid "Failied to initialize plugin {0}"
-msgstr "No se ha podido inicializar la extensión {0}"
+msgstr "Nepodařilo se inicializovat doplněk {0}"
 
 #: src/metabase/plugins.clj
 msgid "Loading plugins in {0}..."
-msgstr "Cargando extensiones en {0}..."
+msgstr "Načítám doplňky v {0}..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Using Clojure base loader as shared context classloader: {0}"
-msgstr "Uso del cargador base de Clojure como cargador de clases de contexto compartido: {0}"
+msgstr "Použití základního zavaděče Clojure jako sdíleného kontextového zavaděče tříd: {0}"
 
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to shared classloader {0}..."
-msgstr "Estableciendo el contexto de subprocesos al cargador de clases compartido {0}..."
+msgstr "Probíhá nastavování aktuálního kontextového zavaděče vláken na sdílený ClassLoader {0}..."
 
 #. it's important that we deref the promise again here instead of using the one we just created because it is
 #. possible thru a race condition that somebody else delivered the promise before we did; in that case,
@@ -11778,318 +11800,318 @@ msgstr "Estableciendo el contexto de subprocesos al cargador de clases compartid
 #. value of it rather than one that ends up getting discarded
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to NEWLY CREATED classloader {0}..."
-msgstr "Configurando el contexto actual para el NUEVO cargador de clases {0} ..."
+msgstr "Nastavuji současné vlákno načítání kontextu pro NOVO VYTVOŘENÝ ClassLoader {0}..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Added URL {0} to classpath"
-msgstr "URL {0} añadida a classpath"
+msgstr "Byla přidána adresa URL {0} pro classpath"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugin {0} declares a dependency that Metabase does not understand: {1}"
-msgstr "La extensión {0} declara una dependencia que Metabase no entiende: {1}"
+msgstr "Plugin {0} deklaruje závislost, které Metabase nerozumí: {1}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Refer to the plugin manifest reference for a complete list of valid plugin dependencies:"
-msgstr "Consulta la referencia del manifest de la extensión para obtener una lista completa de las dependencias válidas del mismo:"
+msgstr "Úplný seznam platných závislostí doplňku naleznete v manifestu doplňku:"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Metabase cannot initialize plugin {0} due to required dependencies."
-msgstr "Metabase no puede inicializar el complemento {0} debido a las dependencias requeridas."
+msgstr "Metabase nemůže inicializovat doplněk {0} kvůli požadovaným závislostem."
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Class not found: {0}"
-msgstr "Clase {0} no encontrada"
+msgstr "Třída nebyla nalezena: {0}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugin ''{0}'' depends on plugin ''{1}''"
-msgstr "La extensión ''{0}'' depende de la extensión ''{1}''"
+msgstr "Doplněk ''{0}'' závisí na doplňku ''{1}''"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "{0} dependency {1} satisfied? {2}"
-msgstr "{0} dependencia {1} satisfecha? {2}"
+msgstr "{0} závislost {1} funkční? {2}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugins with unsatisfied deps: {0}"
-msgstr "Extensiones con dependencias no satisfechas: {0}"
+msgstr "Doplňky s nefunkčními závislostmi: {0}"
 
 #: src/metabase/util/files.clj
 msgid "Extract file {0} -> {1}"
-msgstr "Extraer fichero {0} -> {1}"
+msgstr "Extrahovat soubor {0} -> {1}"
 
 #: src/metabase/util/files.clj
 msgid "Resource does not exist."
-msgstr "Recurso no existe."
+msgstr "Zdroj neexistuje."
 
 #: src/metabase/plugins/init_steps.clj
 msgid "Loading plugin namespace {0}..."
-msgstr "Cargando espacio de nombres de extensiones {0}..."
+msgstr "Načítám jmenný prostor doplňků {0}..."
 
 #: src/metabase/plugins/initialize.clj
 msgid "Dependencies satisfied; these plugins will now be loaded: {0}"
-msgstr "Dependencias satisfechas; se cargarán las extensiones: {0}"
+msgstr "Závislosti jsou vyřešeny; tyto doplňky se nyní načtou: {0}"
 
 #: src/metabase/plugins/jdbc_proxy.clj
 msgid "Registering JDBC proxy driver for {0}..."
-msgstr "Registrando el controlador proxy JDBC para {0} ..."
+msgstr "Probíhá registrace ovladače JDBC proxy pro {0}..."
 
 #: src/metabase/plugins/jdbc_proxy.clj
 msgid "Deregistering original JDBC driver {0}..."
-msgstr "Anulación del registro del controlador JDBC original {0} ..."
+msgstr "Ruší se registrace původního ovladače JDBC {0}..."
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Default connection property {0} does not exist."
-msgstr "La propiedad de conexión predeterminada {0} no existe."
+msgstr "Výchozí vlastnost připojení {0} neexistuje."
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Invalid connection property {0}: not a string or map."
-msgstr "Propiedad de conexión no válida {0}: no es una cadena o un mapa."
+msgstr "Neplatná vlastnost připojení {0}: nejde o řetězec ani mapu."
 
 #. ok, do the init steps listed in the plugin mainfest
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Load lazy loading driver {0}"
-msgstr "Cargar el controlador de carga oportunista {0}"
+msgstr "Načítám ovladač pro odložené načítání {0}"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Cannot initialize plugin: missing required property `driver-name`"
-msgstr "No se puede inicializar la extensión: falta la propiedad requerida `driver-name`"
+msgstr "Nelze inicializovat doplněk: chybí požadovaná vlastnost `driver-name`"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Warning: plugin manifest for {0} does not include connection properties"
-msgstr "Advertencia: el manifest de la extensión {0} no incluye las propiedades de conexión"
+msgstr "Varování: manifest pluginu pro {0} nezahrnuje vlastnosti připojení"
 
 #. finally, register the Metabase driver
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Registering lazy loading driver {0}..."
-msgstr "Registrando el controlador de carga oportunista {0} ..."
+msgstr "Registruji ovladač pro odložené načítání {0}..."
 
 #: src/metabase/pulse.clj
 msgid "Error running query for Card {0}"
-msgstr "Error al ejecutar la consulta para la tarjeta {0}"
+msgstr "Chyba při spouštění dotazu pro kartu {0}"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
-msgstr "La semana pasada"
+msgstr "Minulý týden"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This week"
-msgstr "Esta semana"
+msgstr "Tento týden"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
-msgstr "El mes pasado"
+msgstr "Minulý měsíc"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This month"
-msgstr "Este mes"
+msgstr "Tento měsíc"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
-msgstr "El trimestre pasado"
+msgstr "Minulý kvartál"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
-msgstr "Este trimestre"
+msgstr "Tento kvartál"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
-msgstr "El año pasado"
+msgstr "Minulý rok"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This year"
-msgstr "Este año"
+msgstr "Tento rok"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "*driver* is unbound."
-msgstr "*controlador* no consolidado."
+msgstr "*ovladač* je nevázaný."
 
 #: src/metabase/sync/sync_metadata/fields.clj
 msgid "Error syncing Fields for Table ''{0}''"
-msgstr "Error sincronizando Campos de la Tabla \"{0}\""
+msgstr "Chyba při synchronizaci polí pro tabulku ''{0}''"
 
 #: src/metabase/sync/sync_metadata/fields.clj
 msgid "Hash of {0} matches stored hash, skipping Fields sync"
-msgstr "El hash de {0} coincide con el hash almacenado, omitiendo la sincronización de campos"
+msgstr "Hash z {0} shod pro uložené hashe, přeskakuji synchronizaci polí"
 
 #: src/metabase/sync/sync_metadata/fields/common.clj
 msgid "Field"
-msgstr "Campo"
+msgstr "Pole"
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Error checking if Fields {0} need to be created or reactivated"
-msgstr "Error al verificar si los Campos {0} necesitan ser creados o reactivados"
+msgstr "Chyba při kontrole, zda je třeba vytvořit nebo reaktivovat pole {0}"
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Marking Field ''{0}'' as inactive."
-msgstr "Marcando el campo \"{0}\" como inactivo"
+msgstr "Označuji pole ''{0}'' jako neaktivní."
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Error retiring {0}"
-msgstr "Error retirando {0}"
+msgstr "Chyba při ukončení {0}"
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Database type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "El tipo de base de datos de {0} ha cambiado de ''{1}'' a ''{2}''."
+msgstr "Typ databáze {0} se změnil z ''{1}'' na ''{2}''."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Base type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "El tipo base de {0} ha cambiado de ''{1}'' a ''{2}''."
+msgstr "Základní typ {0} se změnil z ''{1}'' na ''{2}''."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Special type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "El tipo especial de {0} ha cambiado de ''{1}'' a ''{2}''."
+msgstr "Speciální typ {0} se změnil z ''{1}'' na ''{2}''."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Comment has been added for {0}."
-msgstr "Se ha añadido un comentario para {0}."
+msgstr "Byl přidán komentář pro {0}."
 
 #: src/metabase/task.clj
 msgid "Stopping Quartz Scheduler {0}"
-msgstr "Deteniendo Porgramador {0} de Quartz"
+msgstr "Zastavuji časový plánovač {0}"
 
 #: src/metabase/task.clj
 msgid "Starting Quartz Scheduler {0}"
-msgstr "Inicializando Porgramador {0} de Quartz"
+msgstr "Spouštím časový plánovač {0}"
 
 #: src/metabase/task.clj
 msgid "Error loading tasks namespace {0}"
-msgstr "Error cargando el espacio de nombre de tareas {0}"
+msgstr "Při načítání jmenného prostoru úloh se vyskytla chyba {0}"
 
 #. don't bother logging namespace for now, maybe in the future if there's tasks of the same name in multiple
 #. namespaces we can log it
 #: src/metabase/task.clj
 msgid "Initializing task {0}"
-msgstr "Inicializando tarea {0}"
+msgstr "Inicializuji úlohu {0}"
 
 #: src/metabase/task.clj
 msgid "Error initializing task {0}"
-msgstr "Error inicializando tarea {0}"
+msgstr "Chyba při inicializaci úlohy {0}"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Problem sending abandonment email"
-msgstr "Problema enviando correo electrónico de abandono"
+msgstr "Problém s odesláním e-mailu o opuštění účtu!"
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Sending anonymous usage stats."
-msgstr "Enviando estadísticas anónimas de uso."
+msgstr "Posílám anonymní statistiku o používání."
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Error sending anonymous usage stats"
-msgstr "Error enviando estadísticas anónimas de uso."
+msgstr "Chyba při odesílání anonymních statistik používání"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Error sending Pulse {0}"
-msgstr "Error enviando pulso {0}"
+msgstr "Chyba při posílání pulzu {0}"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Sending scheduled pulses..."
-msgstr "Enviando pulsos programados..."
+msgstr "Posílám naplánované pulzy..."
 
 #: src/metabase/task/send_pulses.clj
 msgid "SendPulses task failed"
-msgstr "La tarea Enviar Pulsos ha fallado"
+msgstr "Úloha SendPulses selhala"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Failed to scheduler tasks for Database {0}"
-msgstr "No se ha podido programar tareas para la base de datos {0}"
+msgstr "Nepodařilo se naplánovat úlohy pro databázi {0}"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Cleaning up task history"
-msgstr "Limpiando el historial de tareas"
+msgstr "Vyčištění historie úloh"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, rows were deleted"
-msgstr "La limpieza del historial de tareas fue exitosa, las filas fueron eliminadas"
+msgstr "Čištění historie úloh bylo úspěšné, řádky byly odstraněny"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, no rows were deleted"
-msgstr "La limpieza del historial de tareas fue exitosa, no se ha eliminado ninguna fila"
+msgstr "Čištění historie úloh bylo úspěšné, žádné řádky nebyly odstraněny"
 
 #: src/metabase/task/upgrade_checks.clj
 msgid "Checking for new Metabase version info."
-msgstr "Buscando información de la versión de Metabase."
+msgstr "Vyhledávají se informace o nové verzi metabase."
 
 #: src/metabase/task/upgrade_checks.clj
 msgid "Error fetching version info"
-msgstr "Error obteniendo la información de versión"
+msgstr "Chyba při načítání informací o verzi"
 
 #: src/metabase/util.clj
 msgid "Maximum memory available to JVM: {0}"
-msgstr "Memoria máxima disponible para JVM: {0}"
+msgstr "Maximální dostupná paměť pro JVM: {0}"
 
 #: src/metabase/util.clj
 msgid "Not something with an ID: {0}"
-msgstr "No es algo con un ID: {0}"
+msgstr "Nemá ID: {0}"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by month of the year"
-msgstr "[[CreateDate]] por mes del año"
+msgstr "[[CreateDate]] podle měsíce v roce"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Here's a quick look at your [[this]]"
-msgstr "Aquí hay un vistazo rápido a tu [[this]]"
+msgstr "Zde je rychlý pohled na vaše [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by hour of the day"
-msgstr "[[CreateTimestamp]] por hora del día"
+msgstr "[[CreateTimestamp]] podle hodiny dne"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Where you've acquired your users"
-msgstr "Donde has adquirido tus usuarios"
+msgstr "Kde jste získali své uživatele"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How it's distributed across time and other categories."
-msgstr "Cómo se distribuye a través del tiempo y otras categorías."
+msgstr "Jak je distribuována v čase a dalších kategoriích."
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Here's a closer look at your [[this]] per source"
-msgstr "Aquí hay una vista más detallada a tu [[this]] por origen"
+msgstr "Zde je bližší pohled na váš [[this]] podle zdroje"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Here's a quick look at the [[this]]"
-msgstr "Aquí hay un vistazo rápido a [[this]]"
+msgstr "Zde je rychlý pohled na [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by day of the month"
-msgstr "[[CreateTimestamp]] por día del mes"
+msgstr "[[CreateTimestamp]] podle dne v měsíci"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Here's an overview of the people in your [[this]]"
-msgstr "Aquí hay un resumen de las personas en tu [[this]]"
+msgstr "Zde je přehled lidí ve vašem [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by quarter of the year"
-msgstr "[[CreateTimestamp]] por trimestre del año"
+msgstr "[[CreateTimestamp]] podle kvartálu roku"
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
-msgstr "Cómo se comparan a través de la ubicación"
+msgstr "Jak si vedou napříč polohou"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Here's a closer look at your [[this]] by products"
-msgstr "Aquí hay una vista con más detalle de tu [[this]] por productos"
+msgstr "Zde je bližší pohled na váš [[this]] podle produktu"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by month of the year"
-msgstr "[[CreateTimestamp]] por mes del año"
+msgstr "[[CreateTimestamp]] podle měsíce v roce"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "An overview of your [[this]] and how it's distributed across time, place, and categories."
-msgstr "Una visión general de tu [[this]] y cómo se distribuye en el tiempo, el lugar y las categorías."
+msgstr "Přehled vašeho [[this]] a jeho distribuce v čase, místě a kategoriích."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "Here's a closer look at your [[this]]"
-msgstr "Aquí hay una vista con más detalle de tu [[this]]"
+msgstr "Zde je bližší pohled na vaše [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by day of the week"
-msgstr "[[CreateTimestamp]] por día de la semana"
+msgstr "[[CreateTimestamp]] podle dne v týdnu"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Here's an overview of your [[this]] data from Google Analytics"
-msgstr "Aquí hay una descripción general de tus datos [[this]] de Google Analytics"
+msgstr "Zde je přehled vašich [[this]] dat ze služby Google Analytics"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
@@ -12098,1646 +12120,1656 @@ msgstr "Aquí hay una descripción general de tus datos [[this]] de Google Analy
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
-msgstr "Aquí hay una visión general de tu [[this]]"
+msgstr "Zde je přehled vašich [[this]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Here's a closer look at your [[this]] field"
-msgstr "Aquí hay una vista con más detalle de tu campo [[this]]"
+msgstr "Zde je bližší pohled na vaše [[this]] pole"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Here's a closer look at your [[this]] per country"
-msgstr "Aquí hay una vista con más detalle de tu [[this]] por país"
+msgstr "Zde je bližší pohled na váš [[this]] podle země"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "If you're into correlations, this is the x-ray for you."
-msgstr "Si te interesan las correlaciones, esta es la radiografía para ti."
+msgstr "Pokud máte rádi souvislosti, toto je to průzkum pro vás."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by day of the week"
-msgstr "[[CreateDate]] por día de la semana"
+msgstr "[[CreateDate]] podle dne v týdnu"
 
+#. duplicity
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "It looks like your [[this]] has transactions, so here's a look at them"
-msgstr "Parece que tu [[this]] tiene transacciones, así que aquí hay un vistazo a ellas"
+msgstr "Vypadá to, že vaše [[this]] obsahuje transakce, takže se na ně podívejte"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Here's a closer look at your [[this]] per state"
-msgstr "Aquí hay una vista con más detalle de tu [[this]] por estado"
+msgstr "Zde je bližší pohled na váš [[this]] podle státu"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by day of the month"
-msgstr "[[CreateDate]] por día del mes"
+msgstr "[[CreateDate]] podle dne v měsíci"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTime]] by hour of the day"
-msgstr "[[CreateTime]] por hora del día"
+msgstr "[[CreateTime]] podle hodiny dne"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Here's a closer look at your [[this]] over time"
-msgstr "Aquí hay una mirada con más detalle de tu [[this]] a lo largo del tiempo"
+msgstr "Zde je bližší pohled na váš [[this]] v průběhu času"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by quarter of the year"
-msgstr "[[CreateDate]] por trimestre del año"
+msgstr "[[CreateDate]] podle kvartálu v roce"
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:202
 msgid "Edit user"
-msgstr "Editar usuario"
+msgstr "Upravit uživatele"
 
 #: frontend/src/metabase/admin/people/containers/NewUserModal.jsx:13
 msgid "New user"
-msgstr "Nuevo usuario"
+msgstr "Nový uživatel"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:206
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
-msgstr "Restablecer contraseña"
+msgstr "Resetovat heslo"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:210
 msgid "Deactivate user"
-msgstr "Desactivar usuario"
+msgstr "Deaktivovat uživatele"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:47
 msgid "Reactivate {0}?"
-msgstr "¿Reactivar {0}?"
+msgstr "Znovu aktivovat {0}?"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:63
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
-msgstr "No se ha podido enviar la invitación por correo electrónico, así que asegúrate de decirles que inicien sesión utilizando {0} y esta contraseña que hemos generado para ellos:"
+msgstr "Nemohli jsme jim poslat emailovou pozvánku. Nezapomeňte jim tedy říci, aby se přihlásili pomocí {0} a tohoto hesla, které jsme pro ně vygenerovali:"
 
 #: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
-msgstr "colección"
+msgstr "sbírka"
 
 #: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
-msgstr "colecciones"
+msgstr "sbírky"
 
 #: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
-msgstr "cuadro de mando"
+msgstr "nástěnka"
 
 #: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
-msgstr "cuadros de mando"
+msgstr "nástěnky"
 
 #: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
-msgstr "El nombre es obligatorio"
+msgstr "Křestní jméno je povinné"
 
 #: frontend/src/metabase/entities/users.js:38
 #: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
-msgstr "Debe ser 100 caracteres o menos"
+msgstr "Musí mít maximálně 100 znaků"
 
 #: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
-msgstr "El apellido es obligatorio"
+msgstr "Příjmení je povinné"
 
 #: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
-msgstr "El email es obligatorio"
+msgstr "Vyžaduje se email"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
-msgstr "Los artículos que archives aparecerán aquí."
+msgstr "Položky které archivujete se zobrazí zde."
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:16
 msgid "No description"
-msgstr "Sin descripción"
+msgstr "Žádný popis"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
-msgstr "Suma de todos los valores"
+msgstr "Součet všech hodnot"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
-msgstr "Ver todos los valores distintos"
+msgstr "Zobrazit všechny jedinečné hodnoty"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:12
 msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started"
-msgstr "Examina el contenido de tus bases de datos, tablas y columnas. Elija una base de datos para empezar"
+msgstr "Projděte si obsah svých databází, tabulek a sloupců. Začněte výběrem databáze."
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is VALID. Thanks!"
-msgstr "Los metadatos de resultados de tarjetas pasados a API son VÁLIDOS. ¡Gracias!"
+msgstr "Metadata výsledků karty předány do API rozhraní jsou správné. Díky!"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is INVALID. Running query to fetch correct metadata."
-msgstr "Los metadatos de resultados de tarjetas pasados a API son INVÁLIDOS. Ejecutando la consulta para obtener los metadatos correctos."
+msgstr "Metadata výsledků karty předány do API rozhraní jsou neplatné. Spouští se dotaz na získání správných metadat."
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is  ISSING. Running query to fetch correct metadata."
-msgstr "Los metadatos de resultados de tarjetas pasados a API NO ESTÁN. Ejecutando la consulta para obtener los metadatos correctos."
+msgstr "Metadata výsledků karty předány do API rozhraní jsou neplatné. Spouští se dotaz na získání správných metadat."
 
 #: src/metabase/api/email.clj
 msgid "{0} was autocorrected to {1}"
-msgstr "se ha autocorregido {0} a {1}"
+msgstr "{0} byl automaticky opraven na {1}"
 
 #: src/metabase/api/metric.clj
 msgid "DELETE /api/metric/:id is deprecated. Instead, change its `archived` value via PUT /api/metric/:id."
-msgstr "DELETE /api/metric/:id está obsoleta. En su lugar cambia el valor de `archivado` con PUT /api/metric/:id."
+msgstr "DELETE /api/metric/:id je zastaralé. Místo toho změňte svoji `archivovanou` hodnotu pomocí PUT /api/metric/:id."
 
 #: src/metabase/api/segment.clj
 msgid "DELETE /api/segment/:id is deprecated. Instead, change its `archived` value via PUT /api/segment/:id."
-msgstr "DELETE /api/segment/:id está obsoleta. En su lugar cambia el valor de `archivado` con PUT /api/segment/:id."
+msgstr "DELETE /api/segment/:id je zastaralé. Místo toho změňte svoji `archivovanou` hodnotu pomocí PUT /api/segment/:id."
 
 #: src/metabase/api/user.clj
 msgid "Value of is_superuser must correspond to presence of Admin group ID in group_ids."
-msgstr "El valor de is_superuser debe corresponder a la presencia de ID de grupo de administración en group_ids."
+msgstr "Hodnota is_superuser musí odpovídat přítomnosti ID administrátorské skupiny v group_ids."
 
 #: src/metabase/async/api_response.clj
 msgid "Unexpected error writing keepalive characters"
-msgstr "Error inesperado al escribir caracteres keepalive"
+msgstr "Neočekávaná chyba při zápisu keepalive znaků"
 
 #: src/metabase/async/api_response.clj
 msgid "Unexpected output in async API response"
-msgstr "Salida inesperada en la respuesta de la API asíncrona"
+msgstr "Neočekávaný výstup v asynchronní odpovědi API rozhraní"
 
 #: src/metabase/async/api_response.clj
 msgid "starting streaming response"
-msgstr "iniciando la respuesta de streaming"
+msgstr "začíná se streamovat odpověď"
 
 #: src/metabase/async/api_response.clj
 msgid "Output chan closed, canceling keepalive request."
-msgstr "Salida cerrada, cancelando la solicitud de keepalive."
+msgstr "Výstupní kanál se zavřel, ruší se požadavek na udržení."
 
 #: src/metabase/async/api_response.clj
 msgid "Async response finished, closing channels."
-msgstr "Respuesta asincrónica finalizada, cerando canales."
+msgstr "Asynchronní odpověď skončila, zavírám kanály."
 
 #: src/metabase/async/api_response.clj
 msgid "No response after waiting {0}. Canceling request."
-msgstr "No hay respuesta después de esperar {0}. Cancelando solicitud."
+msgstr "Žádná odpověď po čekání {0}. Ruším žádost."
 
 #: src/metabase/async/api_response.clj
 msgid "Input channel unexpectedly closed."
-msgstr "Se ha cerrado inesperadamente el canal de entrada."
+msgstr "Vstupní kanál byl neočekávaně ukončen."
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "f finished, permit will be returned"
-msgstr "f ha terminado, se devolverá el permiso"
+msgstr "Po dokončení bude povolení vráceno"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "request canceled, permit will be returned"
-msgstr "solicitud cancelada, se devolverá el permiso"
+msgstr "žádost zrušena, povolení bude vráceno"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Unexpected error attempting to run function after obtaining permit"
-msgstr "Error inesperado al intentar ejecutar la función después de obtener el permiso"
+msgstr "Neočekávaná chyba při pokusu o spuštění funkce po získání povolení"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Not running pending function call: output channel already closed."
-msgstr "No se está ejecutando la llamada de función pendiente: el canal de salida ya está cerrado."
+msgstr "Nezpracované čekající volání funkce: výstupní kanál je již uzavřen"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Current thread already has a permit for {0}, will not wait to acquire another"
-msgstr "El hilo actual ya tiene un permiso para {0}, no esperamos a adquirir otro"
+msgstr "Aktuální vlákno už má povolení pro {0}, nebude čekat na získání dalšího"
 
 #: src/metabase/async/util.clj
 msgid "Output channel closed, will skip running {0}."
-msgstr "Canal de salida cerrado, no se ejecutará {0}."
+msgstr "Výstupní kanál je zavřený, přeskočíme spuštění {0}."
 
 #: src/metabase/async/util.clj
 msgid "Running {0} on separate thread..."
-msgstr "Ejecutando {0} en un hilo separado..."
+msgstr "Spouští se {0} na samostatném vlákně..."
 
 #: src/metabase/async/util.clj
 msgid "Caught error running {0}"
-msgstr "Error capturado ejecutando {0}"
+msgstr "Zachycená chyba při spuštění {0}"
 
 #: src/metabase/async/util.clj
 msgid "Request canceled, canceling future"
-msgstr "Solicitud cancelada, cancelando futuro"
+msgstr "Žádost zrušena, ruším i budoucí"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Closing old connection pool for database {0} ..."
-msgstr "Cerrando el grupo de conexiones antiguas de la base de datos {0} ..."
+msgstr "Zavírá se staré sdružování připojení pro databázi {0} ..."
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s your {0} most recent cards:"
-msgstr "Aquí están tus {0} tarjetas más recientes:"
+msgstr "Zde jsou vaše {0} nedávné karty:"
 
 #: src/metabase/metabot/command.clj
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
-msgstr "¿Podrías ser un poco más específico, o usar la identificación? He encontrado estas tarjetas con nombres que coinciden:"
+msgstr "Mohli byste být trochu konkrétnější nebo použít ID? Našel jsem tyto karty se jmény, které se shodují:"
 
 #: src/metabase/driver/common/parameters/values.clj
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
-msgstr "No se ha encontrado la tarjeta {0}"
+msgstr "Karta {0} se nenašla."
 
 #: src/metabase/middleware/exceptions.clj
 msgid "Exception in API call"
-msgstr "Excepción en la llamada a la API"
+msgstr "Výjimka volání API"
 
 #: src/metabase/middleware/exceptions.clj
 msgid "Request canceled before finishing."
-msgstr "Solicitud cancelada antes de terminar."
+msgstr "Žádost byla zrušena před dokončením."
 
 #: src/metabase/middleware/json.clj
 msgid "Metabase only supports JSON requests."
-msgstr "Metabase solo admite solicitudes JSON."
+msgstr "Metabase podporuje pouze JSON žádosti."
 
 #: src/metabase/middleware/json.clj
 msgid "Make sure you set a 'Content-Type: application/json' header."
-msgstr "Asegúrate de establecer un encabezado 'Content-Type: application / json'."
+msgstr "Ujistěte se, že jste nastavili hlavičku 'Content-Type: application/json'."
 
 #: src/metabase/middleware/misc.clj
 msgid "Setting Metabase site URL to {0}"
-msgstr "Estableciendo la URL de Metabase a {0}"
+msgstr "Nastavuji URL adresu Metabase na {0}"
 
 #: src/metabase/models/database.clj
 msgid "Error scheduling tasks for DB"
-msgstr "Error programando tareas para DB"
+msgstr "Chyba při vytváření plánu úloh pro DB"
 
 #: src/metabase/models/database.clj
 msgid "Error unscheduling tasks for DB."
-msgstr "Error desprogramando tareas para DB"
+msgstr "Chyba při rušení plánu úloh pro DB"
 
 #: src/metabase/models/database.clj
 msgid "{0} Database ''{1}'' sync/analyze schedules have changed!"
-msgstr "\"{1}\" tiempos de sincronización/análisis han cambiado en {0}"
+msgstr "{0} Plán synchronizace a analýzy databáze ''{1}'' byl změněn!"
 
 #: src/metabase/models/database.clj
 msgid "Sync metadata was: ''{0}'' is now: ''{1}''"
-msgstr "Sincronización de metadatos: ''{0}'' es ahora: ''{1}''"
+msgstr "Synchronizované metadata byly: ''{0}'' nyní jsou: ''{1}''"
 
 #: src/metabase/models/database.clj
 msgid "Cache FieldValues was: ''{0}'', is now: ''{1}''"
-msgstr "Valor de campo en cache era: ''{0}'', ahora es: ''{1}''"
+msgstr "Mezipaměť hodnot polí byla: ''{0}'' nyní je: ''{1}''"
 
 #: src/metabase/models/metric.clj
 msgid "You cannot update the creator_id of a Metric."
-msgstr "No se puede cambiar el creado de una métrica."
+msgstr "Nelze aktualizovat creator_id metriky."
 
 #: src/metabase/models/permissions.clj
 msgid "MetaBot can only have Collection permissions."
-msgstr "MetaBot solo puede tener permisos de Colección."
+msgstr "MetaBot může mít oprávnění pouze na sbírku."
 
 #: src/metabase/models/permissions.clj
 msgid "Failed to grant permissions"
-msgstr "Error al otorgar permisos"
+msgstr "Nepodařilo se udělit oprávnění"
 
 #: src/metabase/models/permissions.clj
 msgid "Changing permissions"
-msgstr "Cambiando los permisos"
+msgstr "Měním oprávnění"
 
 #: src/metabase/models/permissions.clj
 msgid "FROM:"
-msgstr "DE:"
+msgstr "OD:"
 
 #: src/metabase/models/permissions.clj
 msgid "TO:"
-msgstr "A:"
+msgstr "DO:"
 
 #: src/metabase/models/segment.clj
 msgid "You cannot update the creator_id of a Segment."
-msgstr "No se puede cambiar el creador de un segmento."
+msgstr "Nemůžete aktualizovat creator_id segmentu."
 
 #: src/metabase/models/setting.clj
 msgid "Attempted to set Setting {0} to obfuscated value. Ignoring change."
-msgstr "Se intentó establecer la configuración {0} en un valor obfuscado. Ignorando el cambio."
+msgstr "Pokusil jste se nastavit {0} na nejasnou hodnotu. Ignorujeme změny."
 
 #: src/metabase/models/setting.clj
 msgid "Using value of env var {0}"
-msgstr "Utilizando el valor de la variable de entorno {0}"
+msgstr "Použití hodnoty env var {0}"
 
 #: src/metabase/models/user.clj
 msgid "Adding User {0} to All Users permissions group..."
-msgstr "Agregando el usuario {0} al grupo de todos los usuarios..."
+msgstr "Přidává se uživatel {0} do skupiny pravomocí \"Všichni uživatelé\" ..."
 
 #: src/metabase/models/user.clj
 msgid "Adding User {0} to Admin permissions group..."
-msgstr "Agregando el usuario {0} al grupo de permisos de administrador..."
+msgstr "Přidává se uživatel {0} do skupiny pravomocí \"Správce\" ..."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
-msgstr "Fallo en la consulta"
+msgstr "Selhání dotazu"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
-msgstr "Número máximo de consultas simultáneas permitidas por base de datos conectada."
+msgstr "Maximální počet současných dotazů, které mohou spuštěny na připojené databázi."
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
-msgstr "Tiempo agotado después de {0} milisegundos."
+msgstr "Časový limit vypršel po {0} milisekundách."
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
 msgid "Misfire Instruction"
-msgstr "Instrucciones de fallo"
+msgstr "Nezdařené instrukce"
 
 #: frontend/src/metabase/components/ArchiveModal.jsx:31
 msgid "Archive this?"
-msgstr "¿Archivar esto?"
+msgstr "Archivovat to?"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
-msgstr "Aprende cosas de nuestros datos"
+msgstr "Dozvědět se více o vašich datech"
 
 #: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
-msgstr "Utiliza DNS SRV al conectar"
+msgstr "Při připojování použijte DNS SRV"
 
+#. duplicity
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
 msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
 "an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
 "leave this disabled."
-msgstr "Esta opción requiere que el host sea FQDN. Si se conecta a un clúster Atlas, es posible que deba habilitar esta opción. Si no sabe lo que esto significa, deje esto deshabilitado."
+msgstr "Použití této volby vyžaduje, aby hostitel byl zadán jako FQDN. Pokud se připojujete ke Atlas klustru, možná bude nutné tuto možnost povolit. Pokud nevíte, co to znamená, nechte to vypnuté."
 
 #: frontend/src/metabase/entities/databases/forms.js:273
 msgid "Automatically run queries when doing simple filtering and summarizing"
-msgstr "Ejecutar consultas automáticamente al realizar un filtrado/resumen simple"
+msgstr "Automaticky spouštět dotazy při jednoduchém filtrování a sumarizaci"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
 msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
-msgstr "Cuando esto está activo en Metabase, se ejecutarán consultas automáticamente cuando los usuarios realicen exploraciones simples con los botones Resumir y Filtrar al ver una tabla o gráfico. Puedes desactivar esto si las consultas de esta base de datos son lentas. Esta configuración no afecta la obtención de detalles ni a las consultas SQL."
+msgstr "Když je toto zapnuto, Metabase automaticky spouští dotazy, když uživatelé dělají jednoduché průzkumy pomocí tlačítek Sumarizovat a Filtrovat během prohlížení tabulky nebo grafu. Tuto možnost lze vypnout, pokud je vyhledávání v této databázi pomalé. Toto nastavení nemá vliv na SQL dotazy."
 
 #: frontend/src/metabase/containers/Overworld.jsx:329
 msgid "Learn about this database"
-msgstr "Aprende cosas sobre esta base de datos"
+msgstr "Další informace o této databázi"
 
 #: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
 msgid "Archive this dashboard?"
-msgstr "¿Archivar este cuadro de mando?"
+msgstr "Archivovat tuto nástěnku?"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:112
 msgid "All results"
-msgstr "Todos los resultados"
+msgstr "Všechny výsledky"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:175
 msgid "Our Analytics"
-msgstr "Nuestras Analíticas"
+msgstr "Naše analytika"
 
 #: frontend/src/metabase/lib/schema_metadata.js:513
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
-msgstr "Suma aditiva de todos los valores de una columna.\\ne.g. ingresos totales a lo largo del tiempo."
+msgstr "Přídavný součet všech hodnot sloupce. .\\ne.x. celkový příjem v čase."
 
 #: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
-msgstr "Conteo aditivo del número de filas.\\ne.g. Número total de ventas en el tiempo."
+msgstr "Přídavný počet řádků. \\ne.x. celkový počet prodejů v čase."
 
 #: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:98
 msgid "Filter"
-msgstr "Filtro"
+msgstr "Filtr"
 
 #: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:50
 msgid "record"
 msgid_plural "records"
-msgstr[0] "registro"
-msgstr[1] "registros"
+msgstr[0] "záznam"
+msgstr[1] "záznamy"
+msgstr[2] "záznamů"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:369
 msgid "Browse Data"
-msgstr "Navegar "
+msgstr "Procházet Data"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:402
 msgid "Write SQL"
-msgstr "Escribir SQL"
+msgstr "Napište SQL"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
-msgstr "Pregunta Simple"
+msgstr "Jednoduchá otázka"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:87
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
-msgstr "Elige algunos datos, visualízalos y fíltralos, resúmelos y analízalos fácilmente."
+msgstr "Vyberte některé údaje, zobrazte je a snadno je filtrujte, sumarizujte a vizualizujte."
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:98
 msgid "Custom question"
-msgstr "Pregunta personalizada"
+msgstr "Vlastní otázka"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:99
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
-msgstr "Utiliza el editor avanzado para unir datos, crear columnas personalizadas, hacer cálculos matemáticos y más."
+msgstr "Použijte pokročilý editor poznámek na spojení dat, vytváření vlastních sloupců, výpočty a další."
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Basic Metrics"
-msgstr "Indicadores básicos"
+msgstr "Základní metriky"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
 msgid "Custom…"
-msgstr "Personalizado..."
+msgstr "Vlastní..."
 
 #: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
 msgid "Add grouping"
-msgstr "Añadir agrupación"
+msgstr "Přidat seskupení"
 
 #: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
 msgid "Pick a limit"
-msgstr "Seleccione un límite"
+msgstr "Vyberte limit"
 
 #: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
 msgid "Show maximum"
-msgstr "Mostrar máximo"
+msgstr "Zobrazit maximum"
 
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:45
 msgid "Get Preview"
-msgstr "Vista previa"
+msgstr "Získejte ukázku"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
 msgid "Back to previous results"
-msgstr "Volver a los resultados anteriores"
+msgstr "Zpět na předchozí výsledky"
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
 msgid "Sample values"
-msgstr "Valores de ejemplo"
+msgstr "Ukázkové hodnoty"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
 msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
-msgstr "Explora el contenido de tus bases de datos, tablas y columnas. Elige una base de datos para empezar."
+msgstr "Projděte si obsah svých databází, tabulek a sloupců. Začněte výběrem databáze."
 
 #: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
 msgid "Visualize"
-msgstr "Visualizar"
+msgstr "Vizualizovat"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
 msgid "Join data"
-msgstr "Unir datos"
+msgstr "Spojit data"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
 msgid "Custom column"
-msgstr "Columna personalizada"
+msgstr "Vlastní sloupec"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
 #: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:60
 msgid "Summarize"
-msgstr "Resumir"
+msgstr "Sumarizovat"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
 msgid "Aggregate"
-msgstr "Agregar"
+msgstr "Shromáždit"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
 msgid "Breakout"
-msgstr "Desglosar"
+msgstr "Průraz"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
 msgid "Pick the metric you want to see"
-msgstr "Elige la métrica que quieres ver"
+msgstr "Vyberte metriku, kterou chcete vidět"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
 msgid "Pick a column to group by"
-msgstr "Elige una columna para agrupar"
+msgstr "Vyberte sloupec na seskupení podle"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:28
 msgid "Pick your starting data"
-msgstr "Elige tus datos iniciales"
+msgstr "Vyberte počáteční data"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select None"
-msgstr "Selecciona Ninguno"
+msgstr "Nevybrat nic"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select All"
-msgstr "Selecciona Todos"
+msgstr "Vybrat vše"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:152
 msgid "Pick a table..."
-msgstr "Elige una tabla..."
+msgstr "Vyberte tabulku"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
 msgid "Enter a limit"
-msgstr "Introduce un límite"
+msgstr "Zadejte limit"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:273
 msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
-msgstr "Los corchetes alrededor de un {0} crean una cláusula opcional en la plantilla. Si se establece \"variable\", la cláusula completa se coloca en la plantilla. Si no, se ignora toda la cláusula."
+msgstr "Závorky kolem {0} vytvoří volitelnou položku v šabloně. Pokud je nastavena \"proměnná\", celá položka se vloží do šablony. Pokud ne, celá položka se ignoruje."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:290
 msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
-msgstr "Cuando se usa un Filtro de Campo, el nombre de la columna no debe incluirse en la SQL. En su lugar, la variable debe asignarse a un campo en el panel lateral."
+msgstr "Při použití filtru pole by se název sloupce neměl zahrnout do SQL. Namísto toho by se proměnná měla namapovat na pole v postranním panelu."
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
 msgid "View the native query"
-msgstr "Ver la consulta nativa"
+msgstr "Zobrazit nativní dotaz"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
 msgid "Native query for this question"
-msgstr "Consulta nativa de esta pregunta"
+msgstr "Nativní dotaz pro tuto otázku"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
 msgid "Convert this question to a native query"
-msgstr "Convertir esta pregunta en una consulta nativa"
+msgstr "Převeďte tuto otázku na nativní dotaz"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
 msgid "SQL for this question"
-msgstr "SQL de esta pregunta"
+msgstr "SQL pro tuto otázku"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
 msgid "Convert this question to SQL"
-msgstr "Convertir esta pregunta a SQL"
+msgstr "Převeďte tuto otázku na SQL"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
 msgid "Get alerts"
-msgstr "Recibir alertas"
+msgstr "Získejte upozornění"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
 msgid "{0} breakout"
 msgid_plural "{0} breakouts"
-msgstr[0] "desglose de {0}"
-msgstr[1] "desgloses de {0}"
+msgstr[0] "{0} průraz"
+msgstr[1] "{0} průrazy"
+msgstr[2] "{0} průrazů"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:41
 msgid "Hide filters"
-msgstr "Esconder filtros"
+msgstr "Skrýt filtry"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:41
 msgid "Show filters"
-msgstr "Mostrar filtros"
+msgstr "Zobrazit filtry"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:18
 msgid "Started from"
-msgstr "Iniciado desde"
+msgstr "Pochází z"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
 msgid "{0} row"
 msgid_plural "{0} rows"
-msgstr[0] "{0} fila"
-msgstr[1] "{0} filas"
+msgstr[0] "{0} řádek"
+msgstr[1] "{0} řádky"
+msgstr[2] "{0} řádků"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
 msgid "Show all rows"
-msgstr "Mostrar todas las filas"
+msgstr "Zobrazit všechny řádky"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
 msgid "Show {0}"
-msgstr "Mostrar {0}"
+msgstr "Zobrazit {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
 msgid "Showing first {0}"
-msgstr "Mostrando los primeros {0}"
+msgstr "Zobrazuji prvních {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
 msgid "Showing {0}"
-msgstr "Mostrando {0}"
+msgstr "Zobrazuje se {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
 msgid "Summarized"
-msgstr "Resumido"
+msgstr "Sumarizované"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionNotebookButton.jsx:17
 msgid "Hide editor"
-msgstr "Esconder editor"
+msgstr "Skrýt editor"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionNotebookButton.jsx:17
 msgid "Show editor"
-msgstr "Mostrar editor"
+msgstr "Zobrazit editor"
 
+#. duplicity
 #: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
 msgid "Pick the metric you'd like to see"
-msgstr "Elige la métrica que quieres ver"
+msgstr "Vyberte metriku, kterou chcete vidět"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:29
 msgid "{0} options"
-msgstr "{0} opciones"
+msgstr "{0} možností"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
 msgid "Choose a visualization"
-msgstr "Elige una visualización"
+msgstr "Vyberte vizualizaci"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
 msgid "Filter by"
-msgstr "Filtrar por"
+msgstr "Filtrovat podle"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
 msgid "Summarize by"
-msgstr "Resumir por"
+msgstr "Sumarizovat podle"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
 msgid "Group by"
-msgstr "Agrupar por"
+msgstr "Seskupit podle"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
 msgid "Add a metric"
-msgstr "Añadir una métrica"
+msgstr "Přidejte metriku"
 
 #: frontend/src/metabase/lib/core.js:137 frontend/src/metabase/lib/core.js:142
 #: frontend/src/metabase/lib/core.js:147 frontend/src/metabase/lib/core.js:152
 #: frontend/src/metabase/lib/core.js:157 frontend/src/metabase/lib/core.js:162
 #: frontend/src/metabase/user/components/UserSettings.jsx:64
 msgid "Profile"
-msgstr "Perfil"
+msgstr "Profil"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:567
 msgid "This is usually pretty fast but seems to be taking a while right now."
-msgstr "Esto suele ser bastante rápido, pero parece estar tardando un poco en este momento."
+msgstr "To je obvykle dost rychlé, ale nyní se zdá, že to chvíli trvá."
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
 msgid "Combo"
-msgstr "Combo"
+msgstr "Kombinace"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
 msgid "Row"
-msgstr "Fila"
+msgstr "Pruhy"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
 msgid "Trend"
-msgstr "Tendencia"
+msgstr "Trend"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:129
 msgid "Boolean"
-msgstr "Booleano"
+msgstr "Logická hodnota"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:62
 msgid "Unknown Segment"
-msgstr "Segmento Desconocido"
+msgstr "Neznámý segment"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:73
 msgid "Unknown Filter"
-msgstr "Filtro Desconocido"
+msgstr "Neznámý filtr"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
 msgid "Left outer join"
-msgstr "Unión izquierda externa"
+msgstr "Levé vnější spojení"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:26
 msgid "Right outer join"
-msgstr "Unión derecha externa"
+msgstr "Pravé vnější spojení"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:27
 msgid "Inner join"
-msgstr "Unión interna"
+msgstr "Vnitřní spojení"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:28
 msgid "Full outer join"
-msgstr "Unión externa completa"
+msgstr "Úplné vnější spojení"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
-msgstr "FALTAN los metadatos de resultados de la tarjeta en el API. Ejecutando la consulta para obtener los metadatos correctos."
+msgstr "Výsledky karty předány do rozhraní API jsou CHYBNÉ. Spouští se dotaz na získání správných metadat."
 
+#. duplicity?
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fall back to local authentication"
-msgstr "Problema al conectarse al servidor LDAP, utilizaré la autentificación local"
+msgstr "Při připojování k serveru LDAP se vyskytl problém, vrátím se k místním účtům"
 
 #: src/metabase/api/setup.clj
 msgid "Cannot create Database: cannot find driver {0}."
-msgstr "No se puede crear la base de datos: no se puede encontrar el controlador {0}."
+msgstr "Nelze vytvořit databázi: nemůžu najít ovladač {0}."
 
 #: src/metabase/api/tiles.clj
 msgid "Query failed"
-msgstr "Falló la consulta"
+msgstr "Dotaz selhal"
 
 #: src/metabase/async/util.clj
 msgid "Warning: {0} returned `nil`"
-msgstr "Aviso: {0} devolvió `nulo`"
+msgstr "Varování: {0} vrátilo \"žádné\""
 
 #: src/metabase/async/util.clj
 msgid "Unexpected error writing result to output channel: already closed"
-msgstr "Error inesperado al escribir el resultado en el canal de salida: ya cerrado"
+msgstr "Neočekávaný chyba zápisu výsledku na výstupní kanál: už je uzavřen"
 
 #: src/metabase/async/util.clj
 msgid "Unexpected error writing exception to output channel: already closed"
-msgstr "Error inesperado al escribir la excepción en el canal de salida: ya cerrado"
+msgstr "Neočekávaný chyba zápisu vyjímky na výstupní kanál: už je uzavřen"
 
 #: src/metabase/async/util.clj
 msgid "Request canceled, canceling future."
-msgstr "Solicitud cancelada, cancelando futuro."
+msgstr "Žádost zrušena, ruším budoucí."
 
 #: src/metabase/cmd/load_from_h2.clj
 msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
-msgstr "Metabase solo puede transferir datos de H2 a Postgres o MySQL/MariaDB."
+msgstr "Metabase může přenášet data pouze z H2 do Postgres nebo MySQL / MariaDB."
 
 #: src/metabase/db.clj
 msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
-msgstr "ADVERTENCIA: No se recomienda usar Metabase con una base de datos de aplicaciones H2 para implementaciones de producción."
+msgstr "UPOZORNĚNÍ: Použití Metabase s aplikační databází H2 se nedoporučuje pro produkční nasazení."
 
 #: src/metabase/db.clj
 msgid "Application database setup"
-msgstr "Configuración de la base de datos de la aplicación"
+msgstr "Nastavení aplikační databáze"
 
 #: src/metabase/driver.clj
 msgid "Could not find {0} driver."
-msgstr "No se pudo encontrar el controlador {0}."
+msgstr "Nelze najít ovladač {0}."
 
 #: src/metabase/driver/impl.clj
 msgid "Abstract drivers cannot derive from concrete parent drivers."
-msgstr "Los controladores abstractos no pueden derivar de controladores padres concretos."
+msgstr "Abstraktní ovladače nemohou pocházet z konkrétních rodičovských ovladačů."
 
 #: src/metabase/driver/mysql.clj
 msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
-msgstr "Es posible que tengas que añadir 'trustServerCertificate=true' a las opciones de conexión adicionales para conectarte con SSL."
+msgstr "Možná budete muset přidat 'trustServerCertificate = true' k dalším možnostem připojení při využití SSL připojení."
 
+#. duplicity
 #: src/metabase/driver/sql/util.clj
 msgid "Don't know how to alias {0}, expected an Identifer."
-msgstr "No sé cómo hacer un alias de {0}, esperaba un identificador."
+msgstr "Nevím, jak určit alias {0}, očekáván je identifikátor."
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Client closed connection, canceling query"
-msgstr "Conexión cerrada por el cliente, cancelando la consulta"
+msgstr "Klient zrušil připojení, ruším dotaz"
 
 #: src/metabase/integrations/ldap.clj
 msgid "{0} is not a valid DN."
-msgstr "{0} no es un DN válido."
+msgstr "{0} není je platný DN."
 
 #: src/metabase/middleware/log.clj
 msgid "Error logging API request"
-msgstr "Error al registrar la solicitud de la API"
+msgstr "Chyba při protokolování žádosti API"
 
 #: src/metabase/middleware/misc.clj
 msgid "Failed to set site-url"
-msgstr "No he podido guardar la URL del sitio"
+msgstr "Nepodařilo se nastavit webovou adresu stránky"
 
 #: src/metabase/models/database.clj
 msgid "Error destroying thread pool for DB."
-msgstr "Error al destruir el grupo de subprocesos para la BBDD."
+msgstr "Chyba při ničení seznamu vláken pro DB."
 
 #: src/metabase/models/humanization.clj
 msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
-msgstr "Actualizando el nombre a mostrar de {0} \"{1}\": \"{2}\" -> \"{3}\""
+msgstr "Aktualizuje se zobrazovaný název pro {0} ''{1}'': ''{2}'' -> ''{3}''"
 
-#. "humanización" no tengo claro que sea la palabra correcta
 #: src/metabase/models/humanization.clj
 msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
-msgstr "Estrategia de humanización no válida \"{0}\". Las estrategias válidas son: {1}"
+msgstr "Neplatná strategie polidštění ''{0}''. Platné strategie jsou: {1}"
 
 #. now rehumanize all the Tables and Fields using the new strategy.
 #. TODO: Should we do this in a background thread because it is potentially slow?
 #: src/metabase/models/humanization.clj
 msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
-msgstr "Cambiando la estrategia de humanización de nombres de tablas y campos de \"{0}\" a \"{1}\""
+msgstr "Měním strategii polidštění tabulek a polí z ''{0}'' na ''{1}''"
 
 #: src/metabase/models/task_history.clj src/metabase/sync/util.clj
 msgid "Error saving task history"
-msgstr "Error guardando el historial de tarea."
+msgstr "Chyba při ukládání historie úloh"
 
 #: src/metabase/plugins.clj
 msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
-msgstr "spark-deps.jar ya no es necesario para Metabase 0.32.0+. Puede eliminarlo del directorio de plugins."
+msgstr "Metabase 0.32.0+ už nepotřebuje spark-deps.jar. Můžete ho odstranit z adresáře doplňků."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
-msgstr "Utilizando la clase NEWLY CREATED como cargador de clases de contexto compartido: {0}"
+msgstr "Použití nově vytvořeného ClassLoader jako sdíleného kontextu, ClassLoader: {0}"
 
 #: src/metabase/util/files.clj
 msgid "Failed to copy file"
-msgstr "No se ha podido copiar el fichero"
+msgstr "Nepodařilo se zkopírovat soubor"
 
 #. check that the URL is valid
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
-msgstr "URL inválida: {0}"
+msgstr "Neplatná URL adresa: {0}"
 
 #: src/metabase/public_settings.clj
 msgid "site-url is invalid; returning nil for now. Will be reset on next request."
-msgstr "la URL del sitio no es válida; devolviendo nulo por ahora. Se restablecerá en la próxima solicitud."
+msgstr "webová adresa je neplatná; zatím nic nevrací. Bude resetováno při příštím dotazu."
 
 #: src/metabase/pulse/render/body.clj
 msgid "More results have been included as a file attachment"
-msgstr "Se han incluido más resultados como un archivo adjunto"
+msgstr "Více výsledků bylo zahrnuto jako přiložený soubor"
 
 #: src/metabase/pulse/render/body.clj
 msgid "This question has been included as a file attachment"
-msgstr "Esta pregunta se ha incluido como un archivo adjunto"
+msgstr "Tato otázka byla zahrnuta jako přiložený soubor"
 
 #: src/metabase/pulse/render/body.clj
 msgid "We were unable to display this Pulse."
-msgstr "No he podido mostrar este Pulso."
+msgstr "Tento pulz se nám nepodařilo zobrazit"
 
 #: src/metabase/pulse/render/body.clj
 msgid "Please view this card in Metabase."
-msgstr "Por favor mostrar esta tarjeta en Metabase."
+msgstr "Prohlédněte si tuto kartu v Metabase."
 
 #: src/metabase/pulse/render/body.clj
 msgid "An error occurred while displaying this card."
-msgstr "Se ha producido un error al mostrar esta tarjeta."
+msgstr "Chyba při zobrazování této karty"
 
 #: src/metabase/query_processor.clj
 msgid "Can only determine expected columns for MBQL queries."
-msgstr "Solo puedo determinar las columnas esperadas para las consultas MBQL."
+msgstr "Může určit pouze očekávané sloupce pro MBQL dotazy."
 
 #: src/metabase/query_processor.clj
 msgid "No columns returned."
-msgstr "No se han obtenido columnas."
+msgstr "Nebyly vráceny žádné sloupce."
 
+#. duplicity
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
-msgstr "Advertencia: no se pueden determinar los campos para una `consulta-fuente` explícita a menos que también incluya` metadatos-fuente`."
+msgstr "UPOZORNĚNÍ: není možné určit pole pro explicitní \"source-query\", pokud nezadáte i \"source-metadata\"."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
-msgstr "No se puede resolver {0}: el campo no existe o su tabla pertenece a una base de datos diferente."
+msgstr "Nelze rozpoznat {0}: Pole neexistuje nebo jeho tabulka patří do jiné databáze."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
-msgstr "No se puede resolver :field-literal inside :fk-> a menos que se una por dentro con un alias explícito."
+msgstr "Nelze rozpoznat :field-literal uvnitř pole: fk-> pokud není vnitřně spojen s explicitním :alias."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot find Table ID for {0}"
-msgstr "No he podido encontrar el ID de tabla {0}"
+msgstr "Nelze najít ID tabulky pro {0}"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "No matching info found."
-msgstr "No se encontró información coincidente."
+msgstr "Nenalezeny žádné odpovídající informace."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Could not resolve {0}"
-msgstr "No se pudo resolver {0}"
+msgstr "Nepodařilo se rozpoznat {0}"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Invalid fk-> clause: nowhere to add corresponding join."
-msgstr "fk-> no válida: no se puede agregar el join correspondiente."
+msgstr "Neplatný řetězec fk->: nikde není možné přidat odpovídající spojení."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "{0} driver does not support foreign keys."
-msgstr "El controlador {0} no soporta claves foráneas"
+msgstr "Ovladač {0} nepodporuje cizí klíče."
 
 #: src/metabase/query_processor/middleware/add_source_metadata.clj
 msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
-msgstr "No se puede inferir `:source-metadata` para la consulta de origen con consulta de origen nativa sin metadatos de origen."
+msgstr "Nelze odvodit `:source-metadata` pro zdrojový dotaz s nativním zdrojovým dotazem bez zdrojových metadat."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Query processor error: number of columns returned by driver does not match results."
-msgstr "Error del procesador de consultas: número de columnas devueltas por el controlador no coincide con los resultados."
+msgstr "Chyba zpracovatele dotazů: počet sloupců vrácených ovladačem neodpovídá výsledkům."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected {0} columns, but first row of resuls has {1} columns."
-msgstr "Se esperaban {0} columnas, pero la primera fila de resultados tiene {1} columnas."
+msgstr "Očekávané sloupce {0}, ale první řádek výsledků má sloupce {1}."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "No expression named {0} found. Found: {1}"
-msgstr "No he encontrado una expresión de nombre {0}. He encontrado {1}"
+msgstr "Nebyl nalezen žádný výraz s názvem {0}. Nalezeno: {1}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Distinct values of {0}"
-msgstr "Valores únicos de {0}"
+msgstr "Jedinečné hodnoty z {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Average of {0}"
-msgstr "Media de {0}"
+msgstr "Průměr z {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Sum of {0}"
-msgstr "Suma de {0}"
+msgstr "Součet z {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "SD of {0}"
-msgstr "DS de {0}"
+msgstr "SD z {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Min of {0}"
-msgstr "Mínimo de {0}"
+msgstr "Min. z {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Max of {0}"
-msgstr "Máximo de {0}"
+msgstr "Max. z {0}"
 
 #. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Sum of {0} matching condition"
-msgstr "Suma de {0} con condición"
+msgstr "Součet z {0} vyhovující podmínce"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Share of rows matching condition"
-msgstr "Cuota de filas con condición"
+msgstr "Podíl řádků odpovídajících podmínce"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of rows matching condition"
-msgstr "Número de filas coincidentes con la condición"
+msgstr "Počet odpovídajících řádků"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Request already canceled, will not run synchronous QP code."
-msgstr "Solicitud ya cancelada, no se ejecutará el código QP síncrono."
+msgstr "Žádost už byla zrušena, nespustí se synchronní QP kód."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unexpectedly got `nil` Query Processor response."
-msgstr "Inesperadamente recibí la respuesta del procesador de consultas `nil`."
+msgstr "Neočekávaná nulová odpověď od zpracovatele dotazů."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Got InterruptedException. Canceling query."
-msgstr "Se interrumpió la excepción. Cancelando consulta."
+msgstr "Nastala výjimka InterruptedException. Ruším dotaz."
 
+#. duplicity
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
-msgstr "Excepción no controlada, se espera que el middleware `catch-exceptions` lo maneje."
+msgstr "Neošetřených výjimka, očekáván middleware `catch-exceptions` na její zpracování."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Query timed out after %s"
-msgstr "Se agotó el tiempo de espera de la consulta después de %s"
+msgstr "Časový limit dotazu vypršel po %s"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Creating new query thread pool for Database {0}"
-msgstr "Creando un nuevo grupo de subprocesos de consulta para la base de datos {0}"
+msgstr "Vytváří se nový dotazový seznam vláken pro databázi {0}"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Destroying query thread pool for Database {0}"
-msgstr "Destrucción del grupo de subprocesos de consulta para la base de datos {0}"
+msgstr "Ruší se dotazový seznam vláken pro databázi {0}"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Request canceled, canceling pending query"
-msgstr "Solicitud cancelada, cancelando consulta pendiente"
+msgstr "Požadavek zrušen, ruší se čekající dotaz"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: query is missing source-metadata"
-msgstr "No se puede actualizar el campo agrupado: faltan los metadatos en la consulta"
+msgstr "Nelze aktualizovat pole s intervaly: v dotaze chybějí zdrojové metadata"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
-msgstr "No se puede actualizar el campo agrupado: no se encontraron metadatos coincidentes para el campo \"{0}\""
+msgstr "Nelze aktualizovat pole s intervaly: nenašli se odpovídající zdrojové metadata pro pole ''{0}''"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Using query processor cache backend: {0}"
-msgstr "Uso el caché del procesador de consultas: {0}"
+msgstr "Používám backend mezipaměť pro zpracovatele dotazů: {0}"
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Invalid metric: {0} reason: {1}"
-msgstr "Métrica inválida: {0} razón: {1}"
+msgstr "Neplatná metrika: {0} důvod: {1}"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Unknown error"
-msgstr "Error desconocido"
+msgstr "Neznámá chyba"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Unexpected nil response from query processor."
-msgstr "Respuesta nula inesperada del procesador de consultas."
+msgstr "Neočekávaná nulová odpověď od zpracovatele dotazů."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query canceled"
-msgstr "Consulta cancelada"
+msgstr "Dotaz byl zrušený"
 
 #: src/metabase/query_processor/middleware/resolve_driver.clj
 msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
-msgstr "No es posible resolver la consulta: falta o no es válida `:database` ID."
+msgstr "Nepodařilo se rozpoznat ovladač pro dotaz: chybí nebo je neplatné ID `: database`."
 
 #: src/metabase/query_processor/middleware/resolve_driver.clj
 msgid "Unable to resolve driver for query: Database {0} does not exist."
-msgstr "No es posible resolver la consulta: base de datos {0} no existe."
+msgstr "Nelze rozpoznat ovladač pro dotaz: Databáze {0} neexistuje."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
-msgstr "No se puede usar :fields :all in join contra la consulta de origen a menos que tenga :source-metadata."
+msgstr "Nelze použít: :fields :all ve spojení proti zdrojovému dotazu, pokud nemá :source-metadata."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
-msgstr "Problema: join entre campos: el join con alias \"{0}\" no existe. Encontrado: {1}"
+msgstr "Špatný :joined-field clause: spojení s aliasem '' {0} '' neexistuje. Nalezeno: {1}"
 
 #: src/metabase/query_processor/middleware/resolve_source_table.clj
 msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
-msgstr "tabla \"{0}\" inválida: ya debería haberse convertido en un ID de tabla."
+msgstr "Neplatná: :source-table ''{0}'': mělo by se rozpoznat pomocí ID tabulky."
 
 #: src/metabase/query_processor/store.clj
 msgid "Cannot store Tables or Fields before Database is stored."
-msgstr "No se pueden guardar tablas o campos antes de guardar la base de datos."
+msgstr "Před uložením databáze není možné uložit tabulky nebo pole."
 
 #: src/metabase/query_processor/store.clj
 msgid "Attempting to fetch second Database. Queries can only reference one Database."
-msgstr "Intentando recuperar la segunda base de datos. Las consultas sólo pueden referenciar a una base de datos."
+msgstr "Pokus o načtení druhé databáze. Dotazy mohou odkazovat pouze na jednu databázi."
 
 #: src/metabase/query_processor/store.clj
 msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
-msgstr "Error al recuperar la Tabla {0}: no existe dicha tabla o pertenece a otra base de datos."
+msgstr "Nepodařilo se načíst tabulku {0}: Tabulka neexistuje, nebo patří do jiné databáze."
 
 #: src/metabase/query_processor/store.clj
 msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
-msgstr "Error al recuperar el Campo {0}: no existe dicho campo o pertenece a otra base de datos."
+msgstr "Nepodařilo se načíst pole {0}: Pole neexistuje nebo patří do jiné databáze."
 
 #: src/metabase/routes/index.clj
 msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
-msgstr "Error al cargar la plantilla \"{0}\". ¿Te acordaste de construir la interfaz de Metabase?"
+msgstr "Nepodařilo se načíst šablonu ''{0}''. Pamatujete jak postavit Metabase frontend?"
 
 #: src/metabase/sample_data.clj
 msgid "Sample dataset DB file ''{0}'' cannot be found."
-msgstr "No se puede encontrar el archivo de base de datos de muestra ''{0}''."
+msgstr "Soubor se vzorovou databází ''{0}'' nelze najít."
 
 #: src/metabase/sample_data.clj
 msgid "Loading sample dataset..."
-msgstr "Cargando datos de muestra..."
+msgstr "Načítá se vzorová databáze..."
 
 #: src/metabase/sample_data.clj
 msgid "Failed to load sample dataset"
-msgstr "No se ha podido cargar los datos de muestra"
+msgstr "Nepodařilo se načíst vzorovou databázi"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Found new tables:"
-msgstr "Encontrado tablas nuevas:"
+msgstr "Nalezeny nové tabulky:"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Marking tables as inactive:"
-msgstr "Marcando tablas como inactivas:"
+msgstr "Označuji tabulky jako neaktivní:"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Updating description for tables:"
-msgstr "Actualizando la descripción de las tablas:"
+msgstr "Aktualizuji popis tabulek:"
 
 #: src/metabase/task.clj
 msgid "Rescheduling job {0}"
-msgstr "Reprogramando el trabajo {0}"
+msgstr "Přeplánování úlohy {0}"
 
 #: src/metabase/task.clj
 msgid "Error rescheduling job"
-msgstr "Error al reprogramar trabajo"
+msgstr "Chyba při změně plánu úlohy"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Starting Pulse Execution: {0}"
-msgstr "Iniciando la ejecución del Pulso: {0}"
+msgstr "Zahajuji vykonání Pulzu: {0}"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Finished Pulse Execution: {0}"
-msgstr "Finalizado la ejecución del Pulso: {0}"
+msgstr "Dokončeno vykonání Pulzu: {0}"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Failed to schedule tasks for Database {0}"
-msgstr "Error al programar tareas para la base de datos {0}"
+msgstr "Nepodařilo se naplánovat úlohy pro databázi {0}"
 
 #: src/metabase/util/schema.clj
 msgid "All elements must be distinct."
-msgstr "Todos los elementos deben ser distintos."
+msgstr "Všechny prvky musí být jedinečné."
 
-#: 
+#:
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
-msgstr "Elige las columnas que quieres incluir"
+msgstr "Vyberte sloupce, které chcete zahrnout"
 
 #: frontend/src/metabase/entities/databases/forms.js:274
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
-msgstr "Al activar esto, Metabase ejecutará consultas automáticamente cuando los usuarios realicen exploraciones simples con los botones Resumir y Filtrar ea tablas o gráficos. Puedes desactivar esto si las consultas de esta base de datos son lentas. Esta configuración no afecta a los detalles ni a las consultas SQL."
+msgstr "Když je toto zapnuto, Metabase automaticky spouští dotazy, když uživatelé dělají jednoduché průzkumy pomocí tlačítek Sumarizovat a Filtrovat během prohlížení tabulky nebo grafu. Tuto možnost lze vypnout, pokud je vyhledávání v této databázi pomalé. Toto nastavení nemá vliv na SQL dotazy."
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
 msgid "Change join type"
-msgstr "Cambia el tipo de unión"
+msgstr "Změnit typ spojení"
 
+#. duplicity
 #: src/metabase/driver/sql/util.clj
 msgid "Don't know how to alias {0}, expected an Identifier."
-msgstr "No sé cómo obtener un alias de {0}, esperaba un identificador."
+msgstr "Nevím, jak určit alias {0}, očekáván je identifikátor."
 
 #: src/metabase/integrations/common.clj
 msgid "Error adding User {0} to Group {1}"
-msgstr "Error añadiendo el Usuario {0} al Grupo {1}"
+msgstr "Chyba při přidávání uživatele {0} do skupiny {1}"
 
 #. now rehumanize all the Tables and Fields using the new strategy.
 #. TODO: Should we do this in a background thread because it is potentially slow?
 #: src/metabase/models/humanization.clj
 msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
-msgstr "Cambiando la estrategia de humanización de nombres de tablas y campos de \"{0}\" a \"{1}\""
+msgstr "Měním strategii polidštění tabulek a polí z ''{0}'' na ''{1}''"
 
 #: src/metabase/query_processor.clj
 msgid "Infinite loop detected: recursively preprocessed query {0} times."
-msgstr "Bucle infinito detectado: consulta preprocesada recursivamente {0} veces."
+msgstr "Byla zjištěna nekonečná smyčka: rekurzivní předzpracovaný dotaz {0} krát."
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
-msgstr "Advertencia: no se pueden determinar los campos de una `consulta-fuente` explícita a menos que también incluya `metadatos`."
+msgstr "UPOZORNĚNÍ: není možné určit pole pro explicitní \"source-query\", pokud nezadáte i \"source-metadata\"."
 
 #: src/metabase/query_processor/middleware/add_source_metadata.clj
 msgid "Error determining expected columns for query"
-msgstr "Error al determinar las columnas esperadas de la consulta"
+msgstr "Chyba při určování očekávaných sloupců pro dotaz"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
-msgstr "Excepción no controlada, se espera que el proceso `catch-exceptions` lo manejara."
+msgstr "Neošetřených výjimka, očekáván middleware `catch-exceptions` na její zpracování."
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
 msgid "Diagnostic Info"
-msgstr "Información de Diagnóstico"
+msgstr "Diagnostické informace"
 
 #: frontend/src/metabase/admin/tasks/containers/Logs.jsx:123
 msgid "Select Metabase process:"
-msgstr "Selecciona el proceso de Metabase:"
+msgstr "Vyberte Metabase proces:"
 
 #: frontend/src/metabase/admin/tasks/containers/Logs.jsx:133
 msgid "All Metabase processes"
-msgstr "Todos los procesos de Metabase"
+msgstr "Všechny Metabase procesy"
 
 #: frontend/src/metabase/auth/components/GoogleButton.jsx:13
 msgid "The window was closed before completing Google Authentication."
-msgstr "Se ha cerrado la ventana sin haber completado la Autentificación con Google"
+msgstr "Okno bylo zavřeno před dokončením Google Authentication."
 
 #: frontend/src/metabase/auth/components/GoogleButton.jsx:51
 msgid "There was an issue signing in with Google. Pleast contact an administrator."
-msgstr "Ha habido un problema validando con Google. Por favor, pregunta a un administrador."
+msgstr "Při přihlašování pomocí Google se vyskytl problém. Prosím kontaktujte správce."
 
 #: frontend/src/metabase/plugins/builtin/auth/password.js:9
 msgid "Sign in with email"
-msgstr "Entrar con email"
+msgstr "Přihlásit se pomocí emailu"
 
 #: frontend/src/metabase/entities/databases/forms.js:23
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
-msgstr "El uso de esta opción requiere que el host proporcionado sea un FQDN. Si te conectas a un clúster de Atlas, es posible que debas habilitar esta opción. Si no sabes lo que significa esto, dejalo deshabilitado."
+msgstr "Použití této volby vyžaduje, aby hostitel byl zadán jako FQDN. Pokud se připojujete ke Atlas klustru, možná bude nutné tuto možnost povolit. Pokud nevíte, co to znamená, nechte to vypnuté."
 
 #: frontend/src/metabase/entities/databases/forms.js:282
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
-msgstr "De manera predeterminada, Metabase realiza una sincronización por hora y un escaneo diario intensivo de valores de campo. Si tienes una base de datos grande, recomendamos activar esto y revisar cuándo y con qué frecuencia ocurren los escaneos de valor de campo."
+msgstr "Metabase standardně provádí odlehčenou hodinovou synchronizaci a intenzivní denní skenování hodnot polí. Pokud máte rozsáhlou databázi, doporučujeme zapnout skenování a zkontrolovat kdy a jak často se uskuteční kontrola hodnot polí."
 
 #: frontend/src/metabase/containers/Overworld.jsx:126
 msgid "Remove these suggestions"
-msgstr "Eliminar estas sugerencias"
+msgstr "Odstraňte tyto návrhy"
 
 #: frontend/src/metabase/containers/Overworld.jsx:135
 msgid "Remove these suggestions?"
-msgstr "Eliminar estas sugerencias?"
+msgstr "Odstranit tyto návrhy?"
 
 #: frontend/src/metabase/containers/Overworld.jsx:151
 msgid "These won’t show up on the homepage for any of your users anymore, but you can always get to x-rays by clicking on Browse Data in the main navigation, then clicking on the lightning bolt icon on one of your tables."
-msgstr "Estos ya no aparecerán en la página de inicio de ninguno de tus usuarios, pero siempre puedes obtener radiografías haciendo clic en Examinar datos en la navegación principal y luego haciendo clic en el icono del rayo en una de las tablas."
+msgstr "Tyto se již nebudou zobrazovat na domovské stránce pro žádného z vašich uživatelů. K prozkoumání se však můžete kdykoli dostat kliknutím na Procházet Data v hlavní navigaci a klepnutím na ikonu blesku na jedné z vašich tabulek."
 
 #: frontend/src/metabase/containers/Overworld.jsx:274
 msgid "Hide this section"
-msgstr "Esconder esta sección"
+msgstr "Skrýt tuto část"
 
 #: frontend/src/metabase/containers/Overworld.jsx:282
 msgid "Remove this section?"
-msgstr "Eliminar esta sección"
+msgstr "Odstranit tuto část?"
 
 #: frontend/src/metabase/containers/Overworld.jsx:298
 msgid "\"Our Data\" won’t show up on the homepage for any of your users anymore, but you can always browse through your databases and tables by clicking Browse Data in the main navigation."
-msgstr "\"Nuestros datos\" ya no aparecerá en la página de inicio de ninguno de tus usuarios, pero siempre puedes navegar por tus bases de datos y tablas haciendo clic en Examinar datos en la navegación principal."
+msgstr "\"Vaše data\" se už na domovské stránce nebudou zobrazovat žádnému z vašich uživatelů. Vždy však můžete prohledávat své databáze a tabulky kliknutím na Procházet Data v hlavní navigaci."
 
 #: frontend/src/metabase/entities/collections.js:95
 msgid "My new fantastic collection"
-msgstr "Mi colección fantástica"
+msgstr "Moje nová úžasná sbírka"
 
 #: frontend/src/metabase/lib/core.js:178
 msgid "Cancelation timestamp"
-msgstr "Tiempo de cancelación"
+msgstr "Časová značka zrušení"
 
 #: frontend/src/metabase/lib/core.js:173
 msgid "Cancelation time"
-msgstr "Tiempo de cancelación"
+msgstr "Čas zrušení"
 
 #: frontend/src/metabase/lib/core.js:168
 msgid "Cancelation date"
-msgstr "Fecha de cancelación"
+msgstr "Datum zrušení"
 
 #: frontend/src/metabase/lib/core.js:208
 msgid "Deletion timestamp"
-msgstr "Tiempo de eliminación"
+msgstr "Časová značka smazání"
 
 #: frontend/src/metabase/lib/core.js:203
 msgid "Deletion time"
-msgstr "Tiempo de eliminación"
+msgstr "Čas smazání"
 
 #: frontend/src/metabase/lib/core.js:198
 msgid "Deletion date"
-msgstr "Fecha de eliminación"
+msgstr "Datum smazání"
 
 #: frontend/src/metabase/lib/core.js:298
 msgid "Only in detail views"
-msgstr "Solo en vistas de detalle"
+msgstr "Pouze v detailních pohledech"
 
 #: frontend/src/metabase/lib/core.js:303
 msgid "Do not include"
-msgstr "No incluir"
+msgstr "Nezahrnout"
 
 #: frontend/src/metabase/lib/core.js:304
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
-msgstr "Este campo no será visible o seleccionable en las preguntas creadas con la aplicación. Todavía será accesible en consultas SQL/nativas."
+msgstr "Toto pole nebude viditelné ani volitelné při otázkách vytvořených pomocí grafických rozhraní. Bude stále přístupná v SQL / nativních dotazech."
 
 #: frontend/src/metabase/lib/schema_metadata.js:512
 msgid "Cumulative sum"
-msgstr "Suma Acumulada"
+msgstr "Kumulativní součet"
 
 #: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Standard deviation"
-msgstr "Desviacion estandar"
+msgstr "Směrodatná odchylka"
 
 #: frontend/src/metabase/lib/settings.js:120
 msgid "must be at least {0} characters long"
-msgstr "debe tener al menos {0} caracteres de longitud"
+msgstr "musí mít alespoň {0} znaků"
 
 #: frontend/src/metabase/lib/settings.js:121
 msgid "Must be at least {0} characters long"
-msgstr "Debe tener al menos {0} caracteres de longitud"
+msgstr "musí mít alespoň {0} znaků"
 
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:82
 msgid "Name (required)"
-msgstr "Nombre (requerido)"
+msgstr "Jméno (povinné)"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
 msgid "Run selected text"
-msgstr "Ejecutar texto seleccionado"
+msgstr "Spustit vybraný text"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
 msgid "Run query"
-msgstr "Ejecutar consulta"
+msgstr "Spustit dotaz"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(⌘ + enter)"
-msgstr "(⌘ + intro)"
+msgstr "(⌘ + enter)"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(Ctrl + enter)"
-msgstr "(Ctrl + intro)"
+msgstr "(Ctrl + enter)"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "Here's where your results will appear"
-msgstr "Aquí es donde aparecerán tus resultados"
+msgstr "Zde se zobrazí vaše výsledky"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:16
 msgid "You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question."
-msgstr "No realizará cambios permanentes en una pregunta guardada a menos que haga clic en Guardar y elija reemplazar la pregunta original."
+msgstr "Na uložené otázce nebudete moci dělat žádné trvalé změny, pokud nekliknete na tlačítko Uložit a nevyberete původní otázku."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:200
 msgid "There aren't any filter widgets for this type of field yet."
-msgstr "Todavía no hay widgets de filtro para este tipo de campo."
+msgstr "Pro tento typ pole zatím neexistují žádné filtrovací widgety."
 
 #: frontend/src/metabase/reference/components/FieldToGroupBy.jsx:27
 msgid "Look up this field"
-msgstr "Buscar este campo"
+msgstr "Podívejte se na toto pole"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:218
 msgid "Why this metric is interesting"
-msgstr "Por que esta métrica es interesante"
+msgstr "Proč je tato metrika zajímavá"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:228
 msgid "Things to be aware of about this metric"
-msgstr "Cosas a tener en cuenta sobre esta métrica"
+msgstr "Co by jste měli vědět o této metrice"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "How this metric is calculated"
-msgstr "Cómo se calcula esta métrica"
+msgstr "Jak se tato metrika počítá"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:215
 msgid "Table this is based on"
-msgstr "Tabla en la que está basada"
+msgstr "Tabulka je postavena na základě"
 
 #: frontend/src/metabase/visualizations/lib/renderer_utils.js:276
 msgid "(empty)"
-msgstr "(vacío)"
+msgstr "(prázdné)"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Goal line"
-msgstr "Meta"
+msgstr "Cílová čára"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Trend line"
-msgstr "Tendencia"
+msgstr "Spojnice trendu"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:317
 msgid "Show values on data points"
-msgstr "Mostrar valores en puntos de datos"
+msgstr "Zobrazit hodnoty v datových bodech"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:325
 msgid "Values to show"
-msgstr "Valores a mostrar"
+msgstr "Hodnoty k zobrazení"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:332
 msgid "As many as can fit nicely"
-msgstr "Tantos como quepan bien"
+msgstr "Tolik, kolik přehlednost umožní"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:333
 msgid "All"
-msgstr "Todos"
+msgstr "Vše"
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:9
 msgid "Data includes missing dimension values."
-msgstr "Los datos incluyen valores de dimensión faltantes."
+msgstr "Údaje zahrnují chybějící hodnoty dimenzí."
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:17
 msgid "We encountered an invalid date: \"{0}\""
-msgstr "Hay una fecha no válida: \"{0}\""
+msgstr "Zaznamenali jsme neplatný datum: \"{0}\""
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:38
 msgid "The query for this chart was run in {0} rather than {1} due to database or driver constraints."
-msgstr "La consulta para este gráfico se ejecutó en {0} en lugar de {1} debido a restricciones de la base de datos o del controlador."
+msgstr "Dotaz pro tento graf byl spuštěn dříve než {0} jako {1} kvůli omezením databáze nebo ovladače."
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:47
 msgid "This chart contains queries run in multiple timezones: {0}"
-msgstr "Este gráfico contiene consultas ejecutadas en varias zonas horarias: {0}"
+msgstr "Tento graf obsahuje dotazy spouštěné ve více časových pásmech: {0}"
 
 #: src/metabase/api/public.clj
 msgid "An error occurred while running the query."
-msgstr "Se produjo un error al ejecutar la consulta."
+msgstr "Při spuštění dotazu se vyskytla chyba"
 
 #: src/metabase/cmd/dump_to_h2.clj
 msgid "Output H2 database already exists: %s, removing."
-msgstr "La base de datos H2 de salida ya existe: %s, eliminando."
+msgstr "Databáze výstupů H2 již existuje:%s, odstraňuji."
 
 #: src/metabase/cmd/dump_to_h2.clj
 msgid "Don't need to migrate, just use the existing H2 file"
-msgstr "No es necesario migrar, utiliza el archivo H2 existente"
+msgstr "Nemusíte migrovat, stačí použít existující H2 soubor"
 
 #: src/metabase/cmd/load_from_h2.clj
 msgid "Target DB is already populated!"
-msgstr "¡La base de datos de destino ya contiene datos!"
+msgstr "Cílová DB je již obsazena!"
 
 #: src/metabase/core.clj
 msgid "System info:n {0}"
-msgstr "Información del sistema:n {0}"
+msgstr "Systémové informace:n {0}"
 
 #: src/metabase/db.clj
 msgid "Database setup"
-msgstr "Configuración de la base de datos"
+msgstr "Nastavení databáze"
 
 #. 4. move everything not in this Collection to a new Collection
 #: src/metabase/db/migrations.clj
 msgid "Moving instances of {0} that aren''t in a Collection to {1} Collection {2}"
-msgstr "Moviendo instancias de {0} que no están en una Colección a {1} Colección {2}"
+msgstr "Přesouvám instance {0}, které nejsou ve sbírce {1} do sbírky {2}"
 
 #: src/metabase/driver/common/parameters/parse.clj
 msgid "Invalid '{{...}}' clause: expected a param name"
-msgstr "Cláusula '{{...}}' no válida: se esperaba un nombre de parámetro"
+msgstr "Neplatná výraz '{{...}}': očekává se název parametru"
 
 #: src/metabase/driver/common/parameters/parse.clj
 msgid "'{{...}}' clauses cannot be empty."
-msgstr "las cláusulas '{{...}}' no pueden estar vacías."
+msgstr "'{{...}}' výrazy nemohou být prázdné."
 
 #: src/metabase/driver/common/parameters/parse.clj
 msgid "'[[...]]' clauses must contain at least one '{{...}}' clause."
-msgstr "las cláusulas '[[...]]' deben contener al menos una cláusula '{{...}}'."
+msgstr "'[[...]]' výrazy musí obsahovat alespoň jeden výraz '{{...}}'."
 
 #: src/metabase/driver/common/parameters/parse.clj
 msgid "Invalid query: found '[[' or '{{' with no matching ']]' or '}}'"
-msgstr "Consulta no válida: se encontró '[[' o '{{' sin coincidencias ']]' o '}}'"
+msgstr "Neplatný dotaz: nalezeno '[[' nebo '{{' bez ukončení ']]' nebo '}}'"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "You''ll need to pick a value for ''{0}'' before this query can run."
-msgstr "Deberá elegir un valor para \"{0}\" antes de que se pueda ejecutar esta consulta."
+msgstr "Před spuštěním tohoto dotazu budete muset vybrat hodnotu pro \"{0}\""
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Can''t find field with ID: {0}"
-msgstr "No se puede encontrar el campo con ID: {0}"
+msgstr "Nelze najít pole s ID: {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Error loading driver namespace"
-msgstr "Error al cargar el espacio de nombres del controlador"
+msgstr "Chyba při načítání jmenného prostoru ovladače"
 
 #: src/metabase/driver/impl.clj
 msgid "Could not load {0} driver."
-msgstr "No se pudo cargar el controlador {0}."
+msgstr "Nepodařilo se načíst ovladač {0}."
 
 #: src/metabase/driver/sql/parameters/substitute.clj
 msgid "Cannot run query: missing required parameters: {0}"
-msgstr "No se puede ejecutar la consulta: faltan los parámetros necesarios: {0}"
+msgstr "Nelze spustit dotaz: chybí požadované parametry: {0}"
 
 #: src/metabase/driver/sql/parameters/substitution.clj
 msgid "Don''t know how to parse {0} {1}"
-msgstr "No sé cómo analizar {0} {1}"
+msgstr "Nevím jak ověřit {0} {1}"
 
 #: src/metabase/driver/sql/util.clj
 msgid "Don''t know how to alias {0}, expected an Identifier."
-msgstr "No sé cómo hacer un alias de {0}, esperaba un identificador."
+msgstr "Nevím, jak určit alias {0}, očekáván je identifikátor."
 
 #. it's better return a slightly broken SQL query with a probably incorrect string representation of the value than
 #. to have the entire QP run fail because of an unknown type.
 #: src/metabase/driver/sql/util/unprepare.clj
 msgid "Don''t know how to unprepare values of class {0}"
-msgstr "No sé cómo deshacer los valores de la clase {0}"
+msgstr "Nevím, jak rozložit hodnoty třídy {0}"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Creating new connection pool for {0} database {1} ..."
-msgstr "Creando un nuevo grupo de conexiones para la base de datos {0} {1} ..."
+msgstr "Vytváří se nové sdružování připojení pro {0} databázi {1} ..."
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Invalid timezone ''{0}''"
-msgstr "Zona horaria inválida \"{0}\""
+msgstr "Neplatné časové pásmo ''{0}''"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Cannot set timezone: invalid or missing SQL format string for driver {0}."
-msgstr "No se puede establecer la zona horaria: cadena de formato SQL no válida o faltante para el controlador {0}."
+msgstr "Nelze nastavit časové pásmo: neplatný nebo chybějící řetězec SQL formát pro ovladač {0}."
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Did you implement set-timezone-sql?"
-msgstr "¿Implementaste set-timezone-sql?"
+msgstr "Implementovali jste set-timezone-sql?"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone ''{0}''"
-msgstr "Error al establecer la zona horaria \"{0}\""
+msgstr "Nepodařilo se nastavit časové pásmo ''{0}''"
 
 #: src/metabase/driver/util.clj
 msgid "Database connection error"
-msgstr "Error de conexión a la base de datos"
+msgstr "Chyba připojení k databázi"
 
 #: src/metabase/models/interface.clj
 msgid "Error parsing JSON"
-msgstr "Error analizando JSON"
+msgstr "Chyba při ověřování JSON"
 
 #: src/metabase/public_settings.clj
 msgid "Whether or not to display data on the homepage. Admins might turn this off in order to direct users to better content than raw data"
-msgstr "Si mostrar o no datos en la página de inicio. Los administradores pueden desactivar esto para dirigir a los usuarios a un mejor contenido que los datos sin procesar"
+msgstr "Zda se mají nebo nemají zobrazovat data na domovské stránce. Správci to mohou vypnout, aby nasměrovaly uživatele na lepší obsah nežli na surové data"
 
 #: src/metabase/public_settings.clj
 msgid "Whether or not to display x-ray suggestions on the homepage. They will also be hidden if any dashboards are pinned. Admins might hide this to direct users to better content than raw data"
-msgstr "Si se muestran o no sugerencias de rayos X en la página de inicio. También estarán ocultos si hay paneles fijados. Los administradores pueden ocultar esto para dirigir a los usuarios a un mejor contenido que los datos sin procesar"
+msgstr "Zda se mají na domovské stránce zobrazovat návrhy procházení. Budou také skryté, pokud se připnou nějaké nástěnky. Správci to mohou vypnout, aby nasměrovaly uživatele na lepší obsah nežli na surové data"
 
 #: src/metabase/public_settings.clj
 msgid "Identify the source of HTTP requests by this header's value, instead of its remote address."
-msgstr "Identifique el origen de las solicitudes HTTP por el valor de este encabezado, en lugar de su dirección remota."
+msgstr "Identifikujte zdroj HTTP požadavků podle hodnoty v této hlavičce namísto jeho vzdálené adresy."
 
 #: src/metabase/public_settings.clj
 msgid "Could not resolve Setting {0}/{1}"
-msgstr "No se pudo resolver la configuración {0}/{1}"
+msgstr "Nastavení {0}/{1} se nepodařilo rozpoznat"
 
 #: src/metabase/public_settings.clj
 msgid "Invalid Setting: {0}/{1}"
-msgstr "Configuración inválida: {0}/{1}"
+msgstr "Neplatné nastavení: {0}/{1}"
 
 #: src/metabase/pulse.clj
 msgid "reached its goal"
-msgstr "alcanzó su objetivo"
+msgstr "dosáhl svého cíle"
 
 #: src/metabase/pulse.clj
 msgid "gone below its goal"
-msgstr "ido por debajo de su objetivo"
+msgstr "spadl pod cíl"
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) via email"
-msgstr "Enviando Pulso ({0}: {1}) vía email"
+msgstr "Odesílá se pulz ({0}: {1}) pomocí emailu"
 
 #: src/metabase/pulse.clj
 msgid "Pulse: {0}"
-msgstr "Pulso: {0}"
+msgstr "Pulz: {0}"
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) via Slack"
-msgstr "Enviando Pulso ({0}: {1}) vía Slack"
+msgstr "Odesílá se pulz ({0}: {1}) přes Slack"
 
 #: src/metabase/pulse.clj
 msgid "Sending Alert ({0}: {1}) via email"
-msgstr "Enviando Alerta ({0}: {1}) vía email"
+msgstr "Odesílání upozornění ({0}: {1}) přes email"
 
 #: src/metabase/pulse.clj
 msgid "Metabase alert: {0} has {1}"
-msgstr "Alerta Metabase: {0} tiene {1}"
+msgstr "Upozornění od metabase: {0} má {1}"
 
 #: src/metabase/pulse.clj
 msgid "Sending Alert ({0}: {1}) via Slack"
-msgstr "Enviando Alerta ({0}: {1}) vía Slack"
+msgstr "Posílá se upozornění ({0}: {1}) přes Slack"
 
 #: src/metabase/pulse.clj
 msgid "Alert: {0}"
-msgstr "Alerta: {0}"
+msgstr "Upozornění: {0}"
 
 #: src/metabase/pulse/render/color.clj
 msgid "Can''t find JS color selector at ''{0}''"
-msgstr "No se puede encontrar el selector de color JS en \"{0}\""
+msgstr "Nelze najít selektor barev JS na ''{0}''"
 
 #. TODO  - there is code that calls this in `render.body` regardless of the types of values
 #: src/metabase/pulse/render/datetime.clj
 msgid "FIXME: These aren''t valid temporal literals: {0} {1}. Why are we attemping to format them as such?"
-msgstr "FIXME: Estos no son literales temporales válidos: {0} {1}. ¿Por qué estamos tratando de formatearlos como tales?"
+msgstr "OPRAV MĚ: Toto nejsou platné časové literály: {0} {1}. Proč se je snažíme takto formátovat?"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "No matching info found for join against Table {0} ''{1}'' on Field {2} ''{3}'' via FK {4} ''{5}''"
-msgstr "No se encontró información coincidente para unir con la tabla {0} \"{1}\" usando el campo {2} \"{3}\" a través de la clave foránea {4} \"{5}\""
+msgstr "Nenašli jsme žádné odpovídající informace pro spojení s tabulkou {0} ''{1}'' v poli {2} ''{3}'' přes FK {4} ''{5}''"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Don''t know how to get information about Field: {0}"
-msgstr "No sé cómo obtener información sobre el campo: {0}"
+msgstr "Nevíme, jak získat informace o poli: {0}"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Query timed out after {0}"
-msgstr "La consulta expiró después de {0}"
+msgstr "Časový limit dotazu vypršel po {0}"
 
 #: src/metabase/query_processor/middleware/format_rows.clj
 msgid "Formatting rows with results timezone ID {0}"
-msgstr "Formateando filas con resultados utilizando la zona horaria {0}"
+msgstr "Formátování řádků s ID časové zóny {0}"
 
 #: src/metabase/query_processor/timezone.clj
 msgid "Invalid timezone ID ''{0}''"
-msgstr "Zona horaria inválida \"{0}\""
+msgstr "Neplatné ID časového pásma ''{0}''"
 
 #: src/metabase/sync/analyze/fingerprint.clj
 msgid "Saving fingerprint for {0}"
-msgstr "Guardar huella digital para {0}"
+msgstr "Ukládá se otisk pro {0}"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandoment email!"
-msgstr "Enviando correo electrónico de abandono!"
+msgstr "Odesíláme e-mail o opuštění účtu!"
 
 #: src/metabase/transforms/core.clj
 msgid "Resulting transforms do not conform to expectations.nExpected: {0}"
-msgstr "Las transformaciones resultantes no se ajustan a las expectativas. Esperado: {0}"
+msgstr "Výsledné transformace nesplňují očekávaní. Očakáváno: {0}"
 
 #: src/metabase/util.clj
 msgid "Timed out after {0}"
-msgstr "Se agotó el tiempo de espera después de {0}"
+msgstr "Čas vypršel po {0}"
 
 #: src/metabase/util/date_2.clj
 msgid "No temporal adjuster named {0}"
-msgstr "Ningún ajustador temporal llamado {0}"
+msgstr "Žádný dočasný seřizovač s názvem {0}"
 
 #: src/metabase/util/date_2.clj
 msgid "Invalid unit: {0}"
-msgstr "Unidad inválida: {0}"
+msgstr "Neplatná jednotka: {0}"
 
 #: src/metabase/util/date_2/parse.clj
 msgid "Don''t know how to parse {0} using format {1}"
-msgstr "No sé cómo analizar {0} usando el formato {1}"
+msgstr "Nevím jak ověřit {0} s použitím formátu {1}"
 
 #: src/metabase/util/embed.clj
 msgid "Token is missing value for keypath {0}"
-msgstr "Al token le falta el valor para keypath {0}"
+msgstr "Tokenu chybí hodnota pro klíčovou cestu {0}"
 
 #: src/metabase/util/stats.clj
 msgid "Sending usage stats FAILED"
-msgstr "Envío de estadísticas de uso FALLIDO"
+msgstr "Odesílání statistik užívání SELHALO"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:69
 msgid "There was an error saving"
-msgstr "Se ha producido un error al guardar"
+msgstr "Při ukládání došlo k chybě"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:75
 msgid "OK"
-msgstr "Vale"
+msgstr "Ok"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:123
 msgid "To allow users to sign in with Google you'll need to give Metabase a Google Developers console application client ID. It only takes a few steps and instructions on how to create a key can be found {0}."
-msgstr "Para permitir a los usuarios iniciar sesión con Google, necesitas dar a Metabase un ID de cliente de aplicación de consola de Google Developers. solo unos pocos pasos y las instrucciones de cómo crear una clave están {0}"
+msgstr "Chcete-li povolit uživatelům přihlásit se pomocí služby Google, musíte Metabase poskytnout ID aplikace Google Developers konzole. To zabere pouze pár kroků a pokyny, jak vytvořit klíč, naleznete {0}."
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:134
 msgid "Be sure to include the full client ID, including the apps.googleusercontent.com suffix."
-msgstr "Asegúrate de incluir el ID de cliente completo, incluyendo el sufijo apps.googleusercontent.com"
+msgstr "Nezapomeňte uvést úplné ID klienta včetně přípony apps.googleusercontent.com."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:30
 msgid "Metabase {0} is available."
-msgstr "Está disponible Metabase {0} "
+msgstr "Metabase {0} je k dispozici."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:31
 msgid "You're running {0}"
-msgstr "Tienes la versión {0}"
+msgstr "Používá se {0}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:57
 msgid "Sorry, we were unable to check for updates at this time."
-msgstr "No se pueden buscar actualizaciones en este momento."
+msgstr "Litujeme, nepodařilo se nám zkontrolovat aktualizace."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:96
 msgid "patch release"
-msgstr "Versión de arreglos"
+msgstr "vydání se záplatami"
 
 #: frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx:10
 msgid "Dates and Times"
-msgstr "Fechas y Horas"
+msgstr "Data a časy"
 
 #: frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx:25
 msgid "Numbers"
-msgstr "Números"
+msgstr "Čísla"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
 msgid "No mappable groups"
-msgstr "No hay grupos asignables"
+msgstr "Žádná mapovatelná skupina"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
-msgstr "Documentación de Metabase"
+msgstr "Dokumentace Metabase"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
-msgstr "Incluye una guía de solución de problemas."
+msgstr "Zahrnuje průvodce řešením problémů"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
 msgid "Post on the Metabase support forum"
-msgstr "Comparte en el foro de soporte de Metabase"
+msgstr "Příspěvek na fóru podpory Metabase"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:114
 msgid "A community forum for all things Metabase"
-msgstr "Un foro comunitario para todas las cosas Metabase"
+msgstr "Komunitní fórum pro Metabase"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
 msgid "File a bug report"
-msgstr "Informar sobre un error"
+msgstr "Odešlete hlášení o chybě"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:119
 msgid "Create a GitHub issue (includes the diagnostic info below)"
-msgstr "Crea una incidencia en GitHub (incluye la información de diagnóstico)"
+msgstr "Vytvořte GitHub issue (obsahuje diagnostické informace níže)"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:127
 msgid "Please include these details in support requests. Thank you!"
-msgstr "Incluye estos detalles en las solicitudes de soporte. ¡Gracias!"
+msgstr "Tyto podrobnosti zahrňte do žádostí o podporu. Děkuji!"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:37
 msgid "youlooknicetoday@email.com"
-msgstr "tevesbienhoy@email.com"
+msgstr "dnestitoslusi@email.com"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:50
 msgid "Remember me"
-msgstr "Recuérdame"
+msgstr "Zapamatovat si mě"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
-msgstr "Por razones de seguridad, los enlaces de restablecimiento de contraseña caducan después de un tiempo. Si aún necesitas restablecer tu contraseña, puedes {0}."
+msgstr "Z bezpečnostních důvodů platnost odkazů na obnovení hesla za chvíli vyprší. Pokud stále potřebujete obnovit své heslo, můžete {0}."
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
 msgid "Save new password"
-msgstr "Guardar nueva contraseña"
+msgstr "Uložit nové heslo"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:424
 msgid "No matching result"
-msgstr "Sin resultados coincidentes"
+msgstr "Žádný odpovídající výsledek"
 
 #: frontend/src/metabase/components/form/CustomForm.jsx:178
 msgid "Submit"
-msgstr "Enviar"
+msgstr "Odeslat"
 
 #: frontend/src/metabase/entities/databases/forms.js:15
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host. This option also provides an extra layer of security when a VPN is not available. Enabling this is usually slower than a direct connection."
-msgstr "Solo se puede acceder a algunas instalaciones de bases de datos conectándose a través de un host de bastión SSH. Esta opción también proporciona una capa adicional de seguridad cuando no se dispone de una VPN. Habilitar esto suele ser más lento que una conexión directa."
+msgstr "Přístup k některým instalacím databáze je možný pouze připojením přes SSH prostředníka. Tato volba také poskytuje další úroveň zabezpečení, když není k dispozici síť VPN. Toto je obvykle pomalejší než přímé připojení."
 
 #: frontend/src/metabase/entities/databases/forms.js:19
 msgid "We suggest you leave this off unless you're doing manual timezone casting in many or most of your queries with this data."
-msgstr "Sugerimos que dejes esto desactivado a menos que realices una conversión manual de zona horaria en muchas o la mayoría de tus consultas con estos datos."
+msgstr "Doporučujeme vám to nechat vypnuté, pokud s tímto údajem neděláte manuální přepnutí časových pásem v mnoha nebo většině otázek."
 
 #: frontend/src/metabase/entities/databases/forms.js:128
 msgid "{0} to get an auth code."
-msgstr "{0} para obtener un código de autenticación."
+msgstr "{0} k získání autorizačního kódu."
 
 #: frontend/src/metabase/entities/databases/forms.js:136
 #: src/metabase/models/collection.clj
 msgid "or"
-msgstr "o"
+msgstr "nebo"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
 #: frontend/src/metabase/entities/databases/forms.js:226
@@ -13745,46 +13777,46 @@ msgstr "o"
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
-msgstr "obligatorio"
+msgstr "povinné"
 
 #: frontend/src/metabase/entities/databases/forms.js:257
 msgid "Database type"
-msgstr "Tipo base de datos"
+msgstr "Typ databáze"
 
 #: frontend/src/metabase/entities/databases/forms.js:291
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
-msgstr "Este es un proceso ligero que busca actualizaciones para el esquema de esta base de datos. En la mayoría de los casos, debería estar bien dejarlo que sincronice cada hora."
+msgstr "Toto je odlehčený proces, který zjišťuje aktualizace schématu této databáze. Zpravidla by mělo vyhovovat nechat hodinovou periodu synchronizace."
 
 #: frontend/src/metabase/entities/databases/forms.js:299
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
-msgstr "Metabase puede escanear los valores presentes en cada campo en esta base de datos para habilitar filtros de casillas de verificación en paneles y preguntas. Este puede ser un proceso de uso intensivo de recursos, especialmente si tienes una base de datos muy grande."
+msgstr "Metabase může skenovat hodnoty přítomné v každém poli v této databázi kvůli povolení fitrů v nástěnkách a otázkách. Může to být proces, který je trochu náročný na prostředky, zejména pokud máte velmi velkou databázi."
 
 #: frontend/src/metabase/entities/questions.js:95
 msgid "Collection"
-msgstr "Colección"
+msgstr "Sbírka"
 
 #: frontend/src/metabase/entities/users/forms.js:55
 msgid "Confirm your password"
-msgstr "Confirma tu contraseña"
+msgstr "Potvrďte svoje heslo"
 
 #: frontend/src/metabase/entities/users/forms.js:60
 msgid "passwords do not match"
-msgstr "las contraseñas no coinciden"
+msgstr "hesla se neshodují"
 
 #: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
-msgstr "Departamento Impresionante"
+msgstr "Pracoviště machrů"
 
 #: frontend/src/metabase/lib/core.js:88 frontend/src/metabase/lib/core.js:93
 #: frontend/src/metabase/lib/core.js:98 frontend/src/metabase/lib/core.js:103
 #: frontend/src/metabase/lib/core.js:108 frontend/src/metabase/lib/core.js:113
 msgid "Financial"
-msgstr "Financiero"
+msgstr "Finanční"
 
 #: frontend/src/metabase/lib/core.js:120 frontend/src/metabase/lib/core.js:125
 #: frontend/src/metabase/lib/core.js:130
 msgid "Numeric"
-msgstr "Numérico"
+msgstr "Číselné"
 
 #: frontend/src/metabase/lib/core.js:169 frontend/src/metabase/lib/core.js:174
 #: frontend/src/metabase/lib/core.js:179 frontend/src/metabase/lib/core.js:184
@@ -13794,42 +13826,42 @@ msgstr "Numérico"
 #: frontend/src/metabase/lib/core.js:219 frontend/src/metabase/lib/core.js:224
 #: frontend/src/metabase/lib/core.js:229 frontend/src/metabase/lib/core.js:234
 msgid "Date and Time"
-msgstr "Fecha y Hora"
+msgstr "Datum a čas"
 
 #: frontend/src/metabase/lib/core.js:241 frontend/src/metabase/lib/core.js:246
 #: frontend/src/metabase/lib/core.js:251
 msgid "Categorical"
-msgstr "Categórico"
+msgstr "Kategorické"
 
 #: frontend/src/metabase/lib/core.js:258 frontend/src/metabase/lib/core.js:263
 #: frontend/src/metabase/lib/core.js:268
 msgid "URLs"
-msgstr "URLs"
+msgstr "odkaz"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
 msgid "Returns the average of the values in the column."
-msgstr "Devuelve el promedio de los valores en la columna."
+msgstr "Vrátí průměr hodnot ve sloupci."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
 msgid "The column whose values to average."
-msgstr "La columna cuyos valores promediar."
+msgstr "Sloupec, jehož hodnoty se mají zprůměrovat."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "start"
-msgstr "inicio"
+msgstr "start"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "end"
-msgstr "fin"
+msgstr "konec"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
 msgid "Checks a date or numeric column's values to see if they're within the specified range."
-msgstr "Comprueba los valores de una fecha o columna numérica para ver si están dentro del rango especificado."
+msgstr "Kontroluje hodnoty data nebo číselného sloupce a zjišťuje, zda se nacházejí v zadaném rozsahu."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
-msgstr "Clasificación"
+msgstr "Hodnocení"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
@@ -13841,172 +13873,172 @@ msgstr "Clasificación"
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
 msgid "condition"
-msgstr "condición"
+msgstr "podmínka"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
 msgid "output"
-msgstr "salida"
+msgstr "výstup"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
-msgstr "Prueba una lista de casos y devuelve el valor correspondiente del primer caso verdadero, con un valor predeterminado opcional si no se cumple ninguno."
+msgstr "Testuje seznam případů a vrací odpovídající hodnotu prvního shodného případu, s volitelnou výchozí hodnotou pro případ pokud není žádný splněn."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
 msgid "Weight"
-msgstr "Peso"
+msgstr "Váha"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
 msgid "Large"
-msgstr "Grande"
+msgstr "Velká"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
 msgid "Medium"
-msgstr "Medio"
+msgstr "Střední"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
 msgid "Small"
-msgstr "Pequeño"
+msgstr "Malá"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
 msgid "Something that should evaluate to true or false."
-msgstr "Algo que debería evaluar como verdadero o falso."
+msgstr "Něco, co by se mělo vyhodnocovat jako PRAVDA nebo NEPRAVDA."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:54
 msgid "The value that will be returned if the preceeding condition is true."
-msgstr "El valor que se devolverá si la condición anterior es verdadera."
+msgstr "Hodnota, která se vrátí, pokud je předchozí podmínka splněna."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "value1"
-msgstr "valor1"
+msgstr "hodnota1"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
 msgid "value2"
-msgstr "valor2"
+msgstr "hodnota2"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
-msgstr "Mira los valores en cada argumento en orden y devuelve el primer valor no nulo para cada fila."
+msgstr "Projde hodnoty v každém argumentu dle jejich pořadí a vrátí první nenulovou hodnotu pro každý řádek."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
 msgid "Comments"
-msgstr "Comentarios"
+msgstr "Komentáře"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
 msgid "Notes"
-msgstr "Notas"
+msgstr "Poznámky"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
 msgid "No comments"
-msgstr "Sin comentarios"
+msgstr "Žádné komentáře"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
 msgid "A column or value."
-msgstr "Una columna o valor"
+msgstr "Sloupec nebo hodnota."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:77
 msgid "If value1 is empty, value2 gets returned if it's not empty, and so on."
-msgstr "Si valor1 está vacío, devuelve valor2 si no está vacío, y así sucesivamente."
+msgstr "Pokud je hodnota1 prázdná, hodnota2 bude vrácena pokud není prázdná, atd."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 msgid "Combines two or more strings of text together."
-msgstr "Combina dos o más cadenas de texto."
+msgstr "Kombinuje dva nebo více řetězců textu dohromady."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
 msgid "Last Name"
-msgstr "Apellidos"
+msgstr "Příjmení"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 msgid "First Name"
-msgstr "Nombre"
+msgstr "Jméno"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
-msgstr "valor2 se añadirá al final de esto."
+msgstr "hodnota2 se připojí na konec."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
-msgstr "Esto se agregará al final del valor1."
+msgstr "Toto se připojí na konec hodnoty1."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
 msgid "string1"
-msgstr "cadena1"
+msgstr "řetězec1"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
 msgid "string2"
-msgstr "cadena2"
+msgstr "řetězec2"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
 msgid "Checks to see if string1 contains string2 within it."
-msgstr "Comprueba si string1 contiene string2."
+msgstr "Zkontroluje, zda řetězec1 obsahuje řetězec2."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
 msgid "Status"
-msgstr "Estado"
+msgstr "Status"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 msgid "Pass"
-msgstr "Pasar"
+msgstr "Prošlo"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
-msgstr "Se verificará el contenido de esta cadena."
+msgstr "Obsah tohoto řetězce se zkontroluje."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
 msgid "The string of text to look for."
-msgstr "La cadena de texto a buscar."
+msgstr "Řetězec textu, který se má hledat."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:116
 msgid "Returns the count of rows in the source data."
-msgstr "Devuelve el número de filas en los datos de origen."
+msgstr "Vrátí počet řádků ve zdrojových datech."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Only counts rows where the condition is true."
-msgstr "Solo cuenta las filas donde la condición es verdadera."
+msgstr "Sečte pouze řádky, ve kterém je podmínka splněna."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
 msgid "Subtotal"
-msgstr "Subtotal"
+msgstr "Mezisoučet"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
 msgid "The additive total of rows across a breakout."
-msgstr "El total aditivo de filas en una ruptura."
+msgstr "Aditivní součet řádků napříč průrazem."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
 msgid "The rolling sum of a column across a breakout."
-msgstr "La suma aditiva de una columna en una ruptura."
+msgstr "Postupný součet sloupce napříč průrazem."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
-msgstr "La columna a sumar."
+msgstr "Sloupec k sečtení"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
 msgid "The number of distinct values in this column."
-msgstr "El número de valores distintos en esta columna."
+msgstr "Počet jedinečných hodnot v tomto sloupci."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "The column whose distinct values to count."
-msgstr "La columna en la que hay que contar los valores distintos."
+msgstr "Sloupec jehož jedinečné hodnoty se mají sečíst."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
@@ -14029,1003 +14061,1008 @@ msgstr "La columna en la que hay que contar los valores distintos."
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
 msgid "text"
-msgstr "texto"
+msgstr "text"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
 msgid "comparison"
-msgstr "comparación"
+msgstr "porovnání"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
 msgid "Returns true if the end of the text matches the comparison text."
-msgstr "Devuelve verdadero si el final del texto coincide con el texto de comparación."
+msgstr "Vrátí PRAVDA pokud konec textu souhlasí s porovnávaným textem."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "Appetite"
-msgstr "Apetito"
+msgstr "Chuť"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "hungry"
-msgstr "hambriento"
+msgstr "hladový"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 msgid "A column or string of text to check."
-msgstr "Una columna o cadena de texto para verificar."
+msgstr "Sloupec nebo řetězec textu na kontrolu."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
 msgid "The string of text that the original text should end with."
-msgstr "La cadena de texto con la que debe terminar el texto original."
+msgstr "Řetězec textu, na který má původní text končit."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 msgid "regular_expression"
-msgstr "expresión_regular"
+msgstr "regulární_výraz"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
 msgid "Extracts matching substrings according to a regular expression."
-msgstr "Extrae subcadenas coincidentes de acuerdo con una expresión regular."
+msgstr "Extrahuje odpovídající podřetězce dle regulárního výrazu."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
 msgid "Address"
-msgstr "Dirección"
+msgstr "Adresa"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 msgid "The column or string of text to search though."
-msgstr "La columna o cadena de texto en la que buscar."
+msgstr "Sloupec nebo řetězec textu, který se má prohledávat."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
 msgid "The regular expression to match."
-msgstr "La expresión regular a evaluar."
+msgstr "Regulární výraz, který se má shodovat."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the string of text in all lowercase."
-msgstr "Devuelve la cadena de texto en minúsculas."
+msgstr "Vrátí řetězec textu v malých písmenech."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to lowercase."
-msgstr "La columna con valores para convertir a minúsculas."
+msgstr "Sloupec s hodnotami pro převod na malá písmena."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 msgid "Removes leading whitespace from a string of text."
-msgstr "Elimina los espacios en blanco iniciales de una cadena de texto."
+msgstr "Odstraní úvodní mezery z textového řetězce."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column with values you want to trim."
-msgstr "La columna con los valores que quieres recortar."
+msgstr "Sloupec s hodnotami, které chcete oříznout."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "Returns the largest value found in the column."
-msgstr "Devuelve el máximo valor encontrado en la columna."
+msgstr "Vrátí největší hodnotu nacházející se ve sloupci."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
 msgid "Age"
-msgstr "Edad"
+msgstr "Věk"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
 msgid "The numeric column whose maximum you want to find."
-msgstr "La columna numérica cuyo máximo quieres encontrar."
+msgstr "Číselný sloupec, jehož maximum chcete najít."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "Returns the smallest value found in the column."
-msgstr "Devuelve el valor más pequeño encontrado en la columna."
+msgstr "Vrátí nejmenší hodnotu nacházející se ve sloupci."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
 msgid "Salary"
-msgstr "Salario"
+msgstr "Plat"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
 msgid "The numeric column whose minimum you want to find."
-msgstr "La columna numérica cuyo mínimo quieres encontrar."
+msgstr "Číselný sloupec, jehož minimum chcete najít."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
 msgid "position"
-msgstr "posición"
+msgstr "pozice"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
 msgid "length"
-msgstr "longitud"
+msgstr "délka"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:185
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "new_text"
-msgstr "texto_nuevo"
+msgstr "nový_text"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
 msgid "Replaces a part of the input text with new text."
-msgstr "Reemplaza una parte del texto de entrada con texto nuevo."
+msgstr "Nahradí část vstupního textu novým textem."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:189
 msgid "Order ID"
-msgstr "ID Pedido"
+msgstr "Číslo objednávky"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:189
 msgid "Updated Part of ID"
-msgstr "Parte actualizada de ID"
+msgstr "Aktualizovaná část ID"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
 msgid "The text that will be modified."
-msgstr "El texto que se modificará."
+msgstr "Text, který bude upraven."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:193
 msgid "The position where the replacing will start."
-msgstr "La posición donde comenzará la sustitución."
+msgstr "Pozice, kde začne nahrazení."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
 msgid "The number of characters to replace."
-msgstr "El número de caracteres a reemplazar."
+msgstr "Počet znaků, které se mají nahradit."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:197
 msgid "The text to use in the replacement."
-msgstr "El texto a usar en el reemplazo."
+msgstr "Text, který má být použit jako náhrada."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "Removes trailing whitespace from a string of text."
-msgstr "Elimina los espacios en blanco finales de una cadena de texto."
+msgstr "Odstraní koncové mezery z textového řetězce."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
-msgstr "Devuelve el porcentaje de filas en los datos que coinciden con la condición, como un decimal."
+msgstr "Vrátí procento řádků v datech které odpovídají podmínce, jako desetinné číslo."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
 msgid "Returns true if the beginning of the text matches the comparison text."
-msgstr "Devuelve verdadero si el comienzo del texto coincide con el texto de comparación."
+msgstr "Vrátí PRAVDA, pokud se začátek textu shoduje se srovnávaným textem."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Course Name"
-msgstr "Nombre del Curso"
+msgstr "Název kurzu"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Computer Science"
-msgstr "Ciencias de la Computación"
+msgstr "Počítačová věda"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
 msgid "The string of text that the original text should start with."
-msgstr "La cadena de texto con la que debe comenzar el texto original."
+msgstr "Řetězec textu, na který má původní text začínat."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
 msgid "Calculates the standard deviation of the column."
-msgstr "Calcula la desviación estándar de la columna."
+msgstr "Vypočte směrodatnou odchylku sloupce"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
 msgid "Population"
-msgstr "Población"
+msgstr "Populace"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
 msgid "A numeric column."
-msgstr "Una columna numérica"
+msgstr "Číselný sloupec."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
 msgid "Returns a portion of the supplied text."
-msgstr "Devuelve una parte del texto proporcionado."
+msgstr "Vrátí část zadaného textu."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:313
 msgid "The text to return a portion of."
-msgstr "El texto del que hay que extraer una parte."
+msgstr "Text ze kterého se má vrátit část."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
 msgid "The position to start copying characters."
-msgstr "La posición para comenzar a copiar caracteres."
+msgstr "Pozice na které se má začít kopírovat znaky."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
 msgid "The number of characters to return."
-msgstr "El número de caracteres a devolver."
+msgstr "Počet znaků, které se mají vrátit."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
 msgid "Adds up all the values of the column."
-msgstr "Suma todos los valores de la columna."
+msgstr "Sčítá všechny hodnoty sloupce."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
 msgid "The numeric column to sum."
-msgstr "La columna numérica a sumar."
+msgstr "Číselný sloupec k sečtení"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
-msgstr "Resume valores en una columna donde las filas coinciden con la condición."
+msgstr "Sčítá hodnoty ve sloupci, jehož řádky odpovídají podmínce."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
 msgid "Order Status"
-msgstr "Estado Pedido"
+msgstr "Stav objednávky"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
 msgid "Valid"
-msgstr "Válido"
+msgstr "Platná"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
 msgid "Removes leading and trailing whitespace from a string of text."
-msgstr "Elimina los espacios en blanco iniciales y finales de una cadena de texto."
+msgstr "Odstraní úvodní a koncové mezery z textového řetězce."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
 msgid "Returns the string of text in all upper case."
-msgstr "Devuelve la cadena de texto en mayúsculas."
+msgstr "Vrátí řetězec textu ve velkých písmenech."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
 msgid "The column with values to convert to upper case."
-msgstr "La columna con valores para convertir a mayúsculas."
+msgstr "Sloupec s hodnotami pro převod na velká písmena."
 
 #: frontend/src/metabase/lib/settings.js:190
 msgid "must be {0} and include {1}."
-msgstr "debe ser {0} e incluir {1}"
+msgstr "musí být {0} a musí obsahovat {1}."
 
 #: frontend/src/metabase/lib/settings.js:192
 msgid "must be {0}."
-msgstr "debe ser {0}"
+msgstr "musí být {0}."
 
 #: frontend/src/metabase/lib/settings.js:194
 msgid "must include {0}."
-msgstr "debe incluir {0}."
+msgstr "musí obsahovat {0}."
 
 #: frontend/src/metabase/lib/settings.js:207
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
-msgstr[0] "al menos {0} carácter"
-msgstr[1] "al menos {0} caracteres"
+msgstr[0] "nejméně {0} znak"
+msgstr[1] "nejméně {0} znaky"
+msgstr[2] "nejméně {0} znaků"
 
 #: frontend/src/metabase/lib/settings.js:216
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
-msgstr[0] "{0} letra minúscula"
-msgstr[1] "{0} letras minúsculas"
+msgstr[0] "{0} malé písmeno"
+msgstr[1] "{0} malé písmena"
+msgstr[2] "{0} malých písmen"
 
 #: frontend/src/metabase/lib/settings.js:225
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
-msgstr[0] "{0} letra mayúscula"
-msgstr[1] "{0} letras mayúsculas"
+msgstr[0] "{0} velké písmeno"
+msgstr[1] "{0} velké písmena"
+msgstr[2] "{0} velkých písmen"
 
 #: frontend/src/metabase/lib/settings.js:234
 msgid "{0} number"
 msgid_plural "{0} numbers"
-msgstr[0] "{0} número"
-msgstr[1] "{0} números"
+msgstr[0] "{0} číslo"
+msgstr[1] "{0} čísla"
+msgstr[2] "{0} čísel"
 
 #: frontend/src/metabase/lib/settings.js:239
 msgid "{0} special character"
 msgid_plural "{0} special characters"
-msgstr[0] "{0} carácter especial"
-msgstr[1] "{0} caracteres especiales"
+msgstr[0] "{0} speciální znak"
+msgstr[1] "{0} speciální znaky"
+msgstr[2] "{0} speciálních znaků"
 
 #: frontend/src/metabase/lib/validate.js:8
 msgid "must be a valid email address"
-msgstr "Debe ser una dirección de correo electrónico válida"
+msgstr "musí být platná emailová adresa"
 
 #: frontend/src/metabase/lib/validate.js:10
 msgid "must be {0} characters or less"
-msgstr "deben tener {0} caracteres o menos"
+msgstr "musí obsahovat {0} znaků nebo méně"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:113
 msgid "Thanks for using Metabase!"
-msgstr "Gracias por utilizar Metabase!"
+msgstr "Děkujeme, že používáte Metabase!"
 
 #: frontend/src/metabase/public/components/LogoBadge.jsx:20
 msgid "Powered by {0}"
-msgstr "Impulsado por {0}"
+msgstr "Běží na {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
 msgid "To:"
-msgstr "A:"
+msgstr "Pro:"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
-msgstr "Esta pregunta no se puede usar porque se basa en una base de datos diferente."
+msgstr "Tuto otázku nelze použít, protože je postavena pro jinou databázi."
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:43
 msgid "Couldn't find a saved question with that ID number."
-msgstr "No he podido encontrar una pregunta guardada con ese número de identificación."
+msgstr "Uloženou otázku s tímto ID se nepodařilo najít."
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:54
 msgid "Pick a saved question"
-msgstr "Elige una pregunta guardada"
+msgstr "Vyberte uloženou otázku"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:56
 msgid "Pick a different question"
-msgstr "Elige una pregunta diferente"
+msgstr "Vyberte jinou otázku"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:61
 msgid "Loading…"
-msgstr "Cargando..."
+msgstr "Načítám..."
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:78
 msgid "Question #…"
-msgstr "Pregunta #..."
+msgstr "Otázka č..."
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
-msgstr "Pregunta #{0}"
+msgstr "Otázka č.{0}"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
-msgstr "Última edición {0}"
+msgstr "Naposledy upraveno {0}"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:250
 msgid "{0} creates a variable in this query template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the query template."
-msgstr "{0} crea una variable en esta plantilla de consulta llamada \"nombre_variable\". Las variables pueden recibir tipos en el panel lateral, lo que cambia su comportamiento. Todos los tipos de variables que no sean \"Filtro de campo\" provocarán automáticamente que se coloque un widget de filtro en esta pregunta; con filtros de campo, esto es opcional. Cuando se completa este widget de filtro, ese valor reemplaza la variable en la plantilla de consulta."
+msgstr "{0} vytvoří proměnnou v této šabloně s dotazem, nazvanou jako \"název proměnné\". Proměnným mohou být v postranním panelu nastaveny typy, které mění jejich chování. U všech typů proměnných, mimo \"Filtru pole\", se na otázku automaticky umístí filtrovací widget, jen u Filtru pole je toto volitelné. Po vyplnění filtrovacího widgetu jeho hodnota nahradí proměnnou v SQL šabloně."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:261
 msgid "Giving a variable the \"Field Filter\" type allows you to link questions to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
-msgstr "Darle a una variable el tipo de \"Filtro de campo\" te permite vincular preguntas a los widgets de filtro del tablero o usar más tipos de widgets de filtro en tu pregunta SQL. Una variable de filtro de campo inserta SQL similar al generado por el generador de consultas GUI al agregar filtros en columnas existentes."
+msgstr "Poskytnutím proměnné typu \"Filtr pole\" můžete propojit otázky s filtrovacími widgety na nástěnce nebo použít více typů filtrovacích widgetů na svůj SQL dotaz. Proměnná Filtr pole vloží SQL podobný té, který byl vytvořen v GUI tvůrci dotazů při přidávání filtrů do stávajících sloupců."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
-msgstr "Nombre de variable"
+msgstr "Název proměnné"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:218
 msgid "Filter widget label"
-msgstr "Etiqueta del widget de filtro"
+msgstr "Popis filtrovacího widgetu"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:64
 msgid "Select a foreign key"
-msgstr "Selecciona una clave foránea"
+msgstr "Vyberte cizí klíč"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:50
 msgid "Hi, {0}. Nice to meet you!"
-msgstr "Hola, {0}. Encantada de conocerte!"
+msgstr "Ahoj, {0}. Rád tě poznávám!"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:270
 msgid "12-hour clock"
-msgstr "Reloj de 12 horas"
+msgstr "12-ti hodinový formát"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:274
 msgid "24-hour clock"
-msgstr "Reloj de 24 horas"
+msgstr "24 hodinový formát"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:341
 msgid "Symbol"
-msgstr "Símbolo"
+msgstr "Symbol"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:365
 msgid "In the column heading"
-msgstr "En el encabezado de la columna"
+msgstr "V záhlaví sloupce"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:366
 msgid "In every table cell"
-msgstr "en cada celda de la tabla"
+msgstr "V každé buňce tabulky"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:341
 msgid "Value formatting"
-msgstr "Formato de valor"
+msgstr "Formátování hodnoty"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:350
 msgid "Full"
-msgstr "Lleno"
+msgstr "Plný"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
 msgid "No change from last {0}"
-msgstr "Sin cambios desde el último {0}"
+msgstr "Žádná změna od poslední {0}"
 
 #: src/metabase/api/database.clj
 msgid "Connection to ''{0}:{1}'' successful, but could not connect to DB."
-msgstr "La conexión a \"{0}:{1}\" se realizó correctamente, pero no se ha podido conectar a la base de datos."
+msgstr "Připojení k ''{0}:{1}'' bylo úspěšné, ale nešlo se připojit k DB."
 
 #: src/metabase/api/database.clj
 msgid "Connection to host ''{0}'' successful, but port {1} is invalid."
-msgstr "La conexión al host \"{0}\" se realizó correctamente, pero el puerto {1} no es válido."
+msgstr "Připojení k hostiteli ''{0}'' bylo úspěšné, ale port {1} je neplatný."
 
 #: src/metabase/api/database.clj
 msgid "Host ''{0}'' is not reachable"
-msgstr "No se puede acceder al host \"{0}\""
+msgstr "Hostitel ''{0}'' není dosažitelný"
 
 #: src/metabase/api/database.clj
 msgid "Unable to connect to database."
-msgstr "Incapaz de conectar a la base de datos."
+msgstr "Nelze se připojit k databázi."
 
 #: src/metabase/api/database.clj
 msgid "Cannot connect to Database"
-msgstr "No se puede conectar a la base de datos"
+msgstr "Nelze se připojit k databázi."
 
 #: src/metabase/api/embed.clj
 msgid "You''re not allowed to specify a value for {0}."
-msgstr "No tienes permiso para especificar un valor de {0}."
+msgstr "Nemáte povolení zadat hodnotu pro {0}."
 
 #: src/metabase/api/embed.clj
 msgid "You can''t specify a value for {0} if it''s already set in the JWT."
-msgstr "No puedes especificar un valor para {0} si ya está configurado en el JWT."
+msgstr "Nelze zadat hodnotu pro {0}, pokud je již nastavena v JWT."
 
 #: src/metabase/api/embed.clj
 msgid "You must specify a value for {0} in the JWT."
-msgstr "Debes especificar un valor para {0} en el JWT."
+msgstr "Musíte zadat hodnotu pro {0} v JWT."
 
 #: src/metabase/api/embed.clj
 msgid "You can only specify a value for {0} in the JWT."
-msgstr "Solo puedes especificar un valor para {0} en el JWT."
+msgstr "V JWT můžete zadat pouze hodnotu pro {0}."
 
 #: src/metabase/api/field.clj
 msgid "Error searching field values"
-msgstr "Error al buscar valores de campo"
+msgstr "Chyba při vyhledávání hodnot pole"
 
 #: src/metabase/api/field.clj
 msgid "Error searching for remapping"
-msgstr "Error al buscar la reasignación"
+msgstr "Chyba při hledání přemapování"
 
 #: src/metabase/api/session.clj
 msgid "Google Auth token appears to be incorrect. "
-msgstr "El token de autenticación de Google parece ser incorrecto."
+msgstr "Token Google Auth se zdá být nesprávný. "
 
 #: src/metabase/api/session.clj
 msgid "Double check that it matches in Google and Metabase."
-msgstr "Verifica que coincida en Google y Metabase."
+msgstr "Zkontrolujte, zda se shoduje ve službách Google a Metabase."
 
 #: src/metabase/api/table.clj
 msgid "Everything else"
-msgstr "Todo lo demás"
+msgstr "Vše ostatní"
 
 #: src/metabase/core.clj
 msgid "WARNING: You have enabled namespace tracing, which could log sensitive information like db passwords."
-msgstr "ADVERTENCIA: Has habilitado el seguimiento del espacio de nombres, que podría registrar información confidencial como contraseñas de la base de datos."
+msgstr "VAROVÁNÍ: Povolili jste sledování jmenného prostoru, tohle může zaznamenávat citlivé informace, jako jsou DB hesla."
 
 #: src/metabase/db.clj
 msgid "Database Upgrade Required"
-msgstr "Actualización de base de datos requerida"
+msgstr "Požadována aktualizace databáze"
 
 #: src/metabase/db.clj
 msgid "NOTICE: Your database requires updates to work with this version of Metabase."
-msgstr "AVISO: tu base de datos requiere actualizaciones para funcionar con esta versión de Metabase."
+msgstr "UPOZORNĚNÍ: Vaše databáze vyžaduje aktualizace, aby mohla fungovat s touto verzí Metabase."
 
 #: src/metabase/db.clj
 msgid "Please execute the following sql commands on your database before proceeding."
-msgstr "Por favor, ejecuta los siguientes comandos SQL en tu base de datos antes de continuar."
+msgstr "Před pokračováním proveďte ve své databázi následující SQL příkazy."
 
 #: src/metabase/db.clj
 msgid "Once your database is updated try running the application again."
-msgstr "En cuanto hayas actualizado tu base de datos, intenta ejecutar la aplicación  de nuevo."
+msgstr "Po aktualizaci databáze zkuste aplikaci spustit znovu."
 
 #: src/metabase/db.clj
 msgid "Database requires manual upgrade."
-msgstr "La base de datos requiere actualización manual."
+msgstr "Databáze vyžaduje manuální aktualizaci."
 
 #. Tell transaction to automatically `.rollback` instead of `.commit` when the transaction finishes
 #: src/metabase/db.clj
 msgid "Set transaction to automatically roll back..."
-msgstr "Establecer la transacción para revertir automáticamente ..."
+msgstr "Nastavit transakci na automatické vrácení zpět..."
 
 #. Disable auto-commit. This should already be off but set it just to be safe
 #: src/metabase/db.clj
 msgid "Disable auto-commit..."
-msgstr "Deshabilitar confirmación automática..."
+msgstr "Zakázat auto-commit..."
 
 #: src/metabase/db.clj
 msgid "Set default db connection with connection pool..."
-msgstr "Establecerla conexión al base de datos predeterminada con el grupo de conexiones..."
+msgstr "Nastavit výchozí DB připojení s využitím sdružování připojení..."
 
 #: src/metabase/db.clj
 msgid "Successfully verified {0} {1} application database connection."
-msgstr "Se verificó correctamente la conexión de la base de datos de la aplicación {0} {1}."
+msgstr "Úspěšně ověřeno připojení k {0} {1} aplikační databázi."
 
 #. if both of the decoders above fail, then the date string is invalid
 #: src/metabase/driver/common/parameters/dates.clj
 msgid "Don''t know how to parse date param ''{0}'' — invalid format"
-msgstr "No sé cómo analizar el parámetro de fecha \"{0}\" - formato no válido"
+msgstr "Nevím jak ověřit parametr datumu ''{0}'' - neplatný formát"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "The sub-query from referenced question #{0} failed with the following error: {1}"
-msgstr "La subconsulta de la pregunta referenciada #{0} falló con el siguiente error: {1}"
+msgstr "Pod-dotaz z referenční otázky #{0} selhal s následující chybou: {1}"
 
 #: src/metabase/driver/mysql.clj
 msgid "WARNING: Metabase only officially supports MySQL {0}/MariaDB {1} and above."
-msgstr "ADVERTENCIA: Metabase solo admite oficialmente MySQL {0}/MariaDB {1} y superior."
+msgstr "UPOZORNĚNÍ: Metabase oficiálně podporuje pouze MySQL {0} / MariaDB {1} a vyšší."
 
 #: src/metabase/driver/mysql.clj
 msgid "All Metabase features may not work properly when using an unsupported version."
-msgstr "Es posible que alguna funcionalidad de Metabase no funcione correctamente cuando se utiliza una versión no compatible."
+msgstr "Při používání nepodporované verze nemusí všechny funkce Metabase fungovat správně."
 
 #: src/metabase/driver/sql/parameters/substitute.clj
 msgid "Unable to substitute parameters"
-msgstr "Incapaz de sustituir parámetros"
+msgstr "Parametry nelze nahradit"
 
 #: src/metabase/driver/sql/parameters/substitute.clj
 msgid "Cannot run the query: missing required parameters: {0}"
-msgstr "No se puede ejecutar la consulta: faltan los parámetros necesarios: {0}"
+msgstr "Dotaz nelze spustit: chybí požadované parametry: {0}"
 
 #: src/metabase/driver/sql/parameters/substitution.clj
 msgid "Don''t know how to parse {0} {1} as a temporal literal"
-msgstr "No sé cómo analizar {0} {1} como un literal temporal"
+msgstr "Nevím jak ověřit {0} {1} jako dočasný výraz"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Setting {0} database timezone with statement: {1}"
-msgstr "Estableciendo la zona horaria de la base de datos {0} con la declaración: {1}"
+msgstr "Nastavení {0} časového pásma databáze s příkazem: {1}"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting connection to readwrite"
-msgstr "Error al establecer la conexión para escritua y lectura"
+msgstr "Chyba při nastavování připojení pro čtení i zápis"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone ''{0}'' for {1} database"
-msgstr "Error al establecer la zona horaria \"{0}\" para la base de datos {1}"
+msgstr "Nelze nastavit časové pásmo \"{0}\" pro databázi {1}"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting transaction isolation level for {0} database to {1}"
-msgstr "Error al establecer el nivel de aislamiento de transacción para la base de datos {0} en {1}"
+msgstr "Chyba při nastavování úrovně izolace transakcí pro {0} databázi na {1}"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting connection to read-only"
-msgstr "Error al establecer la conexión a solo lectura"
+msgstr "Chyba při nastavování připojení pouze pro čtení"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting default holdability for connection"
-msgstr "Error al establecer la capacidad de retención predeterminada para la conexión"
+msgstr "Chyba při nastavování výchozí možnosti připojení"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting result set fetch direction to FETCH_FORWARD"
-msgstr "Error al establecer la dirección de recuperación del conjunto de resultados en FETCH_FORWARD"
+msgstr "Chyba při nastavování směru načítání výsledku na FETCH_FORWARD"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Query canceled, calling PreparedStatement.cancel()"
-msgstr "Consulta cancelada, llamando a PreparedStatement.cancel()"
+msgstr "Dotaz byl zrušen, volám PreparedStatement.cancel()"
 
 #: src/metabase/driver/util.clj
 msgid "Failed to connect to database"
-msgstr "Error al conectarse a la base de datos"
+msgstr "Připojení k databázi selhalo"
 
 #: src/metabase/driver/util.clj
 msgid "Unable to determine connection properties for driver {0}"
-msgstr "No se pueden determinar las propiedades de conexión para el controlador {0}"
+msgstr "Nelze určit vlastnosti připojení pro ovladač {0}"
 
 #: src/metabase/models/field_values.clj
 msgid "Error fetching field values"
-msgstr "Error al recuperar valores de campo"
+msgstr "Chyba při načítání hodnot polí"
 
 #: src/metabase/models/setting.clj
 msgid "You cannot set {0}; it is a read-only setting."
-msgstr "No puedes establecer {0}; Es una configuración de solo lectura."
+msgstr "Nemůžete nastavit {0}; je nastaveno pouze pro čtení."
 
 #: src/metabase/models/setting.clj
 msgid "defsetting descriptions strings must have `:visibilty` `:internal`, `:setter` `:none`, or internationalized, found: `{0}`"
-msgstr "las cadenas de descripción defsetting deben tener `:visibilty` `:internal`, `:setter` `:none`, o internazionalizado, encontrado: `{0}`"
+msgstr "popisy defsetting musí mít `:visibilty` `:internal`, `:setter` `:none`, nebo lokalizované, nalezeno: `{0}`"
 
 #: src/metabase/models/setting.clj
 msgid "Setting {0} is internal"
-msgstr "La configuración {0} es interna"
+msgstr "Nastavení {0} je interní"
 
 #: src/metabase/plugins.clj
 msgid "Loading local plugin manifest at {0}"
-msgstr "Cargando el manifiesto del complemento local en {0}"
+msgstr "Načítám lokální manifest doplňku {0}"
 
 #: src/metabase/public_settings.clj
 msgid "Google Analytics tracking code."
-msgstr "Código de seguimiento de Google Analytics."
+msgstr "Google Analytics tracking code."
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) with {2} Cards via email"
-msgstr "Envío de pulso ({0}: {1}) con {2} tarjetas por correo electrónico"
+msgstr "Odesílá se pulz ({0}: {1}) s {2} kartami prostřednictvím e-mailu"
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) with {2} Cards via Slack"
-msgstr "Envío de pulso ({0}: {1}) con {2} tarjetas por Slack"
+msgstr "Odesílá se pulz ({0}: {1}) s {2} kartami přes Slack"
 
 #: src/metabase/pulse/render.clj
 msgid "Rendering pulse card with chart-type {0} and render-type {1}"
-msgstr "Tarjeta de pulso de representación con tipo de gráfico {0} y tipo de representación {1}"
+msgstr "Renderování karty pulzu s grafem typu {0} a typu renderování {1}"
 
 #. TODO  - there is code that calls this in `render.body` regardless of the types of values
 #: src/metabase/pulse/render/datetime.clj
 msgid "FIXME: These aren''t valid temporal literals: {0} {1}. Why are we attempting to format them as such?"
-msgstr "FIXME: Estos no son literales temporales válidos: {0} {1}. ¿Por qué estamos tratando de formatearlos como tales?"
+msgstr "OPRAV MĚ: Toto nejsou platné literály: {0} {1}. Proč se je snažíme naformátovat?"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Error reducing result rows"
-msgstr "Error al reducir las filas de resultados"
+msgstr "Chyba při zmenšování řádků s výsledky"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Unexpected nil result"
-msgstr "Resultado inesperado nulo"
+msgstr "Neočekávaný nulový výsledek"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Query timed out after {0} ms, raising timeout exception."
-msgstr "La consulta expiró después de {0} ms, generando una excepción de tiempo de espera."
+msgstr "Dotaz vypršel po {0} ms, vyvolávám výjimku z prodlení."
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Timed out after {0}."
-msgstr "Se agotó el tiempo de espera después de {0}."
+msgstr "Vypršel po {0}"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Query canceled before finishing."
-msgstr "Consulta cancelada antes de finalizar."
+msgstr "Dotaz byl zrušen před dokončením."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Unknown query type {0}"
-msgstr "Tipo de consulta desconocido {0}"
+msgstr "Neznámý typ dotazu {0}"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Error purging old cache entires"
-msgstr "Error al depurar entradas de caché antiguas"
+msgstr "Chyba při odstraňování starých položek mezipaměti"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Caching results for next time for query with hash {0}."
-msgstr "Resultados de la consulta con hash {0}, almacenados en caché para la próxima vez."
+msgstr "Ukládám výsledky do mezipaměti pro budoucí dotazy s hashem {0}."
 
 #: src/metabase/query_processor/middleware/cache.clj
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
 msgid "Error saving query results to cache."
-msgstr "Error al guardar los resultados de la consulta en la memoria caché."
+msgstr "Chyba při ukládání výsledků dotazu do mezipaměti."
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Successfully cached results for query."
-msgstr "Resultados de la consulta almacenados en caché con éxito."
+msgstr "Výsledky dotazu byly úspěšně uloženy do mezipaměti."
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Query took {0} to run; miminum for cache eligibility is {1}"
-msgstr "La consulta tardó {0} en ejecutarse; el mínimo para entrar en caché es {1}"
+msgstr "Dotaz zabral {0}; minimum pro uložení do mezipaměti je {1}"
 
 #: src/metabase/query_processor/middleware/cache/impl.clj
 msgid "Results are too large to cache."
-msgstr "Los resultados son demasiado grandes para almacenar en caché."
+msgstr "Výsledky jsou příliš velké na mezipaměť."
 
 #: src/metabase/query_processor/middleware/cache/impl.clj
 msgid "Serialization timed out after {0}."
-msgstr "La serialización se agotó después de {0}."
+msgstr "Serializace vypršela po {0}."
 
 #: src/metabase/query_processor/middleware/cache/impl.clj
 msgid "Error parsing serialized results"
-msgstr "Error al analizar resultados serializados"
+msgstr "Chyba při ověřování serializovaných výsledků"
 
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
 msgid "Error purging old cache entries"
-msgstr "Error al eliminar entradas de caché antiguas"
+msgstr "Chyba při odstranění starých položek mezipaměti"
 
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
 msgid "Caching results for query with hash {0}."
-msgstr "Resultados de almacenamiento en caché para consulta con hash {0}."
+msgstr "Výsledky mezipaměti pro dotaz s hash-em {0}."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Cannot save QueryExecution, missing :context"
-msgstr "No se puede guardar QueryExecution, falta :context"
+msgstr "Nelze uložit QueryExecution, chybí :context"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Error saving query execution info"
-msgstr "Error al guardar la información de ejecución de la consulta"
+msgstr "Chyba při ukládání informací o provádění dotazu"
 
 #: src/metabase/query_processor/middleware/resolve_database_and_driver.clj
 msgid "Unable to resolve database for query: missing or invalid `:database` ID."
-msgstr "No se puede resolver la base de datos para la consulta: falta o no es válida la identificación `:database`."
+msgstr "Nepodařilo se rozpoznat databázi pro dotaz: chybný nebo neplatný `:database` ID."
 
 #: src/metabase/query_processor/middleware/resolve_database_and_driver.clj
 msgid "Unable to resolve driver for query"
-msgstr "No se puede resolver el controlador para la consulta"
+msgstr "Nepodařilo se rozpoznat ovladač pro dotaz"
 
 #: src/metabase/query_processor/middleware/resolve_referenced.clj
 msgid "Referenced question #{0} could not be found"
-msgstr "La pregunta de referencia #{0} no se ha podido encontrar"
+msgstr "Odkazovanou otázku #{0} se nepodařilo najít"
 
 #: src/metabase/query_processor/middleware/resolve_referenced.clj
 msgid "Referenced query is from a different database"
-msgstr "La consulta referenciada es de una base de datos diferente"
+msgstr "Odkazovaný dotaz pochází z jiné databáze"
 
 #: src/metabase/query_processor/middleware/resolve_referenced.clj
 msgid "This query has circular referencing sub-queries. "
-msgstr "Esta consulta tiene subconsultas de referencia circular."
+msgstr "Tento dotaz obsahuje cyklické referenční pod-dotazy. "
 
 #: src/metabase/query_processor/middleware/resolve_referenced.clj
 msgid "These questions seem to be part of the problem: \"{0}\" and \"{1}\"."
-msgstr "Estas preguntas parecen ser parte del problema: \"{0}\" y \"{1}\"."
+msgstr "Zdá se, že tyto otázky jsou součástí problému: \"{0}\" a \"{1}\"."
 
 #: src/metabase/query_processor/middleware/results_metadata.clj
 msgid "Error recording results metadata for query"
-msgstr "Error al registrar metadatos de resultados para consulta"
+msgstr "Chyba při zaznamenávání výsledků metadat dotazu"
 
 #: src/metabase/query_processor/streaming/xlsx.clj
 msgid "Query result"
-msgstr "Resultado consulta"
+msgstr "Výsledek dotazu"
 
 #: src/metabase/sync/analyze/query_results.clj
 msgid "Error generating insights for column:"
-msgstr "Error al generar información para la columna:"
+msgstr "Chyba při generování statistik pro sloupec:"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandonment email!"
-msgstr "Enviando correo electrónico de abandono!"
+msgstr "Odesíláme e-mail o opuštění účtu!"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
-msgstr "Puedes crear métricas guardadas para agregar una opción de métrica con nombre. Las métricas guardadas incluyen el tipo de agregación, el campo agregado y, opcionalmente, cualquier filtro que añadas. Como ejemplo, puedes usar esto para crear algo así como la forma oficial de calcular el \"Precio promedio\" para una tabla de pedidos."
+msgstr "Můžete vytvořit uložené metriky a přidat je do nabídky. Mezi uložené metriky patří typ agregace, agregované pole a případně jakýkoliv filtr, který přidáte. Například, můžete to použít k vytvoření něčeho jako oficiální způsob výpočtu \"průměrné ceny\" pro tabulku Objednávky."
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:105
 msgid "Select and add filters to create your new segment."
-msgstr "Selecciona y añade filtros para crear tu nuevo segmento."
+msgstr "Pro vytvoření Vašeho nového segmentu vyber a přidej filtry."
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
 msgid "Alphabetical"
-msgstr "Alfabético"
+msgstr "Abecední"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
 msgid "Smart"
-msgstr "Ingenioso"
+msgstr "Chytré"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
 msgid "Column order: {0}"
-msgstr "Orden de Columna: {0}"
+msgstr "Pořadí sloupců: {0}"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
 msgid "Unhide all"
-msgstr "Mostrar Todos"
+msgstr "Zobrazit vše"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:204
 msgid "Hide all"
-msgstr "Esconder Todos"
+msgstr "Skrýt vše"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:206
 msgid "Unhide"
-msgstr "Mostrar"
+msgstr "Zobrazit"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:22
 msgid "New metric"
-msgstr "Nueva métrica"
+msgstr "Nová metrika"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:45
 msgid "Create metrics to add them to the Summarize dropdown in the query builder"
-msgstr "Crea métricas para añadirlas al desplegable Resumir en el generador de consultas"
+msgstr "Vytvořte metriky pro jejich zobrazení ve tvůrci dotazů"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:22
 msgid "New segment"
-msgstr "Nuevo segmento"
+msgstr "Nový segment"
 
 #: frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx:71
 msgid "Filter by table"
-msgstr "Filtrar por tabla"
+msgstr "Filtrovat podle tabulky"
 
 #: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:64
 msgid "Checking HTTPS..."
-msgstr "Comprobando HTTPS..."
+msgstr "Ověřuji HTTPS..."
 
 #: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:66
 msgid "It looks like HTTPS is not properly configured"
-msgstr "Parece que HTTPS no está configurado correctamente"
+msgstr "Vypadá to, že HTTPS není správně nakonfigurované"
 
 #: frontend/src/metabase/admin/settings/selectors.js:57
 msgid "Redirect to HTTPS"
-msgstr "Redireccionar a HTTPS"
+msgstr "Přesměrovat na HTTPS"
 
 #: frontend/src/metabase/admin/settings/selectors.js:219
 msgid "Localization"
-msgstr "Localización"
+msgstr "Nastavení jazyka"
 
 #: frontend/src/metabase/admin/settings/selectors.js:222
 msgid "Instance language"
-msgstr "Idioma de Aplicación"
+msgstr "Jazyk rozhraní"
 
 #: frontend/src/metabase/admin/settings/selectors.js:237
 msgid "Localization options"
-msgstr "Opciones de localización"
+msgstr "Možnosti jazyka"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:51
 msgid "This database doesn't have any tables."
-msgstr "Esa base de datos no tiene ninguna tabla."
+msgstr "Tato databáze neobsahuje žádné tabulky"
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
 msgid "This field only accepts a single value because it's used in a SQL query."
-msgstr "Este campo solo acepta un valor único porque se usa en una consulta SQL."
+msgstr "V tomto poli může být pouze jedna hodnota, protože je použitá v SQL dotazu."
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:17
 msgid "Service Accounts"
-msgstr "Cuentas de servicio"
+msgstr "Servisní účty"
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:26
 msgid "Metabase connects to Big Query via {0}."
-msgstr "Metabase conecta con Big Query a través de {0}"
+msgstr "Metabase se připojuje k Big Query pomocí {0}."
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:29
 msgid "Continue using an OAuth application to connect"
-msgstr "Continúa usando una aplicación OAuth para conectarte"
+msgstr "Pokračovat v používání OAuth aplikace"
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:43
 msgid "We recommend switching to use {0} instead of an OAuth application to connect to BigQuery"
-msgstr "Recomendamos cambiar y usar {0} en lugar de una aplicación OAuth para conectarse a BigQuery"
+msgstr "Pro připojení k Big Query doporučujeme použít {0} namísto používání OAuth aplikace"
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:48
 msgid "Connect to a Service Account instead"
-msgstr "O conecta"
+msgstr "Raději se připojit za použití Servisního účtu"
 
 #: frontend/src/metabase/entities/databases/forms.js:44
 msgid "invalid JSON"
-msgstr "JSON Inválido"
+msgstr "nesprávný JSON"
 
 #: frontend/src/metabase/entities/databases/forms.js:50
 msgid "SSH private key"
-msgstr "LLave privada SSH"
+msgstr "SSH primární klíč"
 
 #: frontend/src/metabase/entities/databases/forms.js:51
 msgid "Paste the contents of your ssh private key here"
-msgstr "Pega el contenido de tu clave privada ssh aquí"
+msgstr "Vložte zde obsah svého SSH primárního klíče "
 
 #: frontend/src/metabase/entities/databases/forms.js:55
 msgid "Passphrase for the SSH private key"
-msgstr "Frase de contraseña para la clave privada SSH"
+msgstr "Přístupová fráze pro SSH privátní klíč"
 
 #: frontend/src/metabase/entities/databases/forms.js:58
 msgid "SSH Authentication"
-msgstr "Autentificación SSH"
+msgstr "SSH Autentizace"
 
 #: frontend/src/metabase/entities/databases/forms.js:60
 msgid "SSH Key"
-msgstr "Llave SSH"
+msgstr "SSH klíč"
 
 #: frontend/src/metabase/entities/databases/forms.js:65
 msgid "Server SSL certificate chain"
-msgstr "Cadena de certificados SSL del servidor"
+msgstr "Řetěz serverového SSL certifikátu"
 
 #: frontend/src/metabase/entities/databases/forms.js:66
 msgid "Paste the contents of the server's SSL certificate chain here"
-msgstr "Pega el contenido de la cadena de certificados SSL del servidor aquí"
+msgstr "Vložte zde obsah řetězce serverového SSL certifikátu"
 
 #: frontend/src/metabase/entities/databases/mongo-fields.js:11
 msgid "Paste a connection string"
-msgstr "Pegar una cadena de conexión"
+msgstr "Vložte připojovací řetězec"
 
 #: frontend/src/metabase/entities/databases/mongo-fields.js:12
 msgid "Fill out individual fields"
-msgstr "Rellena campos individuales"
+msgstr "Vyplňte individuální pole"
 
 #: frontend/src/metabase/entities/snippets.js:14
 msgid "Enter some SQL here so you can reuse it later"
-msgstr "Añade SQL aquí para que puedas reutilizarlo más tarde"
+msgstr "Napiš zde nějaký SQL, který můžeš později znovu použít"
 
 #: frontend/src/metabase/entities/snippets.js:24
 msgid "Give your snippet a name"
-msgstr "Dale un nombre a tu fragmento"
+msgstr "Pojmenujte svůj výstřižek"
 
 #: frontend/src/metabase/entities/snippets.js:25
 msgid "Current Customers"
-msgstr "Clientes Actuales"
+msgstr "Stávající zákazníci"
 
 #: frontend/src/metabase/entities/snippets.js:30
 msgid "Add a description"
-msgstr "Añadir una descripción"
+msgstr "Přidat popis"
 
 #: frontend/src/metabase/entities/users/forms.js:37
 msgid "Use site default"
-msgstr "Utilizar el valor por defecto del sitio"
+msgstr "Použít výchozí stránku"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "find"
-msgstr "encontrar"
+msgstr "najít"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
 msgid "replace"
-msgstr "sustituir"
+msgstr "nahradit"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
 msgid "The text to find."
-msgstr "El texto a encontrar."
+msgstr "Text k nalezení."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
 msgid "The text to use as the replacement."
-msgstr "El texto a utilizar para sustituir."
+msgstr "Text, který se má použít jako náhrada."
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
 msgid "Editing {0}"
-msgstr "Editando {0}"
+msgstr "Edituji {0}"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
 msgid "Create your new snippet"
-msgstr "Crea tu nuevo fragmento"
+msgstr "Vytvořte nový výstřižek"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
 msgid "Archived snippets"
-msgstr "Fragmentos archivados"
+msgstr "Archivované výstřižky"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
 msgid "Snippets are reusable bits of SQL"
-msgstr "Fragmentos son porciones de SQL reutilizables"
+msgstr "Výstřižky jsou oblíbené části SQL dotazů"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
 msgid "Create a snippet"
-msgstr "Crea un fragmento"
+msgstr "Vytvořte výstřižek"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets"
-msgstr "Fragmentos"
+msgstr "Výstřižky kódu"
 
 #: frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx:15
 msgid "SQL Snippets"
-msgstr "Fragmentos SQL"
+msgstr "SQL Výstřižky"
 
 #: frontend/src/metabase/setup/components/LanguageStep.jsx:38
 msgid "Your language is set to {0}"
-msgstr "Tu idioma es {0}"
+msgstr "Tvůj jazyk je nastaven na {0}"
 
 #: frontend/src/metabase/setup/components/LanguageStep.jsx:50
 msgid "What's your preferred language?"
-msgstr "¿Cuál es tu idioma preferido?"
+msgstr "Jaký je tvůj preferovaný jazyk?"
 
 #: frontend/src/metabase/setup/components/LanguageStep.jsx:54
 msgid "This language will be used throughout Metabase and will be the default for new users."
-msgstr "Este lenguaje se utilizará en Metabase y será el predeterminado para los nuevos usuarios."
+msgstr "Tento jazyk bude použit v celém Metabase a bude použit jako výchozí pro nové uživatele."
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:159
 msgid "We filtered out {0} row(s) containing null values."
-msgstr "Hemos filtrado {0} filas que contienen valores nulos."
+msgstr "Odfiltrovali jsme {0} záznam(ů) bez hodnoty."
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:133
 msgid "Show values for this series"
-msgstr "Mostrar valores para esta serie"
+msgstr "Zobraz hodnoty pro tuto řadu"
 
 #: src/metabase/api/card.clj
 msgid "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
-msgstr "La duración promedio de ejecución de la pregunta es {0}; usando el TTL ''mágico'' de {1}"
+msgstr "Průměrná doba trvání při provádění otázky je {0}; použitím ''magic'' TTL z {1}"
 
 #: src/metabase/api/native_query_snippet.clj
 msgid "A snippet with that name already exists. Please pick a different name."
-msgstr "Ya existe un fragmento con ese nombre. Por favor, elige un nombre diferente."
+msgstr "Výstřižek s tímto názvem již existuje. Zvolte jiný název."
 
 #: src/metabase/api/query_description.clj
 msgid "[Unknown Metric]"
-msgstr "[Métrica Desconocida]"
+msgstr "[Neznámá metrika]"
 
 #: src/metabase/api/query_description.clj
 msgid "[Unknown Segment]"
-msgstr "[Segmento Desconocido]"
+msgstr "[Neznámý segment]"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Error writing error to output stream"
-msgstr "Error al escribir error en la salida"
+msgstr "Chyba při zápisu chyby do výstupního streamu"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Caught unexpected Exception in streaming response body"
-msgstr "Excepción inesperada en el cuerpo de respuesta al transmitir"
+msgstr "Zachycena neočekávaná výjimka v těle odpovědi"
 
 #: src/metabase/async/streaming_response.clj
 msgid "bound-fn caught unexpected Exception"
-msgstr "Excepción inesperada en bound-fn"
+msgstr "bound-fn zachytil neočekávanou výjimku"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Error determining whether HTTP request was canceled"
-msgstr "Error al determinar si se canceló la solicitud HTTP"
+msgstr "Chyba při určování jestli byl HTTP požadavek zrušen"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Check cancelation status timed out after {0}"
-msgstr "Verificación del estado de cancelación agotado después de {0}"
+msgstr "Stav kontroly o zrušení vypršel po {0}"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Unexpected exception in do-f-async"
-msgstr "Excepción inesperada en do-f-async"
+msgstr "Neočekávaná výjimka v do-f-async"
 
 #: src/metabase/async/streaming_response.clj src/metabase/server.clj
 msgid "Unexpected exception writing error response"
-msgstr "Excepción inesperada al escribir respuesta de error"
+msgstr "Neočekávaná výjimka při zápisu chybové odpovědi"
 
 #: src/metabase/driver/common.clj
 msgid "Server certificate not trusted - did you specify the correct SSL certificate chain?"
-msgstr "Certificado de servidor no confiable: ¿especificó la cadena de certificados SSL correcta?"
+msgstr "Serverový certifikát není věrohodný - specifikovali jste správný SSL certifikační řetězec ?"
 
 #: src/metabase/driver/common.clj
 msgid "Server appears to require SSL - please enable SSL above"
-msgstr "Parece que el servidor requiere SSL; habilita SSL arriba"
+msgstr "Zdá se, že server potřebuje SSL - níže prosím aktivujte SSL"
 
 #: src/metabase/driver/common.clj
 msgid "Username"
-msgstr "Nombre Usuario"
+msgstr "Uživatelské jméno"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Don''t know how to parse parameter of type {0}"
-msgstr "No sé cómo analizar el parámetro de tipo {0}"
+msgstr "Nevím jak ověřit parametr typu {0}"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Invalid :card parameter: missing `:card-id`"
-msgstr ":card parameter: inválido, falta `:card-id`"
+msgstr "Neplatný :card parametr: chybí `:card-id`"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Unable to resolve Snippet: missing `:snippet-id`"
-msgstr "No se puede resolver el fragmento: falta `:snippet-id`"
+msgstr "Nelze rozpoznat výstřižek: chybí `:snippet-id`"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Snippet {0} {1} not found."
-msgstr "Fragmento {0} {1} no encontrado."
+msgstr "Výstřižek {0} {1} nenalezen"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Error determining value for parameter"
-msgstr "Error al determinar el valor del parámetro"
+msgstr "Chyba při zjišťování hodnoty pro parametr"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Error building query parameter map"
-msgstr "Error al generar el mapa de parámetros de consulta"
+msgstr "Chyba při vytváření mapy s parametry dotazu"
 
 #: src/metabase/middleware/log.clj
 msgid "ASYNC"
@@ -15033,169 +15070,168 @@ msgstr "ASYNC"
 
 #: src/metabase/middleware/log.clj
 msgid "{0} ({1} DB calls)"
-msgstr "{0} ({1} llamadas a la BBDD)"
+msgstr "{0} ({1} DB volání)"
 
 #: src/metabase/middleware/log.clj
 msgid "App DB connections: {0}/{1}"
-msgstr "Conexiones BBDD: {0}/{1}"
+msgstr "Spojení k aplikační DB: {0}/{1}"
 
 #: src/metabase/middleware/log.clj
 msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
-msgstr "Hilos Jetty: {0}/{1} ({2} esperando, {3} en cola)"
+msgstr "Vlákna Jetty: {0}/{1} ({2} nečinné, {3} v řadě)"
 
 #: src/metabase/middleware/log.clj
 msgid "({0} total active threads)"
-msgstr "({0} hilos totales activos)"
+msgstr "({0} celkem aktivních vláken)"
 
 #: src/metabase/middleware/log.clj
 msgid "Queries in flight: {0}"
-msgstr "Consultas en ejecución: {0}"
+msgstr "Dotazů v běhu: {0}"
 
 #: src/metabase/middleware/log.clj
 msgid "({0} queued)"
-msgstr "({0} en cola)"
+msgstr "({0} v řadě)"
 
 #: src/metabase/models/collection.clj
 msgid "Collection must be in the same namespace as its parent"
-msgstr "Una colección debe estar en el mismo espacio de nombres que su padre"
+msgstr "Kolekce musí být ve stejném jmenném prostoru jak jeho rodič"
 
 #: src/metabase/models/collection.clj
 msgid "Personal Collections must be in the default namespace"
-msgstr "Las colecciones personales deben estar en el espacio de nombres predeterminado"
+msgstr "Osobní kolekce musí být ve výchozím jmenném prostoru"
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection to a different namespace once it has been created."
-msgstr "No puedes mover una Colección a un espacio de nombres diferente una vez que se haya creado."
+msgstr "Nemůžete přesunout kolekci do jiného jmenného prostoru než ve kterém byla vytvořena."
 
 #: src/metabase/models/collection.clj src/metabase/models/permissions.clj
 msgid "Collection does not exist."
-msgstr "Colección no existe."
+msgstr "Kolekce neexistuje."
 
 #: src/metabase/models/collection.clj
 msgid "A {0} can only go in Collections in the {1} namespace."
-msgstr "Un {0} solo puede ir en Colecciones en el espacio de nombres {1}."
+msgstr "{0} může přejít pouze do kolekcí ve jmenném prostoru {1}."
 
 #: src/metabase/models/database.clj
 msgid "Error sending database deletion notification"
-msgstr "Error al enviar la notificación de eliminación de la base de datos"
+msgstr "Chyba při posílání notifikace o smazání databáze"
 
 #: src/metabase/models/native_query_snippet.clj
 msgid "You cannot update the creator_id of a NativeQuerySnippet."
-msgstr "No puedes actualizar el creator_id de un Fragmento Nativo."
+msgstr "Nemůžete aktualizovat creator_id z NativeQuerySnippet."
 
 #: src/metabase/models/setting.clj
 msgid "Error fetching value of Setting"
-msgstr "Error al recuperar el valor de la configuración"
+msgstr "Chyba při vyvolání hodnoty nastavení"
 
 #: src/metabase/public_settings.clj
 msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
-msgstr "El idioma que se debe usar para la interfaz de usuario de Metabase, correos electrónicos del sistema, pulsos y alertas."
+msgstr "Jazyk, který se má použít pro ovládací rozhraní Metabase, odesílané maily, pulzy a upozornění."
 
 #: src/metabase/public_settings.clj
 msgid "This is also the default language for all users, which they can change from their own account settings."
-msgstr "Este es también el idioma predeterminado para todos los usuarios, que pueden cambiar desde la configuración de su propia cuenta."
+msgstr "Toto je také výchozí jazyk všech uživatelů, ti si jej mohou změnit ve vlastním nastavení účtu."
 
 #: src/metabase/public_settings.clj
 msgid "Invalid locale {0}"
-msgstr "Configuración regional {0} no válida"
+msgstr "Neplatné umístění {0}"
 
 #: src/metabase/public_settings.clj
 msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
-msgstr "Forzar todo el tráfico a usar HTTPS a través de una redirección, si la URL del sitio es HTTPS"
+msgstr "Vynutit veškeré přenosy pomocí HTTPS přesměrování pokud je URL adresa serveru HTTPS"
 
 #: src/metabase/public_settings.clj
 msgid "Cannot redirect requests to HTTPS unless `site-url` is HTTPS."
-msgstr "No se pueden redirigir solicitudes a HTTPS a menos que `site-url` sea HTTPS."
+msgstr "Nelze přesměrovat požadavky na HTTPS pokud není `site-url` HTTPS."
 
 #: src/metabase/pulse/render/png.clj
 msgid "Error registering fonts: Metabase will not be able to send Pulses."
-msgstr "Error al registrar fuentes: Metabase no podrá enviar pulsos."
+msgstr "Chyba při registraci fontů: Matabase nebude moci posílat Pulzy."
 
 #: src/metabase/pulse/render/png.clj
 msgid "This is a known issue with certain JVMs. See {0} and for more details."
-msgstr "Este es un problema conocido con ciertas JVM. Ver {0} para más detalles."
+msgstr "Toto je známý problém s některými JVM. Navštivte {0} pro více detailů."
 
 #: src/metabase/pulse/render/png.clj
 msgid "Error rendering Pulse"
-msgstr "Error al procesar el pulso"
+msgstr "Chyba při vykreslování Pulzu"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Query timed out after {0}, raising timeout exception."
-msgstr "La consulta expiró después de {0}, generando una excepción de tiempo de espera."
+msgstr "Dotaz vypršel po {0}, vyvolávám výjimku o vypršení."
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "No fields found for table {0}."
-msgstr "No se encontraron campos para la tabla {0}."
+msgstr "Žádné pole nenalezeno pro tabulku {0}."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Case"
-msgstr "Caso"
+msgstr "Případ"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Variance of {0}"
-msgstr "Varianza de {0}"
+msgstr "Rozptyl z {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Median of {0}"
-msgstr "Mediana de {0}"
+msgstr "Medián z {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "{0}th percentile of {1}"
-msgstr "percentil {0} de {1}"
+msgstr "{0} percentil z {1}"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Not caching results: results are larger than {0} KB"
-msgstr "No se hará uso del almacenamiento en caché ya que los resultados son mayores de {0} KB"
+msgstr "Neukládám výsledky do mezipaměti: jsou vetší než {0} KB"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Cannot cache results: expected byte array, got {0}"
-msgstr "No se pueden almacenar los resultados en caché: esperaba una matriz de bytes, pero se obtuvo {0}"
+msgstr "Nelze uložit výsledky do mezipaměti: bylo očekáváno bitové pole, přijato {0}"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Request is closed; no one to return cached results to"
-msgstr "La solicitud está cerrada; nadie a quien devolver los resultados almacenados en caché"
+msgstr "Požadavek byl uzavřen: nikdo nevrátil výsledky mezipaměti do"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Error attempting to fetch cached results for query with hash {0}"
-msgstr "Error al intentar obtener resultados en caché para la consulta con el hash {0}"
+msgstr "Chyba při získání výsledků z mezipaměti pro dotaz s hashem {0}"
 
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
 msgid "Error preparing statement to fetch cached query results"
-msgstr "Error al preparar la declaración para recuperar resultados de consultas en caché"
+msgstr "Chyba při přípravě soupisu pro získání výsledků z mezipaměti"
 
 #: src/metabase/query_processor/middleware/catch_exceptions.clj
 msgid "Error processing query: {0}"
-msgstr "Error procesando consulta: {0}"
+msgstr "Chyba při zpracování dotazu: {0}"
 
 #: src/metabase/server.clj
 msgid "Unexpected exception in endpoint"
-msgstr "Excepción inesperada en la llamada"
+msgstr "Neočekávaná výjimka v koncovém bodě"
 
 #: src/metabase/server.clj
 msgid "Unexpected Exception in API request handler"
-msgstr "Excepción inesperada en el controlador de solicitud de API"
+msgstr "Neočekávaná výjimka ve zpracovateli API požadavků"
 
 #: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
 msgid "Error reducing {0}"
-msgstr "Error reduciendo {0}"
+msgstr "Chyba při redukování {0}"
 
 #: src/metabase/sync/analyze/fingerprint/insights.clj
 msgid "Error generating timeseries insight keyed by: {0}"
-msgstr "Error al generar información de series de tiempo con clave: {0}"
+msgstr "Chyba při generování vhledu časových sériích pomocí: {0}"
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "La posición de {0} en la base de datos ha cambiado de ''{1}'' a ''{2}''."
+msgstr "Pozice databáze {0} se změnila z ''{1}'' do ''{2}''."
 
 #: src/metabase/task/sync_databases.clj
 msgid "Unscheduling task for Database {0}: trigger: {1}"
-msgstr "Quitando la tarea de la base de datos {0}: activador: {1}"
+msgstr "Ruším plán úlohy pro databázi {0}: spouštěč: {1}"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a keyword or string."
-msgstr "El valor debe ser una palabra clave o una cadena."
+msgstr "hodnota musí být klíčové slovo nebo řetězec."
 
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
-msgstr "La cadena debe ser un idioma ISO válido de dos letras o un código de idioma-país, p.e. 'en' o 'en_US'."
-
+msgstr "Řetězec musí být platné označení jazyka dle ISO např. 'en' nebo 'en_US'."

--- a/locales/de.po
+++ b/locales/de.po
@@ -29,13 +29,14 @@ msgid "Select a database type"
 msgstr "Wähle einen Datenbanktyp"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:411
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:154
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -48,7 +49,7 @@ msgstr "Speichern"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "Damit Metabase etwas seiner Magie entfalten kann, muss deine Datenbank untersucht werden. Als dann werden wir sie periodisch prüfen, um die Metadaten aktuell zu halten. Du kannst den Zeitpunkt dieses Scans unten festlegen."
 
-#: frontend/src/metabase/entities/databases/forms.js:221
+#: frontend/src/metabase/entities/databases/forms.js:290
 msgid "Database syncing"
 msgstr "Datenbank-Synchronisierung"
 
@@ -63,7 +64,7 @@ msgstr "Dieser Prozess prüft regelmäßig auf Updates der Schemata. Zumeist kan
 msgid "Scan"
 msgstr "Scannen"
 
-#: frontend/src/metabase/entities/databases/forms.js:228
+#: frontend/src/metabase/entities/databases/forms.js:297
 msgid "Scanning for Filter Values"
 msgstr "Nach Filterwerten scannen"
 
@@ -74,7 +75,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase kann Werte eines jeden Feldes der Datenbank prüfen, um Checkboxen in Dashboards und Fragen zu ermöglichen. Dies kann insbesondere für größere Datenbank ein ressourenintensiver Prozess sein."
 
-#: frontend/src/metabase/entities/databases/forms.js:232
+#: frontend/src/metabase/entities/databases/forms.js:301
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Wann soll Metabase Felder automatisch prüfen und Werte puffern?"
 
@@ -96,6 +97,7 @@ msgid "Never, I'll do this manually if I need to"
 msgstr "Niemals, ich werde das manuell machen, falls nötig"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 msgid "Saving..."
@@ -132,9 +134,9 @@ msgid "in this box:"
 msgstr "in dieses Eingabefeld:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:75
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
@@ -151,18 +153,18 @@ msgstr "in dieses Eingabefeld:"
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:301
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:39
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:90
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:99
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:311
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:328
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -179,7 +181,7 @@ msgstr "Löschen"
 #: frontend/src/metabase/admin/permissions/selectors.js:323
 #: frontend/src/metabase/admin/permissions/selectors.js:330
 #: frontend/src/metabase/admin/permissions/selectors.js:441
-#: frontend/src/metabase/admin/routes.jsx:57
+#: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
@@ -199,9 +201,10 @@ msgid "Scheduling"
 msgstr "Planung"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:71
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
@@ -209,8 +212,8 @@ msgid "Save changes"
 msgstr "Änderungen speichern"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:203
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:35
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
 msgstr "Aktionen"
 
@@ -223,8 +226,8 @@ msgstr "Datenbankschema synchronisieren"
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:90
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:98
 msgid "Starting…"
 msgstr "Starten…"
 
@@ -242,13 +245,13 @@ msgstr "Prüfe Feldwerte erneut"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
 msgstr "Scan konnte nicht gestartet werden"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:92
 msgid "Scan triggered!"
 msgstr "Scan gestartet!"
 
@@ -271,15 +274,15 @@ msgid "Add database"
 msgstr "Datenbank hinzufügen"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:28
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:28
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
 #: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:195
+#: frontend/src/metabase/entities/databases/forms.js:264
 #: frontend/src/metabase/entities/questions.js:86
 #: frontend/src/metabase/entities/questions.js:102
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
@@ -319,6 +322,7 @@ msgstr "Erfolgreich gespeichert!"
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Bearbeiten"
@@ -361,44 +365,43 @@ msgstr "Fehlgeschlagen"
 msgid "Success"
 msgstr "Erfolgreich"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:185
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Vorschau"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:93
 msgid "No column description yet"
 msgstr "Keine Spaltenbeschreibung"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:127
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:126
 msgid "Select a field visibility"
 msgstr "Wähle die Sichtbarkeit des Feldes"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:187
 msgid "No special type"
 msgstr "Kein spezieller Typ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
 #: frontend/src/metabase/lib/core.js:275
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:44
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:37
 msgid "Other"
 msgstr "Andere"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:221
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Wähle ein speziellen Typ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:255
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:262
 #: frontend/src/metabase/reference/components/Field.jsx:99
 msgid "Select a target"
 msgstr "Wähle ein Ziel"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
@@ -406,18 +409,18 @@ msgstr "Wähle ein Ziel"
 msgid "Columns"
 msgstr "Spalten"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Spalte"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:144
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:288
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
 msgid "Visibility"
 msgstr "Sichtbarkeit"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
 msgid "Type"
 msgstr "Typ"
 
@@ -425,7 +428,7 @@ msgstr "Typ"
 msgid "Current database:"
 msgstr "Aktuelle Datenbank:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
 msgid "Show original schema"
 msgstr "Originalschema anzeigen"
 
@@ -447,27 +450,27 @@ msgid_plural "{0} schemas"
 msgstr[0] "{0} Schema"
 msgstr[1] "{0} Schemen"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:99
 msgid "Why Hide?"
 msgstr "Warum verbergen?"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:100
 msgid "Technical Data"
 msgstr "Technische Daten"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
 msgstr "Irrelevant"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 msgid "Queryable"
 msgstr "Abfragbar"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:108
 msgid "Hidden"
 msgstr "Versteckt"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136
 msgid "No table description yet"
 msgstr "Keine Tabellenbeschreibung"
 
@@ -475,32 +478,33 @@ msgstr "Keine Tabellenbeschreibung"
 msgid "Metadata Strength"
 msgstr "Metadatenstärke"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0} Abfragbare Tabelle"
 msgstr[1] "{0} Abfragbare Tabellen"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:91
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} Verborgene Tabelle"
 msgstr[1] "{0} Verborgene Tabellen"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:115
 msgid "Find a table"
 msgstr "Finde eine Tabelle"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:128
 msgid "Schemas"
 msgstr "Schemata"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:838
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:21
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:43
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:62
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 msgid "Metrics"
 msgstr "Metrik"
@@ -509,8 +513,8 @@ msgstr "Metrik"
 msgid "Add a Metric"
 msgstr "Hinzufügen einer Metrik"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "Definition"
@@ -519,12 +523,12 @@ msgstr "Definition"
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "Erstelle Metriken, um diese einer Liste in der Ansicht des Abfragengenerators hinzuzufügen"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:21
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
 #: frontend/src/metabase/home/containers/SearchApp.jsx:72
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:961
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:61
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Segmente"
@@ -533,35 +537,35 @@ msgstr "Segmente"
 msgid "Add a Segment"
 msgstr "Hinzufügen eines Segments"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:51
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:45
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "Erstelle Segmente, um diese einer Liste in der Ansicht des Abfragengenerators hinzuzufügen"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:21
 msgid "created"
 msgstr "erstellt"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "reverted to a previous version"
 msgstr "frühere Version wiederhergestellt"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:30
 msgid "edited the title"
 msgstr "Titel bearbeiten"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:32
 msgid "edited the description"
 msgstr "Beschreibung bearbeiten"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:34
 msgid "edited the "
 msgstr "Bearbeitete "
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:40
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "made some changes"
 msgstr "einige Änderungen vorgenommen"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
 #: frontend/src/metabase/home/components/Activity.jsx:83
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
@@ -571,84 +575,84 @@ msgstr "Du"
 msgid "Datamodel"
 msgstr "Datenmodell"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:41
 msgid " History"
 msgstr " Geschichte"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
 msgstr "Revisionshistorie für"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:228
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
 msgid "{0} – Field Settings"
 msgstr "{0} - Feldeinstellungen"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:289
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
 msgid "Where this field will appear throughout Metabase"
 msgstr "Wo dieses Feld in Metabase erscheint"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:311
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
 msgid "Filtering on this field"
 msgstr "Filtern des Feldes"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:312
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Welche Eingaben sollen Benutzer tätigen, wenn sie das Feld filtern möchten?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:437
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
 msgid "No description for this field yet"
 msgstr "Keine Beschreibung für dieses Feld"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
 msgid "Original value"
 msgstr "Originalwert"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:390
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
 msgid "Mapped value"
 msgstr "Zugeordneter Wert"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
 msgid "Enter value"
 msgstr "Wert eingeben"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use original value"
 msgstr "Originalwert verwenden"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Use foreign key"
 msgstr "Verwenden eines Fremdschlüssels"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 msgid "Custom mapping"
 msgstr "Eigene Zuordnung"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
 msgid "Unrecognized mapping type"
 msgstr "Unbestimmter Zuordnungstyp"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Aktuelles Feld ist kein Fremdschlüssel oder es fehlen Metadaten der Fremdschlüssel-Zieltabellen"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
 msgid "The selected field isn't a foreign key"
 msgstr "Das ausgewählte Feld ist kein Fremdschlüssel"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:327
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
 msgid "Display values"
 msgstr "Anzeigewerte"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:328
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Wähle diese Option, um den ursprünglichen Wert aus der Datenbank anzuzeigen, oder lasse dir die zugehörigen oder benutzerdefinierten Informationen in diesem Feld anzeigen."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:278
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
 msgid "Choose a field"
 msgstr "Wähle ein Feld"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:299
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
 msgid "Please select a column to use for display."
 msgstr "Bitte wähle eine anzuzeigende Spalte."
 
@@ -656,16 +660,16 @@ msgstr "Bitte wähle eine anzuzeigende Spalte."
 msgid "Tip:"
 msgstr "Hinweis:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:443
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Möglicherweise möchtest du den Feldnamen aktualisieren, um sicherzustellen, dass er auf der Grundlage deiner Umstellungen noch sinnvoll ist."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:344
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Gepufferte Feldwerte"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:345
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase kann die Werte für dieses Feld prüfen, um Listenfitler für Dashboards und Fragen zu aktivieren."
 
@@ -674,53 +678,53 @@ msgid "Re-scan this field"
 msgstr "Dieses Feld erneut scannen"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
 msgstr "Verwerfen von zwischengespeicherten Feldwerten"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
 msgstr "Werte konnten nicht verworfen werden"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 msgid "Discard triggered!"
 msgstr "Verwerfen gestartet!"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Wähle eine beliebige Tabelle aus, um ihr Schema anzuzeigen und Metadaten hinzuzufügen oder zu bearbeiten."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:36
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "Name ist erforderlich"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:39
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "Beschreibung ist erforderlich"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:43
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Änderungstext ist erforderlich"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
 msgid "Aggregation is required"
 msgstr "Aggregation ist erforderlich"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Edit Your Metric"
 msgstr "Editieren Deiner Metrik"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Create Your Metric"
 msgstr "Erstellen Deiner Metrik"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Nimm Änderungen an deiner Metrik vor und hinterlasse eine Erläuterung."
 
@@ -728,62 +732,62 @@ msgstr "Nimm Änderungen an deiner Metrik vor und hinterlasse eine Erläuterung.
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Du kannst gespeicherte Metriken erstellen, um dieser Tabelle eine benannte Metrikoption hinzuzufügen. Gespeicherte Metriken umfassen den Aggregationstyp, das aggregierte Feld und optional jeden von dir hinzugefügten Filter. Als Beispiel kannst du damit so etwas wie die offizielle Art der Berechnung des \"Durchschnittspreises\" für eine Bestell-Tabelle erstellen."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:180
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
 msgid "Result: "
 msgstr "Ergebnis: "
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
 msgid "Name Your Metric"
 msgstr "Benenne Deine Metrik"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:190
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Give your metric a name to help others find it."
 msgstr "Benenne Deine Metrik, um anderen zu helfen, sie zu finden."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:194
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:152
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Eine Beschreibung, aber nicht zu lang"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:198
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
 msgid "Describe Your Metric"
 msgstr "Beschreibe Deine Metrik"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:199
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Gib deiner Metrik eine Beschreibung, damit andere verstehen, worum es geht."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:203
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Dies ist ein guter Ort, um genauer auf weniger offensichtliche metrische Regeln einzugehen"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:207
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:165
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Grund der Änderung"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:209
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Hinterlasse eine Notiz, um zu erklären, welche Änderungen du vorgenommen hast und warum sie erforderlich waren."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:213
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Dies wird in der Revisionshistorie für diese Metrik angezeigt, damit sich jeder daran erinnern kann, warum sich die Dinge geändert haben"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
 msgstr "Mindestens ein Filter ist erforderlich"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
 msgstr "Abschnitt bearbeiten"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
 msgstr "Abschnitt erstellen"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Nimm Änderungen an deinem Segment vor und hinterlasse eine Erläuterung."
 
@@ -791,33 +795,33 @@ msgstr "Nimm Änderungen an deinem Segment vor und hinterlasse eine Erläuterung
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "Um ein neues Segment für die {0} Tabelle zu erstellen, wähle einen Filter und füge diesen hinzu"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
 msgstr "Abschnitt benennen"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:148
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
 msgstr "Benenne Dein Segment, um anderen zu helfen, sie zu finden."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:156
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
 msgstr "Abschnitt beschreiben"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Gib deinem Segment eine Beschreibung, damit andere verstehen, worum es geht."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "Dies ist ein guter Ort, um etwas genauer auf weniger offensichtliche Segmentregeln einzugehen"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "Dies wird in der Revisionshistorie für dieses Segment angezeigt, damit sich jeder daran erinnern kann, warum sich die Dinge geändert haben"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
-#: frontend/src/metabase/admin/routes.jsx:132
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:215
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
+#: frontend/src/metabase/admin/routes.jsx:137
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
@@ -825,11 +829,11 @@ msgstr "Dies wird in der Revisionshistorie für dieses Segment angezeigt, damit 
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase kann die Werte in dieser Tabelle scannen, um Listenfilter in Dashboards und Fragen zu aktivieren."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
 msgstr "Diese Tabelle erneut scannen"
 
@@ -843,11 +847,11 @@ msgstr "Hinzufügen"
 msgid "Not a valid formatted email address"
 msgstr "Keine gültige formatierte E-Mail-Adresse"
 
-#: frontend/src/metabase/entities/users/forms.js:12
+#: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
 msgstr "Vorname"
 
-#: frontend/src/metabase/entities/users/forms.js:18
+#: frontend/src/metabase/entities/users/forms.js:20
 msgid "Last name"
 msgstr "Nachname"
 
@@ -887,10 +891,10 @@ msgstr "Mitglieder"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
-#: frontend/src/metabase/admin/settings/selectors.js:120
-#: frontend/src/metabase/entities/users/forms.js:24
+#: frontend/src/metabase/admin/settings/selectors.js:121
+#: frontend/src/metabase/entities/users/forms.js:26
 #: frontend/src/metabase/lib/core.js:146
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:294
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:298
 msgid "Email"
 msgstr "E-Mail"
 
@@ -899,14 +903,14 @@ msgid "A group is only as good as its members."
 msgstr "Eine Gruppe ist nur so gut wie ihre Mitglieder."
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
-#: frontend/src/metabase/admin/routes.jsx:52
+#: frontend/src/metabase/admin/routes.jsx:55
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Admin"
 msgstr "Administrator"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:241
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:299
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:288
 msgid "and"
 msgstr "Und"
 
@@ -959,12 +963,12 @@ msgstr "Gruppe löschen"
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:42
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:294
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:397
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:317
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:334
 msgid "Done"
 msgstr "Fertig"
 
@@ -975,8 +979,9 @@ msgstr "Gruppenname"
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
-#: frontend/src/metabase/admin/routes.jsx:92
+#: frontend/src/metabase/admin/routes.jsx:97
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Gruppen"
 
@@ -1006,7 +1011,7 @@ msgstr "Deaktivieren"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:21
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
-#: frontend/src/metabase/admin/routes.jsx:88
+#: frontend/src/metabase/admin/routes.jsx:93
 #: frontend/src/metabase/nav/containers/Navbar.jsx:235
 msgid "People"
 msgstr "Mitglieder"
@@ -1318,25 +1323,25 @@ msgstr "Sammlung ansehen"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:542
+#: frontend/src/metabase/admin/permissions/selectors.js:558
 msgid "Data Access"
 msgstr "Datenzugriff"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:667
-#: frontend/src/metabase/admin/permissions/selectors.js:672
+#: frontend/src/metabase/admin/permissions/selectors.js:665
+#: frontend/src/metabase/admin/permissions/selectors.js:670
 msgid "View tables"
 msgstr "Tabellen ansehen"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:608
+#: frontend/src/metabase/admin/permissions/selectors.js:606
 msgid "SQL Queries"
 msgstr "SQL Queries"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:678
+#: frontend/src/metabase/admin/permissions/selectors.js:676
 msgid "View schemas"
 msgstr "Schemas ansehen"
 
-#: frontend/src/metabase/admin/routes.jsx:63
+#: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
 msgstr "Datenmodell"
@@ -1366,20 +1371,24 @@ msgid "Allows users within your LDAP directory to log in to Metabase with their 
 msgstr "Ermöglicht Benutzern innerhalb deines LDAP-Verzeichnisses, sich mit ihren LDAP-Anmeldeinformationen bei Metabase anzumelden und ein automatisches Zuordnen von LDAP- zu Metabase-Gruppen vorzunehmen."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:19
-#: frontend/src/metabase/admin/settings/selectors.js:167
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
+#: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
 msgstr "Dies ist keine valide E-Mail-Adresse"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
 msgstr "Dies ist keine valide Ganzzahl"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
 msgstr "Änderungen gespeichert!"
 
-#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:178
+#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
 msgid "Looks like we ran into some problems"
 msgstr "Sieht so aus, als wären wir auf ein paar Probleme gestoßen"
 
@@ -1401,7 +1410,7 @@ msgstr "Löschen"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:195
+#: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Authentifizierung"
 
@@ -1453,15 +1462,15 @@ msgstr "Deine Google client ID"
 msgid "Allow users to sign up on their own if their Google account email address is from:"
 msgstr "Erlaube Benutzern sich selbst zu registrieren, wenn deren Google Account von folgender E-Mail-Adresse stammt:"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:242
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:249
 msgid "Answers sent right to your Slack #channels"
 msgstr "Antworten werden direkt an deinen Slack #Kanal gesendet"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:251
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:258
 msgid "Create a Slack Bot User for MetaBot"
 msgstr "Erstelle einen Slack Bot Benutzer für MetaBot"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:261
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:268
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "Sobald du angekommen bist, gib ihm einen Namen und klicke auf {0}. Kopiere alsdann den Bot-API-Token und füge diesen in das Feld unten ein. Sobald du fertig bist, erstelle einen \"metabase_files\"-Kanal in Slack. Metabase benötigt diesen, um Grafiken hochzuladen."
 
@@ -1474,8 +1483,8 @@ msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Metabase {0} ist verfügbar. Du verwendest Version {1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:41
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 msgid "Update"
 msgstr "Update"
 
@@ -1502,16 +1511,16 @@ msgstr "Lösche individuelle Karte"
 #: frontend/src/metabase/containers/Overworld.jsx:293
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:115
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Löschen"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:165
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:141
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
 msgstr "Wähle…"
 
@@ -1695,48 +1704,46 @@ msgid "Generate Key"
 msgstr "Generiere Schlüssel"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:87
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:18
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enabled"
 msgstr "Aktiviert"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:92
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:19
+#: frontend/src/metabase/admin/settings/selectors.js:93
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Deaktiviert"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:112
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:113
 msgid "Unknown setting {0}"
 msgstr "Unbekannte Einstellung {0}"
 
-#: frontend/src/metabase/admin/settings/selectors.js:34
+#: frontend/src/metabase/admin/settings/selectors.js:37
 msgid "Setup"
 msgstr "Einstellungen"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:207
-#: frontend/src/metabase/admin/settings/selectors.js:39
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:214
+#: frontend/src/metabase/admin/settings/selectors.js:42
 msgid "General"
 msgstr "Allgemein"
 
-#: frontend/src/metabase/admin/settings/selectors.js:43
+#: frontend/src/metabase/admin/settings/selectors.js:46
 msgid "Site Name"
 msgstr "Site Name"
 
-#: frontend/src/metabase/admin/settings/selectors.js:48
+#: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Site URL"
 msgstr "Site URL"
 
-#: frontend/src/metabase/admin/settings/selectors.js:53
+#: frontend/src/metabase/admin/settings/selectors.js:64
 msgid "Email Address for Help Requests"
 msgstr "E-Mail-Adresse für Hilfeanfragen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:58
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
 msgstr "Zeitzone der Reporte"
 
-#: frontend/src/metabase/admin/settings/selectors.js:61
+#: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
 msgstr "Datenbank Standard"
 
@@ -1744,11 +1751,11 @@ msgstr "Datenbank Standard"
 msgid "Select a timezone"
 msgstr "Wähle eine Zeitzone"
 
-#: frontend/src/metabase/admin/settings/selectors.js:64
+#: frontend/src/metabase/admin/settings/selectors.js:75
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "Nicht alle Datenbanken unterstützen Zeitzonen. In diesem Fall wird diese Einstellung nicht wirksam."
 
-#: frontend/src/metabase/admin/settings/selectors.js:69
+#: frontend/src/metabase/entities/users/forms.js:34
 msgid "Language"
 msgstr "Sprache"
 
@@ -1756,64 +1763,64 @@ msgstr "Sprache"
 msgid "Select a language"
 msgstr "Wähle eine Sprache"
 
-#: frontend/src/metabase/admin/settings/selectors.js:79
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
 msgstr "Anonymes Tracking"
 
-#: frontend/src/metabase/admin/settings/selectors.js:84
+#: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
 msgstr "Sprechende Tabellen- und Feldnamen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:90
+#: frontend/src/metabase/admin/settings/selectors.js:91
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Ersetze nur Unterstriche und Bindestriche durch Leerzeichen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:98
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Enable Nested Queries"
 msgstr "Aktiviere verschachtelte Abfragen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:109
+#: frontend/src/metabase/admin/settings/selectors.js:110
 msgid "Updates"
 msgstr "Updates"
 
-#: frontend/src/metabase/admin/settings/selectors.js:114
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
 msgstr "Auf Updates prüfen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:125
+#: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
 msgstr "SMTP Host"
 
-#: frontend/src/metabase/admin/settings/selectors.js:133
+#: frontend/src/metabase/admin/settings/selectors.js:134
 msgid "SMTP Port"
 msgstr "SMTP Port"
 
-#: frontend/src/metabase/admin/settings/selectors.js:137
+#: frontend/src/metabase/admin/settings/selectors.js:138
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:47
 msgid "That's not a valid port number"
 msgstr "Dies ist keine valide Portnummer"
 
-#: frontend/src/metabase/admin/settings/selectors.js:141
+#: frontend/src/metabase/admin/settings/selectors.js:142
 msgid "SMTP Security"
 msgstr "SMTP Sicherheit"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:150
 msgid "SMTP Username"
 msgstr "SMTP Benutzername"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "SMTP Password"
 msgstr "SMTP Passwort"
 
-#: frontend/src/metabase/admin/settings/selectors.js:163
+#: frontend/src/metabase/admin/settings/selectors.js:164
 msgid "From Address"
 msgstr "Absenderadresse"
 
-#: frontend/src/metabase/admin/settings/selectors.js:176
+#: frontend/src/metabase/admin/settings/selectors.js:178
 msgid "Slack API Token"
 msgstr "Slack API Token"
 
-#: frontend/src/metabase/admin/settings/selectors.js:178
+#: frontend/src/metabase/admin/settings/selectors.js:180
 msgid "Enter the token you received from Slack"
 msgstr "Gebe den Token ein, den du von Slack erhalten hast"
 
@@ -1842,8 +1849,10 @@ msgid "Username or DN"
 msgstr "Benutzername oder DN"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:43
+#: frontend/src/metabase/entities/databases/forms.js:61
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:64
-#: frontend/src/metabase/user/components/UserSettings.jsx:65
+#: frontend/src/metabase/user/components/UserSettings.jsx:66
+#: src/metabase/driver/common.clj
 msgid "Password"
 msgstr "Passwort"
 
@@ -1879,79 +1888,79 @@ msgstr "Synchronisiere Gruppen-Mitgliedschaften"
 msgid "Group search base"
 msgstr "Gruppen-Suchbasis"
 
-#: frontend/src/metabase/admin/settings/selectors.js:199
+#: frontend/src/metabase/admin/settings/selectors.js:201
 msgid "Maps"
 msgstr "Karten"
 
-#: frontend/src/metabase/admin/settings/selectors.js:203
+#: frontend/src/metabase/admin/settings/selectors.js:205
 msgid "Map tile server URL"
 msgstr "Karten-Server-URL"
 
-#: frontend/src/metabase/admin/settings/selectors.js:204
+#: frontend/src/metabase/admin/settings/selectors.js:206
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Metabase nutzt standardmäßig OpenStreetMaps."
 
-#: frontend/src/metabase/admin/settings/selectors.js:209
+#: frontend/src/metabase/admin/settings/selectors.js:211
 msgid "Custom Maps"
 msgstr "Eigene Karten"
 
-#: frontend/src/metabase/admin/settings/selectors.js:210
+#: frontend/src/metabase/admin/settings/selectors.js:212
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Füge deine eigene GeoJSON Datei hinzu, um verschiedene Kartenvisualisierungen zu aktivieren"
 
-#: frontend/src/metabase/admin/settings/selectors.js:228
+#: frontend/src/metabase/admin/settings/selectors.js:245
 msgid "Public Sharing"
 msgstr "Öffentliches Teilen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:232
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "Enable Public Sharing"
 msgstr "Aktiviere Öffentliches Teilen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:254
 msgid "Shared Dashboards"
 msgstr "Geteilte Dashboards"
 
-#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Shared Questions"
 msgstr "Geteilte Fragen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:250
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Embedding in other Applications"
 msgstr "Einbettung in andere Applikationen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:276
+#: frontend/src/metabase/admin/settings/selectors.js:293
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Aktivieren die Einbettung von Metabase in andere Applikationen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:286
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Embedding secret key"
 msgstr "Einbetten des geheimen Schlüssels"
 
-#: frontend/src/metabase/admin/settings/selectors.js:292
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Embedded Dashboards"
 msgstr "Eingebettete Dashboards"
 
-#: frontend/src/metabase/admin/settings/selectors.js:298
+#: frontend/src/metabase/admin/settings/selectors.js:315
 msgid "Embedded Questions"
 msgstr "Eingebettete Fragen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:322
 msgid "Caching"
 msgstr "Caching"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:326
 msgid "Enable Caching"
 msgstr "Aktiviere Caching"
 
-#: frontend/src/metabase/admin/settings/selectors.js:314
+#: frontend/src/metabase/admin/settings/selectors.js:331
 msgid "Minimum Query Duration"
 msgstr "Minimale Abfragedauer"
 
-#: frontend/src/metabase/admin/settings/selectors.js:321
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Cache Time-To-Live (TTL) Multiplikator"
 
-#: frontend/src/metabase/admin/settings/selectors.js:328
+#: frontend/src/metabase/admin/settings/selectors.js:345
 msgid "Max Cache Entry Size"
 msgstr "Max Cachegröße"
 
@@ -1979,7 +1988,7 @@ msgstr "Passwörter stimmen nicht überein"
 
 #: frontend/src/metabase/auth/components/BackToLogin.jsx:6
 msgid "Back to login"
-msgstr "Zurück zum login"
+msgstr "Zurück zum Login"
 
 #: frontend/src/metabase/auth/components/GoogleNoAccount.jsx:15
 msgid "No Metabase account exists for this Google account."
@@ -2118,7 +2127,8 @@ msgstr "Alle Dashboards, Sammlungen und Pulses in dieser Sammlung werden auch ar
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/routes.jsx:205
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
+#: frontend/src/metabase/routes.jsx:196
 msgid "Archive"
 msgstr "Archiv"
 
@@ -2134,21 +2144,21 @@ msgstr "Sieh dir das Archiv an"
 msgid "Unarchive this {0}"
 msgstr "Stelle Archiv {0} wieder her"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:39
-#: frontend/src/metabase/components/BrowseApp.jsx:102
-#: frontend/src/metabase/components/BrowseApp.jsx:194
+#: frontend/src/metabase/components/BrowseApp.jsx:46
+#: frontend/src/metabase/components/BrowseApp.jsx:112
+#: frontend/src/metabase/components/BrowseApp.jsx:204
 #: frontend/src/metabase/containers/Overworld.jsx:270
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
 msgstr "Unsere Daten"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:146
+#: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
 msgid "X-ray this table"
 msgstr "X-Ray für diese Tabelle"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:161
+#: frontend/src/metabase/components/BrowseApp.jsx:171
 msgid "Learn about this table"
 msgstr "Lerne etwas über diese Tabelle"
 
@@ -2243,7 +2253,7 @@ msgstr "Pins"
 msgid "Drag something here to pin it to the top"
 msgstr "Ziehe etwas hierher, um es oben anzupinnen"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:755
+#: frontend/src/metabase/admin/permissions/selectors.js:753
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2297,7 +2307,7 @@ msgstr "Neue Sammlung"
 msgid "Copied!"
 msgstr "Kopiert!"
 
-#: frontend/src/metabase/entities/databases/forms.js:12
+#: frontend/src/metabase/entities/databases/forms.js:14
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Benutze einen SSH-Tunnel für Datenbankverbindungen"
 
@@ -2307,7 +2317,7 @@ msgid "Some database installations can only be accessed by connecting through an
 "Enabling this is usually slower than a direct connection."
 msgstr "Auf einige Datenbanken können nur mittels SSH Bastion Host zugegriffen werden. Diese Option integriert gleichfalls eine höhere Ebenen an Sicherheit, sobald das VPN nicht erreichbar ist. Im Normalfall ist die Verbindung langsamer als eine Direktanbindung."
 
-#: frontend/src/metabase/entities/databases/forms.js:212
+#: frontend/src/metabase/entities/databases/forms.js:281
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Dies ist eine große Datenbank. Lasst mich also selbst entscheiden, wann Metabase synchronisiert und prüft"
 
@@ -2317,18 +2327,18 @@ msgid "By default, Metabase does a lightweight hourly sync and an intensive dail
 msgstr "Standardmäßig führt Metabase eine stündliche Synchronisation und einen intensiven täglichen Scan der Feldwerte durch.\n"
 "Wenn du eine große Datenbank besitzt, empfehlen wir, diese Option zu aktivieren, um die Intervalle selbst einzustellen."
 
-#: frontend/src/metabase/entities/databases/forms.js:78
+#: frontend/src/metabase/entities/databases/forms.js:113
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0}, um eine Client-ID und ein Client-Secret für dein Projekt zu generieren."
 
 #. Hier klicken
-#: frontend/src/metabase/entities/databases/forms.js:80
-#: frontend/src/metabase/entities/databases/forms.js:95
-#: frontend/src/metabase/entities/databases/forms.js:131
+#: frontend/src/metabase/entities/databases/forms.js:115
+#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:166
 msgid "Click here"
 msgstr "Hier klicken"
 
-#: frontend/src/metabase/entities/databases/forms.js:83
+#: frontend/src/metabase/entities/databases/forms.js:118
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Wähle \"Andere\" als Applikationstyp. Benenne es wie du willst."
 
@@ -2336,19 +2346,19 @@ msgstr "Wähle \"Andere\" als Applikationstyp. Benenne es wie du willst."
 msgid "{0} to get an auth code"
 msgstr "{0} um einen Auth-Code zu erhalten"
 
-#: frontend/src/metabase/entities/databases/forms.js:107
+#: frontend/src/metabase/entities/databases/forms.js:142
 msgid "with Google Drive permissions"
 msgstr "mit Google Drive Berechtigungen"
 
-#: frontend/src/metabase/entities/databases/forms.js:129
+#: frontend/src/metabase/entities/databases/forms.js:164
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "Um Metabase mit diesen Daten verwenden zu können, musst du den API-Zugriff in der Google Developers Console aktivieren."
 
-#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:165
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0}, um zur Konsole zu gelangen, insofern du das noch nicht getan hast."
 
-#: frontend/src/metabase/entities/databases/forms.js:196
+#: frontend/src/metabase/entities/databases/forms.js:265
 msgid "How would you like to refer to this database?"
 msgstr "Wie würdest du gerne auf diese Datenbank referenzieren?"
 
@@ -2357,7 +2367,8 @@ msgstr "Wie würdest du gerne auf diese Datenbank referenzieren?"
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:143
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:70
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:123
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:96
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:126
 #: frontend/src/metabase/setup/components/UserStep.jsx:93
 msgid "Next"
 msgstr "Nächste"
@@ -2540,7 +2551,7 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Wiederhergestellt zu einer früheren Version und {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:290
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "Revisionshistorie"
@@ -2586,7 +2597,7 @@ msgid "Questions"
 msgstr "Fragen"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:320
+#: frontend/src/metabase/routes.jsx:311
 msgid "Pulses"
 msgstr "Pulses"
 
@@ -2631,15 +2642,16 @@ msgstr "Wir fühlen uns etwas hilflos..."
 msgid "Temporary Password"
 msgstr "Temporäres Passwort"
 
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:207
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:481
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
 msgid "Hide"
 msgstr "Verstecken"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:467
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:482
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:471
 msgid "Show"
 msgstr "Anzeigen"
 
@@ -2749,7 +2761,7 @@ msgstr "Tut mir leid, du hast keine Berechtigung um das zu sehen."
 msgid "Unknown error encountered"
 msgstr "Unbekannter Fehler aufgetreten"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/nav/containers/Navbar.jsx:373
 msgid "Create"
 msgstr "Erstellen"
@@ -2762,7 +2774,7 @@ msgstr "Dashboard erstellen"
 msgid "Table"
 msgstr "Tabelle"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
 msgid "Database"
 msgstr "Datenbank"
 
@@ -2782,7 +2794,7 @@ msgstr "Versuche, deinen Filter anzupassen, um das zu finden, wonach du suchst."
 msgid "View by"
 msgstr "Ansicht nach"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:122
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:121
 msgid "of"
 msgstr "von"
 
@@ -2809,33 +2821,33 @@ msgstr "Unsere Analysen"
 msgid "Browse all items"
 msgstr "Durchsuche alle Elemente"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:118
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:117
 msgid "Replace or save as new?"
 msgstr "Überschreibe oder speichere als neu?"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:168
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace original question, \"{0}\""
 msgstr "Überschreibe originale Frage, \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:172
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:171
 msgid "Save as new question"
 msgstr "Speichere als neue Frage"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:92
 msgid "First, save your question"
 msgstr "Speichere zuerst deine Frage"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:94
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
 msgid "Save question"
 msgstr "Speichere Frage"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:133
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
 msgid "What is the name of your card?"
 msgstr "Wie lautet der Name deiner Karte?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
 #: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/entities/questions.js:89
@@ -2851,15 +2863,16 @@ msgstr "Wie lautet der Name deiner Karte?"
 msgid "Description"
 msgstr "Beschreibung"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
 #: frontend/src/metabase/entities/dashboards.js:150
 #: frontend/src/metabase/entities/questions.js:91
 #: frontend/src/metabase/entities/questions.js:107
+#: frontend/src/metabase/entities/snippets.js:31
 msgid "It's optional but oh, so helpful"
 msgstr "Es ist optional, aber sehr hilfreich"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:148
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "In welche Sammlung soll es gehen?"
@@ -2876,19 +2889,19 @@ msgstr "Objekt"
 msgid "Undo"
 msgstr "Rückgängig"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:266
 msgid "Applying Question"
 msgstr "Wende Frage an"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:286
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "That question isn't compatible"
 msgstr "Diese Frage ist inkompatibel"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:322
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:309
 msgid "Search for a question"
 msgstr "Suche nach einer Frage"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:351
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:343
 msgid "We're not sure if this question is compatible"
 msgstr "Wir sind uns nicht sicher, ob die Frage kompatibel ist"
 
@@ -2937,25 +2950,23 @@ msgstr "Füge eine Frage hinzu"
 msgid "Add a question to this dashboard"
 msgstr "Füge eine Frage zu diesem Dashboard hinzu"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
 msgid "Add a filter"
 msgstr "Füge einen Filter hinzu"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:256
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "Parameter"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:276
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:280
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
 msgid "Add a text box"
 msgstr "Füge ein Textfeld hinzu"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:320
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:314
 msgid "Move dashboard"
 msgstr "Bewege das Dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:303
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
 msgid "Edit dashboard"
 msgstr "Ändere das Dashboard"
 
@@ -2963,11 +2974,11 @@ msgstr "Ändere das Dashboard"
 msgid "Edit Dashboard Layout"
 msgstr "Ändere das Dashboard-Layout"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:371
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:365
 msgid "You are editing a dashboard"
 msgstr "Du editierst ein Dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:376
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:370
 msgid "Select the field that should be filtered for each card"
 msgstr "Wähle das Feld aus, welches auf jeder Karte gefiltert werden soll"
 
@@ -3028,7 +3039,7 @@ msgstr "Aktualisiere in"
 
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:30
 msgid "Remove this question?"
-msgstr "Diese frage löschen?"
+msgstr "Diese Frage löschen?"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
@@ -3055,7 +3066,7 @@ msgstr "Diese Karte hat keine Felder oder Parameter, die auf diesen Parametertyp
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Die Werte in diesem Feld überschneiden sich nicht mit den Werten anderer Felder, die du ausgewählt hast."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:162
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "Keine validen Felder"
@@ -3123,7 +3134,7 @@ msgstr "erhielt aktuellste Daten von"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:329
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
 msgid "Unknown"
 msgstr "Unbekannt"
 
@@ -3250,6 +3261,7 @@ msgstr "{0} Elemente ausgewählt"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 msgid "Unarchive"
 msgstr "Stelle aus dem Archiv wieder her"
 
@@ -3342,7 +3354,7 @@ msgid "Longitude"
 msgstr "Länge"
 
 #: frontend/src/metabase/lib/core.js:43
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:45
 msgid "Number"
 msgstr "Nummer"
@@ -3400,7 +3412,7 @@ msgid "User"
 msgstr "Benutzer"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:211
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
 msgid "Source"
 msgstr "Quelle"
 
@@ -3441,16 +3453,17 @@ msgid "Score"
 msgstr "Ergebnis"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Titel"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -3502,9 +3515,9 @@ msgstr "Nicht einbinden"
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
 msgstr "Metabase wird dieses Feld nie abrufen. Benutze dies für vertrauliche oder irrelevante Daten."
 
-#: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:300
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/query/description.js:77
+#: frontend/src/metabase/lib/query/description.js:262
+#: frontend/src/metabase/lib/schema_metadata.js:476
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
@@ -3519,8 +3532,7 @@ msgstr "Anzahl"
 msgid "CumulativeCount"
 msgstr "Kumulative Zählung"
 
-#: frontend/src/metabase/lib/expressions/config.js:9
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:485
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3530,7 +3542,6 @@ msgstr "Summe"
 msgid "CumulativeSum"
 msgstr "Kumulative Summe"
 
-#: frontend/src/metabase/lib/expressions/config.js:11
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Distinct"
 msgstr "Eindeutig"
@@ -3539,25 +3550,22 @@ msgstr "Eindeutig"
 msgid "StandardDeviation"
 msgstr "Standardabweichung"
 
-#: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:494
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Durchschnitt"
 
-#: frontend/src/metabase/lib/expressions/config.js:14
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:539
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Min"
 
-#: frontend/src/metabase/lib/expressions/config.js:15
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:548
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:503
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:492
 msgid "Max"
 msgstr "Max"
 
@@ -3610,54 +3618,66 @@ msgstr "Was hast du auf dem Herzen?"
 msgid "What do you want to find out?"
 msgstr "Was möchtest du herausfinden?"
 
-#: frontend/src/metabase/lib/query.js:298
-#: frontend/src/metabase/lib/schema_metadata.js:466
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:250
+#: frontend/src/metabase/lib/query/description.js:75
+#: frontend/src/metabase/lib/query/description.js:260
+#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Rohdaten"
 
-#: frontend/src/metabase/lib/query.js:302
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/query/description.js:79
+#: frontend/src/metabase/lib/query/description.js:264
+#: frontend/src/metabase/lib/schema_metadata.js:521
 msgid "Cumulative count"
 msgstr "Kumulative Zählung"
 
-#: frontend/src/metabase/lib/query.js:305
+#: frontend/src/metabase/lib/query/description.js:82
+#: frontend/src/metabase/lib/query/description.js:266
 msgid "Average of "
 msgstr "Durchschnitt von "
 
-#: frontend/src/metabase/lib/query.js:310
+#: frontend/src/metabase/lib/query/description.js:87
+#: frontend/src/metabase/lib/query/description.js:268
 msgid "Distinct values of "
 msgstr "Eindeutiger Wert von "
 
-#: frontend/src/metabase/lib/query.js:315
+#: frontend/src/metabase/lib/query/description.js:92
+#: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
 msgstr "Standardabweichung von "
 
-#: frontend/src/metabase/lib/query.js:320
+#: frontend/src/metabase/lib/query/description.js:97
+#: frontend/src/metabase/lib/query/description.js:272
 msgid "Sum of "
 msgstr "Summe von "
 
-#: frontend/src/metabase/lib/query.js:325
+#: frontend/src/metabase/lib/query/description.js:102
+#: frontend/src/metabase/lib/query/description.js:274
 msgid "Cumulative sum of "
 msgstr "Kumulative Summe von "
 
-#: frontend/src/metabase/lib/query.js:330
+#: frontend/src/metabase/lib/query/description.js:107
+#: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
 msgstr "Maximum von "
 
-#: frontend/src/metabase/lib/query.js:335
+#: frontend/src/metabase/lib/query/description.js:112
+#: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
 msgstr "Minimum von "
 
-#: frontend/src/metabase/lib/query.js:349
+#: frontend/src/metabase/lib/query/description.js:126
+#: frontend/src/metabase/lib/query/description.js:286
 msgid "Grouped by "
 msgstr "Gruppieren nach "
 
-#: frontend/src/metabase/lib/query.js:363
+#: frontend/src/metabase/lib/query/description.js:140
+#: frontend/src/metabase/lib/query/description.js:295
 msgid "Filtered by "
 msgstr "Filtern nach "
 
-#: frontend/src/metabase/lib/query.js:392
+#: frontend/src/metabase/lib/query/description.js:169
+#: frontend/src/metabase/lib/query/description.js:320
 msgid "Sorted by "
 msgstr "Sortieren nach "
 
@@ -3669,55 +3689,45 @@ msgstr "Wahr"
 msgid "False"
 msgstr "Falsch"
 
-#: frontend/src/metabase/lib/schema_metadata.js:321
+#: frontend/src/metabase/lib/schema_metadata.js:322
 msgid "Select longitude field"
 msgstr "Wähle limitierendes Feld aus"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:323
 msgid "Enter upper latitude"
 msgstr "Setze oberes Limit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:324
 msgid "Enter left longitude"
 msgstr "Setze linkes Limit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:325
 msgid "Enter lower latitude"
 msgstr "Setze unteres Limit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:326
 msgid "Enter right longitude"
 msgstr "Setze rechtes Limit"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:539
 #: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:397
-#: frontend/src/metabase/lib/schema_metadata.js:405
-#: frontend/src/metabase/lib/schema_metadata.js:411
-#: frontend/src/metabase/lib/schema_metadata.js:416
-msgid "Is"
-msgstr "Ist"
-
 #: frontend/src/metabase/lib/schema_metadata.js:362
 #: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:398
 #: frontend/src/metabase/lib/schema_metadata.js:406
 #: frontend/src/metabase/lib/schema_metadata.js:412
-msgid "Is not"
-msgstr "Ist nicht"
+#: frontend/src/metabase/lib/schema_metadata.js:417
+msgid "Is"
+msgstr "Ist"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:417
-msgid "Is empty"
-msgstr "Ist leer"
+#: frontend/src/metabase/lib/schema_metadata.js:413
+msgid "Is not"
+msgstr "Ist nicht"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:378
@@ -3726,109 +3736,119 @@ msgstr "Ist leer"
 #: frontend/src/metabase/lib/schema_metadata.js:402
 #: frontend/src/metabase/lib/schema_metadata.js:408
 #: frontend/src/metabase/lib/schema_metadata.js:418
+msgid "Is empty"
+msgstr "Ist leer"
+
+#: frontend/src/metabase/lib/schema_metadata.js:365
+#: frontend/src/metabase/lib/schema_metadata.js:379
+#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:395
+#: frontend/src/metabase/lib/schema_metadata.js:403
+#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:419
 msgid "Not empty"
 msgstr "Nicht leer"
 
-#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:371
 msgid "Equal to"
 msgstr "Gleich zu"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:372
 msgid "Not equal to"
 msgstr "Nicht gleich zu"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Greater than"
 msgstr "Größer als"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Less than"
 msgstr "Kleiner als"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Zwischen"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:376
 msgid "Greater than or equal to"
 msgstr "Größer oder gleich als"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Less than or equal to"
 msgstr "Kleiner oder gleich als"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
+#: frontend/src/metabase/lib/schema_metadata.js:384
 msgid "Contains"
 msgstr "Enthält"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:385
 msgid "Does not contain"
 msgstr "Enthält nicht"
 
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:388
 msgid "Starts with"
 msgstr "Startet mit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:389
 msgid "Ends with"
 msgstr "Endet mit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:399
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Vor"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:400
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Nach"
 
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:414
 msgid "Inside"
 msgstr "Intern"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Nur eine Tabelle mit den Zeilen in der Antwort ohne zusätzlichen Operationen."
 
-#: frontend/src/metabase/lib/schema_metadata.js:474
+#: frontend/src/metabase/lib/schema_metadata.js:475
 msgid "Count of rows"
 msgstr "Zählen der Zeilen"
 
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:477
 msgid "Total number of rows in the answer."
 msgstr "Gesamtanzahl der Zeilen einer Antwort."
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Sum of ..."
 msgstr "Summe von..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:486
 msgid "Sum of all the values of a column."
 msgstr "Summe aller Werte einer Spalte."
 
-#: frontend/src/metabase/lib/schema_metadata.js:492
+#: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Average of ..."
 msgstr "Durchschnitt von..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:495
 msgid "Average of all the values of a column"
 msgstr "Durchschnitt aller Werte einer Spalte"
 
-#: frontend/src/metabase/lib/schema_metadata.js:501
+#: frontend/src/metabase/lib/schema_metadata.js:502
 msgid "Number of distinct values of ..."
 msgstr "Anzahl eindeutiger Werte von..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:504
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Anzahl eindeutiger Werte einer Spalte für die Zeilen einer Antwort."
 
-#: frontend/src/metabase/lib/schema_metadata.js:510
+#: frontend/src/metabase/lib/schema_metadata.js:511
 msgid "Cumulative sum of ..."
 msgstr "Kumulative Summe von..."
 
@@ -3836,7 +3856,7 @@ msgstr "Kumulative Summe von..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Additive Summe aller Werte einer Spalte.\\\\ne.x. Gesamtumsatz über die Zeit."
 
-#: frontend/src/metabase/lib/schema_metadata.js:519
+#: frontend/src/metabase/lib/schema_metadata.js:520
 msgid "Cumulative count of rows"
 msgstr "Kumulative Zählung von Zeilen"
 
@@ -3844,27 +3864,27 @@ msgstr "Kumulative Zählung von Zeilen"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Additive Zählung von Reihen.\\\\ne.x. Gesamtanzahl vom Verkauf über die Zeit."
 
-#: frontend/src/metabase/lib/schema_metadata.js:528
+#: frontend/src/metabase/lib/schema_metadata.js:529
 msgid "Standard deviation of ..."
 msgstr "Standardabweichung von..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:531
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Zahl, die angibt, wie stark die Werte einer Spalte zwischen allen Zeilen der Antwort variieren."
 
-#: frontend/src/metabase/lib/schema_metadata.js:537
+#: frontend/src/metabase/lib/schema_metadata.js:538
 msgid "Minimum of ..."
 msgstr "Minimum von ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Minimum value of a column"
 msgstr "Minimalwert einer Spalte"
 
-#: frontend/src/metabase/lib/schema_metadata.js:546
+#: frontend/src/metabase/lib/schema_metadata.js:547
 msgid "Maximum of ..."
 msgstr "Maximum von ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:549
 msgid "Maximum value of a column"
 msgstr "Maximalwert einer Spalte"
 
@@ -4040,7 +4060,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Kategorie, Typ, Modell, Bewertung, usw."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:43
-#: frontend/src/metabase/user/components/UserSettings.jsx:55
+#: frontend/src/metabase/user/components/UserSettings.jsx:56
 msgid "Account settings"
 msgstr "Kontoeinstellungen"
 
@@ -4052,7 +4072,7 @@ msgstr "Verlasse Administration"
 msgid "Logs"
 msgstr "Protokolle"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:103
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:104
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:22
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:65
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:100
@@ -4092,9 +4112,9 @@ msgid "Metabase Admin"
 msgstr "Metabase Administrator"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:36
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:36
 msgid "Ask a question"
 msgstr "Stelle eine Frage"
 
@@ -4115,7 +4135,7 @@ msgstr "Referenz"
 msgid "Which metric?"
 msgstr "Welchen Kennwert?"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "Die Definition gemeinsamer Metriken für dein Team macht es noch einfacher, Fragen zu stellen"
 
@@ -4127,7 +4147,7 @@ msgstr "Wie du Metriken erstellst"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Betrachte Daten über die Zeit, als Kartendiagramm oder als Pivot, um Trends und Veränderungen besser zu verstehen."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:149
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
 msgid "Custom"
 msgstr "Benutzerdefiniert"
 
@@ -4140,13 +4160,13 @@ msgstr "Neue Frage"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Verwende den einfachen Fragen-Builder, um Trends und Listen zu betrachten oder eigene Metriken zu erstellen."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:107
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:110
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Native Abfrage"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:108
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:111
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Für kompliziertere Fragen kannst du deine eigenen SQL- bzw. native Abfragen schreiben."
 
@@ -4251,6 +4271,7 @@ msgid "Enter a default value..."
 msgstr "Trage einen Standardwert ein..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
+#: frontend/src/metabase/containers/Form.jsx:307
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Ein Fehler ist aufgetaucht"
@@ -4500,7 +4521,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "Wir empfehlen, die Pulse klein und essentiell zu halten, damit diese für das Team verständlich bleiben."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:161
-#: frontend/src/metabase/query_builder/components/view/View.jsx:131
+#: frontend/src/metabase/query_builder/components/view/View.jsx:133
 msgid "Pick your data"
 msgstr "Wähle deine Daten"
 
@@ -4516,48 +4537,48 @@ msgstr "E-Mails"
 msgid "Slack messages"
 msgstr "Slack-Nachrichten"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:216
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Versendet"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:217
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} wird gesendet an"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:219
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:235
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "E-Mail jetzt versenden"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:236
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Jetzt an {0} versenden"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:238
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Senden…"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "Senden fehlgeschlagen"
 
 #. How to translate "Pulse"? Is it like Pulse / Heartbeat or the name of the untranslated metabase feature?
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "Wurde nicht versandt, da der Pulse nichts beinhaltet."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Pulse gesendet"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:282
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} muss von einem Administrator eingerichtet werden."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:295
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:299
 msgid "Slack"
 msgstr "Slack"
 
@@ -4712,7 +4733,7 @@ msgstr "Mittel"
 msgid "Distincts"
 msgstr "Besonderheiten"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:55
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "Siehe dieses {0}"
@@ -4723,11 +4744,12 @@ msgstr[1] "Siehe diese {0}"
 msgid "Zoom in"
 msgstr "Heranzoomen"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Benutzerdefinierter Ausdruck"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Common Metrics"
 msgstr "Allgemeine Metriken"
 
@@ -4924,34 +4946,34 @@ msgstr "normalerweise"
 msgid "Pick a segment or table"
 msgstr "Wähle ein Abschnitt oder eine Tabelle"
 
-#: frontend/src/metabase/entities/databases/forms.js:191
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
+#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Wähle eine Datenbank"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:94
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:85
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:31
 msgid "Select..."
 msgstr "Wähle..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:134
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
 msgid "Select a table"
 msgstr "Wähle eine Tabelle"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:819
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:926
 msgid "No tables found in this database."
 msgstr "Es wurde keine Tabelle in der Datenbank gefunden."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:856
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:901
 msgid "Is a question missing?"
 msgstr "Fehlt hier eine Frage?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:863
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:909
 msgid "Learn more about nested queries"
 msgstr "Lerne mehr über verschachtelte Abfragen"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:898
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:951
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:40
 msgid "Fields"
 msgstr "Felder"
 
@@ -4985,11 +5007,11 @@ msgstr "Sortieren"
 msgid "Row limit"
 msgstr "Zeilenlimit"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
 msgid "Unknown Field"
 msgstr "Unbekanntes Feld"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:75
 msgid "field"
 msgstr "Feld"
 
@@ -4997,19 +5019,20 @@ msgstr "Feld"
 msgid "Matches"
 msgstr "Stimmt überein"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:148
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:156
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:135
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Füge Filter hinzu, um deine Antwort einzugrenzen"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:293
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
 msgstr "Füge eine Gruppierung hinzu"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:37
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:313
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
-#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:66
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:67
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:89
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:131
@@ -5025,16 +5048,16 @@ msgstr "Füge eine Gruppierung hinzu"
 msgid "Data"
 msgstr "Daten"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:340
 msgid "Filtered by"
 msgstr "Gefiltert nach"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:376
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:357
 msgid "View"
 msgstr "Ansicht"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:393
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:374
 msgid "Grouped By"
 msgstr "Gruppiert nach"
 
@@ -5042,7 +5065,7 @@ msgstr "Gruppiert nach"
 msgid "None"
 msgstr "Nichts"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:471
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
 msgid "This question is written in {0}."
 msgstr "Diese Frage wurde in {0} geschrieben."
 
@@ -5054,7 +5077,7 @@ msgstr "Verberge Editor"
 msgid "Hide Query"
 msgstr "Verberge Abfrage"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:481
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
 msgid "Open Editor"
 msgstr "Öffne Editor"
 
@@ -5296,7 +5319,7 @@ msgstr "Alle eindeutigen Werte von {0}"
 msgid "Number of {0} grouped by {1}"
 msgstr "Anzahl von {0}, gruppiert nach {1}"
 
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:77
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5355,32 +5378,33 @@ msgstr "Siehe die Rohdaten für {0}"
 msgid "More"
 msgstr "Mehr"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:194
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:216
 msgid "Invalid expression"
 msgstr "Ungültiger Ausdruck"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:269
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:282
 msgid "unknown error"
 msgstr "unbekannter Fehler"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:47
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:53
 msgid "Field formula"
 msgstr "Feld-Formel"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:60
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:64
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Stelle es dir wie das Schreiben einer Formel in einem Tabellenkalkulationsprogramm vor: du kannst Zahlen, Felder und mathematische Symbole wie + und weitere Funktionen für Tabellen verwenden. Du kannst also so etwas wie Zwischensumme eingeben."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:69
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:208
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
 msgid "Learn more"
 msgstr "Mehr erfahren"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:77
 msgid "Give it a name"
 msgstr "Benenne es"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:79
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
 msgid "Something nice and descriptive"
 msgstr "Etwas genau Beschreibendes"
 
@@ -5460,11 +5484,11 @@ msgid "Enter desired number"
 msgstr "Gib die gewünschte Zahl ein"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:154
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:161
 msgid "Empty"
 msgstr "Leer"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:119
 msgid "Find a value"
 msgstr "Finde einen Wert"
 
@@ -5532,35 +5556,35 @@ msgstr "Lies die Dokumentation"
 msgid "Filter label"
 msgstr "Filterbezeichnung"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:135
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:134
 msgid "Variable type"
 msgstr "Variablentyp"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:143
 msgid "Text"
 msgstr "Text"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
 msgid "Date"
 msgstr "Datum"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:147
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
 msgid "Field Filter"
 msgstr "Feldfilter"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Field to map to"
 msgstr "Feld soll Folgendes verknüpft werden"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:180
 msgid "Filter widget type"
 msgstr "Feld-Widget-Typ"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:230
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
 msgid "Required?"
 msgstr "Wird benötigt?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:240
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
 msgid "Default filter widget value"
 msgstr "Standard Filter-Widget-Wert"
 
@@ -5572,7 +5596,7 @@ msgstr "Archivieren dieser Frage?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Diese Frage wird von allen Dashboards oder Pulse, die sie verwenden, entfernt."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:158
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
 msgid "Question"
 msgstr "Frage"
 
@@ -5742,7 +5766,7 @@ msgid "Details"
 msgstr "Details"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
-#: frontend/src/metabase/reference/databases/TableList.jsx:116
+#: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
 msgstr "Tabellen in {0}"
 
@@ -5824,24 +5848,24 @@ msgstr "Warum ist diese Tabelle interessant"
 msgid "Things to be aware of about this table"
 msgstr "Dinge, auf die man bei dieser Tabelle achten sollte"
 
-#: frontend/src/metabase/reference/databases/TableList.jsx:30
+#: frontend/src/metabase/reference/databases/TableList.jsx:29
 msgid "Tables in this database will appear here as they're added"
 msgstr "Tabellen dieser Datenbank werden hier erscheinen, sobald sie hinzugefügt sind"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:34
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:33
 msgid "Questions about this table will appear here as they're added"
 msgstr "Fragen über diese Tabelle werden hier erscheinen, sobald sie hinzugefügt sind"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:73
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:77
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:76
 msgid "Questions about {0}"
 msgstr "Fragen zum {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
 msgid "Created {0} by {1}"
 msgstr "Erstellt {0} von {1}"
 
@@ -6030,19 +6054,19 @@ msgstr "Andere Felder, nach denen die Metrik gruppiert werden kann"
 msgid "Fields you can group this metric by"
 msgstr "Felder, nach denen die Metrik gruppiert werden kann"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "Metriken sind die offiziellen Zahlen, um die sich dein Team kümmert"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Metrics will appear here once your admins have created some"
 msgstr "Metriken werden hier erscheinen, sobald die Administratoren sie erstellen"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:28
 msgid "Learn how to create metrics"
 msgstr "Lerne Metriken zu erstellen"
 
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:34
 msgid "Questions about this metric will appear here as they're added"
 msgstr "Fragen zu dieser Metrik erscheinen hier, wenn sie hinzugefügt werden"
 
@@ -6068,23 +6092,23 @@ msgstr "Weshalb dieser Abschnitt interessant ist"
 msgid "Things to be aware of about this Segment"
 msgstr "Wissenswertes über diesen Abschnitt"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
 msgid "Segments are interesting subsets of tables"
 msgstr "Abschnitte sind interessante Teilmengen von Tabellen"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "Die Definition gemeinsamer Abschnitte für Dein Team macht es noch einfacher, Fragen zu stellen"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Segments will appear here once your admins have created some"
 msgstr "Abschnitte erscheinen hier, sobald dein Administrator welche erstellt hat"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
 msgid "Learn how to create segments"
 msgstr "Lerne wie man Abschnitte erstellt"
 
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:35
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:34
 msgid "Questions about this segment will appear here as they're added"
 msgstr "Fragen zu diesem Abschnitt erscheinen hier, wenn sie hinzugefügt werden"
 
@@ -6104,22 +6128,22 @@ msgstr "Fragen über diesen Abschnitt"
 msgid "X-ray this segment"
 msgstr "X-Ray für diesen Abschnitt"
 
-#: frontend/src/metabase/routes.jsx:178 frontend/src/metabase/routes.jsx:179
+#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
 msgid "Login"
 msgstr "Anmeldung"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:303
 #: frontend/src/metabase/containers/ItemPicker.jsx:115
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:204
+#: frontend/src/metabase/routes.jsx:195
 msgid "Search"
 msgstr "Suche"
 
-#: frontend/src/metabase/routes.jsx:223
+#: frontend/src/metabase/routes.jsx:214
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#: frontend/src/metabase/routes.jsx:236
+#: frontend/src/metabase/routes.jsx:227
 msgid "New Question"
 msgstr "Neue Frage"
 
@@ -6163,63 +6187,63 @@ msgstr "Danke, dass sie uns bei der Verbesserung helfen"
 msgid "We won't collect any usage events"
 msgstr "Wir sammeln keine Benutzerereignisse"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:88
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Um uns bei der Verbesserung von Metabase zu helfen, möchten wir bestimmte Daten über die Nutzung durch Google Analytics sammeln."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:90
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Here's a full list of everything we track and why."
 msgstr "Hier ist eine vollständige Liste von allem, was wir verfolgen und weshalb."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Erlaube Metabase das anonyme Sammeln von Ereignisinformationen"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:113
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0} sammelt alles über deine Daten oder Frageergebnisse."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:114
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
 msgid "never"
 msgstr "niemals"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:119
 msgid "All collection is completely anonymous."
 msgstr "Die gesamte Sammlung ist völlig anonym."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Die Sammlung kann an jeder beliebigen Stelle in den administrativen Einstellungen deaktiviert werden."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:44
+#: frontend/src/metabase/setup/components/Setup.jsx:59
 msgid "If you feel stuck"
 msgstr "Wenn du feststeckst"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:49
+#: frontend/src/metabase/setup/components/Setup.jsx:64
 msgid "our getting started guide"
 msgstr "unsere Startanleitung"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:50
+#: frontend/src/metabase/setup/components/Setup.jsx:65
 msgid "is just a click away."
 msgstr "ist nur einen Klick entfernt."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:92
+#: frontend/src/metabase/setup/components/Setup.jsx:111
 msgid "Welcome to Metabase"
 msgstr "Willkommen bei Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:93
+#: frontend/src/metabase/setup/components/Setup.jsx:112
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Sieht so aus, als ob alles funktioniert. Lass uns gemeinsam kennenlernen, deine Daten verbinden und anfangen, ein paar Antworten für dich zu finden!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:97
+#: frontend/src/metabase/setup/components/Setup.jsx:116
 msgid "Let's get started"
 msgstr "Lass uns loslegen"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:142
+#: frontend/src/metabase/setup/components/Setup.jsx:166
 msgid "You're all set up!"
 msgstr "Es ist alles eingerichtet!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:153
+#: frontend/src/metabase/setup/components/Setup.jsx:177
 msgid "Take me to Metabase"
 msgstr "Führe mich zu Metabase"
 
@@ -6231,13 +6255,13 @@ msgstr "Wie sollen wir dich nennen?"
 msgid "Hi, {0}. nice to meet you!"
 msgstr "Hallo {0}. Schön, dich kennenzulernen!"
 
-#: frontend/src/metabase/entities/users/forms.js:33
+#: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
 msgstr "Erstelle ein Passwort"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:44
-#: frontend/src/metabase/entities/users/forms.js:35
-#: frontend/src/metabase/entities/users/forms.js:82
+#: frontend/src/metabase/entities/users/forms.js:50
+#: frontend/src/metabase/entities/users/forms.js:97
 msgid "Shhh..."
 msgstr "Pssst..."
 
@@ -6245,11 +6269,11 @@ msgstr "Pssst..."
 msgid "Confirm password"
 msgstr "Bestätige das Passwort"
 
-#: frontend/src/metabase/entities/users/forms.js:42
+#: frontend/src/metabase/entities/users/forms.js:57
 msgid "Shhh... but one more time so we get it right"
 msgstr "Pssst...aber noch einmal, damit wir es richtig machen"
 
-#: frontend/src/metabase/entities/users/forms.js:70
+#: frontend/src/metabase/entities/users/forms.js:85
 msgid "Your company or team name"
 msgstr "Dein Unternehmens- oder Teamname"
 
@@ -6418,7 +6442,7 @@ msgstr "Passwort erfolgreich aktualisiert!"
 msgid "Account updated successfully!"
 msgstr "Konto erfolgreich aktualisiert!"
 
-#: frontend/src/metabase/entities/users/forms.js:81
+#: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
 msgstr "Aktuelles Passwort"
 
@@ -6430,7 +6454,7 @@ msgstr "Mit Google E-Mail Adresse einloggen"
 msgid "User Details"
 msgstr "Benutzerdetails"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:327
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:344
 msgid "Reset to defaults"
 msgstr "Auf Standard zurücksetzen"
 
@@ -6455,15 +6479,15 @@ msgstr "Welche Felder möchtest du für die X- und Y-Achse verwenden?"
 msgid "Choose fields"
 msgstr "Felder auswählen"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:217
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:234
 msgid "Save as default view"
 msgstr "Als Standard-Ansicht speichern"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Draw box to filter"
 msgstr "Zeichne eine Box um zu filtern "
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Cancel filter"
 msgstr "Filter abbrechen"
 
@@ -6492,19 +6516,19 @@ msgstr "Konnte keine Visualisierung finden"
 msgid "Could not display this chart with this data."
 msgstr "Konnte das Diagramm mit diesen Daten nicht anzeigen."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:526
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
 msgid "No results!"
 msgstr "Keine Ergebnisse!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:547
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
 msgid "Still Waiting..."
 msgstr "Warte weiterhin..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:550
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
 msgid "This usually takes an average of {0}."
 msgstr "Das dauert gewöhnlich durchschnittlich {0}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:556
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Das ist ein wenig lange für ein Dashboard)"
 
@@ -6663,19 +6687,19 @@ msgstr "Regel hinzufügen"
 msgid "Update rule"
 msgstr "Regel aktualisieren"
 
-#: frontend/src/metabase/visualizations/index.js:32
+#: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
 msgstr "Visualisierung ist NULL"
 
-#: frontend/src/metabase/visualizations/index.js:37
+#: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
 msgstr "Die Visualisierung muss eine statische Variable \"Identifier\" definieren: "
 
-#: frontend/src/metabase/visualizations/index.js:43
+#: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
 msgstr "Die Visualisierung mit dieser Kennung ist bereits registriert: "
 
-#: frontend/src/metabase/visualizations/index.js:71
+#: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
 msgstr "Keine Visualisierung für {0}"
 
@@ -6701,23 +6725,23 @@ msgid "Doh! The data from your query doesn't fit the chosen display choice. This
 msgstr "Mist! Die Daten aus deiner Abfrage passen nicht zu der gewählten Darstellungs-Wahl. Diese Visualisierung erfordert mindestens {0} {1} der Daten."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:9
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:117
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:120
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:161
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:169
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:249
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:267
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "Spalte"
@@ -6829,83 +6853,83 @@ msgstr "Nichts"
 msgid "Linear Interpolated"
 msgstr "Linear interpoliert"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
 msgstr "X-Achsen Skala"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
 msgstr "Zeitreihe"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:454
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
 msgid "Linear"
 msgstr "Linear"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
 msgid "Power"
 msgstr "Potenz"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:428
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:445
 msgid "Log"
 msgstr "Logarithmus"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:441
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:430
 msgid "Histogram"
 msgstr "Histogramm"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
 msgstr "Ordnungszahl"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
 msgstr "Y-Achsen-Skala"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:462
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
 msgstr "Zeige Linie und Markierungen der X-Achse"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:360
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:468
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:349
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
 msgid "Compact"
 msgstr "Kompakt"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:469
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
 msgid "Rotate 45°"
 msgstr "Drehen 45°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:459
 msgid "Rotate 90°"
 msgstr "Drehen 90°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
 msgid "Show y-axis line and marks"
 msgstr "Zeige Linie und Markierungen der Y-Achse"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:489
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Auto y-axis range"
 msgstr "Automatische Y-Achsen-Skalierung"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:533
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:522
 msgid "Use a split y-axis when necessary"
 msgstr "Verwende bei Bedarf eine geteilte y-Achse"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:540
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:529
 msgid "Show label on x-axis"
 msgstr "Beschriftung auf der X-Achse anzeigen"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:546
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:535
 msgid "X-axis label"
 msgstr "Beschriftung X-Achse"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:555
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:544
 msgid "Show label on y-axis"
 msgstr "Beschriftung auf der Y-Achse anzeigen"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:561
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:550
 msgid "Y-axis label"
 msgstr "Beschriftung Y-Achse"
 
@@ -7031,23 +7055,23 @@ msgstr "Min. Transparenz"
 msgid "Max Zoom"
 msgstr "Max. Zoom"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:231
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:234
 msgid "No relationships found."
 msgstr "Keine Beziehungen gefunden."
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:269
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:272
 msgid "via {0}"
 msgstr "via {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:347
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
 msgid "This {0} is connected to:"
 msgstr "{0} ist verbunden mit:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "Object Detail"
 msgstr "Objekt Detail"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:93
 msgid "object"
 msgstr "Objekt"
 
@@ -7150,7 +7174,6 @@ msgid "Visible fields"
 msgstr "Sichtbare Felder"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
-#, fuzzy
 msgid "Write here, and use Markdown if you'd like"
 msgstr "Schreibe hier und verwende Markdown, wenn du möchtest"
 
@@ -7220,9 +7243,8 @@ msgid "invalid value for rule name"
 msgstr "Ungültiger Wert für Regelbezeichnung"
 
 #: src/metabase/api/automagic_dashboards.clj
-#, fuzzy
 msgid "value couldn''t be parsed as base64 encoded JSON"
-msgstr "Wert konnte nicht als base64-kodierter JSON geparsed werden"
+msgstr "Wert konnte nicht als base64-kodiertes JSON geparsed werden"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "Invalid entity type"
@@ -7442,7 +7464,7 @@ msgstr "Du hast eine Menge Fragen in {0}? Erstelle Sammlungen um sie zu organisi
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:149 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -8003,12 +8025,10 @@ msgid "Failed to connect to database: {0}"
 msgstr "Fehler beim Verbinden mit der Datenbank: {0}"
 
 #: src/metabase/driver/bigquery.clj
-#, fuzzy
 msgid "Invalid BigQuery identifier: ''{0}''"
 msgstr "Ungültiger BigQuery-Identifier: \"{0}\""
 
 #: src/metabase/driver/bigquery.clj
-#, fuzzy
 msgid "BigQuery statements can't be parameterized!"
 msgstr "BigQuery-Anweisungen können nicht parameterisiert werden!"
 
@@ -9001,19 +9021,19 @@ msgstr "Kann diese Sammlung und ihre Inhalte editieren"
 msgid "Can view items in this collection"
 msgstr "Kann Objekte in dieser Sammlung sehen"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:767
+#: frontend/src/metabase/admin/permissions/selectors.js:765
 msgid "Collection Access"
 msgstr "Sammlungszugriff"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:841
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Diese Gruppe hat die Erlaubnis, mindestens eine Untersammlung dieser Sammlung zu sehen."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:848
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Diese Gruppe hat die Erlaubnis, mindestens eine Untersammlung dieser Sammlung zu bearbeiten."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:861
+#: frontend/src/metabase/admin/permissions/selectors.js:859
 msgid "View sub-collections"
 msgstr "Untersammlungen anzeigen"
 
@@ -9021,7 +9041,7 @@ msgstr "Untersammlungen anzeigen"
 msgid "Remember Me"
 msgstr "Angemeldet bleiben"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:63
+#: frontend/src/metabase/components/BrowseApp.jsx:73
 msgid "X-ray this schema"
 msgstr "Dieses Schema durchleuchten"
 
@@ -9082,15 +9102,15 @@ msgstr "Metabase konnte keine Ergebnisse für deine Suche finden."
 msgid "No metrics"
 msgstr "Keine Metriken"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:31
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:41
 msgid "Aggregations"
 msgstr "Aggregationen"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:32
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:42
 msgid "Operators"
 msgstr "Operatoren"
 
-#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:30
+#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:35
 msgid "Custom fields"
 msgstr "Benutzerdefinierte Felder"
 
@@ -9257,7 +9277,7 @@ msgstr "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
 msgid "toucan_sightings"
 msgstr "toucan_sightings"
 
-#: src/metabase/driver/sparksql.clj
+#: src/metabase/models/collection.clj
 #, fuzzy
 msgid "default"
 msgstr "standard"
@@ -9286,10 +9306,10 @@ msgstr "N/A"
 msgid "Windows domain"
 msgstr "Windows Domain"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:539
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:545
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:554
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:560
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:528
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:534
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:543
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
 msgstr "Beschriftungen"
 
@@ -9324,9 +9344,9 @@ msgstr "Teilen"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:286
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:294
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:302
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:319
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:324
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
@@ -9341,19 +9361,18 @@ msgstr "Teilen"
 msgid "Display"
 msgstr "Anzeige"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:461
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:476
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:502
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:532
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:402
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:465
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:483
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:521
 msgid "Axes"
 msgstr "Achsen"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:212
-#: frontend/src/metabase/admin/settings/selectors.js:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:219
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:62
 msgid "Formatting"
@@ -9387,7 +9406,7 @@ msgstr "X-Ray"
 msgid "Compare to the rest"
 msgstr "Vergleiche mit dem Rest"
 
-#: frontend/src/metabase/entities/databases/forms.js:16
+#: frontend/src/metabase/entities/databases/forms.js:18
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Verwende die Java Virtual Machine (JVM) Zeitzone"
 
@@ -9418,24 +9437,24 @@ msgstr "Verwende JVM Zeitzone"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Wir analysieren gerade die Tabellen und Felder, um dir bei der Untersuchung der Daten helfen zu können."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
 msgid "Tip: "
 msgstr "Tipp: "
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:237
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
 msgstr "Wähle einen Währungstypen"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:300
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
 msgid "Field Type"
 msgstr "Feld-Typ"
 
-#: frontend/src/metabase/admin/routes.jsx:113
+#: frontend/src/metabase/admin/routes.jsx:118
 #: frontend/src/metabase/nav/containers/Navbar.jsx:267
 msgid "Troubleshooting"
 msgstr "Fehlerbehebung"
 
-#: frontend/src/metabase/admin/settings/selectors.js:103
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Enable X-ray features"
 msgstr "X-Ray-Funktionen aktivieren"
 
@@ -9480,7 +9499,7 @@ msgstr "Dauer (ms) "
 msgid "Currency"
 msgstr "Währung"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
 msgstr "Wähle einen Benutzer oder einen Kanal"
 
@@ -9629,7 +9648,7 @@ msgstr "Linien-Style"
 msgid "Show dots on lines"
 msgstr "Zeige Punkte an den Linien"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:348
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
@@ -9643,7 +9662,7 @@ msgstr "Welche Achse?"
 msgid "Line + Bar"
 msgstr "Linie + Balken"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
 msgid "line and bar chart"
 msgstr "Line- und Bar-Chart"
 
@@ -11092,7 +11111,7 @@ msgstr "Wie diese Kennzahl auf verschiedene Zahlen verteilt ist"
 msgid "Sessions by page where the session began"
 msgstr "Sitzungen nach Seite, auf der die Sitzung begann."
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:503
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -11461,7 +11480,7 @@ msgstr "Eintrag duplizieren"
 msgid "Archive this item"
 msgstr "Eintrag archivieren"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:331
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:325
 msgid "Duplicate dashboard"
 msgstr "Dashboard duplizieren"
 
@@ -11566,7 +11585,7 @@ msgid_plural "Quarters of year"
 msgstr[0] "Quartal im Jahr"
 msgstr[1] "Quartale im Jahr"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
@@ -11582,8 +11601,8 @@ msgstr "[Q]Q"
 msgid "This"
 msgstr "Dieses"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:97
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:137
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:136
 msgid "Invalid"
 msgstr "Ungültig"
 
@@ -12348,6 +12367,7 @@ msgstr "Hier sind deine letzten {0} Karten:"
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
 msgstr "Kannst du etwas genauer sein oder die ID verwenden? Ich habe folgende passende Karten gefunden:"
 
+#: src/metabase/driver/common/parameters/values.clj
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
 msgstr "Karte {0} nicht gefunden."
@@ -12456,11 +12476,11 @@ msgstr "Fehlzündungsanweisung"
 msgid "Archive this?"
 msgstr "Archivieren?"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:243
+#: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
 msgstr "Erfahre mehr über deine Daten"
 
-#: frontend/src/metabase/entities/databases/forms.js:20
+#: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
 msgstr "Verwende DNS SRV zum Verbinden"
 
@@ -12472,9 +12492,9 @@ msgstr "Die Verwendung dieser Option setzt voraus, dass der angegebene Host ein 
 "einen Atlas-Cluster verbinden, musst du diese Option möglicherweise aktivieren. Wenn du nicht weißt, was das bedeutet,\n"
 "lasse es deaktiviert."
 
-#: frontend/src/metabase/entities/databases/forms.js:204
+#: frontend/src/metabase/entities/databases/forms.js:273
 msgid "Automatically run queries when doing simple filtering and summarizing"
-msgstr "Führe Abfragen bei einechem Filtern und Zusammenfassen automatisch aus"
+msgstr "Führe Abfragen bei einfachen Filtern und Zusammenfassen automatisch aus"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
 msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
@@ -12496,11 +12516,11 @@ msgstr "Alle Ergebnisse"
 msgid "Our Analytics"
 msgstr "Unsere Analysen"
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:513
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
 msgstr "Additive Summe aller Werte einer Spalte.\\ne.x. Gesamtumsatz über die Zeit."
 
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
 msgstr "Additive Zählung der Anzahl der Zeilen.\\ne.x. Gesamtzahl der Verkäufe über die Zeit."
 
@@ -12510,7 +12530,7 @@ msgstr "Additive Zählung der Anzahl der Zeilen.\\ne.x. Gesamtzahl der Verkäufe
 msgid "Filter"
 msgstr "Filter"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:50
 msgid "record"
 msgid_plural "records"
 msgstr[0] "Eintrag"
@@ -12524,27 +12544,27 @@ msgstr "Daten anzeigen"
 msgid "Write SQL"
 msgstr "Sql schreiben"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:83
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
 msgstr "Einfache Frage"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:84
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:87
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
 msgstr "Wähle einige Daten aus, betrachte, filter, summiere und visualisiere sie."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:95
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:98
 msgid "Custom question"
 msgstr "Benutzerdefinierte Frage"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:96
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:99
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Verwende den erweiterten Notebook-Editor, um Daten zu verknüpfen, benutzerdefinierte Spalten zu erstellen, Berechnungen durchzuführen und vieles mehr."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Basic Metrics"
 msgstr "Einfache Metriken"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:322
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
 msgid "Custom…"
 msgstr "Benutzerdefiniert..."
 
@@ -12613,15 +12633,15 @@ msgstr "Wähle eine Spalte für die Gruppierung"
 msgid "Pick your starting data"
 msgstr "Wähle deine Start-Daten"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select None"
 msgstr "Nichts auswählen"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select All"
 msgstr "Alles auswählen"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:151
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:152
 msgid "Pick a table..."
 msgstr "Wähle eine Tabelle..."
 
@@ -12744,15 +12764,15 @@ msgstr "Metrik hinzufügen"
 #: frontend/src/metabase/lib/core.js:137 frontend/src/metabase/lib/core.js:142
 #: frontend/src/metabase/lib/core.js:147 frontend/src/metabase/lib/core.js:152
 #: frontend/src/metabase/lib/core.js:157 frontend/src/metabase/lib/core.js:162
-#: frontend/src/metabase/user/components/UserSettings.jsx:63
+#: frontend/src/metabase/user/components/UserSettings.jsx:64
 msgid "Profile"
 msgstr "Profil"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:560
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "Das geht normalerweise zeimlich schnell aber scheint gerade sehr lange zu dauern."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
 msgid "Combo"
 msgstr "Combo"
 
@@ -12768,11 +12788,11 @@ msgstr "Trend"
 msgid "Boolean"
 msgstr "Boolean"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:62
 msgid "Unknown Segment"
 msgstr "Unbekanntes Segment"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:73
 msgid "Unknown Filter"
 msgstr "Unbekannter Filter"
 
@@ -12902,6 +12922,7 @@ msgstr "Verwende NEULICH ERSTELLT Klassenlader als geteilter Kontextklassenlader
 msgid "Failed to copy file"
 msgstr "Fehler beim Kopieren der Datei."
 
+#. check that the URL is valid
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
 msgstr "Ungültige Seiten-URL: {0}"
@@ -13176,7 +13197,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Wähle die Spalten aus, die Du einbeziehen möchtest."
 
-#: frontend/src/metabase/entities/databases/forms.js:205
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Wenn dies aktiviert ist, führt Metabase automatisch Abfragen aus, wenn Benutzer einfache Erkundungen mit den Schaltflächen Zusammenfassen und Filtern durchführen, wenn sie eine Tabelle oder ein Diagramm anzeigen. Sie können dies ausschalten, wenn die Abfrage dieser Datenbank langsam ist. Diese Einstellung hat keinen Einfluss auf Drill-Throughs oder SQL-Abfragen."
 
@@ -13214,7 +13235,7 @@ msgstr "Fehler beim Bestimmen der erwarteten Spalten für die Abfrage"
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "Unbehandelte Ausnahme, erwartete `catch-exceptions` Middleware um es zu behandeln."
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:125
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
 msgid "Diagnostic Info"
 msgstr "Diagnoseinformationen"
 
@@ -13238,11 +13259,11 @@ msgstr "Es gab ein Problem bei der Anmeldung mit Google. Bitte kontaktiere einen
 msgid "Sign in with email"
 msgstr "Anmeldung per E-Mail"
 
-#: frontend/src/metabase/entities/databases/forms.js:21
+#: frontend/src/metabase/entities/databases/forms.js:23
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "Die Auswahl dieser Option erfordert einen Host, der über einen FQDN verfügt. Wenn zu einem Atlas-Cluster verbunden wird, musst Du diese Option eventuell aktivieren. Falls Du nicht weißt, was diese Option bedeutet, lass sie deaktiviert."
 
-#: frontend/src/metabase/entities/databases/forms.js:213
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Standardmäßig führt Metabase eine leichte stündliche Synchronisierung und eine intensive tägliche Überprüfung der Feldwerte durch. Wenn Du eine große Datenbank hast, empfehlen wir Dir, das hier einzuschalten und zu überprüfen, wann und wie oft die Feldwertüberprüfungen stattfinden."
 
@@ -13310,11 +13331,11 @@ msgstr "Nicht enthalten"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "Dieses Feld ist bei Fragen, die mit den GUI-Oberflächen erstellt wurden, nicht sichtbar oder auswählbar. Es wird weiterhin in SQL/nativen Abfragen verfügbar sein."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:512
 msgid "Cumulative sum"
 msgstr "Kumulierte Summe"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Standard deviation"
 msgstr "Standardabweichung"
 
@@ -13326,23 +13347,23 @@ msgstr "muss mindestens {0} Zeichen lang sein"
 msgid "Must be at least {0} characters long"
 msgstr "Muss mindestens {0} Zeichen lang sein"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:389
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:82
 msgid "Name (required)"
 msgstr "Name (erforderlich)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:556
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
 msgid "Run selected text"
 msgstr "Führe ausgewählten Text aus"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:557
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
 msgid "Run query"
 msgstr "Führe Abfrage aus"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(⌘ + enter)"
 msgstr "(⌘ + Enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(Ctrl + enter)"
 msgstr "(STRG + Enter)"
 
@@ -13354,7 +13375,7 @@ msgstr "An dieser Stelle werden Deine Resultate erscheinen"
 msgid "You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question."
 msgstr "Du wirst keine dauerhaften Änderungen an einer gespeicherten Frage vornehmen, es sei denn, Du klickst auf Speichern und wählst die ursprüngliche Frage zum Ersetzen aus."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:199
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:200
 msgid "There aren't any filter widgets for this type of field yet."
 msgstr "Es existieren momentan keine Filter-Steuerelemente für diesen Feldtyp."
 
@@ -13390,19 +13411,19 @@ msgstr "Ziellinie"
 msgid "Trend line"
 msgstr "Trendlinie"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:320
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:317
 msgid "Show values on data points"
 msgstr "Werte auf Datenpunkten anzeigen"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:334
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:325
 msgid "Values to show"
 msgstr "Anzuzeigende Werte"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:342
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:332
 msgid "As many as can fit nicely"
 msgstr "So viele wie möglich, die gut passen"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:343
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
 msgid "All"
 msgstr "Alle"
 
@@ -13477,7 +13498,7 @@ msgstr "Kann nicht das Feld mit der ID: {0} finden"
 
 #: src/metabase/driver/impl.clj
 msgid "Error loading driver namespace"
-msgstr "Fehler beim Laden des Treiber-Namensraums"
+msgstr "Fehler beim Laden des Treiber-Namespaces"
 
 #: src/metabase/driver/impl.clj
 msgid "Could not load {0} driver."
@@ -13695,31 +13716,31 @@ msgstr "Zahlen"
 msgid "No mappable groups"
 msgstr "Keine verknüpfbaren Gruppen"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:107
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
 msgstr "Metabase Dokumentation"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
 msgstr "Enthält eine Anleitung zur Fehlerbehebung"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:112
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
 msgid "Post on the Metabase support forum"
 msgstr "Schreibe ins Metabase-Support-Forum"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:114
 msgid "A community forum for all things Metabase"
 msgstr "Ein Gemeinschaftsforum für alle Dinge von Metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:117
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
 msgid "File a bug report"
 msgstr "Fehlerbericht einreichen"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:119
 msgid "Create a GitHub issue (includes the diagnostic info below)"
 msgstr "Erstelle ein Issue auf Github (enthät untenstehende Daten)"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:127
 msgid "Please include these details in support requests. Thank you!"
 msgstr "Bitte füge folgende Details in deine Support-Anfrage ein, vielen Dank!"
 
@@ -13729,7 +13750,7 @@ msgstr "youlooknicetoday@email.com"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:50
 msgid "Remember me"
-msgstr "Erinnere mich"
+msgstr "Angemeldet bleiben"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
@@ -13747,38 +13768,40 @@ msgstr "Kein passendes Ergebnis"
 msgid "Submit"
 msgstr "Einreichen"
 
-#: frontend/src/metabase/entities/databases/forms.js:13
+#: frontend/src/metabase/entities/databases/forms.js:15
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host. This option also provides an extra layer of security when a VPN is not available. Enabling this is usually slower than a direct connection."
 msgstr "Manche Datenbanksysteme können nur über einen Sprungserver via SSH erreicht werden. Dieses Vorgehen erhöht die Sicherheit, auch wenn kein VPN verfügbar ist. Ist aber eventuell langsamer als eine Direktverbindung."
 
-#: frontend/src/metabase/entities/databases/forms.js:17
+#: frontend/src/metabase/entities/databases/forms.js:19
 msgid "We suggest you leave this off unless you're doing manual timezone casting in many or most of your queries with this data."
 msgstr "Wir raten an, dies ausgeschaltet zu lassen, außer Sie führen manuelle Umrechnungen der Zeitzonen in vielen oder den meisten Ihrer Abfragen durch."
 
-#: frontend/src/metabase/entities/databases/forms.js:93
+#: frontend/src/metabase/entities/databases/forms.js:128
 msgid "{0} to get an auth code."
 msgstr "{0} um einen Auth-Code zu erhalten."
 
-#: frontend/src/metabase/entities/databases/forms.js:101
+#: frontend/src/metabase/entities/databases/forms.js:136
+#: src/metabase/models/collection.clj
 msgid "or"
 msgstr "oder"
 
-#: frontend/src/metabase/entities/databases/forms.js:159
-#: frontend/src/metabase/entities/databases/forms.js:197
-#: frontend/src/metabase/entities/users/forms.js:44
+#: frontend/src/metabase/entities/databases/forms.js:39
+#: frontend/src/metabase/entities/databases/forms.js:226
+#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "erforderlich"
 
-#: frontend/src/metabase/entities/databases/forms.js:188
+#: frontend/src/metabase/entities/databases/forms.js:257
 msgid "Database type"
 msgstr "Datenbanktyp"
 
-#: frontend/src/metabase/entities/databases/forms.js:222
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Dies ist ein leichtgewichtiger Prozess, der auf Aktualisierungen des Datenbank-Schemas prüft. In den meisten Fällen sollte die stündliche Synchronisation in Ordnung sein."
 
-#: frontend/src/metabase/entities/databases/forms.js:230
+#: frontend/src/metabase/entities/databases/forms.js:299
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase kann die Werte dieses Feldes in der Datenbank scannen um Checkbox-Filter in den Dashboard und Fragen bereitzustellen. Dies kann ein sehr ressourcen-intensiver Prozess sein, insbesondere wenn Sie eine sehr große Datenbank verwenden."
 
@@ -13786,15 +13809,15 @@ msgstr "Metabase kann die Werte dieses Feldes in der Datenbank scannen um Checkb
 msgid "Collection"
 msgstr "Sammlung"
 
-#: frontend/src/metabase/entities/users/forms.js:40
+#: frontend/src/metabase/entities/users/forms.js:55
 msgid "Confirm your password"
 msgstr "Bestätige Dein Passwort"
 
-#: frontend/src/metabase/entities/users/forms.js:45
+#: frontend/src/metabase/entities/users/forms.js:60
 msgid "passwords do not match"
 msgstr "Passwörter stimmen nicht überein"
 
-#: frontend/src/metabase/entities/users/forms.js:71
+#: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
 msgstr "Großartige Abteilung"
 
@@ -13834,328 +13857,324 @@ msgid "Returns the average of the values in the column."
 msgstr "Gibt den Durchscnitt aller Werte einer Spalte zurück."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:18
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
 msgid "The column whose values to average."
 msgstr "Spalte deren Durchschnitt gebildet werden soll."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "start"
 msgstr "Start"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "end"
 msgstr "Ende"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
 msgid "Checks a date or numeric column's values to see if they're within the specified range."
 msgstr "Überprüft die Werte eines Datums oder einer numerischen Spalte, um festzustellen, ob sie innerhalb des angegebenen Bereichs liegen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
 msgstr "Bewertung"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:24
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:98
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
 msgid "condition"
 msgstr "Bedingung"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
 msgid "output"
 msgstr "Ausgabe"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Testet eine Liste von Fällen und gibt den Wert des ersten \"True\"-Falls zurück. Ein optionaler Default-Wert kann ebenfalls angegeben werden, wenn kein Fall zutrifft."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
 msgid "Weight"
 msgstr "Gewicht"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
 msgid "Large"
 msgstr "Groß"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
 msgid "Medium"
 msgstr "Mittel"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
 msgid "Small"
 msgstr "Klein"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
 msgid "Something that should evaluate to true or false."
 msgstr "Etwas mit dem Ergebnis wahr oder falsch."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:54
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "Der Wert, der zurückgegeben wird, wenn die vorangehende Bedingung wahr ist."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:62
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "value1"
 msgstr "Wert1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:74
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
 msgid "value2"
 msgstr "Wert2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Betrachtet die Werte jedes Parameters in der gegebenen Reihenfolge und gibt den ersten Non-NULL Wert für jede Zeile zurück."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:56
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
 msgid "Comments"
 msgstr "Kommentare"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
 msgid "Notes"
 msgstr "Notizen"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
 msgid "No comments"
 msgstr "Keine Kommentare"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
 msgid "A column or value."
 msgstr "Eine Spalte oder Wert."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:65
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:77
 msgid "If value1 is empty, value2 gets returned if it's not empty, and so on."
 msgstr "Wenn Wert1 leer ist, wird Wert2 zurückgegeben falls dieser nicht leer ist, usw."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 msgid "Combines two or more strings of text together."
 msgstr "Kombiniert zwei oder mehr Textfolgen miteinander."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
 msgid "Last Name"
 msgstr "Nachname"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 msgid "First Name"
 msgstr "Vorname"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
 msgstr "Wert2 wird am Ende angefügt."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
 msgstr "Wird am Ende von Wert1 angefügt."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
 msgid "string1"
 msgstr "Zeichenkette1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
 msgid "string2"
 msgstr "Zeichenkette2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:80
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Prüft, ob Zeichenfolge1 Zeichenfolge2 enthält."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:284
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
 msgid "Status"
 msgstr "Status"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 msgid "Pass"
 msgstr "In Ordnung"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
 msgstr "Der Inhalt dieser Zeichenkette wird geprüft."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
 msgid "The string of text to look for."
 msgstr "Text, nach dem gesucht werden soll."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:90
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:116
 msgid "Returns the count of rows in the source data."
 msgstr "Gibt die Anzahl der Zeilen der Quelldaten zurück."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Only counts rows where the condition is true."
 msgstr "Zählt Zeilen nur bei erfüllter Bedingung."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:97
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:261
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
 msgid "Subtotal"
 msgstr "Zwischensumme"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
 msgid "The additive total of rows across a breakout."
 msgstr "Die kumulative Anzahl von Zeilen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:110
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
 msgid "The rolling sum of a column across a breakout."
 msgstr "Die kumulative Summe einer Spalte."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:113
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:268
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
 msgstr "Die zu summierende Spalte."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
 msgid "The number of distinct values in this column."
 msgstr "Anzahl eindeutiger Werte in dieser Spalte."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "The column whose distinct values to count."
 msgstr "Spalte deren Werte eindeutig gezählt werden sollen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:128
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:145
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:153
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:201
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:274
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
 msgid "text"
 msgstr "Text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:130
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:223
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
 msgid "comparison"
 msgstr "Vergleich"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Gibt bei passendem Vergleich des Text-Endes true zurück."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "Appetite"
 msgstr "Appetit"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "hungry"
 msgstr "hungrig"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 msgid "A column or string of text to check."
 msgstr "Eine Spalte oder Zeichenfolge mit zu prüfendem Text."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
 msgid "The string of text that the original text should end with."
 msgstr "Text mit dem der ursprüngliche Text enden soll."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 msgid "regular_expression"
 msgstr "regulärer Ausdruck"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:136
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Extrahiert Zeichenketten anhand eines regulären Ausdrucks."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:137
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
 msgid "Address"
 msgstr "Adresse"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 msgid "The column or string of text to search though."
 msgstr "Zu durchsuchende Spalte oder Text."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
 msgid "The regular expression to match."
 msgstr "Zutreffender regulärer Ausduck."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the string of text in all lowercase."
 msgstr "Gibt den Text in Kleinbuchstaben zurück."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:149
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to lowercase."
 msgstr "Spalten deren Werte in Kleinbuchstaben konvertiert werden sollen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:154
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 msgid "Removes leading whitespace from a string of text."
 msgstr "Entfernt vorgestellte Leerzeichen aus einem Text."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:157
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column with values you want to trim."
 msgstr "Spalte deren vor- und nachgestellte Leerzeichen entfernt werden sollen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "Returns the largest value found in the column."
 msgstr "Gibt den größten Wert aus der Spalte zurück."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
 msgid "Age"
 msgstr "Alter"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:165
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
 msgid "The numeric column whose maximum you want to find."
 msgstr "Numerisch Spalte deren Maximalwert gefunden werden soll."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:170
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "Returns the smallest value found in the column."
 msgstr "Gibt den kleinsten Wert aus der Spalte zurück."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
 msgid "Salary"
 msgstr "Gehalt"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:173
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
 msgid "The numeric column whose minimum you want to find."
 msgstr "Numerische Spalte deren Minimalwert gefunden werden soll."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:181
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:242
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
 msgid "position"
 msgstr "Position"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:194
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
 msgid "length"
 msgstr "Länge"
 
@@ -14164,7 +14183,7 @@ msgstr "Länge"
 msgid "new_text"
 msgstr "new_text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:187
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
 msgid "Replaces a part of the input text with new text."
 msgstr "Ersetzt einen Teil der Eingabe mit neuem Text."
 
@@ -14176,7 +14195,7 @@ msgstr "Bestellnummer"
 msgid "Updated Part of ID"
 msgstr "Neuer Teil der ID"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
 msgid "The text that will be modified."
 msgstr "Zu ändernder Text."
 
@@ -14192,87 +14211,87 @@ msgstr "Anzahl der zu ersetzenden Zeichen."
 msgid "The text to use in the replacement."
 msgstr "Text in dem ersetzt werden soll."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Entfern nachgestellte Leerzeichen aus einem Text."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:210
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Gibt den prozentualen Anteil der Zeilen als Dezimalzahl zurück, auf welche die Bedingung zutrifft."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:218
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Gibt bei passendem Vergleich des Text-Anfangs true zurück."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Course Name"
 msgstr "Kursname"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Computer Science"
 msgstr "Informatik"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
 msgid "The string of text that the original text should start with."
 msgstr "Die Zeichenfolge, mit der der ursprüngliche Text beginnen soll."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:229
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
 msgid "Calculates the standard deviation of the column."
 msgstr "Berechnet die Standardabweichung der Spalte."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:230
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
 msgid "Population"
 msgstr "Bevölkerung"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
 msgid "A numeric column."
 msgstr "Eine numerische Spalte."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
 msgid "Returns a portion of the supplied text."
 msgstr "Gibt einen Teil des übergebenen Textes zurück."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:241
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:313
 msgid "The text to return a portion of."
 msgstr "Text aus dem ein Teil zurückgegeben wird"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
 msgid "The position to start copying characters."
 msgstr "Die Startposition zum Kopieren der Zeichen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:245
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
 msgid "The number of characters to return."
 msgstr "Zurückzugebende Anzahl der Zeichen"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
 msgid "Adds up all the values of the column."
 msgstr "Addiert alle Werte der Spalte."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:253
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
 msgid "The numeric column to sum."
 msgstr "Die numerische Spalte, deren Summe ermittelt werden soll."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Summiert in einer Spalte alle Werte, auf welche die Bedingung zutrifft."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
 msgid "Order Status"
 msgstr "Bestellstatus"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
 msgid "Valid"
 msgstr "Gültig"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Entfernt vor- und nachgestellte Leerzeichen aus der Zeichenfolge."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
 msgid "Returns the string of text in all upper case."
 msgstr "Gibt den Text in Großbuchstaben zurück."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
 msgid "The column with values to convert to upper case."
 msgstr "Die Spalte mit Werten, die in Großbuchstaben umgewandelt werden sollen."
 
@@ -14334,39 +14353,39 @@ msgstr "Danke, dass Du Metabase verwendest!"
 msgid "Powered by {0}"
 msgstr "Angetrieben von {0}"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:191
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
 msgid "To:"
 msgstr "An:"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:40
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
 msgstr "Diese Frage kann nicht verwendet werden, da sie auf einer anderen Datenbank basiert."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:44
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:43
 msgid "Couldn't find a saved question with that ID number."
 msgstr "Eine gespeicherte Frage mit dieser ID-Nummer konnte nicht gefunden werden."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:55
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:54
 msgid "Pick a saved question"
 msgstr "Wähle eine gespeicherte Frage"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:57
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:56
 msgid "Pick a different question"
 msgstr "Wähle eine andere Frage"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:62
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:61
 msgid "Loading…"
 msgstr "Lade..."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:79
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:78
 msgid "Question #…"
 msgstr "Frage #..."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:81
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
 msgstr "Frage #{0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:115
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
 msgstr "Zuletzt bearbeitet {0}"
 
@@ -14378,11 +14397,11 @@ msgstr "{0} erzeugt eine Variable namens \"variable_name\" in dieser Abfrage-Vor
 msgid "Giving a variable the \"Field Filter\" type allows you to link questions to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "Einer Variable den Typ Feldfilter zu geben erlaubt das Verknüpfen von Fragen zu Filter-Widgets in Dashboards oder das Verwenden mehrerer Typen von Filter-Widgets in SQL-Fragen. Eine Feldfiltervariable generiert SQL, ähnlich wie es der Query Builder bei Filtern für bestehende Spalten tun würde."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:131
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
 msgstr "Variablenname"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:217
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:218
 msgid "Filter widget label"
 msgstr "Beschriftung des Filter-Widgets"
 
@@ -14414,11 +14433,11 @@ msgstr "In der Spaltenüberschrift"
 msgid "In every table cell"
 msgstr "In jeder Tabellenzelle"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:351
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:341
 msgid "Value formatting"
 msgstr "Formatierung des Wertes"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:361
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
 msgid "Full"
 msgstr "Vollständig"
 
@@ -14748,3 +14767,484 @@ msgstr "Fehler bei der Generierung von Einsichten für die Spalte:"
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandonment email!"
 msgstr "Sende Verlassensemail!"
+
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
+msgstr "Sie können Metriken speichern um eine Benannte-Metrik Option hinzuzufügen.\n"
+"Gespeicherte Metriken beinhalten den Aggrgations-Typ, das aggregierte Feld und optional beliebige Filter, die Sie hinzufügen.\n"
+"Zum Beispiel könnten Sie dies benutzen, um den offiziellen Weg zu definieren, wie der \"durchnittliche Preis\" für die Auftrags-Tabelle berechnet wird."
+
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:105
+msgid "Select and add filters to create your new segment."
+msgstr "Wählen und fügen Sie Filter hinzu, um Ihr neues Segment zu erstellen."
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+msgid "Alphabetical"
+msgstr "Alphabetisch geordnet"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+msgid "Smart"
+msgstr "Intelligent"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+msgid "Column order: {0}"
+msgstr "Reihenfolge der Spalten: {0}"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
+msgid "Unhide all"
+msgstr "Alle einblenden"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:204
+msgid "Hide all"
+msgstr "Alle ausblenden"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:206
+msgid "Unhide"
+msgstr "Einblenden"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:22
+msgid "New metric"
+msgstr "Neue Metrik"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:45
+msgid "Create metrics to add them to the Summarize dropdown in the query builder"
+msgstr "Erstellen Sie Metriken um sie dem Summierungs-DropDown des Query-Builders hinzuzufügen"
+
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:22
+msgid "New segment"
+msgstr "Neues Segment"
+
+#: frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx:71
+msgid "Filter by table"
+msgstr "Filtern nach Tabelle"
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:64
+msgid "Checking HTTPS..."
+msgstr "Überprüfen von HTTPS..."
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:66
+msgid "It looks like HTTPS is not properly configured"
+msgstr "Es sieht so aus, als ob HTTPS nicht richtig konfiguriert ist"
+
+#: frontend/src/metabase/admin/settings/selectors.js:57
+msgid "Redirect to HTTPS"
+msgstr "Weiterleitung zu HTTPS"
+
+#: frontend/src/metabase/admin/settings/selectors.js:219
+msgid "Localization"
+msgstr "Sprache"
+
+#: frontend/src/metabase/admin/settings/selectors.js:222
+msgid "Instance language"
+msgstr "Instanz-Sprache"
+
+#: frontend/src/metabase/admin/settings/selectors.js:237
+msgid "Localization options"
+msgstr "Sprache-Optionen"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:51
+msgid "This database doesn't have any tables."
+msgstr "Diese Datenbank hat keine Tabellen."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
+msgid "This field only accepts a single value because it's used in a SQL query."
+msgstr "Dieses Feld akzeptiert nur einen einzigen Wert, da es in einer SQL-Abfrage verwendet wird."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:17
+msgid "Service Accounts"
+msgstr "Dienstliche Konten"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:26
+msgid "Metabase connects to Big Query via {0}."
+msgstr "Metabase verbindet sich mit Big Query über {0}."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:29
+msgid "Continue using an OAuth application to connect"
+msgstr "Verwenden Sie weiterhin eine OAuth-Anwendung zum Verbinden"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:43
+msgid "We recommend switching to use {0} instead of an OAuth application to connect to BigQuery"
+msgstr "Wir empfehlen, anstatt einer OAuth Applikation {0} zu verwenden, um eine Verbindung zu BigQuery herzustellen."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:48
+msgid "Connect to a Service Account instead"
+msgstr "Stattdessen mit einem Servicekonto verbinden"
+
+#: frontend/src/metabase/entities/databases/forms.js:44
+msgid "invalid JSON"
+msgstr "ungültiger JSON"
+
+#: frontend/src/metabase/entities/databases/forms.js:50
+msgid "SSH private key"
+msgstr "Privater SSH-Schlüssel"
+
+#: frontend/src/metabase/entities/databases/forms.js:51
+msgid "Paste the contents of your ssh private key here"
+msgstr "Fügen Sie den Inhalt Ihres privaten ssh-Schlüssels hier"
+
+#: frontend/src/metabase/entities/databases/forms.js:55
+msgid "Passphrase for the SSH private key"
+msgstr "Passphrase für den privaten SSH-Schlüssel"
+
+#: frontend/src/metabase/entities/databases/forms.js:58
+msgid "SSH Authentication"
+msgstr "SSH-Authentifizierung"
+
+#: frontend/src/metabase/entities/databases/forms.js:60
+msgid "SSH Key"
+msgstr "SSH-Schlüssel"
+
+#: frontend/src/metabase/entities/databases/forms.js:65
+msgid "Server SSL certificate chain"
+msgstr "SSL-Zertifikatskette für Server"
+
+#: frontend/src/metabase/entities/databases/forms.js:66
+msgid "Paste the contents of the server's SSL certificate chain here"
+msgstr "Fügen Sie den Inhalt der SSL-Zertifikatskette des Servers hier ein"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:11
+msgid "Paste a connection string"
+msgstr "Einfügen einer Verbindungszeichenfolge"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:12
+msgid "Fill out individual fields"
+msgstr "Füllen Sie die einzelnen Felder aus"
+
+#: frontend/src/metabase/entities/snippets.js:14
+msgid "Enter some SQL here so you can reuse it later"
+msgstr "Geben Sie hier etwas SQL ein, damit Sie es später wiederverwenden können."
+
+#: frontend/src/metabase/entities/snippets.js:24
+msgid "Give your snippet a name"
+msgstr "Geben Sie Ihrem Snippet einen Namen"
+
+#: frontend/src/metabase/entities/snippets.js:25
+msgid "Current Customers"
+msgstr "Aktuelle Kunden"
+
+#: frontend/src/metabase/entities/snippets.js:30
+msgid "Add a description"
+msgstr "Eine Beschreibung hinzufügen"
+
+#: frontend/src/metabase/entities/users/forms.js:37
+msgid "Use site default"
+msgstr "Website-Vorgabe verwenden"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+msgid "find"
+msgstr "finden"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+msgid "replace"
+msgstr "ersetzen"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+msgid "The text to find."
+msgstr "Der zu findende Text."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "The text to use as the replacement."
+msgstr "Der als Ersatz zu verwendende Text."
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+msgid "Editing {0}"
+msgstr "Bearbeiten {0}"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+msgid "Create your new snippet"
+msgstr "Erstellen Sie Ihr neues Snippet"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+msgid "Archived snippets"
+msgstr "Archivierte Schnipsel"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+msgid "Snippets are reusable bits of SQL"
+msgstr "Snippets sind wiederverwendbare Teile von SQL"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+msgid "Create a snippet"
+msgstr "Ausschnitt erstellen"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+msgid "Snippets"
+msgstr "Schnipsel"
+
+#: frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx:15
+msgid "SQL Snippets"
+msgstr "SQL-Schnipsel"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:38
+msgid "Your language is set to {0}"
+msgstr "Ihre Sprache ist auf {0} eingestellt."
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:50
+msgid "What's your preferred language?"
+msgstr "Was ist Ihre bevorzugte Sprache?"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:54
+msgid "This language will be used throughout Metabase and will be the default for new users."
+msgstr "Diese Sprache wird in der gesamten Metabase verwendet und ist der Standard für neue Benutzer."
+
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:159
+msgid "We filtered out {0} row(s) containing null values."
+msgstr "Wir haben {0} Zeile(n) mit Nullwerten herausgefiltert."
+
+#: frontend/src/metabase/visualizations/lib/settings/series.js:133
+msgid "Show values for this series"
+msgstr "Werte für diese Serie anzeigen"
+
+#: src/metabase/api/card.clj
+msgid "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
+msgstr "Die durchschnittliche Ausführungsdauer der Frage ist {0}; bei Verwendung der \"magischen\" TTL von {1}"
+
+#: src/metabase/api/native_query_snippet.clj
+msgid "A snippet with that name already exists. Please pick a different name."
+msgstr "Ein Snippet mit diesem Namen existiert bereits. Bitte wählen Sie einen anderen Namen."
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Metric]"
+msgstr "[Unbekannte Metrik]"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Segment]"
+msgstr "[Unbekannte Segment]"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error writing error to output stream"
+msgstr "Fehler beim Schreiben in den Ausgabestrom"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Caught unexpected Exception in streaming response body"
+msgstr "Es ist ein unerwarteter Fehler beim streamen des Antworts-Bodys aufgetreten."
+
+#: src/metabase/async/streaming_response.clj
+msgid "bound-fn caught unexpected Exception"
+msgstr "bound-fn hat eine unerwartete Ausnahme gefangen."
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error determining whether HTTP request was canceled"
+msgstr "Fehler beim Prüfen, ob die HTTP Anfrage abgebrochen wurde"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Check cancelation status timed out after {0}"
+msgstr "Der Check-Annullierungsstatus ist nach {0} abgelaufen"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Unexpected exception in do-f-async"
+msgstr "Unerwarteter Fehler in do-f-async"
+
+#: src/metabase/async/streaming_response.clj src/metabase/server.clj
+msgid "Unexpected exception writing error response"
+msgstr "Unerwarteter Fehler beim Schreiben der Antwort."
+
+#: src/metabase/driver/common.clj
+msgid "Server certificate not trusted - did you specify the correct SSL certificate chain?"
+msgstr "Dem Server-Zertifikat wird nicht vertraut - haben Sie die korrekte SSL-Zertifikatskette gewählt/gesetzt?"
+
+#: src/metabase/driver/common.clj
+msgid "Server appears to require SSL - please enable SSL above"
+msgstr "Server scheint SSL zu erfordern - bitte aktivieren Sie SSL oben"
+
+#: src/metabase/driver/common.clj
+msgid "Username"
+msgstr "Benutzername"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Don''t know how to parse parameter of type {0}"
+msgstr "Der Parameter vom Typ {0} kann nicht geparsed werden."
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Invalid :card parameter: missing `:card-id`"
+msgstr "Ungültiger :card parameter. ':card-id' fehlt"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Unable to resolve Snippet: missing `:snippet-id`"
+msgstr "Kann Snippet nicht auflösen: ':snippet-id' fehlt"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Snippet {0} {1} not found."
+msgstr "Schnipsel {0} {1} nicht gefunden."
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error determining value for parameter"
+msgstr "Fehler beim Bestimmen eines Wertes für den Parameter."
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error building query parameter map"
+msgstr "Fehler beim Erzeugen der Abfrage-Parameter Map"
+
+#: src/metabase/middleware/log.clj
+msgid "ASYNC"
+msgstr "ASYNC"
+
+#: src/metabase/middleware/log.clj
+msgid "{0} ({1} DB calls)"
+msgstr "{0} ({1} DB-Aufrufe)"
+
+#: src/metabase/middleware/log.clj
+msgid "App DB connections: {0}/{1}"
+msgstr "DB-Verbindungen anwenden: {0}/{1}"
+
+#: src/metabase/middleware/log.clj
+msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
+msgstr "Jetty threads: {0}/{1} ({2} untätig, {3} wartend)"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} total active threads)"
+msgstr "({0} aktive threads ingesamt)"
+
+#: src/metabase/middleware/log.clj
+msgid "Queries in flight: {0}"
+msgstr "Abfragen in Ausführung: {0}"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} queued)"
+msgstr "({0} wartend)"
+
+#: src/metabase/models/collection.clj
+msgid "Collection must be in the same namespace as its parent"
+msgstr "Die Sammlung muss im selben Namespace sein wie die übergeordnete Sammlung."
+
+#: src/metabase/models/collection.clj
+msgid "Personal Collections must be in the default namespace"
+msgstr "Persönliche Sammlungen müssen im Default-Namespace sein."
+
+#: src/metabase/models/collection.clj
+msgid "You cannot move a Collection to a different namespace once it has been created."
+msgstr "Sie können eine Sammlung nicht in einen anderen Namensraum verschieben sobald sie erstellt wurde."
+
+#: src/metabase/models/collection.clj src/metabase/models/permissions.clj
+msgid "Collection does not exist."
+msgstr "Sammlung existiert nicht."
+
+#: src/metabase/models/collection.clj
+msgid "A {0} can only go in Collections in the {1} namespace."
+msgstr "{0} kann nur in Sammlungen des Namensraums {1} enthalten sein."
+
+#: src/metabase/models/database.clj
+msgid "Error sending database deletion notification"
+msgstr "Fehler beim Senden einer Benachrichtigung über Datenbanklöschung"
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "You cannot update the creator_id of a NativeQuerySnippet."
+msgstr "Sie können die creator_id eines NativeQuerySnippets nicht aktualisieren."
+
+#: src/metabase/models/setting.clj
+msgid "Error fetching value of Setting"
+msgstr "Fehlerabrufwert von Setting"
+
+#: src/metabase/public_settings.clj
+msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
+msgstr "Die Sprache, die in der Metabase GUI, System-Mails, Pulsen und Alarmen verwendet werden soll."
+
+#: src/metabase/public_settings.clj
+msgid "This is also the default language for all users, which they can change from their own account settings."
+msgstr "Dies ist auch die Default-Sprache für alle Benutzer, die sie in ihren Account-Einstellungen ändern können."
+
+#: src/metabase/public_settings.clj
+msgid "Invalid locale {0}"
+msgstr "Ungültige Sprache {0}"
+
+#: src/metabase/public_settings.clj
+msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
+msgstr "HTTPS-Verkehr per Umleitung erzwingen, wenn die Site-URL HTTPS ist"
+
+#: src/metabase/public_settings.clj
+msgid "Cannot redirect requests to HTTPS unless `site-url` is HTTPS."
+msgstr "Anfragen an HTTPS können nicht umgeleitet werden, außer die `site-url` ist ebenfalls HTTPS."
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error registering fonts: Metabase will not be able to send Pulses."
+msgstr "Fehler beim Registrieren der Fonts. Metabase wird nicht in der Lage sein, Pulse zu versenden."
+
+#: src/metabase/pulse/render/png.clj
+msgid "This is a known issue with certain JVMs. See {0} and for more details."
+msgstr "Dies ist ein bekanntes Problem mit bestimmten JVMs. Für weitere Details: {0}"
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error rendering Pulse"
+msgstr "Fehler beim Versenden des Pulses."
+
+#: src/metabase/query_processor/context/default.clj
+msgid "Query timed out after {0}, raising timeout exception."
+msgstr "Die Abfrage wurde nach {0} abgebrochen, wodurch eine Zeitüberschreitungsausnahme ausgelöst wird."
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "No fields found for table {0}."
+msgstr "Für Tabelle {0} wurden keine Felder gefunden."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Case"
+msgstr "Fall"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Variance of {0}"
+msgstr "Abweichung von {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Median of {0}"
+msgstr "Median von {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "{0}th percentile of {1}"
+msgstr "{0}. Perzentil von {1}"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Not caching results: results are larger than {0} KB"
+msgstr "Ergebnisse werden nicht gecached: Ergebnisse sind größer als {0} KB"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Cannot cache results: expected byte array, got {0}"
+msgstr "Ergebnisse können nicht gecached werden: Es wurde ein Byte-Array erwartet, jedoch erhalten: {0}"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Request is closed; no one to return cached results to"
+msgstr "Anfrage ist geschlossen, kann die"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Error attempting to fetch cached results for query with hash {0}"
+msgstr "Fehler beim Versuch, die gecachten Ergebnisse zur Abfrage mit dem Hash {0} zu laden"
+
+#: src/metabase/query_processor/middleware/cache_backend/db.clj
+msgid "Error preparing statement to fetch cached query results"
+msgstr "Fehler bei der Vorbereitung des Statements zum laden der gecachten Abfrageergebnisse."
+
+#: src/metabase/query_processor/middleware/catch_exceptions.clj
+msgid "Error processing query: {0}"
+msgstr "Fehlerverarbeitungsanfrage: {0}"
+
+#: src/metabase/server.clj
+msgid "Unexpected exception in endpoint"
+msgstr "Unerwarteter Fehler im Endpunkt"
+
+#: src/metabase/server.clj
+msgid "Unexpected Exception in API request handler"
+msgstr "Unerwartete Ausnahme in der API Anfrage-Behandlung"
+
+#: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+msgid "Error reducing {0}"
+msgstr "Fehler beim Verkleinern von {0}"
+
+#: src/metabase/sync/analyze/fingerprint/insights.clj
+msgid "Error generating timeseries insight keyed by: {0}"
+msgstr "Fehler bei der Generierung der Zeitreiheneinsicht mit dem Schlüssel: {0} "
+
+#: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
+msgstr "Die Position der Datenbank {0} hat sich von \"{1}\" auf \"{2}\" geändert"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Unscheduling task for Database {0}: trigger: {1}"
+msgstr "Task der Datenbank {0}: Trigger {1} wird beendet"
+
+#: src/metabase/util/schema.clj
+msgid "value must be a keyword or string."
+msgstr "Der Wert muss ein Schlüsselwort oder eine Zeichenkette sein."
+
+#: src/metabase/util/schema.clj
+msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
+msgstr "Die Zeichenfolge muss ein gültiger zweibuchstabiger ISO-Sprach- oder Sprach-Ländercode sein, z.B. 'de' oder 'de_DE'."

--- a/locales/fa.po
+++ b/locales/fa.po
@@ -33,13 +33,14 @@ msgid "Select a database type"
 msgstr "یک نوع پایگاه داده را انتخاب کن"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:411
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:154
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -54,7 +55,7 @@ msgid "To do some of its magic, Metabase needs to scan your database. We will al
 msgstr "برای ادامه کار، متابیس نیاز دارد پایگاه داده شما را اسکن کند.\n"
 "همچنان برای آپدیت ماندن متابیس این کار به صورت دوره ای و اتوماتیک نیز انجام میشود، شما میتوانید زمان بازه ها را تنظیم کنید."
 
-#: frontend/src/metabase/entities/databases/forms.js:221
+#: frontend/src/metabase/entities/databases/forms.js:290
 #, fuzzy
 msgid "Database syncing"
 msgstr "همگام سازی پایگاه داده"
@@ -71,7 +72,7 @@ msgstr "این یک فرایند سبک برای برسی بروز بودن شم
 msgid "Scan"
 msgstr "بررسی"
 
-#: frontend/src/metabase/entities/databases/forms.js:228
+#: frontend/src/metabase/entities/databases/forms.js:297
 #, fuzzy
 msgid "Scanning for Filter Values"
 msgstr "جستجو برای مقادیر فیلتر"
@@ -83,7 +84,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "متابیس می‌تواند تمامی مقادیر حاضر در هر فید این دیتابیس را اسکن کند تا فیلترهای جعبه چک را در داشبوردها و سؤالات فعّال کند. این می‌تواند تاحدّی یک پردازش با مصرف زیاد از منابع باشد، به‌خصوص اگر شما یک دیتابیس خیلی بزرگ دارید."
 
-#: frontend/src/metabase/entities/databases/forms.js:232
+#: frontend/src/metabase/entities/databases/forms.js:301
 #, fuzzy
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "چه زمانی باید متابیس به صورت اتوماتیک مقادیر فیلدها را برسی و در حافظه نگه دارد؟"
@@ -108,6 +109,7 @@ msgid "Never, I'll do this manually if I need to"
 msgstr "هرگز، اگر لازم داشته باشم به صورت دستی انجام خواهم داد"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 #, fuzzy
@@ -147,9 +149,9 @@ msgid "in this box:"
 msgstr "داخل این کادر:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:75
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
@@ -166,18 +168,18 @@ msgstr "داخل این کادر:"
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:301
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:39
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:90
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:99
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:311
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:328
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "لغو"
@@ -194,7 +196,7 @@ msgstr "حذف"
 #: frontend/src/metabase/admin/permissions/selectors.js:323
 #: frontend/src/metabase/admin/permissions/selectors.js:330
 #: frontend/src/metabase/admin/permissions/selectors.js:441
-#: frontend/src/metabase/admin/routes.jsx:57
+#: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
@@ -214,9 +216,10 @@ msgid "Scheduling"
 msgstr "برنامه ریزی کردن"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:71
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
@@ -224,8 +227,8 @@ msgid "Save changes"
 msgstr "ذخیره کردن تغییرات"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:203
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:35
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
 msgstr "اقدام"
 
@@ -237,8 +240,8 @@ msgstr "در حال همگام سازی شمای دیتابیس"
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:90
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:98
 msgid "Starting…"
 msgstr "در حال شروع..."
 
@@ -256,13 +259,13 @@ msgstr "در حال بررسی مجدد مقادیر فیلد"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
 msgstr "بررسی انجام نگرفت"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:92
 msgid "Scan triggered!"
 msgstr "اسکن شروع شد"
 
@@ -285,15 +288,15 @@ msgid "Add database"
 msgstr "اضافه کردن پایگاه داده"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:28
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:28
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
 #: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:195
+#: frontend/src/metabase/entities/databases/forms.js:264
 #: frontend/src/metabase/entities/questions.js:86
 #: frontend/src/metabase/entities/questions.js:102
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
@@ -333,6 +336,7 @@ msgstr "با موفقیت ذخیره شد!"
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "ویرایش"
@@ -375,7 +379,7 @@ msgstr "ناموفق"
 msgid "Success"
 msgstr "موفقیت"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:185
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
@@ -383,37 +387,36 @@ msgstr "موفقیت"
 msgid "Preview"
 msgstr "پیش نمایش"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:93
 msgid "No column description yet"
 msgstr "هیچ توصیف ستونی هنوز وجود ندارد"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:127
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:126
 msgid "Select a field visibility"
 msgstr "انتخاب قابلیت مشاهده یک فیلد"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:187
 msgid "No special type"
 msgstr "نوع خاصی یافت نشد"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
 #: frontend/src/metabase/lib/core.js:275
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:44
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:37
 msgid "Other"
 msgstr "سایر"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:221
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "یک نوع خاص را انتخاب کنید"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:255
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:262
 #: frontend/src/metabase/reference/components/Field.jsx:99
 msgid "Select a target"
 msgstr "یک هدف را انتخاب کنید"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
@@ -421,18 +424,18 @@ msgstr "یک هدف را انتخاب کنید"
 msgid "Columns"
 msgstr "ستون‌ها"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "ستون"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:144
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:288
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
 msgid "Visibility"
 msgstr "رؤیت"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
 msgid "Type"
 msgstr "نوع"
 
@@ -440,7 +443,7 @@ msgstr "نوع"
 msgid "Current database:"
 msgstr "پایگاه داده فعلی:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
 msgid "Show original schema"
 msgstr "نمایش طرح اولیه"
 
@@ -461,27 +464,27 @@ msgid "{0} schema"
 msgid_plural "{0} schemas"
 msgstr[0] "{0} طرح"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:99
 msgid "Why Hide?"
 msgstr "چرا پنهان شدی؟"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:100
 msgid "Technical Data"
 msgstr "داده های فنی"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
 msgstr "بی ربط / Cruft"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 msgid "Queryable"
 msgstr "قابل پرس و جو"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:108
 msgid "Hidden"
 msgstr "پنهان"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136
 msgid "No table description yet"
 msgstr "هیچ توضیحی در جدول وجود ندارد"
 
@@ -489,30 +492,31 @@ msgstr "هیچ توضیحی در جدول وجود ندارد"
 msgid "Metadata Strength"
 msgstr "قدرت متادیتا"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0} جدول پرس و جو"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:91
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} جدول پنهان"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:115
 msgid "Find a table"
 msgstr "یک جدول را پیدا کنید"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:128
 msgid "Schemas"
 msgstr "طرح ها"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:838
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:21
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:43
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:62
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 msgid "Metrics"
 msgstr "متریک‌ها"
@@ -521,8 +525,8 @@ msgstr "متریک‌ها"
 msgid "Add a Metric"
 msgstr "یک سنجش اضافه کن"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "تعریف"
@@ -531,12 +535,12 @@ msgstr "تعریف"
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "ایجاد متریک برای اضافه کردن آنها به نمایش کشویی در سازنده پرس و جو"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:21
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
 #: frontend/src/metabase/home/containers/SearchApp.jsx:72
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:961
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:61
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "بخش ها"
@@ -545,35 +549,35 @@ msgstr "بخش ها"
 msgid "Add a Segment"
 msgstr "یک بخش اضافه کن"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:51
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:45
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "ایجاد بخش ها برای افزودن آنها به فیلتر کشویی در کوری ساز"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:21
 msgid "created"
 msgstr "ایجاد شده"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "reverted to a previous version"
 msgstr "به نسخه قبلی برگشت"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:30
 msgid "edited the title"
 msgstr "ویرایش عنوان"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:32
 msgid "edited the description"
 msgstr "ویرایش توضیحات"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:34
 msgid "edited the "
 msgstr "ویرایش ␣"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:40
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "made some changes"
 msgstr "ایجاد بعضی تغییرات"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
 #: frontend/src/metabase/home/components/Activity.jsx:83
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
@@ -583,84 +587,84 @@ msgstr "شما"
 msgid "Datamodel"
 msgstr "مدل داده"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:41
 msgid " History"
 msgstr "تاریخچه␣"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
 msgstr "تاریخچه نسخه گذاری برای"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:228
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
 msgid "{0} – Field Settings"
 msgstr "{0} - تنظیمات فیلد"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:289
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
 msgid "Where this field will appear throughout Metabase"
 msgstr "کجا این فیلد در سراسر Metabase ظاهر می شود"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:311
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
 msgid "Filtering on this field"
 msgstr "فیلتر کردن این فیلد"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:312
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "هنگامی که این فیلد در یک فیلتر استفاده می شود، چه افرادی باید برای وارد کردن مقدار مورد نظر برای فیلتر کردن، چه استفاده کنند؟"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:437
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
 msgid "No description for this field yet"
 msgstr "هنوز برای این قیلد توضیحی نوشته نشده است"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
 msgid "Original value"
 msgstr "مقدار اصلی"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:390
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
 msgid "Mapped value"
 msgstr "مقدار Map شده"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
 msgid "Enter value"
 msgstr "مقدار را وارد کنید"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use original value"
 msgstr "از مقدار اصلی استفاده کنید"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Use foreign key"
 msgstr "از کلید خارجی استفاده کنید"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 msgid "Custom mapping"
 msgstr "Map سفارشی"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
 msgid "Unrecognized mapping type"
 msgstr "نوع Map غیر قابل تشخیص"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "فیلد جاری دارای کلید خارجی نیست یا متا دیتای جدولی که هدف کلید خارجی است وجود ندارد"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
 msgid "The selected field isn't a foreign key"
 msgstr "فیلد انتخابی کلید خارجی نیست"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:327
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
 msgid "Display values"
 msgstr "نمایش مقادیر"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:328
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "انتخاب کنید که ارزش اصلی را از پایگاه داده نشان می دهد یا این اطلاعات را نمایش داده یا مرتبط کنید."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:278
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
 msgid "Choose a field"
 msgstr "یک فیلد را انخاب کنید"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:299
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
 msgid "Please select a column to use for display."
 msgstr "لطفا یک ستون را برای نمایش انتخاب کنید."
 
@@ -668,16 +672,16 @@ msgstr "لطفا یک ستون را برای نمایش انتخاب کنید."
 msgid "Tip:"
 msgstr "نکته:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:443
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "شما ممکن است بخواهید نام فیلد را به روز کنید تا مطمئن شوید که هنوز بر اساس گزینه های بازخوانی شما منطقی است."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:344
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "مقادیر فیلد ذخیره شده"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:345
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase می تواند مقادیر این فیلد را فعال کند تا فیلترهای جعبه چک را در داشبورد و سوالات فعال کند."
 
@@ -686,54 +690,54 @@ msgid "Re-scan this field"
 msgstr "دوباره این زمینه را اسکن کنید"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
 msgstr "نادیده گرفتن مقادیر فیلد ذخیره شده"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
 msgstr "نادیده گرفتن مقادیر ناموفق بود"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 msgid "Discard triggered!"
 msgstr "تغییرات را نادیده بگیر!"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "جدولی را برای مشاهد شما و یا ویرایش متادیتا انتخاب نمایید."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:36
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
 #, fuzzy
 msgid "Name is required"
 msgstr "نام مورد نیاز است"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:39
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "توضیح مورد نیاز است"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:43
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "پیام بازبینی مورد نیاز است"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
 msgid "Aggregation is required"
 msgstr "یکپارچه‌سازی لازم است"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Edit Your Metric"
 msgstr "متریک خود را ویرایش کنید"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Create Your Metric"
 msgstr "متریک خود را ایجاد کنید"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "تغییر در متریک خود را انجام دهید و یک یادداشت توضیحی را ترک کنید."
 
@@ -741,62 +745,62 @@ msgstr "تغییر در متریک خود را انجام دهید و یک یا�
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "شما می توانید معیارهای ذخیره شده را برای افزودن یک گزینه متریک نام به این جدول ایجاد کنید. معیارهای ذخیره شده شامل نوع تجمع، فیلد جمع شده و به صورت اختیاری هر فیلتر اضافه می شود. به عنوان مثال، شما ممکن است از این برای ایجاد چیزی شبیه روش رسمی محاسبه \"میانگین قیمت\" برای جدول سفارشات استفاده کنید."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:180
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
 msgid "Result: "
 msgstr "نتیجه:"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
 msgid "Name Your Metric"
 msgstr "نام متریک خود را"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:190
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Give your metric a name to help others find it."
 msgstr "نام متریک خود را برای کمک به دیگران پیدا کنید."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:194
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:152
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "چیزی توصیفی اما نه خیلی طولانی"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:198
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
 msgid "Describe Your Metric"
 msgstr "متریک خود را شرح دهید"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:199
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "توضیحات متریک خود را برای کمک به دیگران درک کنید."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:203
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "این مکان بسیار خوبی است که درمورد قوانین متریک کمتر آشکارتر باشد"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:207
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:165
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "دلیل تغییرات"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:209
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "یک یادداشت را برای توضیح آنچه که تغییراتی ایجاد کرده اید و چرا آنها مورد نیاز بود را ترک کنید."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:213
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "این در تاریخ تجدید نظر برای این متریک نشان داده خواهد شد تا به همه کمک کند که به یاد داشته باشید که چرا همه چیز تغییر کرده است"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
 msgstr "حداقل یک فیلتر مورد نیاز است"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
 msgstr "بخش شما را ویرایش کنید"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
 msgstr "ایجاد بخش شما"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "تغییرات را در بخش خود انجام دهید و یک یادداشت توضیحی را ترک کنید."
 
@@ -804,33 +808,33 @@ msgstr "تغییرات را در بخش خود انجام دهید و یک یا�
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "برای ایجاد بخش جدید خود برای جدول {0} را انتخاب کنید و فیلترها را اضافه کنید"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
 msgstr "بخش خود را بنویسید"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:148
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
 msgstr "بخش خود را به نام برای کمک به دیگران پیدا کنید."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:156
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
 msgstr "بخش خود را توصیف کنید"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "شرح خود را به بخش خود بدهید تا دیگران را در درک آنچه در مورد آن هستید کمک کنید."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "این مکان خوبی است که در مورد قوانین جزئی کمتر آشکار باشد"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "این در تاریخ تجدید نظر برای این بخش نشان داده خواهد شد تا به همه کمک کند که به یاد داشته باشید که چرا همه چیز تغییر کرده است"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
-#: frontend/src/metabase/admin/routes.jsx:132
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:215
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
+#: frontend/src/metabase/admin/routes.jsx:137
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
@@ -838,11 +842,11 @@ msgstr "این در تاریخ تجدید نظر برای این بخش نشان
 msgid "Settings"
 msgstr "تنضیمات"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase می تواند مقادیر در این جدول را اسکن کند تا فیلترهای جعبه چک را در داشبورد و سوالات فعال کند."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
 msgstr "دوباره این جدول را اسکن کنید"
 
@@ -856,11 +860,11 @@ msgstr "اضافه کردن"
 msgid "Not a valid formatted email address"
 msgstr "یک آدرس ایمیل فرمت معتبر نیست"
 
-#: frontend/src/metabase/entities/users/forms.js:12
+#: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
 msgstr "نام"
 
-#: frontend/src/metabase/entities/users/forms.js:18
+#: frontend/src/metabase/entities/users/forms.js:20
 msgid "Last name"
 msgstr "نام خانوادگی"
 
@@ -901,10 +905,10 @@ msgstr "اعضا"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
-#: frontend/src/metabase/admin/settings/selectors.js:120
-#: frontend/src/metabase/entities/users/forms.js:24
+#: frontend/src/metabase/admin/settings/selectors.js:121
+#: frontend/src/metabase/entities/users/forms.js:26
 #: frontend/src/metabase/lib/core.js:146
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:294
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:298
 msgid "Email"
 msgstr "ایمیل"
 
@@ -913,14 +917,14 @@ msgid "A group is only as good as its members."
 msgstr "گروه فقط به عنوان اعضای آن است."
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
-#: frontend/src/metabase/admin/routes.jsx:52
+#: frontend/src/metabase/admin/routes.jsx:55
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Admin"
 msgstr "مدیر/ مدیر سیستم"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:241
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:299
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:288
 msgid "and"
 msgstr "و"
 
@@ -972,12 +976,12 @@ msgstr "حذف گروه"
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:42
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:294
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:397
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:317
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:334
 msgid "Done"
 msgstr "انجام شد"
 
@@ -988,8 +992,9 @@ msgstr "نام گروه"
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
-#: frontend/src/metabase/admin/routes.jsx:92
+#: frontend/src/metabase/admin/routes.jsx:97
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "گروه‌ها"
 
@@ -1019,7 +1024,7 @@ msgstr "غیرفعال"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:21
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
-#: frontend/src/metabase/admin/routes.jsx:88
+#: frontend/src/metabase/admin/routes.jsx:93
 #: frontend/src/metabase/nav/containers/Navbar.jsx:235
 msgid "People"
 msgstr "مردم"
@@ -1332,25 +1337,25 @@ msgstr "مشاهده مجموعه"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:542
+#: frontend/src/metabase/admin/permissions/selectors.js:558
 msgid "Data Access"
 msgstr "دسترسی به داده ها"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:667
-#: frontend/src/metabase/admin/permissions/selectors.js:672
+#: frontend/src/metabase/admin/permissions/selectors.js:665
+#: frontend/src/metabase/admin/permissions/selectors.js:670
 msgid "View tables"
 msgstr "مشاهده جداول"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:608
+#: frontend/src/metabase/admin/permissions/selectors.js:606
 msgid "SQL Queries"
 msgstr "SQL Queries"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:678
+#: frontend/src/metabase/admin/permissions/selectors.js:676
 msgid "View schemas"
 msgstr "نمایش طرح ها"
 
-#: frontend/src/metabase/admin/routes.jsx:63
+#: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
 msgstr "مدل داده"
@@ -1380,20 +1385,24 @@ msgid "Allows users within your LDAP directory to log in to Metabase with their 
 msgstr "اجازه می دهد تا کاربران در دایرکتوری LDAP خود را به Metabase با اعتبار LDAP خود وارد شوند، و اجازه می دهد تا نقشه های خودکار LDAP را به گروه های Metabase بطور خودکار."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:19
-#: frontend/src/metabase/admin/settings/selectors.js:167
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
+#: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
 msgstr "این یک آدرس ایمیل معتبر نیست"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
 msgstr "این یک عدد صحیح معتبر نیست"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
 msgstr "تغییرات ذخیره شد!"
 
-#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:178
+#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
 msgid "Looks like we ran into some problems"
 msgstr "به نظر می رسد ما به برخی از مشکلات رسیدگی کردیم"
 
@@ -1415,7 +1424,7 @@ msgstr "پاک کردن"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:195
+#: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "احراز هویت"
 
@@ -1467,15 +1476,15 @@ msgstr "نشانه کاربری شما در گوگل"
 msgid "Allow users to sign up on their own if their Google account email address is from:"
 msgstr "اجازه دهید کاربران خود را ثبت نام کنند اگر آدرس ایمیل حساب Google خود از آن است:"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:242
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:249
 msgid "Answers sent right to your Slack #channels"
 msgstr "پاسخ های ارسال شده به اسلک #channels شما درست است"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:251
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:258
 msgid "Create a Slack Bot User for MetaBot"
 msgstr "برای استفاده از MetaBot یک کاربر Slack Bot ایجاد کنید"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:261
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:268
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "هنگامی که شما آنجا هستید، نام آن را بنویسید و {0} را کلیک کنید. سپس Token Bot API را به فیلد زیر کپی و جایگذاری کنید. پس از اتمام کار، کانال \"metabase_files\" را در Slack ایجاد کنید. Metabase برای بارگذاری نمودارها نیاز دارد."
 
@@ -1488,8 +1497,8 @@ msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Metabase {0} در دسترس است شما در حال اجرا {1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:41
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 msgid "Update"
 msgstr "به روز رسانی"
 
@@ -1516,16 +1525,16 @@ msgstr "حذف نقشه سفارشی"
 #: frontend/src/metabase/containers/Overworld.jsx:293
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:115
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "پاک کردن"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:165
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:141
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
 msgstr "اتخاب..."
 
@@ -1710,48 +1719,46 @@ msgid "Generate Key"
 msgstr "تولید کلید"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:87
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:18
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enabled"
 msgstr "فعالسازی"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:92
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:19
+#: frontend/src/metabase/admin/settings/selectors.js:93
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "غیرفعال سازی"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:112
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:113
 msgid "Unknown setting {0}"
 msgstr "تنظیم ناشناخته {0}"
 
-#: frontend/src/metabase/admin/settings/selectors.js:34
+#: frontend/src/metabase/admin/settings/selectors.js:37
 msgid "Setup"
 msgstr "برپایی"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:207
-#: frontend/src/metabase/admin/settings/selectors.js:39
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:214
+#: frontend/src/metabase/admin/settings/selectors.js:42
 msgid "General"
 msgstr "عمومی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:43
+#: frontend/src/metabase/admin/settings/selectors.js:46
 msgid "Site Name"
 msgstr "نام پایگاه"
 
-#: frontend/src/metabase/admin/settings/selectors.js:48
+#: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Site URL"
 msgstr "لینک پایگاه"
 
-#: frontend/src/metabase/admin/settings/selectors.js:53
+#: frontend/src/metabase/admin/settings/selectors.js:64
 msgid "Email Address for Help Requests"
 msgstr "آدرس ایمیل برای درخواست کمک"
 
-#: frontend/src/metabase/admin/settings/selectors.js:58
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
 msgstr "گزارش منطقه زمانی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:61
+#: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
 msgstr "پایگاه داده پیش فرض"
 
@@ -1759,11 +1766,11 @@ msgstr "پایگاه داده پیش فرض"
 msgid "Select a timezone"
 msgstr "یک منطقه زمانی انتخاب کنید"
 
-#: frontend/src/metabase/admin/settings/selectors.js:64
+#: frontend/src/metabase/admin/settings/selectors.js:75
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "همه پایگاه های داده از زمان زنجیره پشتیبانی نمی کنند، و در این صورت این تنظیم تاثیری نخواهد داشت."
 
-#: frontend/src/metabase/admin/settings/selectors.js:69
+#: frontend/src/metabase/entities/users/forms.js:34
 msgid "Language"
 msgstr "زبان"
 
@@ -1771,64 +1778,64 @@ msgstr "زبان"
 msgid "Select a language"
 msgstr "یک زبان انتخاب کنید"
 
-#: frontend/src/metabase/admin/settings/selectors.js:79
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
 msgstr "پیگیری ناشناس"
 
-#: frontend/src/metabase/admin/settings/selectors.js:84
+#: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
 msgstr "جدول دوستانه و نام های میدان"
 
-#: frontend/src/metabase/admin/settings/selectors.js:90
+#: frontend/src/metabase/admin/settings/selectors.js:91
 msgid "Only replace underscores and dashes with spaces"
 msgstr "فقط با استفاده از فضاهای زیر حروف و خطوط را جایگزین کنید"
 
-#: frontend/src/metabase/admin/settings/selectors.js:98
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Enable Nested Queries"
 msgstr "مسدود سازی پرس و جوها را فعال کنید"
 
-#: frontend/src/metabase/admin/settings/selectors.js:109
+#: frontend/src/metabase/admin/settings/selectors.js:110
 msgid "Updates"
 msgstr "به روز رسانی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:114
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
 msgstr "بررسی برای به روز رسانی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:125
+#: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
 msgstr "میزبان SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:133
+#: frontend/src/metabase/admin/settings/selectors.js:134
 msgid "SMTP Port"
 msgstr "پورت SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:137
+#: frontend/src/metabase/admin/settings/selectors.js:138
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:47
 msgid "That's not a valid port number"
 msgstr "این یک شماره پورت معتبر نیست"
 
-#: frontend/src/metabase/admin/settings/selectors.js:141
+#: frontend/src/metabase/admin/settings/selectors.js:142
 msgid "SMTP Security"
 msgstr "SMTP امنیت"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:150
 msgid "SMTP Username"
 msgstr "نام کاربری SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "SMTP Password"
 msgstr "رمز عبور SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:163
+#: frontend/src/metabase/admin/settings/selectors.js:164
 msgid "From Address"
 msgstr "از آدرس"
 
-#: frontend/src/metabase/admin/settings/selectors.js:176
+#: frontend/src/metabase/admin/settings/selectors.js:178
 msgid "Slack API Token"
 msgstr "Slack API Token"
 
-#: frontend/src/metabase/admin/settings/selectors.js:178
+#: frontend/src/metabase/admin/settings/selectors.js:180
 msgid "Enter the token you received from Slack"
 msgstr "رمزتان را که از Slack دریافت کرده اید وارد کنید"
 
@@ -1857,8 +1864,10 @@ msgid "Username or DN"
 msgstr "نام کاربری یا DN"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:43
+#: frontend/src/metabase/entities/databases/forms.js:61
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:64
-#: frontend/src/metabase/user/components/UserSettings.jsx:65
+#: frontend/src/metabase/user/components/UserSettings.jsx:66
+#: src/metabase/driver/common.clj
 msgid "Password"
 msgstr "کلمه عبور"
 
@@ -1894,79 +1903,79 @@ msgstr "همگام سازی اعضای گروه"
 msgid "Group search base"
 msgstr "پایگاه جستجوی گروهی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:199
+#: frontend/src/metabase/admin/settings/selectors.js:201
 msgid "Maps"
 msgstr "نقشه"
 
-#: frontend/src/metabase/admin/settings/selectors.js:203
+#: frontend/src/metabase/admin/settings/selectors.js:205
 msgid "Map tile server URL"
 msgstr "URL کاشی نقشه کاشی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:204
+#: frontend/src/metabase/admin/settings/selectors.js:206
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Metabase از طریق OpenStreetMaps به طور پیش فرض استفاده می کند."
 
-#: frontend/src/metabase/admin/settings/selectors.js:209
+#: frontend/src/metabase/admin/settings/selectors.js:211
 msgid "Custom Maps"
 msgstr "نقشه های سفارشی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:210
+#: frontend/src/metabase/admin/settings/selectors.js:212
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "فایل های GeoJSON خودتان را برای افزودن تصویر های مختلف نقشه های منطقه اضافه کنید"
 
-#: frontend/src/metabase/admin/settings/selectors.js:228
+#: frontend/src/metabase/admin/settings/selectors.js:245
 msgid "Public Sharing"
 msgstr "اشتراک عمومی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:232
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "Enable Public Sharing"
 msgstr "اشتراکگذاری عمومی را فعال کنید"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:254
 msgid "Shared Dashboards"
 msgstr "داشبورد به اشتراک گذاشته شده"
 
-#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Shared Questions"
 msgstr "سوالات مشترک"
 
-#: frontend/src/metabase/admin/settings/selectors.js:250
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Embedding in other Applications"
 msgstr "تعبیه در برنامه های دیگر"
 
-#: frontend/src/metabase/admin/settings/selectors.js:276
+#: frontend/src/metabase/admin/settings/selectors.js:293
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Enable Embedage Metabase در برنامه های دیگر"
 
-#: frontend/src/metabase/admin/settings/selectors.js:286
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Embedding secret key"
 msgstr "بستن کلید مخفی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:292
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Embedded Dashboards"
 msgstr "داشبورد جاسازی شده"
 
-#: frontend/src/metabase/admin/settings/selectors.js:298
+#: frontend/src/metabase/admin/settings/selectors.js:315
 msgid "Embedded Questions"
 msgstr "سوالات جاسازی شده"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:322
 msgid "Caching"
 msgstr "ذخیره سازی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:326
 msgid "Enable Caching"
 msgstr "فعال کردن ذخیره سازی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:314
+#: frontend/src/metabase/admin/settings/selectors.js:331
 msgid "Minimum Query Duration"
 msgstr "حداقل مدت زمان پرس و جو"
 
-#: frontend/src/metabase/admin/settings/selectors.js:321
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "زمان کشیدن به زمان (TTL) ضرب"
 
-#: frontend/src/metabase/admin/settings/selectors.js:328
+#: frontend/src/metabase/admin/settings/selectors.js:345
 msgid "Max Cache Entry Size"
 msgstr "حداکثر اندازه ورودی کش"
 
@@ -2134,7 +2143,8 @@ msgstr "داشبورد، مجموعه ها و پالس ها در این مجمو
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/routes.jsx:205
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
+#: frontend/src/metabase/routes.jsx:196
 msgid "Archive"
 msgstr "آرشیو"
 
@@ -2150,21 +2160,21 @@ msgstr "آرشیو را ببینید"
 msgid "Unarchive this {0}"
 msgstr "این را {0} بایگانی کنید"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:39
-#: frontend/src/metabase/components/BrowseApp.jsx:102
-#: frontend/src/metabase/components/BrowseApp.jsx:194
+#: frontend/src/metabase/components/BrowseApp.jsx:46
+#: frontend/src/metabase/components/BrowseApp.jsx:112
+#: frontend/src/metabase/components/BrowseApp.jsx:204
 #: frontend/src/metabase/containers/Overworld.jsx:270
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
 msgstr "اطلاعات ما"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:146
+#: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
 msgid "X-ray this table"
 msgstr "اشعه ایکس این جدول"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:161
+#: frontend/src/metabase/components/BrowseApp.jsx:171
 msgid "Learn about this table"
 msgstr "درباره این جدول اطلاعاتی کسب کنید"
 
@@ -2259,7 +2269,7 @@ msgstr "پین"
 msgid "Drag something here to pin it to the top"
 msgstr "چیزی را در اینجا بکشید تا آن را به بالا ببرید"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:755
+#: frontend/src/metabase/admin/permissions/selectors.js:753
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2312,7 +2322,7 @@ msgstr "مجموعه جدید"
 msgid "Copied!"
 msgstr "کپی شده!"
 
-#: frontend/src/metabase/entities/databases/forms.js:12
+#: frontend/src/metabase/entities/databases/forms.js:14
 msgid "Use an SSH-tunnel for database connections"
 msgstr "برای اتصال به پایگاه داده از یک تونل SSH استفاده کنید"
 
@@ -2324,7 +2334,7 @@ msgstr "برخی از تاسیسات پایگاه داده تنها با اتص�
 "این گزینه همچنین یک لایه اضافی امنیتی را هنگامی که یک VPN در دسترس نیست فراهم می کند.\n"
 "فعال کردن این معمولا کمتر از یک اتصال مستقیم است."
 
-#: frontend/src/metabase/entities/databases/forms.js:212
+#: frontend/src/metabase/entities/databases/forms.js:281
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "این یک پایگاه داده بزرگ است، بنابراین اجازه دهید زمانی که Metabase همگام سازی و اسکن کند، انتخاب کنم"
 
@@ -2334,17 +2344,17 @@ msgid "By default, Metabase does a lightweight hourly sync and an intensive dail
 msgstr "به طور پیش فرض، Metabase یک همگام سازی ساعته سبک و یک روزه اسکن شدید از مقادیر فیلد را می دهد.\n"
 "اگر شما یک پایگاه داده بزرگ دارید، توصیه می کنیم این را به کار ببندید و بررسی کنید که چه زمانی و چه مقدار ارزش فیلد اتفاق می افتد."
 
-#: frontend/src/metabase/entities/databases/forms.js:78
+#: frontend/src/metabase/entities/databases/forms.js:113
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0} برای ایجاد شناسه مشتری و مشتری راز برای پروژه شما."
 
-#: frontend/src/metabase/entities/databases/forms.js:80
-#: frontend/src/metabase/entities/databases/forms.js:95
-#: frontend/src/metabase/entities/databases/forms.js:131
+#: frontend/src/metabase/entities/databases/forms.js:115
+#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:166
 msgid "Click here"
 msgstr "اینجا کلیک کنید"
 
-#: frontend/src/metabase/entities/databases/forms.js:83
+#: frontend/src/metabase/entities/databases/forms.js:118
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "به عنوان نوع برنامه، \"دیگر\" را انتخاب کنید. نام هر آنچه را که دوست دارید."
 
@@ -2352,19 +2362,19 @@ msgstr "به عنوان نوع برنامه، \"دیگر\" را انتخاب ک�
 msgid "{0} to get an auth code"
 msgstr "{0} برای دریافت کد Auth"
 
-#: frontend/src/metabase/entities/databases/forms.js:107
+#: frontend/src/metabase/entities/databases/forms.js:142
 msgid "with Google Drive permissions"
 msgstr "با مجوزهای Google Drive"
 
-#: frontend/src/metabase/entities/databases/forms.js:129
+#: frontend/src/metabase/entities/databases/forms.js:164
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "برای استفاده از Metabase با این داده ها باید دسترسی API را در کنسول Google Developers ها فعال کنید."
 
-#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:165
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} برای رفتن به کنسول اگر قبلا چنین کاری نکرده اید."
 
-#: frontend/src/metabase/entities/databases/forms.js:196
+#: frontend/src/metabase/entities/databases/forms.js:265
 msgid "How would you like to refer to this database?"
 msgstr "چگونه می خواهید به این پایگاه داده مراجعه کنید؟"
 
@@ -2373,7 +2383,8 @@ msgstr "چگونه می خواهید به این پایگاه داده مراج�
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:143
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:70
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:123
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:96
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:126
 #: frontend/src/metabase/setup/components/UserStep.jsx:93
 msgid "Next"
 msgstr "بعدی"
@@ -2556,7 +2567,7 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "بازگشت به یک نسخه پیشین و {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:290
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "تاریخچه ویرایشهای"
@@ -2602,7 +2613,7 @@ msgid "Questions"
 msgstr "سوال"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:320
+#: frontend/src/metabase/routes.jsx:311
 msgid "Pulses"
 msgstr "پالس ها"
 
@@ -2647,15 +2658,16 @@ msgstr "ما کمی گم شده ..."
 msgid "Temporary Password"
 msgstr "گذرواژه موقت"
 
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:207
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:481
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
 msgid "Hide"
 msgstr "پنهان"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:467
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:482
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:471
 msgid "Show"
 msgstr "نمایش دادن"
 
@@ -2765,7 +2777,7 @@ msgstr "با عرض پوزش، شما مجاز به دیدن آن نیستید"
 msgid "Unknown error encountered"
 msgstr "خطای ناشناخته رخ داده است"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/nav/containers/Navbar.jsx:373
 msgid "Create"
 msgstr "بسازید"
@@ -2778,7 +2790,7 @@ msgstr "ایجاد داشبورد"
 msgid "Table"
 msgstr "جدول"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
 msgid "Database"
 msgstr "پایگاه داده"
 
@@ -2798,7 +2810,7 @@ msgstr "سعی کنید فیلتر خود را برای پیدا کردن آنچ
 msgid "View by"
 msgstr "مشاهده توسط"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:122
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:121
 msgid "of"
 msgstr "از"
 
@@ -2825,33 +2837,33 @@ msgstr "تجزیه و تحلیل ما"
 msgid "Browse all items"
 msgstr "همه موارد را مرور کنید"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:118
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:117
 msgid "Replace or save as new?"
 msgstr "جایگزین یا ذخیره شده به عنوان جدید؟"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:168
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace original question, \"{0}\""
 msgstr "سوال اصلی را تغییر دهید، \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:172
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:171
 msgid "Save as new question"
 msgstr "به عنوان سوال جدید ذخیره کنید"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:92
 msgid "First, save your question"
 msgstr "اول، سوال خود را ذخیره کنید"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:94
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
 msgid "Save question"
 msgstr "صرفه جویی در سوال"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:133
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
 msgid "What is the name of your card?"
 msgstr "نام کارت شما چیست؟"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
 #: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/entities/questions.js:89
@@ -2867,15 +2879,16 @@ msgstr "نام کارت شما چیست؟"
 msgid "Description"
 msgstr "توضیحات"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
 #: frontend/src/metabase/entities/dashboards.js:150
 #: frontend/src/metabase/entities/questions.js:91
 #: frontend/src/metabase/entities/questions.js:107
+#: frontend/src/metabase/entities/snippets.js:31
 msgid "It's optional but oh, so helpful"
 msgstr "این اختیاری است اما اوه، خیلی مفید است"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:148
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "کدام مجموعه باید این باشد؟"
@@ -2892,19 +2905,19 @@ msgstr "آیتم"
 msgid "Undo"
 msgstr "لغو"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:266
 msgid "Applying Question"
 msgstr "درخواست سوال"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:286
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "That question isn't compatible"
 msgstr "این سوال سازگار نیست"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:322
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:309
 msgid "Search for a question"
 msgstr "جستجو برای یک سوال"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:351
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:343
 msgid "We're not sure if this question is compatible"
 msgstr "ما مطمئن نیستیم که آیا این سوال سازگار است"
 
@@ -2953,25 +2966,23 @@ msgstr "سوالی اضافه کنید"
 msgid "Add a question to this dashboard"
 msgstr "یک سوال به این داشبورد اضافه کنید"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
 msgid "Add a filter"
 msgstr "یک فیلتر اضافه کنید"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:256
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "مولفه های"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:276
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:280
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
 msgid "Add a text box"
 msgstr "یک جعبه متن را اضافه کنید"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:320
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:314
 msgid "Move dashboard"
 msgstr "حرکت داشبورد"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:303
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
 msgid "Edit dashboard"
 msgstr "ویرایش داشبورد"
 
@@ -2979,11 +2990,11 @@ msgstr "ویرایش داشبورد"
 msgid "Edit Dashboard Layout"
 msgstr "ویرایش طرح بندی داشبورد"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:371
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:365
 msgid "You are editing a dashboard"
 msgstr "شما در حال ویرایش داشبورد هستید"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:376
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:370
 msgid "Select the field that should be filtered for each card"
 msgstr "فیلد را انتخاب کنید که باید برای هر کارت فیلتر شود"
 
@@ -3071,7 +3082,7 @@ msgstr "این کارت هیچ فیلدی یا پارامتری ندارد که 
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "مقادیر این فیلد با مقادیر هر فیلد دیگری که انتخاب کرده اید همپوشانی ندارد."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:162
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "هیچ فیلد معتبر وجود ندارد"
@@ -3139,7 +3150,7 @@ msgstr "آخرین اطلاعات دریافت شده از"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:329
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
 msgid "Unknown"
 msgstr "ناشناخته"
 
@@ -3266,6 +3277,7 @@ msgstr "{0} مورد انتخاب شده است"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 msgid "Unarchive"
 msgstr "بازخوانی"
 
@@ -3358,7 +3370,7 @@ msgid "Longitude"
 msgstr "عرض جغرافیایی"
 
 #: frontend/src/metabase/lib/core.js:43
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:45
 msgid "Number"
 msgstr "شماره"
@@ -3415,7 +3427,7 @@ msgid "User"
 msgstr "کاربر"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:211
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
 msgid "Source"
 msgstr "منبع"
 
@@ -3456,16 +3468,17 @@ msgid "Score"
 msgstr "امتیاز"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "عنوان"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
 msgid "Comment"
 msgstr "اظهار نظر"
 
@@ -3517,9 +3530,9 @@ msgstr "شامل نیست"
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
 msgstr "Metabase هرگز این فیلد را بازیابی نخواهد کرد. از این اطلاعات برای اطلاعات حساس یا بی اهمیت استفاده کنید."
 
-#: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:300
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/query/description.js:77
+#: frontend/src/metabase/lib/query/description.js:262
+#: frontend/src/metabase/lib/schema_metadata.js:476
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
@@ -3534,8 +3547,7 @@ msgstr "شمردن"
 msgid "CumulativeCount"
 msgstr "جمع انباشته"
 
-#: frontend/src/metabase/lib/expressions/config.js:9
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:485
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3545,7 +3557,6 @@ msgstr "جمع"
 msgid "CumulativeSum"
 msgstr "مجموع جمله"
 
-#: frontend/src/metabase/lib/expressions/config.js:11
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Distinct"
 msgstr "متمایز"
@@ -3554,25 +3565,22 @@ msgstr "متمایز"
 msgid "StandardDeviation"
 msgstr "انحراف معیار"
 
-#: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:494
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "میانگین"
 
-#: frontend/src/metabase/lib/expressions/config.js:14
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:539
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "کمترین"
 
-#: frontend/src/metabase/lib/expressions/config.js:15
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:548
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:503
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:492
 msgid "Max"
 msgstr "بیشترین"
 
@@ -3623,54 +3631,66 @@ msgstr "در ذهن شما چیست؟"
 msgid "What do you want to find out?"
 msgstr "چه می خواهید بیرون بیایید؟"
 
-#: frontend/src/metabase/lib/query.js:298
-#: frontend/src/metabase/lib/schema_metadata.js:466
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:250
+#: frontend/src/metabase/lib/query/description.js:75
+#: frontend/src/metabase/lib/query/description.js:260
+#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "داده های خام"
 
-#: frontend/src/metabase/lib/query.js:302
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/query/description.js:79
+#: frontend/src/metabase/lib/query/description.js:264
+#: frontend/src/metabase/lib/schema_metadata.js:521
 msgid "Cumulative count"
 msgstr "شمارش تجمعی"
 
-#: frontend/src/metabase/lib/query.js:305
+#: frontend/src/metabase/lib/query/description.js:82
+#: frontend/src/metabase/lib/query/description.js:266
 msgid "Average of "
 msgstr "میانگین از"
 
-#: frontend/src/metabase/lib/query.js:310
+#: frontend/src/metabase/lib/query/description.js:87
+#: frontend/src/metabase/lib/query/description.js:268
 msgid "Distinct values of "
 msgstr "مقادیر مشخصی از"
 
-#: frontend/src/metabase/lib/query.js:315
+#: frontend/src/metabase/lib/query/description.js:92
+#: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
 msgstr "انحراف استاندارد از"
 
-#: frontend/src/metabase/lib/query.js:320
+#: frontend/src/metabase/lib/query/description.js:97
+#: frontend/src/metabase/lib/query/description.js:272
 msgid "Sum of "
 msgstr "مجموع از"
 
-#: frontend/src/metabase/lib/query.js:325
+#: frontend/src/metabase/lib/query/description.js:102
+#: frontend/src/metabase/lib/query/description.js:274
 msgid "Cumulative sum of "
 msgstr "جمع تجمعی"
 
-#: frontend/src/metabase/lib/query.js:330
+#: frontend/src/metabase/lib/query/description.js:107
+#: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
 msgstr "حداکثر"
 
-#: frontend/src/metabase/lib/query.js:335
+#: frontend/src/metabase/lib/query/description.js:112
+#: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
 msgstr "حداقل از"
 
-#: frontend/src/metabase/lib/query.js:349
+#: frontend/src/metabase/lib/query/description.js:126
+#: frontend/src/metabase/lib/query/description.js:286
 msgid "Grouped by "
 msgstr "گروه بندی شده توسط"
 
-#: frontend/src/metabase/lib/query.js:363
+#: frontend/src/metabase/lib/query/description.js:140
+#: frontend/src/metabase/lib/query/description.js:295
 msgid "Filtered by "
 msgstr "فیلتر شده توسط"
 
-#: frontend/src/metabase/lib/query.js:392
+#: frontend/src/metabase/lib/query/description.js:169
+#: frontend/src/metabase/lib/query/description.js:320
 msgid "Sorted by "
 msgstr "مرتب شده بر اساس"
 
@@ -3682,55 +3702,45 @@ msgstr "درست است"
 msgid "False"
 msgstr "نادرست"
 
-#: frontend/src/metabase/lib/schema_metadata.js:321
+#: frontend/src/metabase/lib/schema_metadata.js:322
 msgid "Select longitude field"
 msgstr "فیلد طول جغرافیایی را انتخاب کنید"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:323
 msgid "Enter upper latitude"
 msgstr "طول عرضی بالا را وارد کنید"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:324
 msgid "Enter left longitude"
 msgstr "طول جغرافیایی را وارد کنید"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:325
 msgid "Enter lower latitude"
 msgstr "عرض پایین را وارد کنید"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:326
 msgid "Enter right longitude"
 msgstr "طول جغرافیایی را وارد کنید"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:539
 #: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:397
-#: frontend/src/metabase/lib/schema_metadata.js:405
-#: frontend/src/metabase/lib/schema_metadata.js:411
-#: frontend/src/metabase/lib/schema_metadata.js:416
-msgid "Is"
-msgstr "است"
-
 #: frontend/src/metabase/lib/schema_metadata.js:362
 #: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:398
 #: frontend/src/metabase/lib/schema_metadata.js:406
 #: frontend/src/metabase/lib/schema_metadata.js:412
-msgid "Is not"
-msgstr "نیست"
+#: frontend/src/metabase/lib/schema_metadata.js:417
+msgid "Is"
+msgstr "است"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:417
-msgid "Is empty"
-msgstr "خالی است"
+#: frontend/src/metabase/lib/schema_metadata.js:413
+msgid "Is not"
+msgstr "نیست"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:378
@@ -3739,109 +3749,119 @@ msgstr "خالی است"
 #: frontend/src/metabase/lib/schema_metadata.js:402
 #: frontend/src/metabase/lib/schema_metadata.js:408
 #: frontend/src/metabase/lib/schema_metadata.js:418
+msgid "Is empty"
+msgstr "خالی است"
+
+#: frontend/src/metabase/lib/schema_metadata.js:365
+#: frontend/src/metabase/lib/schema_metadata.js:379
+#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:395
+#: frontend/src/metabase/lib/schema_metadata.js:403
+#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:419
 msgid "Not empty"
 msgstr "خالی نیست"
 
-#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:371
 msgid "Equal to"
 msgstr "مساوی با"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:372
 msgid "Not equal to"
 msgstr "برابر نیست با"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Greater than"
 msgstr "بزرگتر از"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Less than"
 msgstr "کمتر از"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "بین"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:376
 msgid "Greater than or equal to"
 msgstr "بزرگتر یا مساوی با"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Less than or equal to"
 msgstr "کمتر یا برابر است"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
+#: frontend/src/metabase/lib/schema_metadata.js:384
 msgid "Contains"
 msgstr "شامل"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:385
 msgid "Does not contain"
 msgstr "شامل نمی شود"
 
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:388
 msgid "Starts with"
 msgstr "شروع می شود با"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:389
 msgid "Ends with"
 msgstr "به پایان می رسد با"
 
-#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:399
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "قبل از"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:400
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "بعد از"
 
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:414
 msgid "Inside"
 msgstr "داخل"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "فقط یک جدول با ردیف در پاسخ، هیچ عملیات اضافی."
 
-#: frontend/src/metabase/lib/schema_metadata.js:474
+#: frontend/src/metabase/lib/schema_metadata.js:475
 msgid "Count of rows"
 msgstr "تعداد ردیف ها"
 
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:477
 msgid "Total number of rows in the answer."
 msgstr "تعداد ردیف ها در پاسخ."
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Sum of ..."
 msgstr "مجموع ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:486
 msgid "Sum of all the values of a column."
 msgstr "مجموع تمام مقادیر یک ستون."
 
-#: frontend/src/metabase/lib/schema_metadata.js:492
+#: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Average of ..."
 msgstr "میانگین ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:495
 msgid "Average of all the values of a column"
 msgstr "میانگین تمام مقادیر یک ستون"
 
-#: frontend/src/metabase/lib/schema_metadata.js:501
+#: frontend/src/metabase/lib/schema_metadata.js:502
 msgid "Number of distinct values of ..."
 msgstr "تعداد مقادیر متمایز ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:504
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "تعداد مقادیر منحصر به فرد یک ستون در میان تمام ردیف در پاسخ."
 
-#: frontend/src/metabase/lib/schema_metadata.js:510
+#: frontend/src/metabase/lib/schema_metadata.js:511
 msgid "Cumulative sum of ..."
 msgstr "جمع تجمعی ..."
 
@@ -3849,7 +3869,7 @@ msgstr "جمع تجمعی ..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "مجموع افزودنی تمام مقادیر یک ستون. \\\\ ne.x. درآمد کل در طول زمان."
 
-#: frontend/src/metabase/lib/schema_metadata.js:519
+#: frontend/src/metabase/lib/schema_metadata.js:520
 msgid "Cumulative count of rows"
 msgstr "تعداد تجمعی ردیف"
 
@@ -3857,27 +3877,27 @@ msgstr "تعداد تجمعی ردیف"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "تعداد افزودنی تعداد ردیفها. \\\\ ne.x. تعداد کل فروش در طول زمان."
 
-#: frontend/src/metabase/lib/schema_metadata.js:528
+#: frontend/src/metabase/lib/schema_metadata.js:529
 msgid "Standard deviation of ..."
 msgstr "انحراف استاندارد ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:531
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "شماره ای که بیان می کند مقدار مقادیر یک ستون در میان تمام ردیف ها در جواب متفاوت است."
 
-#: frontend/src/metabase/lib/schema_metadata.js:537
+#: frontend/src/metabase/lib/schema_metadata.js:538
 msgid "Minimum of ..."
 msgstr "حداقل از ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Minimum value of a column"
 msgstr "حداقل مقدار یک ستون"
 
-#: frontend/src/metabase/lib/schema_metadata.js:546
+#: frontend/src/metabase/lib/schema_metadata.js:547
 msgid "Maximum of ..."
 msgstr "حداکثر ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:549
 msgid "Maximum value of a column"
 msgstr "حداکثر مقدار یک ستون"
 
@@ -4053,7 +4073,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "رده، نوع، مدل، رتبه و غیره"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:43
-#: frontend/src/metabase/user/components/UserSettings.jsx:55
+#: frontend/src/metabase/user/components/UserSettings.jsx:56
 msgid "Account settings"
 msgstr "تنظیمات حساب"
 
@@ -4065,7 +4085,7 @@ msgstr "خروج از مدیر"
 msgid "Logs"
 msgstr "سیاههها"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:103
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:104
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:22
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:65
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:100
@@ -4105,9 +4125,9 @@ msgid "Metabase Admin"
 msgstr "مدیر متاباکس"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:36
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:36
 msgid "Ask a question"
 msgstr "یک سوال بپرس"
 
@@ -4128,7 +4148,7 @@ msgstr "ارجاع"
 msgid "Which metric?"
 msgstr "کدام متریک؟"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "تعریف معیارهای رایج برای تیم شما باعث می شود که سؤالاتتان را حتی ساده تر کنید"
 
@@ -4140,7 +4160,7 @@ msgstr "چگونه برای ایجاد معیارهای"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "اطلاعات را در طول زمان مشاهده کنید، به عنوان یک نقشه، و یا چرخش برای کمک به شما در درک روند و یا تغییرات."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:149
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
 msgid "Custom"
 msgstr "سفارشی"
 
@@ -4153,13 +4173,13 @@ msgstr "سوال جدید"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "از سازنده سؤال ساده برای دیدن روند، فهرستی از چیزها یا برای ایجاد معیارهای خود استفاده کنید."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:107
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:110
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "پرس و جو بومی"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:108
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:111
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "برای سوالات پیچیده تر، شما می توانید پرس و جو SQL خود و یا بومی خود را بنویسید."
 
@@ -4261,6 +4281,7 @@ msgid "Enter a default value..."
 msgstr "مقدار پیش فرض را وارد کنید ..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
+#: frontend/src/metabase/containers/Form.jsx:307
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "یک خطا رخ داده است"
@@ -4508,7 +4529,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "ما توصیه می کنیم پالس ها را کوچک نگه داریم و متمرکز شویم تا بتوانیم آنها را هضم کنیم و برای کل تیم مفید باشیم."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:161
-#: frontend/src/metabase/query_builder/components/view/View.jsx:131
+#: frontend/src/metabase/query_builder/components/view/View.jsx:133
 msgid "Pick your data"
 msgstr "اطلاعات خود را انتخاب کنید"
 
@@ -4524,47 +4545,47 @@ msgstr "ایمیل ها"
 msgid "Slack messages"
 msgstr "پیام های خالی"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:216
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "ارسال شد"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:217
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} فرستاده خواهد شد"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:219
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "پیام ها"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:235
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "اکنون ایمیل بفرست"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:236
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "ارسال به {0} در حال حاضر"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:238
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "در حال ارسال…"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "ارسال نشد"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "فرستاده نشد زیرا پالس هیچ نتیجه ای ندارد"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "پالس ارسال شد"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:282
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} باید توسط یک مدیر تنظیم شود."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:295
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:299
 msgid "Slack"
 msgstr "لاغر"
 
@@ -4717,7 +4738,7 @@ msgstr "میانگین"
 msgid "Distincts"
 msgstr "تمایز"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:55
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "مشاهده این {0}"
@@ -4727,11 +4748,12 @@ msgstr[0] "مشاهده این {0}"
 msgid "Zoom in"
 msgstr "بزرگنمایی"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "عبارتی سفارشی"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Common Metrics"
 msgstr "معیارهای معمول"
 
@@ -4928,34 +4950,34 @@ msgstr "معمولا"
 msgid "Pick a segment or table"
 msgstr "یک بخش یا جدول را انتخاب کنید"
 
-#: frontend/src/metabase/entities/databases/forms.js:191
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
+#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "یک پایگاه داده را انتخاب کنید"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:94
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:85
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:31
 msgid "Select..."
 msgstr "انتخاب کنید..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:134
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
 msgid "Select a table"
 msgstr "یک جدول را انتخاب کنید"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:819
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:926
 msgid "No tables found in this database."
 msgstr "هیچ جداول موجود در این پایگاه داده یافت نشد."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:856
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:901
 msgid "Is a question missing?"
 msgstr "یک سوال گم شده است؟"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:863
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:909
 msgid "Learn more about nested queries"
 msgstr "درباره پرس و جوهای توزیع شده بیشتر بدانید"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:898
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:951
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:40
 msgid "Fields"
 msgstr "زمینه های"
 
@@ -4989,11 +5011,11 @@ msgstr "مرتب سازی"
 msgid "Row limit"
 msgstr "محدودیت ردیف"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
 msgid "Unknown Field"
 msgstr "میدان ناشناخته"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:75
 msgid "field"
 msgstr "رشته"
 
@@ -5001,19 +5023,20 @@ msgstr "رشته"
 msgid "Matches"
 msgstr "مسابقات"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:148
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:156
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:135
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "فیلتر را اضافه کنید تا پاسخ شما محدود شود"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:293
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
 msgstr "یک گروه را اضافه کنید"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:37
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:313
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
-#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:66
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:67
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:89
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:131
@@ -5029,16 +5052,16 @@ msgstr "یک گروه را اضافه کنید"
 msgid "Data"
 msgstr "داده ها"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:340
 msgid "Filtered by"
 msgstr "فیلتر شده توسط"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:376
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:357
 msgid "View"
 msgstr "چشم انداز"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:393
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:374
 msgid "Grouped By"
 msgstr "گروه بندی شده توسط"
 
@@ -5046,7 +5069,7 @@ msgstr "گروه بندی شده توسط"
 msgid "None"
 msgstr "هیچ یک"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:471
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
 msgid "This question is written in {0}."
 msgstr "این سوال در {0} نوشته شده است."
 
@@ -5058,7 +5081,7 @@ msgstr "مخفی کردن ویرایشگر"
 msgid "Hide Query"
 msgstr "پنهان کردن پرس و جو"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:481
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
 msgid "Open Editor"
 msgstr "بازکردن ویرایشگر"
 
@@ -5298,7 +5321,7 @@ msgstr "تمام مقادیر متمایز {0}"
 msgid "Number of {0} grouped by {1}"
 msgstr "تعداد {0} گروه بندی شده توسط {1}"
 
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:77
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5357,32 +5380,33 @@ msgstr "داده های خام برای {0}"
 msgid "More"
 msgstr "بیشتر"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:194
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:216
 msgid "Invalid expression"
 msgstr "عبارت نادرست"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:269
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:282
 msgid "unknown error"
 msgstr "خطای ناشناخته"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:47
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:53
 msgid "Field formula"
 msgstr "فرمول فیلد"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:60
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:64
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "از این به عنوان نوعی از نوشتن یک فرمول در یک برنامه صفحه گسترده استفاده کنید. میتوانید از اعداد، فیلدها در این جدول، نمادهای ریاضی مانند + و برخی از توابع استفاده کنید. بنابراین شما می توانید چیزی مانند Subtotal - Cost را تایپ کنید."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:69
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:208
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
 msgid "Learn more"
 msgstr "بیشتر بدانید"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:77
 msgid "Give it a name"
 msgstr "نام آن را بدهید"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:79
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
 msgid "Something nice and descriptive"
 msgstr "چیزی خوب و توصیفی"
 
@@ -5462,11 +5486,11 @@ msgid "Enter desired number"
 msgstr "شماره مورد نظر را وارد کنید"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:154
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:161
 msgid "Empty"
 msgstr "خالی"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:119
 msgid "Find a value"
 msgstr "ارزش را پیدا کنید"
 
@@ -5534,35 +5558,35 @@ msgstr "مستندات کامل را بخوانید"
 msgid "Filter label"
 msgstr "برچسب فیلتر"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:135
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:134
 msgid "Variable type"
 msgstr "نوع متغیر"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:143
 msgid "Text"
 msgstr "متن"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
 msgid "Date"
 msgstr "تاریخ"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:147
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
 msgid "Field Filter"
 msgstr "فیلتر فیلد"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Field to map to"
 msgstr "فیلد برای نقشه"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:180
 msgid "Filter widget type"
 msgstr "نوع ویجت فیلتر"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:230
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
 msgid "Required?"
 msgstr "ضروری؟"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:240
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
 msgid "Default filter widget value"
 msgstr "مقدار ویجت فیلتر پیش فرض"
 
@@ -5574,7 +5598,7 @@ msgstr "بایگانی این سوال؟"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "این سوال از هر داشبورد یا پالس از آن حذف خواهد شد."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:158
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
 msgid "Question"
 msgstr "سوال"
 
@@ -5744,7 +5768,7 @@ msgid "Details"
 msgstr "جزئیات"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
-#: frontend/src/metabase/reference/databases/TableList.jsx:116
+#: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
 msgstr "جداول در {0}"
 
@@ -5825,24 +5849,24 @@ msgstr "چرا این جدول جالب است"
 msgid "Things to be aware of about this table"
 msgstr "چیزهایی که باید در مورد این جدول آگاه باشند"
 
-#: frontend/src/metabase/reference/databases/TableList.jsx:30
+#: frontend/src/metabase/reference/databases/TableList.jsx:29
 msgid "Tables in this database will appear here as they're added"
 msgstr "جداول در این پایگاه داده در اینجا به همان شکل اضافه می شوند"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:34
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:33
 msgid "Questions about this table will appear here as they're added"
 msgstr "سوالات در مورد این جدول در اینجا به عنوان آنها اضافه شده است"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:73
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:77
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:76
 msgid "Questions about {0}"
 msgstr "سوالات در مورد {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
 msgid "Created {0} by {1}"
 msgstr "{0} توسط {1} ایجاد شد"
 
@@ -6031,19 +6055,19 @@ msgstr "دیگر زمینه های شما می توانید این متریک ب
 msgid "Fields you can group this metric by"
 msgstr "زمینه های شما می توانید این متریک با گروه"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "معیارهای رسمی اعداد رسمی است که تیم شما در مورد آن مورد توجه قرار گرفته است"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Metrics will appear here once your admins have created some"
 msgstr "پس از اینکه مدیران شما برخی از آنها ایجاد کرد، معیارها در اینجا ظاهر می شوند"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:28
 msgid "Learn how to create metrics"
 msgstr "یاد بگیرید چگونه برای ایجاد معیارها"
 
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:34
 msgid "Questions about this metric will appear here as they're added"
 msgstr "سوالاتی درباره این معیار در اینجا به عنوان آنها اضافه شده است"
 
@@ -6069,23 +6093,23 @@ msgstr "چرا این بخش جالب است"
 msgid "Things to be aware of about this Segment"
 msgstr "چیزهایی که در مورد این بخش آگاهی دارند"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
 msgid "Segments are interesting subsets of tables"
 msgstr "بخش ها بخش های جالب از جداول هستند"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "تعریف بخش های عادی برای تیم شما، باعث می شود که سؤالات بیشتری از شما بپرسید"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Segments will appear here once your admins have created some"
 msgstr "Segments در اینجا ظاهر خواهد شد، هنگامی که مدیران شما برخی را ایجاد کرده اند"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
 msgid "Learn how to create segments"
 msgstr "یاد بگیرید چگونه برای ایجاد بخش"
 
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:35
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:34
 msgid "Questions about this segment will appear here as they're added"
 msgstr "سوالات در مورد این بخش در اینجا به عنوان آنها اضافه می شود"
 
@@ -6105,22 +6129,22 @@ msgstr "سوالات در مورد این بخش"
 msgid "X-ray this segment"
 msgstr "اشعه ایکس این بخش"
 
-#: frontend/src/metabase/routes.jsx:178 frontend/src/metabase/routes.jsx:179
+#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
 msgid "Login"
 msgstr "ورود"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:303
 #: frontend/src/metabase/containers/ItemPicker.jsx:115
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:204
+#: frontend/src/metabase/routes.jsx:195
 msgid "Search"
 msgstr "جستجو کردن"
 
-#: frontend/src/metabase/routes.jsx:223
+#: frontend/src/metabase/routes.jsx:214
 msgid "Dashboard"
 msgstr "داشبورد"
 
-#: frontend/src/metabase/routes.jsx:236
+#: frontend/src/metabase/routes.jsx:227
 msgid "New Question"
 msgstr "سوال جدید"
 
@@ -6164,63 +6188,63 @@ msgstr "با تشکر برای کمک به بهبود ما"
 msgid "We won't collect any usage events"
 msgstr "ما هر گونه رویداد استفاده را جمع آوری نخواهیم کرد"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:88
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "به منظور کمک به بهبود Metabase، ما می خواهیم اطلاعات خاصی در مورد استفاده از طریق Google Analytics جمع آوری کنیم."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:90
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Here's a full list of everything we track and why."
 msgstr "در اینجا یک لیست کامل از همه چیز ما پیگیری و به همین دلیل است."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "اجازه دهید Metabase به صورت ناشناس رویدادهای استفاده را جمع آوری کند"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:113
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0} اطلاعاتی درباره نتایج یا نتایج شما را جمع آوری می کند."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:114
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
 msgid "never"
 msgstr "هرگز"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:119
 msgid "All collection is completely anonymous."
 msgstr "تمام مجموعه کاملا ناشناس است."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "مجموعه را می توانید در هر نقطه از تنظیمات مدیریت خود خاموش کنید."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:44
+#: frontend/src/metabase/setup/components/Setup.jsx:59
 msgid "If you feel stuck"
 msgstr "اگر احساس می کنید گیر کرده اید"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:49
+#: frontend/src/metabase/setup/components/Setup.jsx:64
 msgid "our getting started guide"
 msgstr "راهنمای شروع به کار ما"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:50
+#: frontend/src/metabase/setup/components/Setup.jsx:65
 msgid "is just a click away."
 msgstr "فقط یک کلیک دور است"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:92
+#: frontend/src/metabase/setup/components/Setup.jsx:111
 msgid "Welcome to Metabase"
 msgstr "به Metabase خوش آمدید"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:93
+#: frontend/src/metabase/setup/components/Setup.jsx:112
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "به نظر می رسد همه چیز در حال کار است اکنون اجازه دهید شما را بشناسیم، با داده هایتان ارتباط برقرار کنید و برخی از پاسخ ها را پیدا کنید!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:97
+#: frontend/src/metabase/setup/components/Setup.jsx:116
 msgid "Let's get started"
 msgstr "بیا شروع کنیم"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:142
+#: frontend/src/metabase/setup/components/Setup.jsx:166
 msgid "You're all set up!"
 msgstr "همه شما تنظیم شده اند!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:153
+#: frontend/src/metabase/setup/components/Setup.jsx:177
 msgid "Take me to Metabase"
 msgstr "من را به Metabase ببر"
 
@@ -6232,13 +6256,13 @@ msgstr "ما باید با شما تماس بگیریم؟"
 msgid "Hi, {0}. nice to meet you!"
 msgstr "سلام {0} از ملاقات شما خوشبختم!"
 
-#: frontend/src/metabase/entities/users/forms.js:33
+#: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
 msgstr "یک رمز عبور ایجاد کنید"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:44
-#: frontend/src/metabase/entities/users/forms.js:35
-#: frontend/src/metabase/entities/users/forms.js:82
+#: frontend/src/metabase/entities/users/forms.js:50
+#: frontend/src/metabase/entities/users/forms.js:97
 msgid "Shhh..."
 msgstr "شیخ ..."
 
@@ -6246,11 +6270,11 @@ msgstr "شیخ ..."
 msgid "Confirm password"
 msgstr "رمز عبور را تایید کنید"
 
-#: frontend/src/metabase/entities/users/forms.js:42
+#: frontend/src/metabase/entities/users/forms.js:57
 msgid "Shhh... but one more time so we get it right"
 msgstr "شوش ... اما یک بار دیگر، بنابراین ما آن را درست می گیریم"
 
-#: frontend/src/metabase/entities/users/forms.js:70
+#: frontend/src/metabase/entities/users/forms.js:85
 msgid "Your company or team name"
 msgstr "نام شرکت یا تیم شما"
 
@@ -6420,7 +6444,7 @@ msgstr "گذرواژه با موفقیت بهروز شد"
 msgid "Account updated successfully!"
 msgstr "حساب با موفقیت به روز شد!"
 
-#: frontend/src/metabase/entities/users/forms.js:81
+#: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
 msgstr "رمز عبور فعلی"
 
@@ -6432,7 +6456,7 @@ msgstr "با آدرس ایمیل Google وارد شوید"
 msgid "User Details"
 msgstr "اطلاعات کاربر"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:327
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:344
 msgid "Reset to defaults"
 msgstr "بازنشانی به پیش فرضها"
 
@@ -6457,15 +6481,15 @@ msgstr "کدام زمینه ها برای محورهای X و Y مورد است�
 msgid "Choose fields"
 msgstr "زمینه ها را انتخاب کنید"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:217
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:234
 msgid "Save as default view"
 msgstr "نمایش به صورت پیش فرض ذخیره شود"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Draw box to filter"
 msgstr "جعبه قرعه کشی برای فیلتر کردن"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Cancel filter"
 msgstr "لغو فیلتر"
 
@@ -6493,19 +6517,19 @@ msgstr "تجسم یافت نشد"
 msgid "Could not display this chart with this data."
 msgstr "این نمودار را نمیتوان با این اطلاعات نمایش داد."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:526
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
 msgid "No results!"
 msgstr "هیچ نتیجه ای!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:547
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
 msgid "Still Waiting..."
 msgstr "هنوز منتظرم..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:550
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
 msgid "This usually takes an average of {0}."
 msgstr "این معمولا طول می کشد به طور متوسط ​​{0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:556
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
 msgid "(This is a bit long for a dashboard)"
 msgstr "(این کمی طولانی برای داشبورد است)"
 
@@ -6665,19 +6689,19 @@ msgstr "اضافه کردن قانون"
 msgid "Update rule"
 msgstr "به روز رسانی قانون"
 
-#: frontend/src/metabase/visualizations/index.js:32
+#: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
 msgstr "تجسم صفر است"
 
-#: frontend/src/metabase/visualizations/index.js:37
+#: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
 msgstr "تجسم باید متغیر ایستا 'شناسه' را تعریف کند:"
 
-#: frontend/src/metabase/visualizations/index.js:43
+#: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
 msgstr "تجسم با آن شناسه قبلا ثبت شده است:"
 
-#: frontend/src/metabase/visualizations/index.js:71
+#: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
 msgstr "هیچ تصویری برای {0}"
 
@@ -6703,23 +6727,23 @@ msgid "Doh! The data from your query doesn't fit the chosen display choice. This
 msgstr "دوو! داده های درخواست شما متناسب با انتخاب انتخاب صفحه نمایش نیست. این تجسم نیاز به حداقل {0} {1} داده دارد."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:9
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:117
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:120
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:161
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:169
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:249
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:267
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "ستون"
@@ -6829,83 +6853,83 @@ msgstr "هیچ چی"
 msgid "Linear Interpolated"
 msgstr "خطی Interpolated"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
 msgstr "مقیاس محور X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
 msgstr "سری زمانی"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:454
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
 msgid "Linear"
 msgstr "خطی"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
 msgid "Power"
 msgstr "قدرت"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:428
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:445
 msgid "Log"
 msgstr "ورود"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:441
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:430
 msgid "Histogram"
 msgstr "هیستوگرام"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
 msgstr "Ordinal"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
 msgstr "مقیاس محور Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:462
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
 msgstr "نمایش خط x محور و علائم"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:360
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:468
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:349
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
 msgid "Compact"
 msgstr "فشرده"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:469
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
 msgid "Rotate 45°"
 msgstr "چرخش 45 درجه"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:459
 msgid "Rotate 90°"
 msgstr "چرخش 90 درجه"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
 msgid "Show y-axis line and marks"
 msgstr "نمایش خط محور y و علائم"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:489
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Auto y-axis range"
 msgstr "محدوده ی محدوده ی خودکار"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:533
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:522
 msgid "Use a split y-axis when necessary"
 msgstr "در صورت لزوم از محور y تقسیم استفاده کنید"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:540
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:529
 msgid "Show label on x-axis"
 msgstr "برچسب را روی محور x نشان دهید"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:546
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:535
 msgid "X-axis label"
 msgstr "برچسب محور X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:555
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:544
 msgid "Show label on y-axis"
 msgstr "نمایش برچسب در محور y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:561
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:550
 msgid "Y-axis label"
 msgstr "برچسب محور Y"
 
@@ -7031,23 +7055,23 @@ msgstr "حداقل ابعاد"
 msgid "Max Zoom"
 msgstr "حداکثر زوم"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:231
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:234
 msgid "No relationships found."
 msgstr "هیچ روابطی پیدا نشد"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:269
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:272
 msgid "via {0}"
 msgstr "از طریق {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:347
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
 msgid "This {0} is connected to:"
 msgstr "این {0} به متصل است:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "Object Detail"
 msgstr "جزئیات شیء"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:93
 msgid "object"
 msgstr "هدف - شی"
 
@@ -7436,7 +7460,7 @@ msgstr "سوالهای ذخیره شده زیادی در {0} دارید؟ ایج
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:149 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -8950,19 +8974,19 @@ msgstr "می توانید این مجموعه و محتویات آن را ویر
 msgid "Can view items in this collection"
 msgstr "می توانید آیتم های موجود در این مجموعه را مشاهده کنید"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:767
+#: frontend/src/metabase/admin/permissions/selectors.js:765
 msgid "Collection Access"
 msgstr "دسترسی به مجموعه"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:841
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "این گروه اجازه می دهد حداقل یک زیر مجموعه از این مجموعه را مشاهده کنید."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:848
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "این گروه اجازه ویرایش حداقل یک زیر مجموعه از این مجموعه را دارد."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:861
+#: frontend/src/metabase/admin/permissions/selectors.js:859
 msgid "View sub-collections"
 msgstr "مشاهده زیر مجموعه ها"
 
@@ -8970,7 +8994,7 @@ msgstr "مشاهده زیر مجموعه ها"
 msgid "Remember Me"
 msgstr "مرا به خاطر بسپار"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:63
+#: frontend/src/metabase/components/BrowseApp.jsx:73
 msgid "X-ray this schema"
 msgstr "اشعه ایکس این طرح"
 
@@ -9031,15 +9055,15 @@ msgstr "Metabase نمی تواند برای جستجوی شما هیچ نتیج�
 msgid "No metrics"
 msgstr "بدون معیارهای"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:31
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:41
 msgid "Aggregations"
 msgstr "انباشتگی"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:32
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:42
 msgid "Operators"
 msgstr "عمل‌گرها"
 
-#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:30
+#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:35
 msgid "Custom fields"
 msgstr "موضوعات سفارشی"
 
@@ -9205,7 +9229,7 @@ msgstr "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
 msgid "toucan_sightings"
 msgstr "toucan_sightings"
 
-#: src/metabase/driver/sparksql.clj
+#: src/metabase/models/collection.clj
 msgid "default"
 msgstr "پیش‌فرض"
 
@@ -9233,10 +9257,10 @@ msgstr "ناموجود"
 msgid "Windows domain"
 msgstr "دامین ویندوز"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:539
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:545
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:554
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:560
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:528
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:534
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:543
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
 msgstr "برچسب ها"
 
@@ -9272,9 +9296,9 @@ msgstr "اشتراک گذاری"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:286
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:294
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:302
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:319
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:324
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
@@ -9289,19 +9313,18 @@ msgstr "اشتراک گذاری"
 msgid "Display"
 msgstr "نمایش دادن"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:461
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:476
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:502
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:532
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:402
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:465
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:483
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:521
 msgid "Axes"
 msgstr "محورها"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:212
-#: frontend/src/metabase/admin/settings/selectors.js:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:219
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:62
 msgid "Formatting"
@@ -9335,7 +9358,7 @@ msgstr "اشعه X"
 msgid "Compare to the rest"
 msgstr "با بقیه مقایسه کن."
 
-#: frontend/src/metabase/entities/databases/forms.js:16
+#: frontend/src/metabase/entities/databases/forms.js:18
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "از منطقه زمانی ماشین مجازی جاوا استفاده کن."
 
@@ -9365,24 +9388,24 @@ msgstr "استفاده از منطقه زمانی JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "برای کمک به  در حال تحلیل جداول و "
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
 msgid "Tip: "
 msgstr "نکته:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:237
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
 msgstr "یک واحد پول انتخاب کنید"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:300
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
 msgid "Field Type"
 msgstr "نوع فیلد"
 
-#: frontend/src/metabase/admin/routes.jsx:113
+#: frontend/src/metabase/admin/routes.jsx:118
 #: frontend/src/metabase/nav/containers/Navbar.jsx:267
 msgid "Troubleshooting"
 msgstr "عیب‌یابی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:103
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Enable X-ray features"
 msgstr "فعال‌کردن ویژگی X-ray"
 
@@ -9427,7 +9450,7 @@ msgstr "دیرش (میلی ثانیه)"
 msgid "Currency"
 msgstr "واحد پول"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
 msgstr "یک کاربر یا کانال را انتخاب کنید..."
 
@@ -9575,7 +9598,7 @@ msgstr "سبک خط"
 msgid "Show dots on lines"
 msgstr "نمایش نقاط بر روی خط"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:348
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
@@ -9589,7 +9612,7 @@ msgstr "کدام محور؟"
 msgid "Line + Bar"
 msgstr "خط + نوار"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
 msgid "line and bar chart"
 msgstr "نمودار خط و نوار"
 
@@ -11041,7 +11064,7 @@ msgstr "نحوه توزیع این متریک در اعداد مختلف"
 msgid "Sessions by page where the session began"
 msgstr "جلسات براساس صفحه ای که جلسه شروع شده است"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:503
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -11411,7 +11434,7 @@ msgstr "این مورد را کپی کنید"
 msgid "Archive this item"
 msgstr "بایگانی این مورد"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:331
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:325
 msgid "Duplicate dashboard"
 msgstr "داشبورد کپی"
 
@@ -11507,7 +11530,7 @@ msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] "ربع سال"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
@@ -11522,8 +11545,8 @@ msgstr "[Q]Q"
 msgid "This"
 msgstr "این"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:97
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:137
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:136
 msgid "Invalid"
 msgstr "بی اعتبار"
 
@@ -12286,6 +12309,7 @@ msgstr "جدیدترین کارتهای {0} شما در اینجا آمده اس
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
 msgstr "آیا می توانید کمی خاص تر باشید یا از شناسنامه استفاده کنید؟ این کارتها را با اسامی مطابقت داشتم:"
 
+#: src/metabase/driver/common/parameters/values.clj
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
 msgstr "کارت {0} یافت نشد."
@@ -12394,11 +12418,11 @@ msgstr "دستورالعمل سوء استفاده"
 msgid "Archive this?"
 msgstr "بایگانی این؟"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:243
+#: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
 msgstr "درباره داده های ما اطلاعات کسب کنید"
 
-#: frontend/src/metabase/entities/databases/forms.js:20
+#: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
 msgstr "هنگام اتصال از DNS SRV استفاده کنید"
 
@@ -12410,7 +12434,7 @@ msgstr "استفاده از این گزینه مستلزم آن است که می
 "ممکن است لازم باشد این گزینه را فعال کنید. اگر نمی دانید این به چه معنی است ،\n"
 "این را غیرفعال کنید."
 
-#: frontend/src/metabase/entities/databases/forms.js:204
+#: frontend/src/metabase/entities/databases/forms.js:273
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "هنگام انجام فیلتر کردن ساده و جمع بندی ساده ، نمایش داده شد"
 
@@ -12434,11 +12458,11 @@ msgstr "همه نتایج"
 msgid "Our Analytics"
 msgstr "تحلیل ما"
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:513
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
 msgstr "جمع اضافی از تمام مقادیر یک ستون. \\ ne.x. درآمد کل در طول زمان"
 
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
 msgstr "تعداد افزودنی تعداد ردیف ها. \\ ne.x. تعداد کل فروش در طول زمان"
 
@@ -12448,7 +12472,7 @@ msgstr "تعداد افزودنی تعداد ردیف ها. \\ ne.x. تعداد 
 msgid "Filter"
 msgstr "فیلتر"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:50
 msgid "record"
 msgid_plural "records"
 msgstr[0] "رکورد"
@@ -12461,27 +12485,27 @@ msgstr "مرور داده ها"
 msgid "Write SQL"
 msgstr "SQL بنویسید"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:83
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
 msgstr "سوال ساده"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:84
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:87
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
 msgstr "برخی از داده ها را انتخاب کنید ، آن را مشاهده کنید و به راحتی آن را فیلتر ، خلاصه و تجسم کنید."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:95
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:98
 msgid "Custom question"
 msgstr "سوال سفارشی"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:96
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:99
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "از ویرایشگر نوت بوک پیشرفته برای پیوستن به داده ها ، ایجاد ستون های سفارشی ، انجام ریاضی و موارد دیگر استفاده کنید."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Basic Metrics"
 msgstr "اندازه گیری های اساسی"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:322
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
 msgid "Custom…"
 msgstr "سفارشی…"
 
@@ -12550,15 +12574,15 @@ msgstr "یک ستون را برای گروه انتخاب کنید"
 msgid "Pick your starting data"
 msgstr "داده شروع را انتخاب کنید"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select None"
 msgstr "هیچ کدام را انتخاب نکنید"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select All"
 msgstr "انتخاب همه"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:151
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:152
 msgid "Pick a table..."
 msgstr "انتخاب یک جدول ..."
 
@@ -12679,15 +12703,15 @@ msgstr "متریک اضافه کنید"
 #: frontend/src/metabase/lib/core.js:137 frontend/src/metabase/lib/core.js:142
 #: frontend/src/metabase/lib/core.js:147 frontend/src/metabase/lib/core.js:152
 #: frontend/src/metabase/lib/core.js:157 frontend/src/metabase/lib/core.js:162
-#: frontend/src/metabase/user/components/UserSettings.jsx:63
+#: frontend/src/metabase/user/components/UserSettings.jsx:64
 msgid "Profile"
 msgstr "مشخصات"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:560
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "این معمولاً خیلی سریع است اما به نظر می رسد اکنون مدتی طول می کشد."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
 msgid "Combo"
 msgstr "ترکیب"
 
@@ -12703,11 +12727,11 @@ msgstr "روند"
 msgid "Boolean"
 msgstr "بولی"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:62
 msgid "Unknown Segment"
 msgstr "بخش ناشناخته"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:73
 msgid "Unknown Filter"
 msgstr "فیلتر ناشناخته"
 
@@ -12837,6 +12861,7 @@ msgstr "با استفاده از لودر کلاس جديد ساخته شده ب
 msgid "Failed to copy file"
 msgstr "کپی کردن پرونده انجام نشد"
 
+#. check that the URL is valid
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
 msgstr "URL سایت نامعتبر: {0}"
@@ -12939,11 +12964,11 @@ msgstr "SD of {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Min of {0}"
-msgstr "حداقل {0}"
+msgstr "Min of {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Max of {0}"
-msgstr "حداکثر {0}"
+msgstr "Max of {0}"
 
 #. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
 #: src/metabase/query_processor/middleware/annotate.clj
@@ -13111,7 +13136,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "ستون هایی را که می خواهید گنجانید انتخاب کنید"
 
-#: frontend/src/metabase/entities/databases/forms.js:205
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "هنگامی که این کار روشن است ، وقتی کاربر در هنگام مشاهده جدول یا نمودار ، دکمه های خلاصه و فیلتر را با استفاده از کاوش ساده انجام می دهد ، Metabase به صورت خودکار نمایش داده می شود. اگر جستجوی این پایگاه داده کند است ، می توانید این را خاموش کنید. این تنظیم تأثیر نمی گذارد از طریق مته یا سؤالهای SQL."
 
@@ -13149,7 +13174,7 @@ msgstr "خطا در تعیین ستون های مورد انتظار برای پ
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "استثناء نامحدود ، انتظار می رود واسطه میانجی \"گرفتن استثناء\" برای رسیدگی به آن."
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:125
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
 msgid "Diagnostic Info"
 msgstr "اطلاعات تشخیصی"
 
@@ -13173,11 +13198,11 @@ msgstr "مشکلی برای ورود از طریق گوگل وجود دارد. �
 msgid "Sign in with email"
 msgstr "ورود با ایمیل"
 
-#: frontend/src/metabase/entities/databases/forms.js:21
+#: frontend/src/metabase/entities/databases/forms.js:23
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "استفاده از این گزینه مستلزم آن است که میزبان ارائه شده FQDN باشد. در صورت اتصال به یک خوشه اطلس ، شاید لازم باشد این گزینه را فعال کنید. اگر نمی دانید این به چه معنی است ، این را غیرفعال کنید."
 
-#: frontend/src/metabase/entities/databases/forms.js:213
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "به طور پیش فرض ، Metabase یک همگام ساعته سبک و یک اسکن روزانه فشرده از مقادیر میدانی را انجام می دهد. اگر یک بانک اطلاعاتی بزرگ دارید ، توصیه می کنیم این مورد را روشن کنید و بررسی کنید چه زمان و چند وقت یکبار بررسی اسکن های مقدار انجام می شود."
 
@@ -13245,11 +13270,11 @@ msgstr "شامل نشود"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "این قسمت در سؤالات ایجاد شده با رابط های رابط کاربری گرافیکی قابل مشاهده یا انتخاب نخواهد بود. همچنان در سؤالات SQL / بومی قابل دسترسی خواهد بود."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:512
 msgid "Cumulative sum"
 msgstr "مبلغ تجمعی"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Standard deviation"
 msgstr "انحراف معیار"
 
@@ -13261,23 +13286,23 @@ msgstr "باید حداقل {0} نویسه داشته باشد"
 msgid "Must be at least {0} characters long"
 msgstr "طول باید حداقل  {0} کاراکتر باشد"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:389
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:82
 msgid "Name (required)"
 msgstr "نام (اجباری)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:556
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
 msgid "Run selected text"
 msgstr "متن انتخاب شده را اجرا کن"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:557
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
 msgid "Run query"
 msgstr "کوئری را اجرا کن"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(⌘ + enter)"
 msgstr "(⌘ + enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + enter)"
 
@@ -13289,7 +13314,7 @@ msgstr "نتایج در این قسمت نمایش داده خواهند شد"
 msgid "You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question."
 msgstr "شما هیچ تغییر دائمی در یک سؤال ذخیره شده ایجاد نخواهید کرد ، مگر اینکه روی ذخیره کلیک کرده و گزینه جایگزینی سوال اصلی را انتخاب کنید."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:199
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:200
 msgid "There aren't any filter widgets for this type of field yet."
 msgstr "هیچ ابزارک فیلتر برای این نوع زمینه هنوز وجود ندارد."
 
@@ -13325,19 +13350,19 @@ msgstr "خط هدف"
 msgid "Trend line"
 msgstr "خط روند"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:320
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:317
 msgid "Show values on data points"
 msgstr "مقادیر را در نقاط داده نمایش دهید"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:334
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:325
 msgid "Values to show"
 msgstr "مقادیر نمایش داده شونده"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:342
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:332
 msgid "As many as can fit nicely"
 msgstr "به قدری که بتوان به خوبی آنها را نمایش داد"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:343
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
 msgid "All"
 msgstr "همه"
 
@@ -13630,31 +13655,31 @@ msgstr "شماره"
 msgid "No mappable groups"
 msgstr "هیچ گروه قابل جابجایی نیست"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:107
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
 msgstr "مستندات بانک اطلاعاتی"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
 msgstr "شامل یک راهنمای عیب یابی است"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:112
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
 msgid "Post on the Metabase support forum"
 msgstr "ارسال در انجمن پشتیبانی Metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:114
 msgid "A community forum for all things Metabase"
 msgstr "انجمن  برای همه چیز"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:117
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
 msgid "File a bug report"
 msgstr "گزارش اشکال دهید"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:119
 msgid "Create a GitHub issue (includes the diagnostic info below)"
 msgstr "یک شماره GitHub ایجاد کنید (شامل اطلاعات تشخیصی زیر است)"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:127
 msgid "Please include these details in support requests. Thank you!"
 msgstr "لطفاً این جزئیات را در درخواستهای پشتیبانی درج کنید. متشکرم!"
 
@@ -13682,38 +13707,40 @@ msgstr "نتیجه مطابقت ندارد"
 msgid "Submit"
 msgstr "ارسال"
 
-#: frontend/src/metabase/entities/databases/forms.js:13
+#: frontend/src/metabase/entities/databases/forms.js:15
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host. This option also provides an extra layer of security when a VPN is not available. Enabling this is usually slower than a direct connection."
 msgstr "برخی از تاسیسات پایگاه داده فقط با اتصال از طریق میزبان سنگر SSH قابل دسترسی هستند. این گزینه همچنین در صورت عدم دسترسی به VPN ، لایه امنیتی بیشتری را فراهم می کند. فعال کردن این کار معمولاً کندتر از یک اتصال مستقیم است."
 
-#: frontend/src/metabase/entities/databases/forms.js:17
+#: frontend/src/metabase/entities/databases/forms.js:19
 msgid "We suggest you leave this off unless you're doing manual timezone casting in many or most of your queries with this data."
 msgstr "ما پیشنهاد می کنیم این کار را خاموش کنید ، مگر اینکه در این بخش یا بیشتر داده های خود را در بسیاری از بخشهای بیشتر از درخواستهای خود انجام دهید."
 
-#: frontend/src/metabase/entities/databases/forms.js:93
+#: frontend/src/metabase/entities/databases/forms.js:128
 msgid "{0} to get an auth code."
 msgstr "{0} برای دریافت کد مجوز"
 
-#: frontend/src/metabase/entities/databases/forms.js:101
+#: frontend/src/metabase/entities/databases/forms.js:136
+#: src/metabase/models/collection.clj
 msgid "or"
 msgstr "یا"
 
-#: frontend/src/metabase/entities/databases/forms.js:159
-#: frontend/src/metabase/entities/databases/forms.js:197
-#: frontend/src/metabase/entities/users/forms.js:44
+#: frontend/src/metabase/entities/databases/forms.js:39
+#: frontend/src/metabase/entities/databases/forms.js:226
+#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "ضروری"
 
-#: frontend/src/metabase/entities/databases/forms.js:188
+#: frontend/src/metabase/entities/databases/forms.js:257
 msgid "Database type"
 msgstr "نوع بانک اطلاعاتی"
 
-#: frontend/src/metabase/entities/databases/forms.js:222
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "این یک پروسه سبک است که به روزرسانی های طرحواره این پایگاه داده را بررسی می کند. در بیشتر موارد ، شما باید خوب باشید که این مجموعه را ساعتی همگام کنید."
 
-#: frontend/src/metabase/entities/databases/forms.js:230
+#: frontend/src/metabase/entities/databases/forms.js:299
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase می تواند مقادیر موجود در هر فیلد را در این پایگاه داده اسکن کند تا فیلترهای جعبه کادر در داشبورد و سؤالات را فعال کند. این می تواند یک فرآیند تا حدی پرانرژی باشد ، به خصوص اگر پایگاه داده ای بسیار بزرگ داشته باشید"
 
@@ -13721,15 +13748,15 @@ msgstr "Metabase می تواند مقادیر موجود در هر فیلد را
 msgid "Collection"
 msgstr "مجموعه"
 
-#: frontend/src/metabase/entities/users/forms.js:40
+#: frontend/src/metabase/entities/users/forms.js:55
 msgid "Confirm your password"
 msgstr "رمزعبور خود را تأیید کنید"
 
-#: frontend/src/metabase/entities/users/forms.js:45
+#: frontend/src/metabase/entities/users/forms.js:60
 msgid "passwords do not match"
 msgstr "رمزهای ورود مطابقت ندارند"
 
-#: frontend/src/metabase/entities/users/forms.js:71
+#: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
 msgstr "گروه عالی"
 
@@ -13769,328 +13796,324 @@ msgid "Returns the average of the values in the column."
 msgstr "میانگین مقادیر موجود در ستون را برمی گرداند."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:18
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
 msgid "The column whose values to average."
 msgstr "ستونی که مقادیر آن به طور متوسط است."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "start"
 msgstr "شروع"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "end"
 msgstr "پایان"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
 msgid "Checks a date or numeric column's values to see if they're within the specified range."
 msgstr "مقادیر ستون تاریخ یا عددی را بررسی می کند تا ببیند که آنها در محدوده مشخص شده قرار دارند یا خیر."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
 msgstr "رتبه بندی"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:24
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:98
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
 msgid "condition"
 msgstr "وضعیت"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
 msgid "output"
 msgstr "خروجی"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "لیستی از موارد را آزمایش کرده و در صورت برآورده شدن مقدار دیگری ، مقدار مربوط به اولین مورد واقعی را برمی گرداند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
 msgid "Weight"
 msgstr "وزن"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
 msgid "Large"
 msgstr "بزرگ"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
 msgid "Medium"
 msgstr "متوسط"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
 msgid "Small"
 msgstr "کوچک"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
 msgid "Something that should evaluate to true or false."
 msgstr "چیزی که باید آن را درست یا نادرست ارزیابی کند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:54
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "مقداری که در صورت صحت شرط قبلی برمی گردد."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:62
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "value1"
 msgstr "مقدار۱"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:74
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
 msgid "value2"
 msgstr "مقدار۲"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "به ترتیب به مقادیر موجود در هر آرگومان می پردازد و اولین مقدار غیر تهی را برای هر سطر برمی گرداند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:56
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
 msgid "Comments"
 msgstr "نظرات"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
 msgid "Notes"
 msgstr "یادداشت"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
 msgid "No comments"
 msgstr "بدون نظر"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
 msgid "A column or value."
 msgstr "یک ستون یا مقدار."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:65
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:77
 msgid "If value1 is empty, value2 gets returned if it's not empty, and so on."
 msgstr "اگر مقدار1 خالی باشد ، مقدار خالص 2 اگر خالی نباشد ، باز می گردد و غیره."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 msgid "Combines two or more strings of text together."
 msgstr "دو یا چند رشته متن را با هم ترکیب می کند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
 msgid "Last Name"
 msgstr "نام خانوادگی"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 msgid "First Name"
 msgstr "نام"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
 msgstr "مقدار2 به انتهای این اضافه می شود."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
 msgstr "این به پایان مقدار 1 اضافه می شود."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
 msgid "string1"
 msgstr "رشته۱"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
 msgid "string2"
 msgstr "رشته۲"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:80
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "بررسی می کند که آیا رشته۱ شامل رشته۲ است."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:284
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
 msgid "Status"
 msgstr "وضعیت"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 msgid "Pass"
 msgstr "عبور"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
 msgstr "محتوای این رشته بررسی خواهد شد."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
 msgid "The string of text to look for."
 msgstr "رشته متن را جستجو کنید."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:90
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:116
 msgid "Returns the count of rows in the source data."
 msgstr "شمارش ردیف ها را در داده های منبع برمی گرداند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Only counts rows where the condition is true."
 msgstr "فقط ردیف هایی را که شرایط در آن است صحیح شمرده می کند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:97
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:261
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
 msgid "Subtotal"
 msgstr "فرعی"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
 msgid "The additive total of rows across a breakout."
 msgstr "مجموع مواد افزودنی ردیفها در یک برک آوت."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:110
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
 msgid "The rolling sum of a column across a breakout."
 msgstr "جمع نورد ستون در یک برک آوت."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:113
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:268
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
 msgstr "جمع ستون."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
 msgid "The number of distinct values in this column."
 msgstr "تعداد مقادیر مشخص در این ستون."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "The column whose distinct values to count."
 msgstr "ستونی که مقادیر مشخص آن برای شمارش است."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:128
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:145
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:153
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:201
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:274
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
 msgid "text"
 msgstr "متن"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:130
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:223
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
 msgid "comparison"
 msgstr "مقایسه"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "اگر انتهای متن متن متن مقایسه باشد مطابقت دارد."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "Appetite"
 msgstr "اشتها"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "hungry"
 msgstr "گرسنه"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 msgid "A column or string of text to check."
 msgstr "ستونی یا رشته متن برای بررسی."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
 msgid "The string of text that the original text should end with."
 msgstr "رشته متن که متن اصلی باید با آن پایان یابد."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 msgid "regular_expression"
 msgstr "regular_expression"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:136
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "بسترهای مطابق با یک عبارت معمولی را استخراج می کنند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:137
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
 msgid "Address"
 msgstr "نشانی"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 msgid "The column or string of text to search though."
 msgstr "ستون یا رشته متن برای جستجو."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
 msgid "The regular expression to match."
 msgstr "عبارت منظم برای مطابقت"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the string of text in all lowercase."
 msgstr "رشته متن را با تمام حروف کوچک برمی گرداند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:149
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to lowercase."
 msgstr "ستون با مقادیر برای تبدیل به حروف کوچک."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:154
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 msgid "Removes leading whitespace from a string of text."
 msgstr "فضای سفید پیشرو را از متن متن حذف می کند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:157
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column with values you want to trim."
 msgstr "ستونی با مقادیر مورد نظر برای ترمیم."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "Returns the largest value found in the column."
 msgstr "بزرگترین مقدار یافت شده در ستون را برمی گرداند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
 msgid "Age"
 msgstr "سن"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:165
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
 msgid "The numeric column whose maximum you want to find."
 msgstr "ستون عددی که حداکثر شما می خواهید آن را پیدا کنید."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:170
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "Returns the smallest value found in the column."
 msgstr "کمترین مقدار یافت شده در ستون را برمی گرداند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
 msgid "Salary"
 msgstr "حقوق"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:173
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
 msgid "The numeric column whose minimum you want to find."
 msgstr "ستون عددی که حداقل شما می خواهید آن را پیدا کنید."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:181
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:242
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
 msgid "position"
 msgstr "موقعیت"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:194
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
 msgid "length"
 msgstr "طول"
 
@@ -14099,7 +14122,7 @@ msgstr "طول"
 msgid "new_text"
 msgstr "متن جدید"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:187
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
 msgid "Replaces a part of the input text with new text."
 msgstr "بخشی از متن ورودی را با متن جدید جایگزین می کند."
 
@@ -14111,7 +14134,7 @@ msgstr "شماره سفارش"
 msgid "Updated Part of ID"
 msgstr "بخشی از شناسه به روز شد"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
 msgid "The text that will be modified."
 msgstr "متنی که اصلاح می شود."
 
@@ -14127,87 +14150,87 @@ msgstr "تعداد کاراکترهای جایگزین"
 msgid "The text to use in the replacement."
 msgstr "متن مورد استفاده در جایگزینی."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "Removes trailing whitespace from a string of text."
 msgstr "فضای سفید را دنبال می کند از متن."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:210
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "درصد ردیف ها را در داده هایی که مطابقت با شرایط دارند ، به صورت اعشاری برمی گرداند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:218
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "اگر متن متن با متن مقایسه مطابقت داشته باشد ، برمی گردد."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Course Name"
 msgstr "نام دوره"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Computer Science"
 msgstr "علوم کامپیوتر"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
 msgid "The string of text that the original text should start with."
 msgstr "رشته متن که متن اصلی باید با آن شروع شود."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:229
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
 msgid "Calculates the standard deviation of the column."
 msgstr "انحراف استاندارد ستون را محاسبه می کند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:230
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
 msgid "Population"
 msgstr "جمعیت"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
 msgid "A numeric column."
 msgstr "یک ستون عددی."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
 msgid "Returns a portion of the supplied text."
 msgstr "بخشی از متن ارائه شده را برمی گرداند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:241
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:313
 msgid "The text to return a portion of."
 msgstr "متن برای برگرداندن بخشی از."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
 msgid "The position to start copying characters."
 msgstr "موقعیت شروع به کپی کردن کاراکترها."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:245
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
 msgid "The number of characters to return."
 msgstr "تعداد کاراکترها برای بازگشت."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
 msgid "Adds up all the values of the column."
 msgstr "تمام مقادیر ستون را اضافه می کند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:253
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
 msgid "The numeric column to sum."
 msgstr "جمع ستون عددی."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
 msgstr "مقادیر را در ستونی که ردیف ها با شرایط مطابقت دارند ، جمع می کند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
 msgid "Order Status"
 msgstr "وضعیت سفارش"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
 msgid "Valid"
 msgstr "معتبر"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "فضای سفید پیشرو و دنبال کننده را از متن متن حذف می کند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
 msgid "Returns the string of text in all upper case."
 msgstr "رشته متن را در تمام موارد بزرگ برمی گرداند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
 msgid "The column with values to convert to upper case."
 msgstr "ستون با مقادیر برای تبدیل به پرونده بزرگ."
 
@@ -14264,39 +14287,39 @@ msgstr "با تشکر از شما برای استفاده از Metabase!"
 msgid "Powered by {0}"
 msgstr "طراحی شده توسط {0"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:191
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
 msgid "To:"
 msgstr "به:"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:40
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
 msgstr "این سؤال قابل استفاده نیست زیرا بر اساس یک پایگاه داده متفاوت است."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:44
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:43
 msgid "Couldn't find a saved question with that ID number."
 msgstr "با آن شماره شناسه سوالی ذخیره نشده یافت نشد."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:55
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:54
 msgid "Pick a saved question"
 msgstr "یک سؤال ذخیره شده انتخاب کنید"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:57
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:56
 msgid "Pick a different question"
 msgstr "یک سؤال دیگر را انتخاب کنید"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:62
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:61
 msgid "Loading…"
 msgstr "بارگذاری…"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:79
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:78
 msgid "Question #…"
 msgstr "سوال #…"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:81
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
 msgstr "سوال # {0"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:115
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
 msgstr "آخرین ویرایش {0}"
 
@@ -14308,11 +14331,11 @@ msgstr "{0 a یک متغیر را در این الگوی پرسشی ایجاد �
 msgid "Giving a variable the \"Field Filter\" type allows you to link questions to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "ارائه متغیر از نوع \"فیلترینگ فیلد\" به شما امکان می دهد سوالات را به ویدجتهای فیلتر داشبورد پیوند دهید یا از انواع بیشتری از ابزارکهای فیلتر در سؤال SQL خود استفاده کنید. یک متغیر Field Filter باعث اضافه شدن SQL مشابه آن می شود که توسط سازنده درخواست GUI هنگام افزودن فیلتر روی ستون های موجود ایجاد شده است."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:131
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
 msgstr "نام متغیر"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:217
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:218
 msgid "Filter widget label"
 msgstr "برچسب ویجت فیلتر کنید"
 
@@ -14344,11 +14367,11 @@ msgstr "در عنوان ستون"
 msgid "In every table cell"
 msgstr "در هر سلول جدول"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:351
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:341
 msgid "Value formatting"
 msgstr "قالب بندی ارزش"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:361
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
 msgid "Full"
 msgstr "پر شده"
 
@@ -14676,3 +14699,482 @@ msgstr "خطا در ایجاد بینش برای ستون:"
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandonment email!"
 msgstr "ارسال ایمیل رها!"
+
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
+msgstr "می توانید معیارهای ذخیره شده ایجاد کنید تا گزینه متریک نامگذاری شده اضافه شود. معیارهای ذخیره شده شامل نوع جمع ، میدان جمع شده و هر فیلتر دیگری که اضافه می کنید به صورت اختیاری است. به عنوان نمونه ، شما می توانید از این گزینه برای ایجاد چیزی مانند روش رسمی محاسبه \"قیمت متوسط\" برای جدول سفارشات استفاده کنید."
+
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:105
+msgid "Select and add filters to create your new segment."
+msgstr "فیلترها را برای ایجاد بخش جدید خود انتخاب و اضافه کنید."
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+msgid "Alphabetical"
+msgstr "الفبایی"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+msgid "Smart"
+msgstr "هوشمندانه"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+msgid "Column order: {0}"
+msgstr "سفارش ستون: {0"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
+msgid "Unhide all"
+msgstr "آشکارکردن همه"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:204
+msgid "Hide all"
+msgstr "همه را پنهان کن"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:206
+msgid "Unhide"
+msgstr "لغو"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:22
+msgid "New metric"
+msgstr "متریک جدید"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:45
+msgid "Create metrics to add them to the Summarize dropdown in the query builder"
+msgstr "معیارهایی ایجاد کنید تا آنها را به بخش خلاصه خلاصه سازنده پرس و جو اضافه کنید"
+
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:22
+msgid "New segment"
+msgstr "بخش جدید"
+
+#: frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx:71
+msgid "Filter by table"
+msgstr "فیلتر بر اساس جدول"
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:64
+msgid "Checking HTTPS..."
+msgstr "در حال بررسی HTTPS ..."
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:66
+msgid "It looks like HTTPS is not properly configured"
+msgstr "به نظر می رسد HTTPS به درستی پیکربندی نشده است"
+
+#: frontend/src/metabase/admin/settings/selectors.js:57
+msgid "Redirect to HTTPS"
+msgstr "به HTTPS تغییر مسیر دهید"
+
+#: frontend/src/metabase/admin/settings/selectors.js:219
+msgid "Localization"
+msgstr "بومی سازی"
+
+#: frontend/src/metabase/admin/settings/selectors.js:222
+msgid "Instance language"
+msgstr "زبان نمونه"
+
+#: frontend/src/metabase/admin/settings/selectors.js:237
+msgid "Localization options"
+msgstr "گزینه های محلی سازی"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:51
+msgid "This database doesn't have any tables."
+msgstr "این پایگاه داده هیچ جدول ندارد."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
+msgid "This field only accepts a single value because it's used in a SQL query."
+msgstr "این قسمت فقط یک مقدار واحد را می پذیرد زیرا در یک پرس و جو SQL استفاده می شود."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:17
+msgid "Service Accounts"
+msgstr "حساب خدمات"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:26
+msgid "Metabase connects to Big Query via {0}."
+msgstr "Metabase از طریق {0 to به Big Query متصل می شود."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:29
+msgid "Continue using an OAuth application to connect"
+msgstr "برای اتصال به برنامه OAuth ادامه دهید"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:43
+msgid "We recommend switching to use {0} instead of an OAuth application to connect to BigQuery"
+msgstr "برای اتصال به BigQuery توصیه می کنیم به جای یک برنامه OAuth ، از {0 استفاده کنید"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:48
+msgid "Connect to a Service Account instead"
+msgstr "به جای آن به یک حساب کاربری متصل شوید"
+
+#: frontend/src/metabase/entities/databases/forms.js:44
+msgid "invalid JSON"
+msgstr "JSON نامعتبر است"
+
+#: frontend/src/metabase/entities/databases/forms.js:50
+msgid "SSH private key"
+msgstr "کلید خصوصی SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:51
+msgid "Paste the contents of your ssh private key here"
+msgstr "محتویات کلید خصوصی ssh خود را در اینجا جایگذاری کنید"
+
+#: frontend/src/metabase/entities/databases/forms.js:55
+msgid "Passphrase for the SSH private key"
+msgstr "عبارات کلیدی برای کلید خصوصی SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:58
+msgid "SSH Authentication"
+msgstr "احراز هویت SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:60
+msgid "SSH Key"
+msgstr "کلید SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:65
+msgid "Server SSL certificate chain"
+msgstr "زنجیره گواهی SSL سرور"
+
+#: frontend/src/metabase/entities/databases/forms.js:66
+msgid "Paste the contents of the server's SSL certificate chain here"
+msgstr "محتویات زنجیره صدور گواهینامه SSL سرور را در اینجا جایگذاری کنید"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:11
+msgid "Paste a connection string"
+msgstr "یک رشته اتصال را بچسبانید"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:12
+msgid "Fill out individual fields"
+msgstr "فیلدهای فردی را پر کنید"
+
+#: frontend/src/metabase/entities/snippets.js:14
+msgid "Enter some SQL here so you can reuse it later"
+msgstr "مقداری SQL را در اینجا وارد کنید تا بعدا بتوانید دوباره از آن استفاده کنید"
+
+#: frontend/src/metabase/entities/snippets.js:24
+msgid "Give your snippet a name"
+msgstr "نام قطعه خود را بگذارید"
+
+#: frontend/src/metabase/entities/snippets.js:25
+msgid "Current Customers"
+msgstr "مشتریان فعلی"
+
+#: frontend/src/metabase/entities/snippets.js:30
+msgid "Add a description"
+msgstr "توضیحات اضافه کنید"
+
+#: frontend/src/metabase/entities/users/forms.js:37
+msgid "Use site default"
+msgstr "از پیش فرض سایت استفاده کنید"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+msgid "find"
+msgstr "پیدا کردن"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+msgid "replace"
+msgstr "جایگزین کردن"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+msgid "The text to find."
+msgstr "متن برای پیدا کردن"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "The text to use as the replacement."
+msgstr "متن مورد استفاده به عنوان جایگزین"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+msgid "Editing {0}"
+msgstr "ویرایش {0"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+msgid "Create your new snippet"
+msgstr "قطعه جدید خود را ایجاد کنید"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+msgid "Archived snippets"
+msgstr "قطعه های بایگانی شده"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+msgid "Snippets are reusable bits of SQL"
+msgstr "قطعه قطعه ها قابل استفاده مجدد از SQL هستند"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+msgid "Create a snippet"
+msgstr "یک قطعه قطعه ایجاد کنید"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+msgid "Snippets"
+msgstr "قطعه قطعه"
+
+#: frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx:15
+msgid "SQL Snippets"
+msgstr "قطعه SQL"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:38
+msgid "Your language is set to {0}"
+msgstr "زبان شما روی 0 {تنظیم شده است"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:50
+msgid "What's your preferred language?"
+msgstr "زبان مورد نظر شما چیست؟"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:54
+msgid "This language will be used throughout Metabase and will be the default for new users."
+msgstr "این زبان در سراسر Metabase استفاده خواهد شد و به طور پیش فرض برای کاربران جدید خواهد بود."
+
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:159
+msgid "We filtered out {0} row(s) containing null values."
+msgstr "ما ردیف 0} 0 containing حاوی مقادیر تهی را فیلتر کردیم."
+
+#: frontend/src/metabase/visualizations/lib/settings/series.js:133
+msgid "Show values for this series"
+msgstr "مقادیر این سری را نشان دهید"
+
+#: src/metabase/api/card.clj
+msgid "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
+msgstr "میانگین مدت زمان اجرای سوال 0 {} است. استفاده از TTL \"Magic\" از {1"
+
+#: src/metabase/api/native_query_snippet.clj
+msgid "A snippet with that name already exists. Please pick a different name."
+msgstr "قطعه قطعه ای با این نام در حال حاضر وجود دارد. لطفاً نام دیگری را انتخاب کنید"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Metric]"
+msgstr "[متریک ناشناخته]"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Segment]"
+msgstr "[بخش ناشناخته]"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error writing error to output stream"
+msgstr "خطا در نوشتن خطا در خروجی جریان"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Caught unexpected Exception in streaming response body"
+msgstr "استثناء غیر منتظره در بدنه پاسخ جریان است"
+
+#: src/metabase/async/streaming_response.clj
+msgid "bound-fn caught unexpected Exception"
+msgstr "مرز fn گرفتار استثناء غیر منتظره"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error determining whether HTTP request was canceled"
+msgstr "خطایی در مورد لغو درخواست HTTP"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Check cancelation status timed out after {0}"
+msgstr "وضعیت انصراف بعد از {0 ed به پایان رسیده است"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Unexpected exception in do-f-async"
+msgstr "استثناء غیر منتظره در do-f-async"
+
+#: src/metabase/async/streaming_response.clj src/metabase/server.clj
+msgid "Unexpected exception writing error response"
+msgstr "استثناء غیر منتظره پاسخ خطای نوشتن"
+
+#: src/metabase/driver/common.clj
+msgid "Server certificate not trusted - did you specify the correct SSL certificate chain?"
+msgstr "گواهی سرور مورد اعتماد نیست - آیا شما زنجیره صحیح گواهی SSL را مشخص کردید؟"
+
+#: src/metabase/driver/common.clj
+msgid "Server appears to require SSL - please enable SSL above"
+msgstr "به نظر می رسد سرور به SSL نیاز دارد - لطفا SSL را در بالا فعال کنید"
+
+#: src/metabase/driver/common.clj
+msgid "Username"
+msgstr "نام کاربری"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Don''t know how to parse parameter of type {0}"
+msgstr "نمی دانید چگونه پارامتر از نوع {0 p را تجزیه کنید"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Invalid :card parameter: missing `:card-id`"
+msgstr "نامعتبر: پارامتر کارت: از دست رفته `: card-id`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Unable to resolve Snippet: missing `:snippet-id`"
+msgstr "امکان حل کردن قطعه قطعی وجود ندارد: از دست رفته `: snippet-id`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Snippet {0} {1} not found."
+msgstr "Snippet 0} 1} یافت نشد."
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error determining value for parameter"
+msgstr "خطا در تعیین مقدار پارامتر"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error building query parameter map"
+msgstr "خطا در ساخت نقشه پارامتر پرس و جو"
+
+#: src/metabase/middleware/log.clj
+msgid "ASYNC"
+msgstr "ASYNC"
+
+#: src/metabase/middleware/log.clj
+msgid "{0} ({1} DB calls)"
+msgstr "{0} (1 {تماس DB)"
+
+#: src/metabase/middleware/log.clj
+msgid "App DB connections: {0}/{1}"
+msgstr "اتصالات برنامه DB: {0} / {1"
+
+#: src/metabase/middleware/log.clj
+msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
+msgstr "موضوعات جت: {0} / {1} (2 {بیکار ، 3 پوند در حالت آماده باش)"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} total active threads)"
+msgstr "(0 {کل موضوعات فعال)"
+
+#: src/metabase/middleware/log.clj
+msgid "Queries in flight: {0}"
+msgstr "نمایش داده شد در پرواز: {0"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} queued)"
+msgstr "({0} صف)"
+
+#: src/metabase/models/collection.clj
+msgid "Collection must be in the same namespace as its parent"
+msgstr "مجموعه باید در همان فضای نام و نام خانوادگی خود باشد"
+
+#: src/metabase/models/collection.clj
+msgid "Personal Collections must be in the default namespace"
+msgstr "مجموعه های شخصی باید در فضای نام پیش فرض قرار داشته باشند"
+
+#: src/metabase/models/collection.clj
+msgid "You cannot move a Collection to a different namespace once it has been created."
+msgstr "پس از ایجاد ، نمی توانید یک مجموعه را به یک نام دیگر تغییر دهید."
+
+#: src/metabase/models/collection.clj src/metabase/models/permissions.clj
+msgid "Collection does not exist."
+msgstr "مجموعه وجود ندارد."
+
+#: src/metabase/models/collection.clj
+msgid "A {0} can only go in Collections in the {1} namespace."
+msgstr "{0} فقط می تواند در مجموعه نامها در فضای نام {1 go برود."
+
+#: src/metabase/models/database.clj
+msgid "Error sending database deletion notification"
+msgstr "خطا در ارسال اعلان حذف پایگاه داده"
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "You cannot update the creator_id of a NativeQuerySnippet."
+msgstr "شما نمی توانید creator_id یک NativeQuerySnippet را به روز کنید."
+
+#: src/metabase/models/setting.clj
+msgid "Error fetching value of Setting"
+msgstr "خطا در واکشی مقدار تنظیمات"
+
+#: src/metabase/public_settings.clj
+msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
+msgstr "زبانی که باید برای UI UA Metabase ، ایمیل های سیستم ، پالس ها و هشدارها استفاده شود."
+
+#: src/metabase/public_settings.clj
+msgid "This is also the default language for all users, which they can change from their own account settings."
+msgstr "این همچنین زبان پیش فرض برای همه کاربران است که می توانند از طریق تنظیمات حساب کاربری خود تغییر دهند."
+
+#: src/metabase/public_settings.clj
+msgid "Invalid locale {0}"
+msgstr "محلی نامعتبر {0"
+
+#: src/metabase/public_settings.clj
+msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
+msgstr "اگر آدرس سایت HTTPS باشد ، تمام ترافیک را مجبور به استفاده از HTTPS از طریق تغییر مسیر می کند"
+
+#: src/metabase/public_settings.clj
+msgid "Cannot redirect requests to HTTPS unless `site-url` is HTTPS."
+msgstr "نمی توان درخواستها را به HTTPS هدایت کرد مگر اینکه \"سایت-آدرس\" HTTPS باشد."
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error registering fonts: Metabase will not be able to send Pulses."
+msgstr "خطا در ثبت فونت ها: Metabase قادر به ارسال پالس نیست."
+
+#: src/metabase/pulse/render/png.clj
+msgid "This is a known issue with certain JVMs. See {0} and for more details."
+msgstr "این یک مسئله شناخته شده با JVM های خاص است. برای جزئیات بیشتر به {0} مراجعه کنید."
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error rendering Pulse"
+msgstr "خطایی در ارائه پالس"
+
+#: src/metabase/query_processor/context/default.clj
+msgid "Query timed out after {0}, raising timeout exception."
+msgstr "زمان پرس و جو بعد از {0 {به پایان رسید و استثناء زمان پایان را افزایش داد."
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "No fields found for table {0}."
+msgstr "هیچ زمینه ای برای جدول {0 found یافت نشد."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Case"
+msgstr "مورد"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Variance of {0}"
+msgstr "واریانس {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Median of {0}"
+msgstr "متوسط {0"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "{0}th percentile of {1}"
+msgstr "percent 0} صدک of 1 {"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Not caching results: results are larger than {0} KB"
+msgstr "نتایج نهان ذخیره سازی: نتایج بزرگتر از {0} KB است"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Cannot cache results: expected byte array, got {0}"
+msgstr "نتایج حافظه پنهان امکان پذیر نیست: آرایه بایت مورد انتظار ، got 0 got"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Request is closed; no one to return cached results to"
+msgstr "درخواست بسته است؛ هیچ کس برای بازگشت نتایج ذخیره شده به"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Error attempting to fetch cached results for query with hash {0}"
+msgstr "خطایی در واگذاری نتایج ذخیره شده ذخیره شده برای پرس و جو با hash {0"
+
+#: src/metabase/query_processor/middleware/cache_backend/db.clj
+msgid "Error preparing statement to fetch cached query results"
+msgstr "خطا در تهیه عبارت برای واکشی نتایج جستجوی ذخیره شده خطایی"
+
+#: src/metabase/query_processor/middleware/catch_exceptions.clj
+msgid "Error processing query: {0}"
+msgstr "خطای پردازش خطا: {0"
+
+#: src/metabase/server.clj
+msgid "Unexpected exception in endpoint"
+msgstr "استثناء غیر منتظره در نقطه پایانی"
+
+#: src/metabase/server.clj
+msgid "Unexpected Exception in API request handler"
+msgstr "استثناء غیر منتظره در کنترل کننده درخواست API"
+
+#: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+msgid "Error reducing {0}"
+msgstr "خطا در کاهش {0"
+
+#: src/metabase/sync/analyze/fingerprint/insights.clj
+msgid "Error generating timeseries insight keyed by: {0}"
+msgstr "خطایی در ایجاد بینش زمانی که توسط: {0 ایجاد شده است"
+
+#: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
+msgstr "موقعیت پایگاه داده {0 from از '' {1} '' به '' {2} '' تغییر کرده است."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Unscheduling task for Database {0}: trigger: {1}"
+msgstr "وظیفه عدم اجرای پایگاه داده {0: ماشه: {1"
+
+#: src/metabase/util/schema.clj
+msgid "value must be a keyword or string."
+msgstr "مقدار باید یک کلمه کلیدی یا رشته باشد."
+
+#: src/metabase/util/schema.clj
+msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
+msgstr "رشته باید یک زبان ISO معتبر دو حرف یا کد کشور-کشور مثلاً باشد. 'en' یا 'en_US'."

--- a/locales/fr.po
+++ b/locales/fr.po
@@ -31,13 +31,14 @@ msgid "Select a database type"
 msgstr "Sélectionner un type de base de données"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:411
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:154
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -50,7 +51,7 @@ msgstr "Sauvegarder"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "Metabase doit analyser votre base de données. Nous procéderons à une nouvelle analyse périodique pour maintenir les métadonnées à jour. Vous pouvez contrôler ci-dessous le moment où ces analyses périodiques auront lieu."
 
-#: frontend/src/metabase/entities/databases/forms.js:221
+#: frontend/src/metabase/entities/databases/forms.js:290
 msgid "Database syncing"
 msgstr "Synchronisation de la base de données"
 
@@ -66,7 +67,7 @@ msgstr "Ceci est un processus léger qui vérifie les\n"
 msgid "Scan"
 msgstr "Analyser"
 
-#: frontend/src/metabase/entities/databases/forms.js:228
+#: frontend/src/metabase/entities/databases/forms.js:297
 msgid "Scanning for Filter Values"
 msgstr "Analyse des valeurs de filtre"
 
@@ -77,7 +78,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase peut analyser les champs de cette base de données pour en proposer les valeurs dans les filtres des tableaux de bord et des questions. Cette analyse peut être un processus gourmand en ressources, surtout si vous avez une très grande base de données."
 
-#: frontend/src/metabase/entities/databases/forms.js:232
+#: frontend/src/metabase/entities/databases/forms.js:301
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Quand Metabase doit-il automatiquement analyser et mettre en cache les valeurs des champs ?"
 
@@ -99,6 +100,7 @@ msgid "Never, I'll do this manually if I need to"
 msgstr "Jamais, je le ferai manuellement au besoin"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 msgid "Saving..."
@@ -135,9 +137,9 @@ msgid "in this box:"
 msgstr "dans cette case :"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:75
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
@@ -154,18 +156,18 @@ msgstr "dans cette case :"
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:301
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:39
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:90
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:99
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:311
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:328
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "Annuler"
@@ -182,7 +184,7 @@ msgstr "Supprimer"
 #: frontend/src/metabase/admin/permissions/selectors.js:323
 #: frontend/src/metabase/admin/permissions/selectors.js:330
 #: frontend/src/metabase/admin/permissions/selectors.js:441
-#: frontend/src/metabase/admin/routes.jsx:57
+#: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
@@ -202,9 +204,10 @@ msgid "Scheduling"
 msgstr "Planification"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:71
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
@@ -212,8 +215,8 @@ msgid "Save changes"
 msgstr "Sauvegarder les modifications"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:203
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:35
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
 msgstr "Actions"
 
@@ -225,8 +228,8 @@ msgstr "Synchroniser le schéma de base de données"
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:90
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:98
 msgid "Starting…"
 msgstr "Démarrage..."
 
@@ -244,13 +247,13 @@ msgstr "Analyser à nouveau les valeurs des filtres maintenant"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
 msgstr "Impossible de démarrer l analyse"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:92
 msgid "Scan triggered!"
 msgstr "Analyse déclenchée !"
 
@@ -274,15 +277,15 @@ msgid "Add database"
 msgstr "Ajouter une base de données"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:28
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:28
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
 #: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:195
+#: frontend/src/metabase/entities/databases/forms.js:264
 #: frontend/src/metabase/entities/questions.js:86
 #: frontend/src/metabase/entities/questions.js:102
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
@@ -322,6 +325,7 @@ msgstr "Sauvegarde réussie!"
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Modifier"
@@ -364,44 +368,43 @@ msgstr "Échec"
 msgid "Success"
 msgstr "Succès"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:185
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Prévisualisation"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:93
 msgid "No column description yet"
 msgstr "Aucune description pour cette colonne"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:127
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:126
 msgid "Select a field visibility"
 msgstr "Sélectionner une visibilité de champ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:187
 msgid "No special type"
 msgstr "Aucun type particulier"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
 #: frontend/src/metabase/lib/core.js:275
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:44
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:37
 msgid "Other"
 msgstr "Autre"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:221
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Sélectionner un type"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:255
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:262
 #: frontend/src/metabase/reference/components/Field.jsx:99
 msgid "Select a target"
 msgstr "Sélectionner une cible"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
@@ -409,18 +412,18 @@ msgstr "Sélectionner une cible"
 msgid "Columns"
 msgstr "Colonnes"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Colonne"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:144
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:288
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
 msgid "Visibility"
 msgstr "Visibilité"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
 msgid "Type"
 msgstr "Type"
 
@@ -428,7 +431,7 @@ msgstr "Type"
 msgid "Current database:"
 msgstr "Base de données actuelle :"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
 msgid "Show original schema"
 msgstr "Montrer le schéma original"
 
@@ -450,27 +453,27 @@ msgid_plural "{0} schemas"
 msgstr[0] "{0} schéma"
 msgstr[1] "{0} schémas"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:99
 msgid "Why Hide?"
 msgstr "Pourquoi masquer ?"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:100
 msgid "Technical Data"
 msgstr "Donnée technique"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
 msgstr "Non pertinent"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 msgid "Queryable"
 msgstr "Interrogeable"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:108
 msgid "Hidden"
 msgstr "Masqué"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136
 msgid "No table description yet"
 msgstr "Aucune description pour cette table"
 
@@ -478,32 +481,33 @@ msgstr "Aucune description pour cette table"
 msgid "Metadata Strength"
 msgstr "Force des métadonnées"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0} Table interrogeable"
 msgstr[1] "{0} Tables interrogeables"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:91
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} Table cachée"
 msgstr[1] "{0} Tables cachées"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:115
 msgid "Find a table"
 msgstr "Trouver une table"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:128
 msgid "Schemas"
 msgstr "Schémas"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:838
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:21
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:43
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:62
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 msgid "Metrics"
 msgstr "Métriques"
@@ -512,8 +516,8 @@ msgstr "Métriques"
 msgid "Add a Metric"
 msgstr "Ajouter une métrique"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "Définition"
@@ -523,12 +527,12 @@ msgstr "Définition"
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "Créer des métriques pour les ajouter au menu déroulant 'Vue' du générateur de requêtes"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:21
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
 #: frontend/src/metabase/home/containers/SearchApp.jsx:72
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:961
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:61
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Segments"
@@ -537,35 +541,35 @@ msgstr "Segments"
 msgid "Add a Segment"
 msgstr "Ajouter un segment"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:51
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:45
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "Créer des segments pour les ajouter à la liste déroulante Filtre dans le générateur de requêtes"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:21
 msgid "created"
 msgstr "créé"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "reverted to a previous version"
 msgstr "retour à une version précédente"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:30
 msgid "edited the title"
 msgstr "modifier le titre"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:32
 msgid "edited the description"
 msgstr "modifier la description"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:34
 msgid "edited the "
 msgstr "modifier le "
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:40
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "made some changes"
 msgstr "a fait des modifications"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
 #: frontend/src/metabase/home/components/Activity.jsx:83
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
@@ -575,84 +579,84 @@ msgstr "Vous"
 msgid "Datamodel"
 msgstr "Modèle de données"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:41
 msgid " History"
 msgstr " Historique"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
 msgstr "Historique de modification pour"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:228
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
 msgid "{0} – Field Settings"
 msgstr "{0} – Réglages du champ"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:289
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
 msgid "Where this field will appear throughout Metabase"
 msgstr "Où ce champ apparaîtra dans Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:311
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
 msgid "Filtering on this field"
 msgstr "Filtrer sur ce champ"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:312
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Lorsque ce champ est utilisé dans un filtre, que doivent faire les utilisateurs pour saisir la valeur à filtrer?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:437
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
 msgid "No description for this field yet"
 msgstr "Aucune description pour ce champ"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
 msgid "Original value"
 msgstr "Valeur d'origine"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:390
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
 msgid "Mapped value"
 msgstr "Valeur correspondante"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
 msgid "Enter value"
 msgstr "Saisir une valeur"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use original value"
 msgstr "Utiliser la valeur d'origine"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Use foreign key"
 msgstr "Utiliser la clé étrangère"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 msgid "Custom mapping"
 msgstr "Correspondance personnalisée"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
 msgid "Unrecognized mapping type"
 msgstr "Type de correspondance non reconnu"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Le champ actuel n'est pas une clé étrangère ou les métadonnées de la table cible de la clé étrangère sont manquantes"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
 msgid "The selected field isn't a foreign key"
 msgstr "Le champ sélectionné n'est pas une clé étrangère"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:327
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
 msgid "Display values"
 msgstr "Afficher les valeurs"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:328
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Choisir d'afficher la valeur originale dans la base de données, ou une information associée ou personnalisée."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:278
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
 msgid "Choose a field"
 msgstr "Choisissez un champ"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:299
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
 msgid "Please select a column to use for display."
 msgstr "S'il vous plaît, sélectionnez une colonne à utiliser pour l'affichage"
 
@@ -660,16 +664,16 @@ msgstr "S'il vous plaît, sélectionnez une colonne à utiliser pour l'affichage
 msgid "Tip:"
 msgstr "Astuce:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:443
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Il se peut que vous vouliez mettre à jour le nom du champ pour s'assurer qu'il est toujours pertinent selon vos choix de mise en corespondance."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:344
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Valeurs des filtres mises en cache"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:345
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase peut analyser les valeurs de ce champ pour proposer des filtres dans les tableaux de bord et les questions."
 
@@ -678,53 +682,53 @@ msgid "Re-scan this field"
 msgstr "Analyser à nouveau ce champ"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
 msgstr "Supprimer les valeurs des filtres du cache"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
 msgstr "Impossible de supprimer les valeurs"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 msgid "Discard triggered!"
 msgstr "Suppression lancée"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Sélectionner une table pour voir son schéma et enrichir ses métadonnées"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:36
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "Le nom est requis"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:39
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "La description est requise"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:43
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Un message d'historique est requis"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
 msgid "Aggregation is required"
 msgstr "Une agrégation est requise."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Edit Your Metric"
 msgstr "Éditer votre métrique"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Create Your Metric"
 msgstr "Créer votre métrique"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Modifier votre métrique et laisser un commentaire pour ces changements."
 
@@ -732,96 +736,96 @@ msgstr "Modifier votre métrique et laisser un commentaire pour ces changements.
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Sauvegardez des métriques pour les rendre disponibles dans l'option de Vue de cette table. Les métriques se définissent par un type d'agrégation, un champ aggrégé, et optionnellement tous filtres que vous y ajouterez. Par exemple, vous pourriez vouloir créer une métrique pour définir la façon officielle de calculer le \"Prix moyen\" d'une table qui contient des Commandes."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:180
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
 msgid "Result: "
 msgstr "Résultat : "
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
 msgid "Name Your Metric"
 msgstr "Nommez votre métrique"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:190
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Give your metric a name to help others find it."
 msgstr "Donnez un nom à votre métrique pour aider les autres à la retrouver."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:194
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:152
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Description syntétique"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:198
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
 msgid "Describe Your Metric"
 msgstr "Décrivez votre métrique"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:199
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Donnez une description à votre métrique pour aider les autres à mieux l'utiliser."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:203
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "C'est le bon endroit pour expliquer plus précisement à quoi sert votre métrique et comment vous l'avez construite."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:207
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:165
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Raison des modifications"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:209
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Laisser un mot d'explication sur les changements que vous avez fait et pourquoi ils étaient nécessaires."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:213
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Sera affiché dans l'historique des révisions de cette métrique afin d'aider tout le monde à se souvenir des changements effectués."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
 msgstr "Au moins un filtre est requis"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
 msgstr "Modifier votre segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
 msgstr "Créez votre segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Faites des changement à votre segment et laissez une note explicative"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
-msgstr "Sélectionnez et ajoutez des filtres pour créer un nouveau segement pour la table {0}"
+msgstr "Sélectionnez et ajoutez des filtres pour créer un nouveau segment pour la table {0}"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
 msgstr "Nommez votre segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:148
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
 msgstr "Donnez un nom à votre segment pour aider les utilisateurs à le retrouver."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:156
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
 msgstr "Décrivez votre segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Donnez une description à votre segment pour aider les autres à mieux l'utiliser."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "C'est le bon endroit pour être plus spécifique sur les règles de segment moins évidentes"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
-msgstr "Ce sera affiché dans l'historique des révisions pour ce segement, afin d'aider tout le monde à se souvenir pour ça a été changé"
+msgstr "Ce sera affiché dans l'historique des révisions pour ce segment, afin d'aider tout le monde à se souvenir pour ça a été changé"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
-#: frontend/src/metabase/admin/routes.jsx:132
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:215
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
+#: frontend/src/metabase/admin/routes.jsx:137
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
@@ -829,11 +833,11 @@ msgstr "Ce sera affiché dans l'historique des révisions pour ce segement, afin
 msgid "Settings"
 msgstr "Paramètres"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase peut analyser les valeurs des champs de cette table pour activer les filtres de case à cocher dans les tableaux de bord et les questions."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
 msgstr "Analyser à nouveau cette table"
 
@@ -847,11 +851,11 @@ msgstr "Ajouter"
 msgid "Not a valid formatted email address"
 msgstr "Format de l'adresse électronique invalide"
 
-#: frontend/src/metabase/entities/users/forms.js:12
+#: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
 msgstr "Prénom"
 
-#: frontend/src/metabase/entities/users/forms.js:18
+#: frontend/src/metabase/entities/users/forms.js:20
 msgid "Last name"
 msgstr "Nom"
 
@@ -890,10 +894,10 @@ msgstr "Membres"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
-#: frontend/src/metabase/admin/settings/selectors.js:120
-#: frontend/src/metabase/entities/users/forms.js:24
+#: frontend/src/metabase/admin/settings/selectors.js:121
+#: frontend/src/metabase/entities/users/forms.js:26
 #: frontend/src/metabase/lib/core.js:146
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:294
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:298
 msgid "Email"
 msgstr "Adresse électronique"
 
@@ -903,14 +907,14 @@ msgstr "Un groupe n'a de valeur que lorsqu'il contient des utilisateurs."
 
 #. tous les items du menu paramètres sont des noms...
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
-#: frontend/src/metabase/admin/routes.jsx:52
+#: frontend/src/metabase/admin/routes.jsx:55
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Admin"
 msgstr "Administration"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:241
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:299
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:288
 msgid "and"
 msgstr "et"
 
@@ -963,12 +967,12 @@ msgstr "Supprimer le groupe"
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:42
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:294
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:397
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:317
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:334
 msgid "Done"
 msgstr "Fait"
 
@@ -979,8 +983,9 @@ msgstr "Nom du groupe"
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
-#: frontend/src/metabase/admin/routes.jsx:92
+#: frontend/src/metabase/admin/routes.jsx:97
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Groupes"
 
@@ -1010,7 +1015,7 @@ msgstr "Désactiver"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:21
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
-#: frontend/src/metabase/admin/routes.jsx:88
+#: frontend/src/metabase/admin/routes.jsx:93
 #: frontend/src/metabase/nav/containers/Navbar.jsx:235
 msgid "People"
 msgstr "Utilisateurs"
@@ -1322,25 +1327,25 @@ msgstr "Voir le contenu d'une collection"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:542
+#: frontend/src/metabase/admin/permissions/selectors.js:558
 msgid "Data Access"
 msgstr "Accès aux données"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:667
-#: frontend/src/metabase/admin/permissions/selectors.js:672
+#: frontend/src/metabase/admin/permissions/selectors.js:665
+#: frontend/src/metabase/admin/permissions/selectors.js:670
 msgid "View tables"
 msgstr "Voir les tables"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:608
+#: frontend/src/metabase/admin/permissions/selectors.js:606
 msgid "SQL Queries"
 msgstr "Requêtes SQL"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:678
+#: frontend/src/metabase/admin/permissions/selectors.js:676
 msgid "View schemas"
 msgstr "Voir les schémas"
 
-#: frontend/src/metabase/admin/routes.jsx:63
+#: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
 msgstr "Modèles de données"
@@ -1370,20 +1375,24 @@ msgid "Allows users within your LDAP directory to log in to Metabase with their 
 msgstr "Permet aux utilisateurs de votre annuaire LDAP de se connecter à Metabase avec leur compte LDAP, et offre la possibilité de réaliser une correspondance automatique des groupes LDAP et Metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:19
-#: frontend/src/metabase/admin/settings/selectors.js:167
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
+#: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
 msgstr "Ce n'est pas une adresse électronique valide"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
 msgstr "Ce n'est pas un entier valide"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
 msgstr "Modifications sauvegardées!"
 
-#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:178
+#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
 msgid "Looks like we ran into some problems"
 msgstr "Il semble que nous avons rencontré des problèmes"
 
@@ -1405,7 +1414,7 @@ msgstr "Effacer"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:195
+#: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Authentification"
 
@@ -1457,15 +1466,15 @@ msgstr "Votre Google client ID"
 msgid "Allow users to sign up on their own if their Google account email address is from:"
 msgstr "Autoriser les utilisateurs à se connecter uniquement si leur compte Google se termine par :"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:242
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:249
 msgid "Answers sent right to your Slack #channels"
 msgstr "Réponses envoyées directement vers vos #canaux Slack"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:251
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:258
 msgid "Create a Slack Bot User for MetaBot"
 msgstr "Créer un Slack Bot User pour MetaBot"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:261
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:268
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "Cela fait, donnez lui/elle un nom et cliquer {0}. Copier et coller ensuite le Bot API Token dans le champ ci-dessous. Enfin, créez un canal Slack \"metabase_files\" . Metabase en a besoin pour télécharger les graphiques."
 
@@ -1478,8 +1487,8 @@ msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Metabase {0} est disponible. Vous faites actuellement tourner {1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:41
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 msgid "Update"
 msgstr "Mettre à jour"
 
@@ -1506,16 +1515,16 @@ msgstr "Supprimer une carte personnalisée"
 #: frontend/src/metabase/containers/Overworld.jsx:293
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:115
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Supprimer"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:165
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:141
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
 msgstr "Sélectionner..."
 
@@ -1700,48 +1709,46 @@ msgid "Generate Key"
 msgstr "Générer une clé"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:87
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:18
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enabled"
 msgstr "Activé"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:92
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:19
+#: frontend/src/metabase/admin/settings/selectors.js:93
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Désactivé"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:112
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:113
 msgid "Unknown setting {0}"
 msgstr "Réglage inconnu {0}"
 
-#: frontend/src/metabase/admin/settings/selectors.js:34
+#: frontend/src/metabase/admin/settings/selectors.js:37
 msgid "Setup"
 msgstr "Réglages"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:207
-#: frontend/src/metabase/admin/settings/selectors.js:39
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:214
+#: frontend/src/metabase/admin/settings/selectors.js:42
 msgid "General"
 msgstr "Général"
 
-#: frontend/src/metabase/admin/settings/selectors.js:43
+#: frontend/src/metabase/admin/settings/selectors.js:46
 msgid "Site Name"
 msgstr "Nom du site"
 
-#: frontend/src/metabase/admin/settings/selectors.js:48
+#: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Site URL"
 msgstr "URL du site"
 
-#: frontend/src/metabase/admin/settings/selectors.js:53
+#: frontend/src/metabase/admin/settings/selectors.js:64
 msgid "Email Address for Help Requests"
 msgstr "Adresse électronique pour les demandes d'aide"
 
-#: frontend/src/metabase/admin/settings/selectors.js:58
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
 msgstr "Fuseau horaire des rapports"
 
-#: frontend/src/metabase/admin/settings/selectors.js:61
+#: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
 msgstr "Valeur par défaut de la base de données"
 
@@ -1749,11 +1756,11 @@ msgstr "Valeur par défaut de la base de données"
 msgid "Select a timezone"
 msgstr "Choisir un fuseau horaire"
 
-#: frontend/src/metabase/admin/settings/selectors.js:64
+#: frontend/src/metabase/admin/settings/selectors.js:75
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "Toutes les bases de données ne gèrent pas les fuseaux horaires, le cas échéant ce réglage sera sans effet."
 
-#: frontend/src/metabase/admin/settings/selectors.js:69
+#: frontend/src/metabase/entities/users/forms.js:34
 msgid "Language"
 msgstr "Langage"
 
@@ -1761,64 +1768,64 @@ msgstr "Langage"
 msgid "Select a language"
 msgstr "Choisir une langue"
 
-#: frontend/src/metabase/admin/settings/selectors.js:79
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
 msgstr "Tracking anonyme"
 
-#: frontend/src/metabase/admin/settings/selectors.js:84
+#: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
 msgstr "Adaptation des noms de table et de champ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:90
+#: frontend/src/metabase/admin/settings/selectors.js:91
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Remplacer seulement les soulignés et tirés par un espace"
 
-#: frontend/src/metabase/admin/settings/selectors.js:98
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Enable Nested Queries"
 msgstr "Autoriser les requêtes imbriquées"
 
-#: frontend/src/metabase/admin/settings/selectors.js:109
+#: frontend/src/metabase/admin/settings/selectors.js:110
 msgid "Updates"
 msgstr "Mises à jour"
 
-#: frontend/src/metabase/admin/settings/selectors.js:114
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
 msgstr "Rechercher des mises à jour"
 
-#: frontend/src/metabase/admin/settings/selectors.js:125
+#: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
 msgstr "Hôte SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:133
+#: frontend/src/metabase/admin/settings/selectors.js:134
 msgid "SMTP Port"
 msgstr "Port SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:137
+#: frontend/src/metabase/admin/settings/selectors.js:138
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:47
 msgid "That's not a valid port number"
 msgstr "Ce n'est pas un numéro de port valide"
 
-#: frontend/src/metabase/admin/settings/selectors.js:141
+#: frontend/src/metabase/admin/settings/selectors.js:142
 msgid "SMTP Security"
 msgstr "Sécurité SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:150
 msgid "SMTP Username"
 msgstr "Utilisateur SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "SMTP Password"
 msgstr "Mot de passe SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:163
+#: frontend/src/metabase/admin/settings/selectors.js:164
 msgid "From Address"
 msgstr "Depuis l'adresse"
 
-#: frontend/src/metabase/admin/settings/selectors.js:176
+#: frontend/src/metabase/admin/settings/selectors.js:178
 msgid "Slack API Token"
 msgstr "Jeton d'API Slack"
 
-#: frontend/src/metabase/admin/settings/selectors.js:178
+#: frontend/src/metabase/admin/settings/selectors.js:180
 msgid "Enter the token you received from Slack"
 msgstr "Saisissez le jeton que vous avez reçu de Slack"
 
@@ -1847,8 +1854,10 @@ msgid "Username or DN"
 msgstr "Utilisateur"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:43
+#: frontend/src/metabase/entities/databases/forms.js:61
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:64
-#: frontend/src/metabase/user/components/UserSettings.jsx:65
+#: frontend/src/metabase/user/components/UserSettings.jsx:66
+#: src/metabase/driver/common.clj
 msgid "Password"
 msgstr "Mot de passe"
 
@@ -1884,80 +1893,80 @@ msgstr "Synchroniser les appartenances de groupe"
 msgid "Group search base"
 msgstr "Base de recherche des groupes"
 
-#: frontend/src/metabase/admin/settings/selectors.js:199
+#: frontend/src/metabase/admin/settings/selectors.js:201
 msgid "Maps"
 msgstr "Cartes"
 
-#: frontend/src/metabase/admin/settings/selectors.js:203
+#: frontend/src/metabase/admin/settings/selectors.js:205
 msgid "Map tile server URL"
 msgstr "URL du serveur de cartes"
 
-#: frontend/src/metabase/admin/settings/selectors.js:204
+#: frontend/src/metabase/admin/settings/selectors.js:206
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Metabase utilise OpenStreetMaps par défaut."
 
-#: frontend/src/metabase/admin/settings/selectors.js:209
+#: frontend/src/metabase/admin/settings/selectors.js:211
 msgid "Custom Maps"
 msgstr "Cartes personnalisées"
 
-#: frontend/src/metabase/admin/settings/selectors.js:210
+#: frontend/src/metabase/admin/settings/selectors.js:212
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Ajouter vos propres fichiers GeoJSON pour permettre la visualisation sur d'autres régions"
 
-#: frontend/src/metabase/admin/settings/selectors.js:228
+#: frontend/src/metabase/admin/settings/selectors.js:245
 msgid "Public Sharing"
 msgstr "Partage public"
 
-#: frontend/src/metabase/admin/settings/selectors.js:232
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "Enable Public Sharing"
 msgstr "Activer le partage public"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:254
 msgid "Shared Dashboards"
 msgstr "Tableaux de bord partagés"
 
-#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Shared Questions"
 msgstr "Questions partagées"
 
-#: frontend/src/metabase/admin/settings/selectors.js:250
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Embedding in other Applications"
 msgstr "Intégration dans d'autres applications"
 
-#: frontend/src/metabase/admin/settings/selectors.js:276
+#: frontend/src/metabase/admin/settings/selectors.js:293
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Autoriser l'intégration de Metabase dans d'autres applications"
 
-#: frontend/src/metabase/admin/settings/selectors.js:286
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Embedding secret key"
 msgstr "Clé secrète d'intégration"
 
-#: frontend/src/metabase/admin/settings/selectors.js:292
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Embedded Dashboards"
 msgstr "Tableaux de bord intégrés"
 
-#: frontend/src/metabase/admin/settings/selectors.js:298
+#: frontend/src/metabase/admin/settings/selectors.js:315
 msgid "Embedded Questions"
 msgstr "Questions intégrées"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:322
 msgid "Caching"
 msgstr "Mise en cache"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:326
 msgid "Enable Caching"
 msgstr "Autoriser la mise en cache"
 
-#: frontend/src/metabase/admin/settings/selectors.js:314
+#: frontend/src/metabase/admin/settings/selectors.js:331
 msgid "Minimum Query Duration"
 msgstr "Durée d'exécution minimum d'une requête"
 
-#: frontend/src/metabase/admin/settings/selectors.js:321
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Multiplicateur de durée de vie en cache (TTL)"
 
 #. Erreur de compréhension dans ma première traduction
-#: frontend/src/metabase/admin/settings/selectors.js:328
+#: frontend/src/metabase/admin/settings/selectors.js:345
 msgid "Max Cache Entry Size"
 msgstr "Taille maximum d'une entrée du cache"
 
@@ -2125,7 +2134,8 @@ msgstr "Les tableaux de bord, collections et pulses de cette collection seront a
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/routes.jsx:205
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
+#: frontend/src/metabase/routes.jsx:196
 msgid "Archive"
 msgstr "Archiver"
 
@@ -2141,21 +2151,21 @@ msgstr "Voir l'archive"
 msgid "Unarchive this {0}"
 msgstr "Annuler l'archivage de ce/cette {0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:39
-#: frontend/src/metabase/components/BrowseApp.jsx:102
-#: frontend/src/metabase/components/BrowseApp.jsx:194
+#: frontend/src/metabase/components/BrowseApp.jsx:46
+#: frontend/src/metabase/components/BrowseApp.jsx:112
+#: frontend/src/metabase/components/BrowseApp.jsx:204
 #: frontend/src/metabase/containers/Overworld.jsx:270
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
 msgstr "Nos données"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:146
+#: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
 msgid "X-ray this table"
 msgstr "Radiographier cette table"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:161
+#: frontend/src/metabase/components/BrowseApp.jsx:171
 msgid "Learn about this table"
 msgstr "Apprendre au sujet de cette table"
 
@@ -2250,7 +2260,7 @@ msgstr "Epingles"
 msgid "Drag something here to pin it to the top"
 msgstr "Déposer quelque chose ici pour l'épingler en haut"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:755
+#: frontend/src/metabase/admin/permissions/selectors.js:753
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2304,7 +2314,7 @@ msgstr "Nouvelle collection"
 msgid "Copied!"
 msgstr "Copié(e)(s) !"
 
-#: frontend/src/metabase/entities/databases/forms.js:12
+#: frontend/src/metabase/entities/databases/forms.js:14
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Utiliser un tunnel SSH pour les connexions à la base de données"
 
@@ -2314,7 +2324,7 @@ msgid "Some database installations can only be accessed by connecting through an
 "Enabling this is usually slower than a direct connection."
 msgstr "Certaines bases de données ne sont accessibles qu'en SSH au travers d'un serveur bastion. Cette option ajoute aussi une couche de sécurité lors d'une connexion hors VPN. L'activer est plus lent qu'une connexion directe."
 
-#: frontend/src/metabase/entities/databases/forms.js:212
+#: frontend/src/metabase/entities/databases/forms.js:281
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "C'est une grande base de données, laissez-moi donc choisir quand Metabase lance les synchronisations et les analyses"
 
@@ -2324,17 +2334,17 @@ msgid "By default, Metabase does a lightweight hourly sync and an intensive dail
 msgstr "Par défaut, Metabase effectue une synchronisation horaire légère et un analyse journalière intensive des valeurs de filtre.\n"
 "Si vous avez une grande base de données, nous vous recommandons d'activer cette option et de définir quand et à quelle fréquence l'analyse des valeurs de filtre s'effectue."
 
-#: frontend/src/metabase/entities/databases/forms.js:78
+#: frontend/src/metabase/entities/databases/forms.js:113
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0} pour générer un ID et un secret client pour votre projet."
 
-#: frontend/src/metabase/entities/databases/forms.js:80
-#: frontend/src/metabase/entities/databases/forms.js:95
-#: frontend/src/metabase/entities/databases/forms.js:131
+#: frontend/src/metabase/entities/databases/forms.js:115
+#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:166
 msgid "Click here"
 msgstr "Cliquer ici"
 
-#: frontend/src/metabase/entities/databases/forms.js:83
+#: frontend/src/metabase/entities/databases/forms.js:118
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Choisir \"Autre\" comme type d'application. La nommer comme bon vous semble."
 
@@ -2342,19 +2352,19 @@ msgstr "Choisir \"Autre\" comme type d'application. La nommer comme bon vous sem
 msgid "{0} to get an auth code"
 msgstr "{0} pour obtenir un code d'authentification"
 
-#: frontend/src/metabase/entities/databases/forms.js:107
+#: frontend/src/metabase/entities/databases/forms.js:142
 msgid "with Google Drive permissions"
 msgstr "avec les permissions de Google Drive"
 
-#: frontend/src/metabase/entities/databases/forms.js:129
+#: frontend/src/metabase/entities/databases/forms.js:164
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "Pour pouvoir utiliser Metabase avec cette donnée, vous devez activer l'accès à l'API dans la Google Developers Console."
 
-#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:165
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} pour se rendre dans la console si ce n'est déjà fait."
 
-#: frontend/src/metabase/entities/databases/forms.js:196
+#: frontend/src/metabase/entities/databases/forms.js:265
 msgid "How would you like to refer to this database?"
 msgstr "Sous quel nom souhaitez-vous référencer cette base de données ?"
 
@@ -2363,7 +2373,8 @@ msgstr "Sous quel nom souhaitez-vous référencer cette base de données ?"
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:143
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:70
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:123
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:96
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:126
 #: frontend/src/metabase/setup/components/UserStep.jsx:93
 msgid "Next"
 msgstr "Suivant"
@@ -2546,7 +2557,7 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Ramené(e) à une précédente version et {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:290
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "Historique des modifications"
@@ -2592,7 +2603,7 @@ msgid "Questions"
 msgstr "Questions"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:320
+#: frontend/src/metabase/routes.jsx:311
 msgid "Pulses"
 msgstr "Pulses"
 
@@ -2637,15 +2648,16 @@ msgstr "Nous sommes un peu perdus..."
 msgid "Temporary Password"
 msgstr "Mot de passe temporaire"
 
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:207
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:481
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
 msgid "Hide"
 msgstr "Masquer"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:467
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:482
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:471
 msgid "Show"
 msgstr "Montrer"
 
@@ -2755,7 +2767,7 @@ msgstr "Désolé, vous n'avez pas la permission de voir cela."
 msgid "Unknown error encountered"
 msgstr "Un erreur inconnue a été rencontrée"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/nav/containers/Navbar.jsx:373
 msgid "Create"
 msgstr "Créer"
@@ -2768,7 +2780,7 @@ msgstr "Créer un tableau de bord"
 msgid "Table"
 msgstr "Table"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
 msgid "Database"
 msgstr "Base de données"
 
@@ -2788,7 +2800,7 @@ msgstr "Essayez d'ajuster votre filtre pour trouver ce que vous recherchez"
 msgid "View by"
 msgstr "Voir par"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:122
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:121
 msgid "of"
 msgstr "de"
 
@@ -2815,33 +2827,33 @@ msgstr "Notre décisionnel"
 msgid "Browse all items"
 msgstr "Parcourir tous les éléments"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:118
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:117
 msgid "Replace or save as new?"
 msgstr "Remplacer ou sauvegarder en tant que nouvel élément ?"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:168
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace original question, \"{0}\""
 msgstr "Remplacer la question originale. \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:172
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:171
 msgid "Save as new question"
 msgstr "Sauvegarder en tant que nouvelle question"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:92
 msgid "First, save your question"
 msgstr "Avant toute chose, sauvegardez votre question"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:94
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
 msgid "Save question"
 msgstr "Sauvegarder la question"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:133
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
 msgid "What is the name of your card?"
 msgstr "Quel est le nom de votre carte ?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
 #: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/entities/questions.js:89
@@ -2857,15 +2869,16 @@ msgstr "Quel est le nom de votre carte ?"
 msgid "Description"
 msgstr "Description"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
 #: frontend/src/metabase/entities/dashboards.js:150
 #: frontend/src/metabase/entities/questions.js:91
 #: frontend/src/metabase/entities/questions.js:107
+#: frontend/src/metabase/entities/snippets.js:31
 msgid "It's optional but oh, so helpful"
 msgstr "C'est facultatif, mais ô combien utile"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:148
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "Dans quelle collection cela devrait-il aller ?"
@@ -2882,19 +2895,19 @@ msgstr "élément"
 msgid "Undo"
 msgstr "Annuler la modification"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:266
 msgid "Applying Question"
 msgstr "Poser la question"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:286
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "That question isn't compatible"
 msgstr "Cette question n'est pas compatible"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:322
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:309
 msgid "Search for a question"
 msgstr "Rechercher une question"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:351
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:343
 msgid "We're not sure if this question is compatible"
 msgstr "Nous ne sommes pas sûr que cette question soit compatible"
 
@@ -2943,25 +2956,23 @@ msgstr "Ajouter une question"
 msgid "Add a question to this dashboard"
 msgstr "Ajouter une question à ce tableau de bord"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
 msgid "Add a filter"
 msgstr "Ajouter un filtre"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:256
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "Paramètres"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:276
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:280
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
 msgid "Add a text box"
 msgstr "Ajouter une zone de texte"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:320
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:314
 msgid "Move dashboard"
 msgstr "Déplacer le tableau de bord"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:303
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
 msgid "Edit dashboard"
 msgstr "Modifier le tableau de bord"
 
@@ -2969,11 +2980,11 @@ msgstr "Modifier le tableau de bord"
 msgid "Edit Dashboard Layout"
 msgstr "Modifier l'agencement du tableau de bord"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:371
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:365
 msgid "You are editing a dashboard"
 msgstr "Vous modifiez un tableau de bord"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:376
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:370
 msgid "Select the field that should be filtered for each card"
 msgstr "Sélectionner le champ qui devrait être filtré pour chaque carte"
 
@@ -3061,7 +3072,7 @@ msgstr "Cette carte n'a aucun champ ou paramètre qui pourrait être mis en corr
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Les valeurs de ce champ ne chevauchent les valeurs d'aucun autre champ sélectionné."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:162
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "Aucun champ valide"
@@ -3130,7 +3141,7 @@ msgstr "a reçu les dernières données de"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:329
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
 msgid "Unknown"
 msgstr "Inconnu"
 
@@ -3257,6 +3268,7 @@ msgstr "{0} élément(s) sélectionné(s)"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 msgid "Unarchive"
 msgstr "Désarchiver"
 
@@ -3350,7 +3362,7 @@ msgid "Longitude"
 msgstr "Longitude"
 
 #: frontend/src/metabase/lib/core.js:43
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:45
 msgid "Number"
 msgstr "Numérique"
@@ -3407,7 +3419,7 @@ msgid "User"
 msgstr "Utilisateur"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:211
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
 msgid "Source"
 msgstr "Origine"
 
@@ -3449,16 +3461,17 @@ msgid "Score"
 msgstr "Score"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Titre"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
 msgid "Comment"
 msgstr "Commentaire"
 
@@ -3510,9 +3523,9 @@ msgstr "Nulle part"
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
 msgstr "Metabase ne récupèrera jamais ce champ. Utilisez ce réglage pour les informations sensibles ou non pertinentes."
 
-#: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:300
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/query/description.js:77
+#: frontend/src/metabase/lib/query/description.js:262
+#: frontend/src/metabase/lib/schema_metadata.js:476
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
@@ -3527,8 +3540,7 @@ msgstr "Nombre de lignes"
 msgid "CumulativeCount"
 msgstr "Nombre cumulé de lignes"
 
-#: frontend/src/metabase/lib/expressions/config.js:9
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:485
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3538,7 +3550,6 @@ msgstr "Somme"
 msgid "CumulativeSum"
 msgstr "Somme cumulée"
 
-#: frontend/src/metabase/lib/expressions/config.js:11
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Distinct"
 msgstr "Nombre de valeurs distinctes"
@@ -3547,25 +3558,22 @@ msgstr "Nombre de valeurs distinctes"
 msgid "StandardDeviation"
 msgstr "Ecart-type"
 
-#: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:494
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Moyenne"
 
-#: frontend/src/metabase/lib/expressions/config.js:14
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:539
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Minimum"
 
-#: frontend/src/metabase/lib/expressions/config.js:15
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:548
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:503
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:492
 msgid "Max"
 msgstr "Maximum"
 
@@ -3618,54 +3626,66 @@ msgstr "Qu'avez-vous en tête ?"
 msgid "What do you want to find out?"
 msgstr "Que voulez-vous déterminer ?"
 
-#: frontend/src/metabase/lib/query.js:298
-#: frontend/src/metabase/lib/schema_metadata.js:466
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:250
+#: frontend/src/metabase/lib/query/description.js:75
+#: frontend/src/metabase/lib/query/description.js:260
+#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Données brutes"
 
-#: frontend/src/metabase/lib/query.js:302
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/query/description.js:79
+#: frontend/src/metabase/lib/query/description.js:264
+#: frontend/src/metabase/lib/schema_metadata.js:521
 msgid "Cumulative count"
 msgstr "Nombre cumulé"
 
-#: frontend/src/metabase/lib/query.js:305
+#: frontend/src/metabase/lib/query/description.js:82
+#: frontend/src/metabase/lib/query/description.js:266
 msgid "Average of "
 msgstr "Moyenne du/de la "
 
-#: frontend/src/metabase/lib/query.js:310
+#: frontend/src/metabase/lib/query/description.js:87
+#: frontend/src/metabase/lib/query/description.js:268
 msgid "Distinct values of "
 msgstr "Valeurs distinctes du/de la "
 
-#: frontend/src/metabase/lib/query.js:315
+#: frontend/src/metabase/lib/query/description.js:92
+#: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
 msgstr "Ecart-type du/de la "
 
-#: frontend/src/metabase/lib/query.js:320
+#: frontend/src/metabase/lib/query/description.js:97
+#: frontend/src/metabase/lib/query/description.js:272
 msgid "Sum of "
 msgstr "Somme du/de la "
 
-#: frontend/src/metabase/lib/query.js:325
+#: frontend/src/metabase/lib/query/description.js:102
+#: frontend/src/metabase/lib/query/description.js:274
 msgid "Cumulative sum of "
 msgstr "Somme cumulée du/de la "
 
-#: frontend/src/metabase/lib/query.js:330
+#: frontend/src/metabase/lib/query/description.js:107
+#: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
 msgstr "Maximum du/de la "
 
-#: frontend/src/metabase/lib/query.js:335
+#: frontend/src/metabase/lib/query/description.js:112
+#: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
 msgstr "Minimum du/de la "
 
-#: frontend/src/metabase/lib/query.js:349
+#: frontend/src/metabase/lib/query/description.js:126
+#: frontend/src/metabase/lib/query/description.js:286
 msgid "Grouped by "
 msgstr "Aggrégé par "
 
-#: frontend/src/metabase/lib/query.js:363
+#: frontend/src/metabase/lib/query/description.js:140
+#: frontend/src/metabase/lib/query/description.js:295
 msgid "Filtered by "
 msgstr "Filtré(e) par "
 
-#: frontend/src/metabase/lib/query.js:392
+#: frontend/src/metabase/lib/query/description.js:169
+#: frontend/src/metabase/lib/query/description.js:320
 msgid "Sorted by "
 msgstr "Trié par "
 
@@ -3677,55 +3697,45 @@ msgstr "Vrai"
 msgid "False"
 msgstr "Faux"
 
-#: frontend/src/metabase/lib/schema_metadata.js:321
+#: frontend/src/metabase/lib/schema_metadata.js:322
 msgid "Select longitude field"
 msgstr "Sélectionner le champ longitude"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:323
 msgid "Enter upper latitude"
 msgstr "Saisir la latitude supérieure"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:324
 msgid "Enter left longitude"
 msgstr "Saisir la longitude inférieure"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:325
 msgid "Enter lower latitude"
 msgstr "Saisir la latitude inférieure"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:326
 msgid "Enter right longitude"
 msgstr "Saisir la longitude supérieure"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:539
 #: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:397
-#: frontend/src/metabase/lib/schema_metadata.js:405
-#: frontend/src/metabase/lib/schema_metadata.js:411
-#: frontend/src/metabase/lib/schema_metadata.js:416
-msgid "Is"
-msgstr "Est"
-
 #: frontend/src/metabase/lib/schema_metadata.js:362
 #: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:398
 #: frontend/src/metabase/lib/schema_metadata.js:406
 #: frontend/src/metabase/lib/schema_metadata.js:412
-msgid "Is not"
-msgstr "N'est pas"
+#: frontend/src/metabase/lib/schema_metadata.js:417
+msgid "Is"
+msgstr "Est"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:417
-msgid "Is empty"
-msgstr "Est vide"
+#: frontend/src/metabase/lib/schema_metadata.js:413
+msgid "Is not"
+msgstr "N'est pas"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:378
@@ -3734,109 +3744,119 @@ msgstr "Est vide"
 #: frontend/src/metabase/lib/schema_metadata.js:402
 #: frontend/src/metabase/lib/schema_metadata.js:408
 #: frontend/src/metabase/lib/schema_metadata.js:418
+msgid "Is empty"
+msgstr "Est vide"
+
+#: frontend/src/metabase/lib/schema_metadata.js:365
+#: frontend/src/metabase/lib/schema_metadata.js:379
+#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:395
+#: frontend/src/metabase/lib/schema_metadata.js:403
+#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:419
 msgid "Not empty"
 msgstr "Non vide"
 
-#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:371
 msgid "Equal to"
 msgstr "Egal(e) à"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:372
 msgid "Not equal to"
 msgstr "Différent(e) de"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Greater than"
 msgstr "Supérieur à"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Less than"
 msgstr "Inférieur à"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Entre"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:376
 msgid "Greater than or equal to"
 msgstr "Supérieur ou égal à"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Less than or equal to"
 msgstr "Inférieur ou égal à"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
+#: frontend/src/metabase/lib/schema_metadata.js:384
 msgid "Contains"
 msgstr "Contient"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:385
 msgid "Does not contain"
 msgstr "Ne contient pas"
 
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:388
 msgid "Starts with"
 msgstr "Commence par"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:389
 msgid "Ends with"
 msgstr "Finit par"
 
-#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:399
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Avant"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:400
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Après"
 
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:414
 msgid "Inside"
 msgstr "Dans"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Juste une table avec ces lignes dans la réponse, aucune opération additionnelle."
 
-#: frontend/src/metabase/lib/schema_metadata.js:474
+#: frontend/src/metabase/lib/schema_metadata.js:475
 msgid "Count of rows"
 msgstr "Nombre de lignes"
 
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:477
 msgid "Total number of rows in the answer."
 msgstr "Nombre total de lignes dans la réponse."
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Sum of ..."
 msgstr "Somme de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:486
 msgid "Sum of all the values of a column."
 msgstr "Somme de toutes les valeurs d'une colonne."
 
-#: frontend/src/metabase/lib/schema_metadata.js:492
+#: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Average of ..."
 msgstr "Moyenne de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:495
 msgid "Average of all the values of a column"
 msgstr "Moyenne de toutes les valeurs d'une colonne"
 
-#: frontend/src/metabase/lib/schema_metadata.js:501
+#: frontend/src/metabase/lib/schema_metadata.js:502
 msgid "Number of distinct values of ..."
 msgstr "Nombre de valeurs distinctes de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:504
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Nombre de valeurs uniques d'une colonne parmi toutes les lignes dans la réponse."
 
-#: frontend/src/metabase/lib/schema_metadata.js:510
+#: frontend/src/metabase/lib/schema_metadata.js:511
 msgid "Cumulative sum of ..."
 msgstr "Somme cumulée de ..."
 
@@ -3844,7 +3864,7 @@ msgstr "Somme cumulée de ..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Somme cumulée de toutes les valeurs d'une colonne. Ex : Gain total au cours du temps."
 
-#: frontend/src/metabase/lib/schema_metadata.js:519
+#: frontend/src/metabase/lib/schema_metadata.js:520
 msgid "Cumulative count of rows"
 msgstr "Nombre cumulé de lignes"
 
@@ -3852,27 +3872,27 @@ msgstr "Nombre cumulé de lignes"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Nombre cumulé de lignes. Ex : Nombre total de ventes au cours du temps."
 
-#: frontend/src/metabase/lib/schema_metadata.js:528
+#: frontend/src/metabase/lib/schema_metadata.js:529
 msgid "Standard deviation of ..."
 msgstr "Ecart-type de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:531
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Nombre qui exprime la dispersion des valeurs d'une colonne parmi toutes les lignes dans la réponse."
 
-#: frontend/src/metabase/lib/schema_metadata.js:537
+#: frontend/src/metabase/lib/schema_metadata.js:538
 msgid "Minimum of ..."
 msgstr "Minimum de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Minimum value of a column"
 msgstr "Valeur minimum d'une colonne"
 
-#: frontend/src/metabase/lib/schema_metadata.js:546
+#: frontend/src/metabase/lib/schema_metadata.js:547
 msgid "Maximum of ..."
 msgstr "Maximum de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:549
 msgid "Maximum value of a column"
 msgstr "Valeur maximum d'une colonne"
 
@@ -4048,7 +4068,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Catégorie, Type, Modèle, Classement"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:43
-#: frontend/src/metabase/user/components/UserSettings.jsx:55
+#: frontend/src/metabase/user/components/UserSettings.jsx:56
 msgid "Account settings"
 msgstr "Réglages du compte utilisateur"
 
@@ -4060,7 +4080,7 @@ msgstr "Quitter le panneau d'administration"
 msgid "Logs"
 msgstr "Journaux"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:103
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:104
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:22
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:65
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:100
@@ -4102,9 +4122,9 @@ msgid "Metabase Admin"
 msgstr "Admin Metabase"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:36
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:36
 msgid "Ask a question"
 msgstr "Poser une question"
 
@@ -4125,7 +4145,7 @@ msgstr "Référentiel"
 msgid "Which metric?"
 msgstr "Quelle métrique ?"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "Définissez des métriques pour aider votre équipe à poser des questions plus simplement"
 
@@ -4138,7 +4158,7 @@ msgstr "Comment créer des métriques"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Voir la donnée comme série chronologique, carte, ou tableau croisé pour vous aider à comprendre les tendances ou les changements."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:149
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
 msgid "Custom"
 msgstr "Personnalisée"
 
@@ -4151,13 +4171,13 @@ msgstr "Nouvelle question"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Utilisez le générateur de questions pour voir des tendances, afficher des listes ou créer vos propres métriques."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:107
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:110
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Requête native"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:108
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:111
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Pour des questions plus complexes, vous pouvez écrire votre propre requête SQL"
 
@@ -4262,6 +4282,7 @@ msgid "Enter a default value..."
 msgstr "Saisir une valeur par défaut..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
+#: frontend/src/metabase/containers/Form.jsx:307
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Une erreur est survenue"
@@ -4513,7 +4534,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "Nous recommandons de garder les pulses petits et ciblés pour aider à les conserver compréhensibles et utiles pour l'ensemble de l'équipe"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:161
-#: frontend/src/metabase/query_builder/components/view/View.jsx:131
+#: frontend/src/metabase/query_builder/components/view/View.jsx:133
 msgid "Pick your data"
 msgstr "Sélectionner vos données"
 
@@ -4529,47 +4550,47 @@ msgstr "Courriels"
 msgid "Slack messages"
 msgstr "Messages Slack"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:216
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Envoyé"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:217
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} sera envoyé à"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:219
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Messages"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:235
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "Envoyer par courriel maintenant"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:236
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Envoyer à {0} maintenant"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:238
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Envoi en cours..."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "L'envoi a échoué"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "L'envoi n'a pas été fait car le pulse n'a aucun résultat."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Pulse envoyé"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:282
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} a besoin d'être configuré(e) par un administrateur."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:295
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:299
 msgid "Slack"
 msgstr "Slack"
 
@@ -4722,7 +4743,7 @@ msgstr "Moyenne"
 msgid "Distincts"
 msgstr "Valeurs distinctes"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:55
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "Visualiser ce/cette {0}"
@@ -4733,11 +4754,12 @@ msgstr[1] "Visualiser ces {0}"
 msgid "Zoom in"
 msgstr "Agrandir"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Expression personnalisée"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Common Metrics"
 msgstr "Métriques communes"
 
@@ -4934,35 +4956,35 @@ msgstr "habituellement"
 msgid "Pick a segment or table"
 msgstr "Choisir un segment ou une table"
 
-#: frontend/src/metabase/entities/databases/forms.js:191
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
+#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Sélectionner une base de données"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:94
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:85
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:31
 msgid "Select..."
 msgstr "Sélectionner..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:134
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
 msgid "Select a table"
 msgstr "Sélectionner une table"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:819
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:926
 msgid "No tables found in this database."
 msgstr "Aucune table trouvé dans cette base de données"
 
 #. Manque-t-il ? https://www.lalanguefrancaise.com/orthographe/y-a-t-il-orthographe/
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:856
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:901
 msgid "Is a question missing?"
 msgstr "Manque-t-il une question ?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:863
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:909
 msgid "Learn more about nested queries"
 msgstr "En savoir plus sur les questions imbriquées"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:898
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:951
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:40
 msgid "Fields"
 msgstr "Champs"
 
@@ -4996,11 +5018,11 @@ msgstr "Trier"
 msgid "Row limit"
 msgstr "Nombre de lignes maximum"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
 msgid "Unknown Field"
 msgstr "Champ inconnu"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:75
 msgid "field"
 msgstr "champ"
 
@@ -5008,19 +5030,20 @@ msgstr "champ"
 msgid "Matches"
 msgstr "Correspondances"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:148
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:156
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:135
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Ajouter des filtres pour préciser votre réponse"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:293
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
 msgstr "Ajouter une agrégation"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:37
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:313
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
-#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:66
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:67
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:89
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:131
@@ -5037,18 +5060,18 @@ msgid "Data"
 msgstr "Données"
 
 #. Si l'on tient à l'enchaînement Données/Fitré par/Vue/Groupé par, le non accord des participes passés jure un peu... Je propose Données/Fitre/Vue/Aggrégation
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:340
 msgid "Filtered by"
 msgstr "Filtre"
 
 #. Bonjour Fabrice, je propose de conserver "Vue" comme tu l'avais indiqué la première fois dans le générateur de requête on aurait alors : "Données" / "Filtrées par" / "Vue" / "Groupées par".
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:376
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:357
 msgid "View"
 msgstr "Vue"
 
 #. Si l'on tient à l'enchaînement Données/Fitré par/Vue/Groupé par, le non accord des participes passés jure un peu... Je propose Données/Fitre/Vue/Aggrégat
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:393
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:374
 msgid "Grouped By"
 msgstr "Agrégat"
 
@@ -5056,7 +5079,7 @@ msgstr "Agrégat"
 msgid "None"
 msgstr "Aucun"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:471
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
 msgid "This question is written in {0}."
 msgstr "Cette question est écrite en {0}."
 
@@ -5068,7 +5091,7 @@ msgstr "Masquer l'éditeur"
 msgid "Hide Query"
 msgstr "Masquer la requête"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:481
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
 msgid "Open Editor"
 msgstr "Ouvrir l'éditeur"
 
@@ -5309,7 +5332,7 @@ msgstr "Toutes les valeurs distinctes de {0}"
 msgid "Number of {0} grouped by {1}"
 msgstr "Nombre de {0} aggrégés par {1}"
 
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:77
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5368,32 +5391,33 @@ msgstr "Voir les données brutes de {0}"
 msgid "More"
 msgstr "Plus"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:194
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:216
 msgid "Invalid expression"
 msgstr "Expression invalide"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:269
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:282
 msgid "unknown error"
 msgstr "erreur inconnue"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:47
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:53
 msgid "Field formula"
 msgstr "Formule du champ"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:60
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:64
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Imaginez cela comme étant une sorte de formule de tableur : vous pouvez utiliser des nombres, champs dans la table, opérations mathématiques comme +, et quelques fonctions. Vous pourriez donc écrire quelque chose comme Soustotal - Cout."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:69
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:208
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
 msgid "Learn more"
 msgstr "En savoir plus"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:77
 msgid "Give it a name"
 msgstr "Donner un nom"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:79
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
 msgid "Something nice and descriptive"
 msgstr "Quelque chose de sympa et descriptif"
 
@@ -5475,11 +5499,11 @@ msgid "Enter desired number"
 msgstr "Saisir le nombre désiré"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:154
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:161
 msgid "Empty"
 msgstr "Vide"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:119
 msgid "Find a value"
 msgstr "Trouver une valeur"
 
@@ -5551,35 +5575,35 @@ msgstr "Lire la documentation complète"
 msgid "Filter label"
 msgstr "Libellé du filtre"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:135
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:134
 msgid "Variable type"
 msgstr "Type de variable"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:143
 msgid "Text"
 msgstr "Texte"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
 msgid "Date"
 msgstr "Date"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:147
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
 msgid "Field Filter"
 msgstr "Filtre de champ"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Field to map to"
 msgstr "Champ lié à"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:180
 msgid "Filter widget type"
 msgstr "Type de filtre"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:230
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
 msgid "Required?"
 msgstr "Obligatoire ?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:240
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
 msgid "Default filter widget value"
 msgstr "Valeur du filtre par défaut"
 
@@ -5591,7 +5615,7 @@ msgstr "Archiver cette question?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Cette question sera retirée de tous les tableaux de bords ou pulses qui l'utilisent."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:158
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
 msgid "Question"
 msgstr "Question"
 
@@ -5763,7 +5787,7 @@ msgid "Details"
 msgstr "Détails"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
-#: frontend/src/metabase/reference/databases/TableList.jsx:116
+#: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
 msgstr "Tables dans {0}"
 
@@ -5844,24 +5868,24 @@ msgstr "Pourquoi cette table est intéressante"
 msgid "Things to be aware of about this table"
 msgstr "Choses dont on doit être conscient à propos de cette table"
 
-#: frontend/src/metabase/reference/databases/TableList.jsx:30
+#: frontend/src/metabase/reference/databases/TableList.jsx:29
 msgid "Tables in this database will appear here as they're added"
 msgstr "Les tables de cette base apparaîtront ici au fur et à mesure de leur ajout"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:34
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:33
 msgid "Questions about this table will appear here as they're added"
 msgstr "Les questions à propos de cette table apparaîtront ici au fur et à mesure de leur ajout"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:73
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:77
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:76
 msgid "Questions about {0}"
 msgstr "Questions sur {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
 msgid "Created {0} by {1}"
 msgstr "{0} créé par {1}"
 
@@ -6052,19 +6076,19 @@ msgstr "Autres champs d'agrégation possibles pour cette métrique"
 msgid "Fields you can group this metric by"
 msgstr "Champs sur lesquels vous pouvez aggréger cette métrique"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "Les métriques sont les chiffres officiels dont s'occupe votre équipe"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Metrics will appear here once your admins have created some"
 msgstr "Les métriques apparaîtront ici une fois que les administrateurs en auront créé"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:28
 msgid "Learn how to create metrics"
 msgstr "Apprendre comment créer des métriques"
 
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:34
 msgid "Questions about this metric will appear here as they're added"
 msgstr "Les questions à propos de cette métrique apparaîtront ici au fil du temps"
 
@@ -6090,23 +6114,23 @@ msgstr "Pourquoi ce segment est intéressant"
 msgid "Things to be aware of about this Segment"
 msgstr "Choses dont on doit être conscient à propos de ce segment"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
 msgid "Segments are interesting subsets of tables"
 msgstr "Les segments sont des sous-ensembles remarquables de table"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "Définir des segments communs à votre équipe rend les questions encore plus facile à poser"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Segments will appear here once your admins have created some"
 msgstr "Les segments apparaîtront ici une fois que les administrateurs en auront créé"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
 msgid "Learn how to create segments"
 msgstr "Apprendre comment créer des segments"
 
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:35
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:34
 msgid "Questions about this segment will appear here as they're added"
 msgstr "Les questions à propos de ce segment apparaîtront ici au fil du temps"
 
@@ -6126,22 +6150,22 @@ msgstr "Questions sur ce segment"
 msgid "X-ray this segment"
 msgstr "Radiographier ce segment"
 
-#: frontend/src/metabase/routes.jsx:178 frontend/src/metabase/routes.jsx:179
+#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
 msgid "Login"
 msgstr "Se connecter"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:303
 #: frontend/src/metabase/containers/ItemPicker.jsx:115
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:204
+#: frontend/src/metabase/routes.jsx:195
 msgid "Search"
 msgstr "Rechercher"
 
-#: frontend/src/metabase/routes.jsx:223
+#: frontend/src/metabase/routes.jsx:214
 msgid "Dashboard"
 msgstr "Tableau de bord"
 
-#: frontend/src/metabase/routes.jsx:236
+#: frontend/src/metabase/routes.jsx:227
 msgid "New Question"
 msgstr "Nouvelle question"
 
@@ -6185,63 +6209,63 @@ msgstr "Merci de nous aider à améliorer Metabase"
 msgid "We won't collect any usage events"
 msgstr "Nous ne collecterons aucun évènement d'utilisation"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:88
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Pour nous aider à améliorer Metabase, nous voudrions collecter certaines données concernant son usage via Google Analytics."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:90
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Here's a full list of everything we track and why."
 msgstr "Voici la liste complète de ce que nous collectons et pourquoi"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Permettre à Metabase de collecter anonymement les événements d'utilisation"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:113
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0} ne collecte rien concernant vos données ou les réponses de vos questions."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:114
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
 msgid "never"
 msgstr "jamais"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:119
 msgid "All collection is completely anonymous."
 msgstr "Toute la collection est complètement anonyme"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "La collection peut être désactivée à tout moment dans vos paramètres d'administration."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:44
+#: frontend/src/metabase/setup/components/Setup.jsx:59
 msgid "If you feel stuck"
 msgstr "Si vous vous sentez coincé"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:49
+#: frontend/src/metabase/setup/components/Setup.jsx:64
 msgid "our getting started guide"
 msgstr "notre guide de démarrage"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:50
+#: frontend/src/metabase/setup/components/Setup.jsx:65
 msgid "is just a click away."
 msgstr "est à portée de clic."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:92
+#: frontend/src/metabase/setup/components/Setup.jsx:111
 msgid "Welcome to Metabase"
 msgstr "Bienvenue sur Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:93
+#: frontend/src/metabase/setup/components/Setup.jsx:112
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Tout semble fonctionner. À présent, dites-nous qui vous êtes, connectez vos données et commencez à trouver des réponses !"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:97
+#: frontend/src/metabase/setup/components/Setup.jsx:116
 msgid "Let's get started"
 msgstr "C'est parti"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:142
+#: frontend/src/metabase/setup/components/Setup.jsx:166
 msgid "You're all set up!"
 msgstr "Tout est configuré !"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:153
+#: frontend/src/metabase/setup/components/Setup.jsx:177
 msgid "Take me to Metabase"
 msgstr "Emmenez-moi dans Metabase"
 
@@ -6253,13 +6277,13 @@ msgstr "Comment devez-nous vous appeler ?"
 msgid "Hi, {0}. nice to meet you!"
 msgstr "Bonjour, {0}, ravi de vous rencontrer !"
 
-#: frontend/src/metabase/entities/users/forms.js:33
+#: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
 msgstr "Créer un mot de passe"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:44
-#: frontend/src/metabase/entities/users/forms.js:35
-#: frontend/src/metabase/entities/users/forms.js:82
+#: frontend/src/metabase/entities/users/forms.js:50
+#: frontend/src/metabase/entities/users/forms.js:97
 msgid "Shhh..."
 msgstr "Chut ..."
 
@@ -6267,11 +6291,11 @@ msgstr "Chut ..."
 msgid "Confirm password"
 msgstr "Confirmez le mot de passe"
 
-#: frontend/src/metabase/entities/users/forms.js:42
+#: frontend/src/metabase/entities/users/forms.js:57
 msgid "Shhh... but one more time so we get it right"
 msgstr "Chut... une seconde fois de façon à s'en assurer"
 
-#: frontend/src/metabase/entities/users/forms.js:70
+#: frontend/src/metabase/entities/users/forms.js:85
 msgid "Your company or team name"
 msgstr "Votre nom d'entreprise ou d'équipe"
 
@@ -6441,7 +6465,7 @@ msgstr "Mot de passe mis à jour avec succès!"
 msgid "Account updated successfully!"
 msgstr "Compte mis à jour avec succès!"
 
-#: frontend/src/metabase/entities/users/forms.js:81
+#: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
 msgstr "Mot de passe actuel"
 
@@ -6453,7 +6477,7 @@ msgstr "Se connecter avec Google"
 msgid "User Details"
 msgstr "Détails de l'utilisateur"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:327
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:344
 msgid "Reset to defaults"
 msgstr "Réinitialiser"
 
@@ -6478,15 +6502,15 @@ msgstr "Quels champs voulez-vous utiliser pour les axes X et Y ?"
 msgid "Choose fields"
 msgstr "Choisissez les champs"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:217
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:234
 msgid "Save as default view"
 msgstr "Sauvegarder comme vue par défaut"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Draw box to filter"
 msgstr "Dessiner un rectangle d'intérêt pour filtrer"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Cancel filter"
 msgstr "Annuler le filtre"
 
@@ -6514,19 +6538,19 @@ msgstr "Impossible de trouver la visualisation"
 msgid "Could not display this chart with this data."
 msgstr "Impossible d'afficher cet graphique avec ces données."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:526
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
 msgid "No results!"
 msgstr "Pas de résultat!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:547
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
 msgid "Still Waiting..."
 msgstr "Toujours en attente..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:550
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
 msgid "This usually takes an average of {0}."
 msgstr "Cela prend habituellement en moyenne {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:556
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
 msgid "(This is a bit long for a dashboard)"
 msgstr "(C'est un peu long pour un tableau de bord)"
 
@@ -6691,19 +6715,19 @@ msgstr "Ajouter une règle"
 msgid "Update rule"
 msgstr "Mettre à jour la règle"
 
-#: frontend/src/metabase/visualizations/index.js:32
+#: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
 msgstr "La visualisation est nulle"
 
-#: frontend/src/metabase/visualizations/index.js:37
+#: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
 msgstr "La visualisation doit définir une variable statique d'identifiant : "
 
-#: frontend/src/metabase/visualizations/index.js:43
+#: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
 msgstr "Une visualisation avec cet identifiant est déjà enregistrée : "
 
-#: frontend/src/metabase/visualizations/index.js:71
+#: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
 msgstr "Aucune visualisation pour {0}"
 
@@ -6729,23 +6753,23 @@ msgid "Doh! The data from your query doesn't fit the chosen display choice. This
 msgstr "Le résultat de votre requête n'est pas adapté au rendu choisi. Cette visualisation nécessite au moins {0} {1} de données."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:9
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:117
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:120
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:161
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:169
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:249
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:267
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "colonne"
@@ -6856,83 +6880,83 @@ msgstr "Rien"
 msgid "Linear Interpolated"
 msgstr "Interpolation linéaire"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
 msgstr "Echelle des abscisses"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
 msgstr "Séries temporelles"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:454
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
 msgid "Linear"
 msgstr "Linéaire"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
 msgid "Power"
 msgstr "Exponentielle"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:428
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:445
 msgid "Log"
 msgstr "Logarithmique"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:441
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:430
 msgid "Histogram"
 msgstr "Histogramme"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
 msgstr "Ordinal"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
 msgstr "Echelle des ordonnées"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:462
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
 msgstr "Afficher l'axe des abscisses et ses graduations"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:360
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:468
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:349
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
 msgid "Compact"
 msgstr "Compacte"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:469
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
 msgid "Rotate 45°"
 msgstr "Tourner de 45°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:459
 msgid "Rotate 90°"
 msgstr "Tourner de 90°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
 msgid "Show y-axis line and marks"
 msgstr "Afficher l'axe des ordonnées et ses graduations"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:489
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Auto y-axis range"
 msgstr "Mise à l'échelle automatique des ordonnées"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:533
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:522
 msgid "Use a split y-axis when necessary"
 msgstr "Utiliser deux axes d'ordonnées si nécessaire"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:540
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:529
 msgid "Show label on x-axis"
 msgstr "Afficher le libellé des abscisses"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:546
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:535
 msgid "X-axis label"
 msgstr "Libellé des abscisses"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:555
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:544
 msgid "Show label on y-axis"
 msgstr "Afficher le libellé des ordonnées"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:561
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:550
 msgid "Y-axis label"
 msgstr "Libellé des ordonnées"
 
@@ -7058,23 +7082,23 @@ msgstr "Opacité minimale"
 msgid "Max Zoom"
 msgstr "Zoom maximum"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:231
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:234
 msgid "No relationships found."
 msgstr "Aucune relation trouvée."
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:269
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:272
 msgid "via {0}"
 msgstr "via {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:347
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
 msgid "This {0} is connected to:"
 msgstr "Ce/cette {0} est relié(e) à :"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "Object Detail"
 msgstr "Détail de l'objet"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:93
 msgid "object"
 msgstr "objet"
 
@@ -7463,7 +7487,7 @@ msgstr "Vous avez beaucoup de questions sauvegardées dans {0} ? Créez des coll
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:149 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -8983,19 +9007,19 @@ msgstr "Peut modifier cette collection et son contenu"
 msgid "Can view items in this collection"
 msgstr "Peut voir les items de cette collection"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:767
+#: frontend/src/metabase/admin/permissions/selectors.js:765
 msgid "Collection Access"
 msgstr "Accès à la collection"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:841
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Ce groupe a la permission de voir au moins une sous-collection de cette collection."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:848
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Ce groupe a le droit de modifier au moins une sous-collection de cette colleciton."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:861
+#: frontend/src/metabase/admin/permissions/selectors.js:859
 msgid "View sub-collections"
 msgstr "Voir les sous-collections"
 
@@ -9003,7 +9027,7 @@ msgstr "Voir les sous-collections"
 msgid "Remember Me"
 msgstr "Se souvenir de moi"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:63
+#: frontend/src/metabase/components/BrowseApp.jsx:73
 msgid "X-ray this schema"
 msgstr "Radiographier ce schéma"
 
@@ -9064,15 +9088,15 @@ msgstr "Metabase n'a trouvé aucun résultat à votre recherche."
 msgid "No metrics"
 msgstr "Aucune métrique"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:31
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:41
 msgid "Aggregations"
 msgstr "Agrégations"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:32
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:42
 msgid "Operators"
 msgstr "Opérateurs"
 
-#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:30
+#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:35
 msgid "Custom fields"
 msgstr "Champs personnalisés"
 
@@ -9238,7 +9262,7 @@ msgstr "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
 msgid "toucan_sightings"
 msgstr "toucan_sightings"
 
-#: src/metabase/driver/sparksql.clj
+#: src/metabase/models/collection.clj
 msgid "default"
 msgstr "défaut"
 
@@ -9267,10 +9291,10 @@ msgid "Windows domain"
 msgstr "Nom de domaine Windows"
 
 #. Il semble que ce soit le libellé d'un des onglets : Données/Visualisation/Axes/Libellés
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:539
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:545
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:554
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:560
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:528
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:534
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:543
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
 msgstr "Libellés"
 
@@ -9306,9 +9330,9 @@ msgstr "Partage"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:286
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:294
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:302
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:319
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:324
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
@@ -9323,19 +9347,18 @@ msgstr "Partage"
 msgid "Display"
 msgstr "Affichage"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:461
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:476
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:502
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:532
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:402
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:465
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:483
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:521
 msgid "Axes"
 msgstr "Axes"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:212
-#: frontend/src/metabase/admin/settings/selectors.js:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:219
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:62
 msgid "Formatting"
@@ -9369,7 +9392,7 @@ msgstr "Radiographie"
 msgid "Compare to the rest"
 msgstr "Comparer au reste"
 
-#: frontend/src/metabase/entities/databases/forms.js:16
+#: frontend/src/metabase/entities/databases/forms.js:18
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Utiliser le fuseau horaire de la machine virtuelle Java (JVM)"
 
@@ -9398,24 +9421,24 @@ msgstr "Utiliser le fuseau horaire de la JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Nous sommes en cours d'analyse des tables et champs pour vous aider à explorer vos données."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
 msgid "Tip: "
 msgstr "Astuce:␣"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:237
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
 msgstr "Sélectionnez un type de devise"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:300
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
 msgid "Field Type"
 msgstr "Type de champ"
 
-#: frontend/src/metabase/admin/routes.jsx:113
+#: frontend/src/metabase/admin/routes.jsx:118
 #: frontend/src/metabase/nav/containers/Navbar.jsx:267
 msgid "Troubleshooting"
 msgstr "Dépannage"
 
-#: frontend/src/metabase/admin/settings/selectors.js:103
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Enable X-ray features"
 msgstr "Activer la radiographie"
 
@@ -9460,7 +9483,7 @@ msgstr "Durée (ms)"
 msgid "Currency"
 msgstr "Devise"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
 msgstr "Choisissez un utilisateur ou un canal ..."
 
@@ -9608,7 +9631,7 @@ msgstr "Format de ligne"
 msgid "Show dots on lines"
 msgstr "Afficher les points sur les lignes"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:348
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
@@ -9622,7 +9645,7 @@ msgstr "Quel axe ?"
 msgid "Line + Bar"
 msgstr "Linéaire + À barres"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
 msgid "line and bar chart"
 msgstr "graphique linéaire et à barres"
 
@@ -11069,7 +11092,7 @@ msgstr "Comment cette métrique est répartie sur différents nombres"
 msgid "Sessions by page where the session began"
 msgstr "Sessions par page où la session a commencé"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:503
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -11439,7 +11462,7 @@ msgstr "Dupliquer cet élément"
 msgid "Archive this item"
 msgstr "Archiver cet élément"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:331
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:325
 msgid "Duplicate dashboard"
 msgstr "Dupliquer le tableau de bord"
 
@@ -11544,7 +11567,7 @@ msgid_plural "Quarters of year"
 msgstr[0] "Trimestre de l'année"
 msgstr[1] "Trimestres de l'année"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
@@ -11560,8 +11583,8 @@ msgstr "[Q]Q"
 msgid "This"
 msgstr "Ce"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:97
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:137
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:136
 msgid "Invalid"
 msgstr "Invalide"
 
@@ -12331,6 +12354,7 @@ msgstr "Voici vos {0} questions les plus récentes :"
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
 msgstr "Pourriez-vous être un peu plus précis, ou utiliser l'ID de la question ? J'ai trouvé ces questions avec des noms correspondants :"
 
+#: src/metabase/driver/common/parameters/values.clj
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
 msgstr "Carte {0} introuvable."
@@ -12439,11 +12463,11 @@ msgstr "Mauvaise instruction"
 msgid "Archive this?"
 msgstr "Archiver ?"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:243
+#: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
 msgstr "Apprenez de vos données"
 
-#: frontend/src/metabase/entities/databases/forms.js:20
+#: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
 msgstr "Utiliser DNS SRV lors de la connexion"
 
@@ -12453,7 +12477,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "L'utilisation de cette option nécessite que l'hôte fourni soit un FQDN. Si vous vous connectez à un cluster Atlas, vous devrez peut-être activer cette option. Si vous ne savez pas ce que cela signifie, laissez-la désactivée."
 
-#: frontend/src/metabase/entities/databases/forms.js:204
+#: frontend/src/metabase/entities/databases/forms.js:273
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Exécuter automatiquement les requêtes lors de filtrages ou de synthèses simples"
 
@@ -12477,11 +12501,11 @@ msgstr "Tous les résultats"
 msgid "Our Analytics"
 msgstr "Nos analyses"
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:513
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
 msgstr "Somme cumulée de toutes les valeurs d'une colonne. \\ne.x. chiffre d'affaires total dans le temps."
 
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
 msgstr "Compte cumulé du nombre de lignes. \\ne.x. nombre total de ventes dans le temps."
 
@@ -12491,7 +12515,7 @@ msgstr "Compte cumulé du nombre de lignes. \\ne.x. nombre total de ventes dans 
 msgid "Filter"
 msgstr "Filtre"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:50
 msgid "record"
 msgid_plural "records"
 msgstr[0] "enregistrement"
@@ -12505,27 +12529,27 @@ msgstr "Parcourir les données"
 msgid "Write SQL"
 msgstr "Ecrire le SQL"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:83
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
 msgstr "Question simple"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:84
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:87
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
 msgstr "Choisissez des données, affichez-les et filtrez-les, résumez-les et visualisez-les facilement."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:95
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:98
 msgid "Custom question"
 msgstr "Question personnalisée"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:96
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:99
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Utilisez l'éditeur de bloc-notes avancé pour joindre des modèles de données, créer des colonnes personnalisées, faire des calculs et bien plus encore."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Basic Metrics"
 msgstr "Métriques de base"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:322
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
 msgid "Custom…"
 msgstr "Personnalisé..."
 
@@ -12594,15 +12618,15 @@ msgstr "Choisissez une colonne d'agrégation"
 msgid "Pick your starting data"
 msgstr "Choisissez vos données de départ"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select None"
 msgstr "Ne rien sélectionner"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select All"
 msgstr "Tout sélectionner"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:151
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:152
 msgid "Pick a table..."
 msgstr "Choisissez une table..."
 
@@ -12725,15 +12749,15 @@ msgstr "Ajouter un métrique"
 #: frontend/src/metabase/lib/core.js:137 frontend/src/metabase/lib/core.js:142
 #: frontend/src/metabase/lib/core.js:147 frontend/src/metabase/lib/core.js:152
 #: frontend/src/metabase/lib/core.js:157 frontend/src/metabase/lib/core.js:162
-#: frontend/src/metabase/user/components/UserSettings.jsx:63
+#: frontend/src/metabase/user/components/UserSettings.jsx:64
 msgid "Profile"
 msgstr "Profil"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:560
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "C'est habituellement agréablement rapide mais semble prendre un moment désormais."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
 msgid "Combo"
 msgstr "Menu déroulant"
 
@@ -12749,11 +12773,11 @@ msgstr "Tendance"
 msgid "Boolean"
 msgstr "Booléen"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:62
 msgid "Unknown Segment"
 msgstr "Segment inconnu"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:73
 msgid "Unknown Filter"
 msgstr "Filtre inconnu"
 
@@ -12883,6 +12907,7 @@ msgstr "Utilisation d'un classloader nouvellement créé comme classloader de co
 msgid "Failed to copy file"
 msgstr "Impossible de copier le fichier"
 
+#. check that the URL is valid
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
 msgstr "URL de site web invalide: {0}"
@@ -13157,7 +13182,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Choisissez les colonnes concernées"
 
-#: frontend/src/metabase/entities/databases/forms.js:205
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Lorsque cette option est activée, Metabase exécute automatiquement des requêtes lorsque les utilisateurs effectuent des explorations simples à l'aide des boutons Résumer et Filtrer lors de l'affichage d'un tableau ou d'un graphique. Vous pouvez désactiver cette option si l'interrogation de cette base de données est lente. Ce paramètre n’affecte pas les accès au détail ni les requêtes SQL."
 
@@ -13195,7 +13220,7 @@ msgstr "Erreur lors de la détermination des colonnes attendues pour la requête
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "Exception non gérée, aurait du être prise en charge par le middleware `catch-exceptions`."
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:125
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
 msgid "Diagnostic Info"
 msgstr "Informations de diagnostic"
 
@@ -13219,11 +13244,11 @@ msgstr "Un problème est survenu lors de la connexion avec Google. Veuillez cont
 msgid "Sign in with email"
 msgstr "Connectez-vous avec un e-mail"
 
-#: frontend/src/metabase/entities/databases/forms.js:21
+#: frontend/src/metabase/entities/databases/forms.js:23
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "L'utilisation de cette option nécessite que l'hôte fourni soit un nom de domaine complet. Si vous vous connectez à un cluster Atlas, vous devrez peut-être activer cette option. Si vous ne savez pas ce que cela signifie, laissez cette option désactivée."
 
-#: frontend/src/metabase/entities/databases/forms.js:213
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Par défaut, Metabase effectue une synchronisation horaire légère et une analyse quotidienne intensive des valeurs de champ. Si vous avez une grande base de données, nous vous recommandons de l'activer et de vérifier quand et à quelle fréquence les analyses de valeur de champ se produisent."
 
@@ -13291,11 +13316,11 @@ msgstr "N'incluez pas"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "Ce champ ne sera ni visible ni sélectionnable dans les questions créées avec le générateur de requêtes. Il sera toujours accessible dans les requêtes SQL / natives."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:512
 msgid "Cumulative sum"
 msgstr "Somme cumulative"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Standard deviation"
 msgstr "Déviation standard"
 
@@ -13307,23 +13332,23 @@ msgstr "doit contenir au moins {0} caractères"
 msgid "Must be at least {0} characters long"
 msgstr "Doit contenir au moins {0} caractères"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:389
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:82
 msgid "Name (required)"
 msgstr "Nom (requis)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:556
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
 msgid "Run selected text"
 msgstr "Exécuter le texte sélectionné"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:557
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
 msgid "Run query"
 msgstr "Exécuter la requête"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(⌘ + enter)"
 msgstr "(⌘ + Entrée)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + Entrée)"
 
@@ -13335,7 +13360,7 @@ msgstr "Voici où vos résultats apparaîtront"
 msgid "You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question."
 msgstr "Vous n'apporterez aucune modification permanente à une question enregistrée, sauf si vous cliquez sur Enregistrer et choisissez de remplacer la question d'origine."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:199
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:200
 msgid "There aren't any filter widgets for this type of field yet."
 msgstr "Il n'y a pas encore de filtres pour ce type de champ."
 
@@ -13371,19 +13396,19 @@ msgstr "Ligne de but"
 msgid "Trend line"
 msgstr "Ligne de tendance"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:320
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:317
 msgid "Show values on data points"
 msgstr "Afficher les valeurs sur les points de données"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:334
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:325
 msgid "Values to show"
 msgstr "Valeurs à afficher"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:342
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:332
 msgid "As many as can fit nicely"
 msgstr "Autant que possible"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:343
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
 msgid "All"
 msgstr "Tout"
 
@@ -13677,31 +13702,31 @@ msgstr "Numéros"
 msgid "No mappable groups"
 msgstr "Aucun groupe cartographiables"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:107
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
 msgstr "Documentation de metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
 msgstr "Comprend un guide de dépannage"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:112
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
 msgid "Post on the Metabase support forum"
 msgstr "Poster sur le forum de support Metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:114
 msgid "A community forum for all things Metabase"
 msgstr "Un forum communautaire pour tout ce qui concerne Metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:117
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
 msgid "File a bug report"
 msgstr "Déposer un rapport de bogue"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:119
 msgid "Create a GitHub issue (includes the diagnostic info below)"
 msgstr "Créer un ticket GitHub (comprend les informations de diagnostic ci-dessous)"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:127
 msgid "Please include these details in support requests. Thank you!"
 msgstr "Veuillez inclure ces détails dans les demandes de support. Merci !"
 
@@ -13729,38 +13754,40 @@ msgstr "Aucun résultat correspondant"
 msgid "Submit"
 msgstr "Envoyer"
 
-#: frontend/src/metabase/entities/databases/forms.js:13
+#: frontend/src/metabase/entities/databases/forms.js:15
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host. This option also provides an extra layer of security when a VPN is not available. Enabling this is usually slower than a direct connection."
 msgstr "Certaines installations de bases de données ne sont accessibles qu'en se connectant via un hôte bastion SSH. Cette option offre également un niveau de sécurité supplémentaire lorsqu'un VPN n'est pas disponible. L'activation de cette option est généralement plus lente qu'une connexion directe."
 
-#: frontend/src/metabase/entities/databases/forms.js:17
+#: frontend/src/metabase/entities/databases/forms.js:19
 msgid "We suggest you leave this off unless you're doing manual timezone casting in many or most of your queries with this data."
 msgstr "Nous vous suggérons de laisser cette option désactivée, à moins que vous ne fassiez un réglage manuel du fuseau horaire dans la plupart de vos requêtes avec ces données."
 
-#: frontend/src/metabase/entities/databases/forms.js:93
+#: frontend/src/metabase/entities/databases/forms.js:128
 msgid "{0} to get an auth code."
 msgstr "{0} pour obtenir un code d'autorisation."
 
-#: frontend/src/metabase/entities/databases/forms.js:101
+#: frontend/src/metabase/entities/databases/forms.js:136
+#: src/metabase/models/collection.clj
 msgid "or"
 msgstr "ou"
 
-#: frontend/src/metabase/entities/databases/forms.js:159
-#: frontend/src/metabase/entities/databases/forms.js:197
-#: frontend/src/metabase/entities/users/forms.js:44
+#: frontend/src/metabase/entities/databases/forms.js:39
+#: frontend/src/metabase/entities/databases/forms.js:226
+#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "requis"
 
-#: frontend/src/metabase/entities/databases/forms.js:188
+#: frontend/src/metabase/entities/databases/forms.js:257
 msgid "Database type"
 msgstr "Type de base de données"
 
-#: frontend/src/metabase/entities/databases/forms.js:222
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Il s'agit d'un processus léger qui vérifie les mises à jour du schéma de cette base de données. Dans la plupart des cas, vous devriez pouvoir laisser ce réglage sur une synchronisation horaire."
 
-#: frontend/src/metabase/entities/databases/forms.js:230
+#: frontend/src/metabase/entities/databases/forms.js:299
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase peut analyser les valeurs présentes dans chaque champ de cette base de données pour activer les filtres de cases à cocher dans les tableaux de bord et les questions. Ce processus peut être quelque peu gourmand en ressources, en particulier si vous disposez d'une très grande base de données."
 
@@ -13768,15 +13795,15 @@ msgstr "Metabase peut analyser les valeurs présentes dans chaque champ de cette
 msgid "Collection"
 msgstr "Collection"
 
-#: frontend/src/metabase/entities/users/forms.js:40
+#: frontend/src/metabase/entities/users/forms.js:55
 msgid "Confirm your password"
 msgstr "Confirmez votre mot de passe"
 
-#: frontend/src/metabase/entities/users/forms.js:45
+#: frontend/src/metabase/entities/users/forms.js:60
 msgid "passwords do not match"
 msgstr "les mots de passe ne correspondent pas"
 
-#: frontend/src/metabase/entities/users/forms.js:71
+#: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
 msgstr "Département de la génialité"
 
@@ -13816,328 +13843,324 @@ msgid "Returns the average of the values in the column."
 msgstr "Retourne la moyenne des valeurs de la colonne."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:18
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
 msgid "The column whose values to average."
 msgstr "La colonne dont les valeurs à la moyenne."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "start"
 msgstr "début"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "end"
 msgstr "fin"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
 msgid "Checks a date or numeric column's values to see if they're within the specified range."
 msgstr "Vérifie les valeurs d'une date ou d'une colonne numérique pour voir si elles se situent dans la plage spécifiée."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
 msgstr "Evaluation"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:24
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:98
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
 msgid "condition"
 msgstr "condition"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
 msgid "output"
 msgstr "sortie"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Teste une liste de cas et renvoie la valeur correspondante du premier cas avéré, avec une valeur par défaut facultative si rien d'autre n'est satisfait."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
 msgid "Weight"
 msgstr "Poids"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
 msgid "Large"
 msgstr "Large"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
 msgid "Medium"
 msgstr "Moyen"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
 msgid "Small"
 msgstr "Petit"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
 msgid "Something that should evaluate to true or false."
 msgstr "Quelque chose qui devrait être évalué comme vrai ou faux."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:54
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "La valeur qui sera retournée si la condition précédente est vraie."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:62
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "value1"
 msgstr "valeur1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:74
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
 msgid "value2"
 msgstr "valeur2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Examine les valeurs de chaque argument dans l'ordre et renvoie la première valeur non nulle pour chaque ligne."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:56
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
 msgid "Comments"
 msgstr "Commentaires"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
 msgid "Notes"
 msgstr "Notes"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
 msgid "No comments"
 msgstr "Aucun commentaire"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
 msgid "A column or value."
 msgstr "Une colonne ou une valeur."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:65
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:77
 msgid "If value1 is empty, value2 gets returned if it's not empty, and so on."
 msgstr "Si la valeur 1 est vide, la valeur 2 est retournée si elle n'est pas vide, et ainsi de suite."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 msgid "Combines two or more strings of text together."
 msgstr "Combine deux ou plusieurs chaînes de texte ensemble."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
 msgid "Last Name"
 msgstr "Nom de famille"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 msgid "First Name"
 msgstr "Prénom"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
 msgstr "valeur2 sera ajoutée à la fin."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
 msgstr "Ceci sera ajouté à la fin de la valeur1."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
 msgid "string1"
 msgstr "chaîne1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
 msgid "string2"
 msgstr "chaîne2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:80
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Vérifie si la chaîne 1 est composée de la chaîne 2."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:284
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
 msgid "Status"
 msgstr "Statut"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 msgid "Pass"
 msgstr "Passe"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
 msgstr "Le contenu de cette chaîne sera vérifié."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
 msgid "The string of text to look for."
 msgstr "La chaîne de texte à rechercher."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:90
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:116
 msgid "Returns the count of rows in the source data."
 msgstr "Renvoie le nombre de lignes dans les données sources."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Only counts rows where the condition is true."
 msgstr "Ne compte que les lignes où la condition est vraie."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:97
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:261
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
 msgid "Subtotal"
 msgstr "Sous-total"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
 msgid "The additive total of rows across a breakout."
 msgstr "Le total cumulé des lignes d'un éclatement."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:110
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
 msgid "The rolling sum of a column across a breakout."
 msgstr "La somme glissante d'une colonne dans un éclatement."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:113
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:268
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
 msgstr "La colonne à additionner."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
 msgid "The number of distinct values in this column."
 msgstr "Le nombre de valeurs distinctes dans cette colonne."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "The column whose distinct values to count."
 msgstr "La colonne dont les valeurs distinctes doivent être comptées."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:128
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:145
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:153
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:201
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:274
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
 msgid "text"
 msgstr "texte"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:130
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:223
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
 msgid "comparison"
 msgstr "comparaison"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Retourne vrai si la fin du texte correspond au texte de comparaison."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "Appetite"
 msgstr "Appétit"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "hungry"
 msgstr "affamé"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 msgid "A column or string of text to check."
 msgstr "Une colonne ou une chaîne de texte à vérifier."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
 msgid "The string of text that the original text should end with."
 msgstr "La chaîne de texte avec laquelle le texte original doit se terminer."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 msgid "regular_expression"
 msgstr "expression_régulière"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:136
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Extrait les sous-chaînes de caractères correspondantes à une expression régulière."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:137
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
 msgid "Address"
 msgstr "Adresse"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 msgid "The column or string of text to search though."
 msgstr "La colonne ou la chaîne de texte à rechercher."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
 msgid "The regular expression to match."
 msgstr "L'expression régulière à faire correspondre."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the string of text in all lowercase."
 msgstr "Retourne la chaîne de texte en minuscules."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:149
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to lowercase."
 msgstr "La colonne avec les valeurs à convertir en minuscules."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:154
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 msgid "Removes leading whitespace from a string of text."
 msgstr "Supprime les espaces en début de chaîne de texte."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:157
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column with values you want to trim."
 msgstr "La colonne avec les valeurs que vous voulez rogner."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "Returns the largest value found in the column."
 msgstr "Retourne la plus grande valeur trouvée dans la colonne."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
 msgid "Age"
 msgstr "Âge"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:165
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
 msgid "The numeric column whose maximum you want to find."
 msgstr "La colonne numérique dont vous voulez trouver le maximum."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:170
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "Returns the smallest value found in the column."
 msgstr "Retourne la plus petite valeur trouvée dans la colonne."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
 msgid "Salary"
 msgstr "Salaire"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:173
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
 msgid "The numeric column whose minimum you want to find."
 msgstr "La colonne numérique dont vous voulez trouver le minimum."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:181
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:242
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
 msgid "position"
 msgstr "position"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:194
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
 msgid "length"
 msgstr "longueur"
 
@@ -14146,7 +14169,7 @@ msgstr "longueur"
 msgid "new_text"
 msgstr "nouveau_texte"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:187
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
 msgid "Replaces a part of the input text with new text."
 msgstr "Remplace une partie du texte d'entrée par un nouveau texte."
 
@@ -14158,7 +14181,7 @@ msgstr "ID de commande"
 msgid "Updated Part of ID"
 msgstr "Partie mise à jour de l'ID"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
 msgid "The text that will be modified."
 msgstr "Le texte qui sera modifié."
 
@@ -14174,87 +14197,87 @@ msgstr "Le nombre de caractères à remplacer."
 msgid "The text to use in the replacement."
 msgstr "Le texte à utiliser dans le remplacement."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Supprime les espaces à la fin d'une chaîne de texte."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:210
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Renvoie le pourcentage de lignes dans les données qui correspondent à la condition, sous forme décimale."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:218
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Retourne vrai si le début du texte correspond au texte de comparaison."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Course Name"
 msgstr "Nom du stage"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Computer Science"
 msgstr "Informatique"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
 msgid "The string of text that the original text should start with."
 msgstr "La chaîne de caractères par laquelle le texte d'origine devrait commencer"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:229
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
 msgid "Calculates the standard deviation of the column."
 msgstr "Calcule l'écart-type de la colonne."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:230
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
 msgid "Population"
 msgstr "Population"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
 msgid "A numeric column."
 msgstr "Une colonne numérique."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
 msgid "Returns a portion of the supplied text."
 msgstr "Renvoie une portion du texte fourni."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:241
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:313
 msgid "The text to return a portion of."
 msgstr "Retourne une partie du texte fourni."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
 msgid "The position to start copying characters."
 msgstr "La position pour démarrer la copie des caractères."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:245
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
 msgid "The number of characters to return."
 msgstr "Le nombre de caractères à retourner."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
 msgid "Adds up all the values of the column."
 msgstr "Adds up all the values of the column."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:253
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
 msgid "The numeric column to sum."
 msgstr "La colonne numérique à additionner."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Additionne les valeurs dans une colonne où les lignes correspondent à la condition."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
 msgid "Order Status"
 msgstr "Statut de la commande"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
 msgid "Valid"
 msgstr "Valide"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Supprime les espaces de début et de fin d'une chaîne de texte."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
 msgid "Returns the string of text in all upper case."
 msgstr "Retourne la chaîne de texte en majuscules."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
 msgid "The column with values to convert to upper case."
 msgstr "La colonne avec les valeurs à convertir en majuscules."
 
@@ -14316,39 +14339,39 @@ msgstr "Merci d'utiliser Metabase !"
 msgid "Powered by {0}"
 msgstr "Propulsé par {0}"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:191
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
 msgid "To:"
 msgstr "Pour :"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:40
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
 msgstr "Cette question ne peut pas être utilisée car elle est basée sur une base de données différente."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:44
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:43
 msgid "Couldn't find a saved question with that ID number."
 msgstr "Impossible de trouver une question sauvegardée avec cet identifiant."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:55
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:54
 msgid "Pick a saved question"
 msgstr "Sélectionnez une question sauvegardée"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:57
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:56
 msgid "Pick a different question"
 msgstr "Sélectionnez une autre question"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:62
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:61
 msgid "Loading…"
 msgstr "Chargement..."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:79
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:78
 msgid "Question #…"
 msgstr "Question n°..."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:81
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
 msgstr "Question no{0}."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:115
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
 msgstr "Dernière édition {0}"
 
@@ -14360,11 +14383,11 @@ msgstr "{0} crée une variable dans ce modèle de requête appelée \"variable_n
 msgid "Giving a variable the \"Field Filter\" type allows you to link questions to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "Donner à une variable le type \"Filtre de champ\" vous permet de lier les questions aux gadgets de filtrage du tableau de bord ou d'utiliser plus de types de gadgets de filtrage sur votre question SQL. Une variable de type \" Filtre de champ \" insère du SQL similaire à celui généré par le constructeur de requêtes de l'interface graphique lors de l'ajout de filtres sur des colonnes existantes."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:131
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
 msgstr "Nom de la variable"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:217
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:218
 msgid "Filter widget label"
 msgstr "Label du gadget de filtrage"
 
@@ -14396,11 +14419,11 @@ msgstr "Dans le titre de la colonne"
 msgid "In every table cell"
 msgstr "Dans chaque cellule"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:351
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:341
 msgid "Value formatting"
 msgstr "Formatage de la valeur"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:361
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
 msgid "Full"
 msgstr "Complet"
 
@@ -14728,3 +14751,482 @@ msgstr "Erreur lors de la génération des aperçus pour la colonne :"
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandonment email!"
 msgstr "Envoi d'un courriel d'abandon !"
+
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
+msgstr "Vous pouvez créer des métriques enregistrées pour ajouter une option de métrique nommée. Les métriques sauvegardées comprennent le type d'agrégation, le champ agrégé et, en option, tout filtre que vous ajoutez. Par exemple, vous pouvez l'utiliser pour créer une méthode officielle de calcul du \"prix moyen\" pour une table de commandes."
+
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:105
+msgid "Select and add filters to create your new segment."
+msgstr "Sélectionnez et ajoutez des filtres pour créer votre nouveau segment."
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+msgid "Alphabetical"
+msgstr "Alphabétique"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+msgid "Smart"
+msgstr "Intelligent"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+msgid "Column order: {0}"
+msgstr "Ordre des colonnes : {0}"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
+msgid "Unhide all"
+msgstr "Tout révéler"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:204
+msgid "Hide all"
+msgstr "Cacher tout"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:206
+msgid "Unhide"
+msgstr "Révéler"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:22
+msgid "New metric"
+msgstr "Nouvelle métrique"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:45
+msgid "Create metrics to add them to the Summarize dropdown in the query builder"
+msgstr "Créer des métriques pour les ajouter au menu déroulant \"Résumé\" dans le générateur de requêtes"
+
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:22
+msgid "New segment"
+msgstr "Nouveau segment"
+
+#: frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx:71
+msgid "Filter by table"
+msgstr "Filtrer par table"
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:64
+msgid "Checking HTTPS..."
+msgstr "Vérification de HTTPS..."
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:66
+msgid "It looks like HTTPS is not properly configured"
+msgstr "Il semble que le HTTPS ne soit pas correctement configuré"
+
+#: frontend/src/metabase/admin/settings/selectors.js:57
+msgid "Redirect to HTTPS"
+msgstr "Rediriger vers le HTTPS"
+
+#: frontend/src/metabase/admin/settings/selectors.js:219
+msgid "Localization"
+msgstr "Localisation"
+
+#: frontend/src/metabase/admin/settings/selectors.js:222
+msgid "Instance language"
+msgstr "Langue de l'instance"
+
+#: frontend/src/metabase/admin/settings/selectors.js:237
+msgid "Localization options"
+msgstr "Options de localisation"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:51
+msgid "This database doesn't have any tables."
+msgstr "Cette base de données n'a pas de tables."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
+msgid "This field only accepts a single value because it's used in a SQL query."
+msgstr "Ce champ n'accepte qu'une seule valeur car il est utilisé dans une requête SQL."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:17
+msgid "Service Accounts"
+msgstr "Comptes de service"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:26
+msgid "Metabase connects to Big Query via {0}."
+msgstr "Metabase se connecte à Big Query via {0}."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:29
+msgid "Continue using an OAuth application to connect"
+msgstr "Continuer à utiliser une application OAuth pour se connecter"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:43
+msgid "We recommend switching to use {0} instead of an OAuth application to connect to BigQuery"
+msgstr "Nous recommandons de passer à l'utilisation de {0} au lieu d'une application OAuth pour se connecter à BigQuery"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:48
+msgid "Connect to a Service Account instead"
+msgstr "Connectez-vous plutôt à un compte de service"
+
+#: frontend/src/metabase/entities/databases/forms.js:44
+msgid "invalid JSON"
+msgstr "JSON invalide"
+
+#: frontend/src/metabase/entities/databases/forms.js:50
+msgid "SSH private key"
+msgstr "Clé privée SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:51
+msgid "Paste the contents of your ssh private key here"
+msgstr "Collez le contenu de votre clé privée ssh ici"
+
+#: frontend/src/metabase/entities/databases/forms.js:55
+msgid "Passphrase for the SSH private key"
+msgstr "Phrase secrète pour la clé privée SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:58
+msgid "SSH Authentication"
+msgstr "Authentification SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:60
+msgid "SSH Key"
+msgstr "Clé SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:65
+msgid "Server SSL certificate chain"
+msgstr "Chaîne de certificats SSL du serveur"
+
+#: frontend/src/metabase/entities/databases/forms.js:66
+msgid "Paste the contents of the server's SSL certificate chain here"
+msgstr "Coller le contenu de la chaîne de certificats SSL du serveur ici"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:11
+msgid "Paste a connection string"
+msgstr "Coller une chaîne de connexion"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:12
+msgid "Fill out individual fields"
+msgstr "Remplir les différents champs"
+
+#: frontend/src/metabase/entities/snippets.js:14
+msgid "Enter some SQL here so you can reuse it later"
+msgstr "Saisissez ici un peu de SQL pour pouvoir le réutiliser plus tard"
+
+#: frontend/src/metabase/entities/snippets.js:24
+msgid "Give your snippet a name"
+msgstr "Donnez un nom à votre snippet"
+
+#: frontend/src/metabase/entities/snippets.js:25
+msgid "Current Customers"
+msgstr "Clients actuels"
+
+#: frontend/src/metabase/entities/snippets.js:30
+msgid "Add a description"
+msgstr "Ajouter une description"
+
+#: frontend/src/metabase/entities/users/forms.js:37
+msgid "Use site default"
+msgstr "Utiliser le défaut du site"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+msgid "find"
+msgstr "Trouver"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+msgid "replace"
+msgstr "Remplacer"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+msgid "The text to find."
+msgstr "Le texte à trouver"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "The text to use as the replacement."
+msgstr "Le texte à utiliser en remplacement."
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+msgid "Editing {0}"
+msgstr "Edition de {0}"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+msgid "Create your new snippet"
+msgstr "Créez votre nouveau snippet"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+msgid "Archived snippets"
+msgstr "Snippets archivés"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+msgid "Snippets are reusable bits of SQL"
+msgstr "Les Snippets sont des bits de SQL réutilisables"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+msgid "Create a snippet"
+msgstr "Créer un snippet"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+msgid "Snippets"
+msgstr "Snippets"
+
+#: frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx:15
+msgid "SQL Snippets"
+msgstr "Snippets SQL"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:38
+msgid "Your language is set to {0}"
+msgstr "Votre langue est définie sur {0}."
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:50
+msgid "What's your preferred language?"
+msgstr "Quelle est votre langue préférée ?"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:54
+msgid "This language will be used throughout Metabase and will be the default for new users."
+msgstr "Cette langue sera utilisée dans l'ensemble de Metabase et sera la langue par défaut pour les nouveaux utilisateurs."
+
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:159
+msgid "We filtered out {0} row(s) containing null values."
+msgstr "Nous avons filtré la ou les lignes {0} contenant des valeurs nulles."
+
+#: frontend/src/metabase/visualizations/lib/settings/series.js:133
+msgid "Show values for this series"
+msgstr "Afficher les valeurs pour cette série"
+
+#: src/metabase/api/card.clj
+msgid "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
+msgstr "La durée moyenne d'exécution de la question est de {0} ; en utilisant un TTL \"magique\" de {1}."
+
+#: src/metabase/api/native_query_snippet.clj
+msgid "A snippet with that name already exists. Please pick a different name."
+msgstr "Il existe déjà une snippet de ce nom. Veuillez choisir un autre nom."
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Metric]"
+msgstr "[Métrique inconnue]"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Segment]"
+msgstr "[Segment inconnu]"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error writing error to output stream"
+msgstr "Erreur d'écriture dans le flux de sortie"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Caught unexpected Exception in streaming response body"
+msgstr "Exception trouvée dans le corps de réponse en flux de sortie"
+
+#: src/metabase/async/streaming_response.clj
+msgid "bound-fn caught unexpected Exception"
+msgstr "bound-fn a provoqué une exception inattendue"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error determining whether HTTP request was canceled"
+msgstr "Erreur déterminant si la demande HTTP a été annulée"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Check cancelation status timed out after {0}"
+msgstr "Vérifier le statut d'annulation après {0}."
+
+#: src/metabase/async/streaming_response.clj
+msgid "Unexpected exception in do-f-async"
+msgstr "Exception inattendue dans do-f-async"
+
+#: src/metabase/async/streaming_response.clj src/metabase/server.clj
+msgid "Unexpected exception writing error response"
+msgstr "Exception inattendue lors de l'écriture de la réponse à l'erreur"
+
+#: src/metabase/driver/common.clj
+msgid "Server certificate not trusted - did you specify the correct SSL certificate chain?"
+msgstr "Certificat de serveur non fiable - avez-vous spécifié une chaîne de certificats SSL correcte ?"
+
+#: src/metabase/driver/common.clj
+msgid "Server appears to require SSL - please enable SSL above"
+msgstr "Le serveur semble nécessiter le SSL - veuillez activer le SSL ci-dessus"
+
+#: src/metabase/driver/common.clj
+msgid "Username"
+msgstr "Nom d'utilisateur"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Don''t know how to parse parameter of type {0}"
+msgstr "Ne sait pas comment analyser le paramètre de type {0}"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Invalid :card parameter: missing `:card-id`"
+msgstr "Paramètre :card invalide : `:card-id` manquant"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Unable to resolve Snippet: missing `:snippet-id`"
+msgstr "Incapable de résoudre la Snippet : `:snippet-id` manquant"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Snippet {0} {1} not found."
+msgstr "Snippet {0} {1} non trouvée."
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error determining value for parameter"
+msgstr "Erreur lors de la détermination de la valeur du paramètre"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error building query parameter map"
+msgstr "Erreur lors de la création de la carte des paramètres de requête"
+
+#: src/metabase/middleware/log.clj
+msgid "ASYNC"
+msgstr "ASYNC"
+
+#: src/metabase/middleware/log.clj
+msgid "{0} ({1} DB calls)"
+msgstr "{0} ({1} appels de DB)"
+
+#: src/metabase/middleware/log.clj
+msgid "App DB connections: {0}/{1}"
+msgstr "Connexions App DB : {0}/{1}"
+
+#: src/metabase/middleware/log.clj
+msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
+msgstr "Threads Jetty : {0}/{1} ({2} inactif, {3} en file d'attente)"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} total active threads)"
+msgstr "({0} total de threads actifs)"
+
+#: src/metabase/middleware/log.clj
+msgid "Queries in flight: {0}"
+msgstr "Requêtes en cours : {0}"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} queued)"
+msgstr "({0} en file d'attente)"
+
+#: src/metabase/models/collection.clj
+msgid "Collection must be in the same namespace as its parent"
+msgstr "La collection doit se trouver dans le même espace de noms que son parent"
+
+#: src/metabase/models/collection.clj
+msgid "Personal Collections must be in the default namespace"
+msgstr "Les collections personnelles doivent se trouver dans l'espace de noms par défaut"
+
+#: src/metabase/models/collection.clj
+msgid "You cannot move a Collection to a different namespace once it has been created."
+msgstr "Vous ne pouvez pas déplacer une collection vers un espace de noms différent une fois qu'elle a été créée."
+
+#: src/metabase/models/collection.clj src/metabase/models/permissions.clj
+msgid "Collection does not exist."
+msgstr "La collection n'existe pas."
+
+#: src/metabase/models/collection.clj
+msgid "A {0} can only go in Collections in the {1} namespace."
+msgstr "Un {0} ne peut aller que dans les Collections de l'espace de noms {1}."
+
+#: src/metabase/models/database.clj
+msgid "Error sending database deletion notification"
+msgstr "Erreur d'envoi de la notification de suppression de la base de données"
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "You cannot update the creator_id of a NativeQuerySnippet."
+msgstr "Vous ne pouvez pas mettre à jour le creator_id d'un NativeQuerySnippet."
+
+#: src/metabase/models/setting.clj
+msgid "Error fetching value of Setting"
+msgstr "Erreur de recherche de la valeur du paramètre"
+
+#: src/metabase/public_settings.clj
+msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
+msgstr "Le langage qui doit être utilisé pour l'interface utilisateur de Metabase, les e-mails du système, les pulses et les alertes."
+
+#: src/metabase/public_settings.clj
+msgid "This is also the default language for all users, which they can change from their own account settings."
+msgstr "C'est également la langue par défaut pour tous les utilisateurs, qu'ils peuvent modifier à partir des paramètres de leur propre compte."
+
+#: src/metabase/public_settings.clj
+msgid "Invalid locale {0}"
+msgstr "Localisation invalide {0}"
+
+#: src/metabase/public_settings.clj
+msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
+msgstr "Forcer tout le trafic à utiliser HTTPS via une redirection, si l'URL du site est HTTPS"
+
+#: src/metabase/public_settings.clj
+msgid "Cannot redirect requests to HTTPS unless `site-url` is HTTPS."
+msgstr "Ne peut pas rediriger les demandes vers le HTTPS à moins que \"site-url\" ne soit HTTPS."
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error registering fonts: Metabase will not be able to send Pulses."
+msgstr "Erreur d'enregistrement des polices : Metabase ne pourra pas envoyer les Pulses."
+
+#: src/metabase/pulse/render/png.clj
+msgid "This is a known issue with certain JVMs. See {0} and for more details."
+msgstr "C'est un problème connu de certaines JVMs. Voir {0} et pour plus de détails."
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error rendering Pulse"
+msgstr "Erreur de rendu du Pulse"
+
+#: src/metabase/query_processor/context/default.clj
+msgid "Query timed out after {0}, raising timeout exception."
+msgstr "La requête a été interrompue après {0}, ce qui a entraîné une exception de délai d'attente."
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "No fields found for table {0}."
+msgstr "Aucun champ trouvé pour la table {0}."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Case"
+msgstr "Casse"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Variance of {0}"
+msgstr "Variance de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Median of {0}"
+msgstr "Médian de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "{0}th percentile of {1}"
+msgstr "{0}ième percentile de {1}"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Not caching results: results are larger than {0} KB"
+msgstr "Pas de mise en cache des résultats : les résultats sont supérieurs à {0} KB"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Cannot cache results: expected byte array, got {0}"
+msgstr "Impossible de mettre en cache les résultats : tableau d'octets attendu, obtenu {0}."
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Request is closed; no one to return cached results to"
+msgstr "La requête est close ; personne ne peut renvoyer les résultats mis en cache à"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Error attempting to fetch cached results for query with hash {0}"
+msgstr "Erreur lors de la tentative de récupération des résultats en cache pour une requête avec le hash {0}"
+
+#: src/metabase/query_processor/middleware/cache_backend/db.clj
+msgid "Error preparing statement to fetch cached query results"
+msgstr "Erreur de préparation de la déclaration pour récupérer les résultats d'une requête en cache"
+
+#: src/metabase/query_processor/middleware/catch_exceptions.clj
+msgid "Error processing query: {0}"
+msgstr "Erreur lors du traitement de la requête : {0}"
+
+#: src/metabase/server.clj
+msgid "Unexpected exception in endpoint"
+msgstr "Exception inattendue dans la ressource"
+
+#: src/metabase/server.clj
+msgid "Unexpected Exception in API request handler"
+msgstr "Exception inattendue dans le gestionnaire de requêtes API"
+
+#: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+msgid "Error reducing {0}"
+msgstr "Erreur lors de la réduction de {0}"
+
+#: src/metabase/sync/analyze/fingerprint/insights.clj
+msgid "Error generating timeseries insight keyed by: {0}"
+msgstr "Erreur lors de la génération des informations de série temporelle saisies par : {0}"
+
+#: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
+msgstr "La position de la base de données de {0} est passée de \" {1} \" à \" {2} \"."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Unscheduling task for Database {0}: trigger: {1}"
+msgstr "Annuler la planification de la tâche pour la base de données {0} : déclencheur {1}"
+
+#: src/metabase/util/schema.clj
+msgid "value must be a keyword or string."
+msgstr "La valeur doit être un mot-clef ou une chaîne"
+
+#: src/metabase/util/schema.clj
+msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
+msgstr "La chaîne doit être une langue ISO valide à deux lettres ou un code langue-pays, par exemple \"en\" ou \"en_US\"."

--- a/locales/it.po
+++ b/locales/it.po
@@ -29,13 +29,14 @@ msgid "Select a database type"
 msgstr "Selezionare il tipo di database"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:411
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:154
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -46,9 +47,9 @@ msgstr "Salva"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:122
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
-msgstr "Per fare qualcosa di magico Metabase ha bisogno di esplorare il tuo database. L'esplorazione viene periodicamente rieseguita. Di seguito puoi controllare quando avverrà la prossima esplorazione."
+msgstr "Per fare qualcosa di magico, Metabase ha bisogno di esplorare il tuo database. L'esplorazione viene periodicamente rieseguita. Di seguito puoi controllare quando avverrà la prossima esplorazione."
 
-#: frontend/src/metabase/entities/databases/forms.js:221
+#: frontend/src/metabase/entities/databases/forms.js:290
 msgid "Database syncing"
 msgstr "Database sincronizzato"
 
@@ -56,14 +57,14 @@ msgstr "Database sincronizzato"
 msgid "This is a lightweight process that checks for\n"
 "updates to this database’s schema. In most cases, you should be fine leaving this\n"
 "set to sync hourly."
-msgstr "Questo é un processo leggero che controlla aggiornamenti allo schema del database. Nella maggior parte dei casi, andrá bene impostarlo ad ogni ora"
+msgstr "Questo è un processo leggero che controlla aggiornamenti allo schema del database. Nella maggior parte dei casi, andrá bene impostarlo ad ogni ora."
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:42
 #: frontend/src/metabase/admin/databases/components/widgets/MetadataSyncScheduleWidget.jsx:22
 msgid "Scan"
 msgstr "Scansione"
 
-#: frontend/src/metabase/entities/databases/forms.js:228
+#: frontend/src/metabase/entities/databases/forms.js:297
 msgid "Scanning for Filter Values"
 msgstr "Ricerca di Valori Filtro"
 
@@ -72,9 +73,9 @@ msgid "Metabase can scan the values present in each\n"
 "field in this database to enable checkbox filters in dashboards and questions. This\n"
 "can be a somewhat resource-intensive process, particularly if you have a very large\n"
 "database."
-msgstr "Metabase puó cercare i valori presenti in ogni campo di questo database per abilitare i checkbox dei filtri nelle dashboard e questions. Questo processo puó essere intensivo, in particolare se hai un database molto grande."
+msgstr "Metabase può cercare i valori presenti in ogni campo di questo database per abilitare i checkbox dei filtri nelle dashboard e questions. Questo processo puó essere intensivo, in particolare se hai un database molto grande."
 
-#: frontend/src/metabase/entities/databases/forms.js:232
+#: frontend/src/metabase/entities/databases/forms.js:301
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Quando Metabase dovrebbe automaticamente scansionare e fare cache dei valori?"
 
@@ -96,6 +97,7 @@ msgid "Never, I'll do this manually if I need to"
 msgstr "Mai, lo farò manualmente se necessario"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 msgid "Saving..."
@@ -132,9 +134,9 @@ msgid "in this box:"
 msgstr "in questa casella:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:75
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
@@ -151,18 +153,18 @@ msgstr "in questa casella:"
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:301
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:39
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:90
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:99
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:311
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:328
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "Annulla"
@@ -179,7 +181,7 @@ msgstr "Elimina"
 #: frontend/src/metabase/admin/permissions/selectors.js:323
 #: frontend/src/metabase/admin/permissions/selectors.js:330
 #: frontend/src/metabase/admin/permissions/selectors.js:441
-#: frontend/src/metabase/admin/routes.jsx:57
+#: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
@@ -199,9 +201,10 @@ msgid "Scheduling"
 msgstr "Schedulazione"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:71
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
@@ -209,8 +212,8 @@ msgid "Save changes"
 msgstr "Salva i cambiamenti"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:203
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:35
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
 msgstr "Azioni"
 
@@ -222,8 +225,8 @@ msgstr "Sincronizza lo schema database ora"
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:90
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:98
 msgid "Starting…"
 msgstr "Avvio..."
 
@@ -241,13 +244,13 @@ msgstr "Ri-scansiona i valori dei campi adesso"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
 msgstr "Inizio della scansione fallito"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:92
 msgid "Scan triggered!"
 msgstr "Scan azionato!"
 
@@ -270,15 +273,15 @@ msgid "Add database"
 msgstr "Aggiungi un database"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:28
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:28
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
 #: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:195
+#: frontend/src/metabase/entities/databases/forms.js:264
 #: frontend/src/metabase/entities/questions.js:86
 #: frontend/src/metabase/entities/questions.js:102
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
@@ -318,6 +321,7 @@ msgstr "Salvataggio riuscito!"
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Edita"
@@ -360,44 +364,43 @@ msgstr "Fallito"
 msgid "Success"
 msgstr "Riuscito"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:185
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Anteprima"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:93
 msgid "No column description yet"
 msgstr "Ancora nessuna descrizione della colonna"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:127
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:126
 msgid "Select a field visibility"
 msgstr "Selezionare la visibilità del campo"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:187
 msgid "No special type"
 msgstr "Nessun tipo speciale"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
 #: frontend/src/metabase/lib/core.js:275
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:44
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:37
 msgid "Other"
 msgstr "Altri"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:221
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Seleziona uno speciale tipo"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:255
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:262
 #: frontend/src/metabase/reference/components/Field.jsx:99
 msgid "Select a target"
 msgstr "Seleziona una destinazione"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
@@ -405,18 +408,18 @@ msgstr "Seleziona una destinazione"
 msgid "Columns"
 msgstr "Colonne"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Colonna"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:144
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:288
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
 msgid "Visibility"
 msgstr "Visibilità"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
 msgid "Type"
 msgstr "Tipo"
 
@@ -424,7 +427,7 @@ msgstr "Tipo"
 msgid "Current database:"
 msgstr "Database corrente:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
 msgid "Show original schema"
 msgstr "Mostra lo schema originale"
 
@@ -446,27 +449,27 @@ msgid_plural "{0} schemas"
 msgstr[0] "{0} schema"
 msgstr[1] "{0} schemi"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:99
 msgid "Why Hide?"
 msgstr "Perché nasconderlo?"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:100
 msgid "Technical Data"
 msgstr "Dati Tecnici"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
 msgstr "Irrilevante/Mal progettato"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 msgid "Queryable"
 msgstr "Interrogabile"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:108
 msgid "Hidden"
 msgstr "Nascosto"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136
 msgid "No table description yet"
 msgstr "Nessuna descrizione della tabella ancora"
 
@@ -474,32 +477,33 @@ msgstr "Nessuna descrizione della tabella ancora"
 msgid "Metadata Strength"
 msgstr "Forza del metadata"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "Tabella interrogabile"
 msgstr[1] "Tabelle interrogabili"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:91
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "Tabella nascosta"
 msgstr[1] "Tabelle nascoste"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:115
 msgid "Find a table"
 msgstr "Trova una tabella"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:128
 msgid "Schemas"
 msgstr "Schemi"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:838
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:21
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:43
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:62
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 msgid "Metrics"
 msgstr "Metriche"
@@ -508,8 +512,8 @@ msgstr "Metriche"
 msgid "Add a Metric"
 msgstr "Aggiungi una metrica"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "Definizione"
@@ -518,12 +522,12 @@ msgstr "Definizione"
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "Crea metriche per aggiungerle al menu a discesa dela Vista nel generatore di query"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:21
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
 #: frontend/src/metabase/home/containers/SearchApp.jsx:72
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:961
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:61
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Segmenti"
@@ -532,35 +536,35 @@ msgstr "Segmenti"
 msgid "Add a Segment"
 msgstr "Aggiungi un segmento"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:51
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:45
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "Crea segmenti per aggiungerle nel menu a discesa dei Filtri nel generatore di query"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:21
 msgid "created"
 msgstr "creato"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "reverted to a previous version"
 msgstr "ritornare alla versione precedente"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:30
 msgid "edited the title"
 msgstr "titolo modificato"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:32
 msgid "edited the description"
 msgstr "Modificato la descrizione"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:34
 msgid "edited the "
 msgstr "Modificato il␣"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:40
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "made some changes"
 msgstr "fatte alcune modifiche"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
 #: frontend/src/metabase/home/components/Activity.jsx:83
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
@@ -570,84 +574,84 @@ msgstr "Tu"
 msgid "Datamodel"
 msgstr "Modello dei dati"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:41
 msgid " History"
 msgstr "Storico"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
 msgstr "Cronologia delle revisioni per"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:228
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
 msgid "{0} – Field Settings"
 msgstr "{0} – Impostazioni dei campi"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:289
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
 msgid "Where this field will appear throughout Metabase"
 msgstr "Dove questo campo apparirà in tutto Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:311
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
 msgid "Filtering on this field"
 msgstr "Filtra per questo campo"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:312
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Quando questo campo é usato in un filtro, cosa dovrebbero usare le persone per inserire il valore per il quale vogliono filtrare?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:437
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
 msgid "No description for this field yet"
 msgstr "Nessuna descrizione per questo campo fino ad ora"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
 msgid "Original value"
 msgstr "Valore originale"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:390
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
 msgid "Mapped value"
 msgstr "Valore mappato"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
 msgid "Enter value"
 msgstr "Inserire valore"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use original value"
 msgstr "Usa il valore originale"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Use foreign key"
 msgstr "Usa la chiave esterna"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 msgid "Custom mapping"
 msgstr "Mapping personalizzato"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
 msgid "Unrecognized mapping type"
 msgstr "Tipo mapping non riconosciuto"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Il campo corrente non é una Foreign Key o il metadata della tabella target della FK é mancante"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
 msgid "The selected field isn't a foreign key"
 msgstr "Il campo selezionato non é una foreign key"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:327
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
 msgid "Display values"
 msgstr "Visualizza valori"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:328
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Scegli se mostrare il valore originale dal database o se visualizzare questo campo associato o informazioni personalizzate."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:278
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
 msgid "Choose a field"
 msgstr "Scegli un campo"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:299
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
 msgid "Please select a column to use for display."
 msgstr "Prego selezionare una colonna da usare per visualizzazione"
 
@@ -655,16 +659,16 @@ msgstr "Prego selezionare una colonna da usare per visualizzazione"
 msgid "Tip:"
 msgstr "Suggerimento:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:443
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Potresti voler aggiornare il nome del campo per assicurarti che abbia ancora senso in base alle tue scelte di rimappatura."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:344
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Valori del campo memorizzato nella cache"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:345
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase può analizzare i valori per questo campo in modo da abilitare i filtri delle caselle di controllo nelle 'dashboard' e nelle 'question'."
 
@@ -673,53 +677,53 @@ msgid "Re-scan this field"
 msgstr "Ri-scansiona questo campo"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
 msgstr "Scarta la cache dei valori"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
 msgstr "Errore durante la cancellazione del valore"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 msgid "Discard triggered!"
 msgstr "Cancellazione avviata"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Seleziona una qualsiasi tabella per vederne lo schema o cambiarne i metadati"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:36
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "Nome è obbligatorio"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:39
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "Descrizione è obbligatorio"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:43
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Sono richieste le informazioni di revisione"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
 msgid "Aggregation is required"
 msgstr "E' richiesta un' aggregazione"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Edit Your Metric"
 msgstr "Modifica la tua Metrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Create Your Metric"
 msgstr "Crea la tua metrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Cambia le tue metriche e aggiungi una nota esplicativa"
 
@@ -727,62 +731,62 @@ msgstr "Cambia le tue metriche e aggiungi una nota esplicativa"
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "È possibile creare metriche salvate per aggiungere un'opzione metrica con nome a questa tabella. Le metriche salvate includono il tipo di aggregazione, il campo aggregato e, facoltativamente, qualsiasi filtro aggiunto. Ad esempio, è possibile utilizzarlo per creare qualcosa come il modo ufficiale di calcolare 'Prezzo medio' per una tabella Ordini."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:180
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
 msgid "Result: "
 msgstr "Risultato:"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
 msgid "Name Your Metric"
 msgstr "Dai un nome alla tua Metrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:190
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Give your metric a name to help others find it."
 msgstr "Dai un nome alla tua Metrica per aiutare gli altri a trovarla."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:194
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:152
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Qualcosa di descrittivo ma non troppo dettagliato"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:198
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
 msgid "Describe Your Metric"
 msgstr "Descrivi la tua Metrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:199
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Dai alla tua Metrica una descrizione per aiutare gli altri a capire di cosa tratta"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:203
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Questo é un buon posto per essere piú specifici riguardo le metriche meno ovvie"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:207
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:165
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Motivo per le modifiche"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:209
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Lascia un commento per spiegare quali cambiamenti hai fatto e perché li ritenevi necessari."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:213
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Questo verrá mostrato nello storico revisioni di questa metrica per aiutare tutti a ricordarsi perché le cose sono cambiate"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
 msgstr "Al meno uno filtro è obbligatorio"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
 msgstr "Modifica il tuo Segmento"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
 msgstr "Crea il tuo Segmento"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Cambia il tuo segmento e aggiungi una nota esplicativa"
 
@@ -790,33 +794,33 @@ msgstr "Cambia il tuo segmento e aggiungi una nota esplicativa"
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "Seleziona un filtro da aggiungere per creare un nuovo segmento sulla tabella {0}"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
 msgstr "Dai un nome al tuo Segmento"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:148
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
 msgstr "Dai un nome al tuo segmento per aiutare gli altri a trovarlo"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:156
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
 msgstr "Discrivi il tuo segmento"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Dai una descrizione al tuo segmento per aiutare gli altri a capire di cosa si tratta."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "questo e' un buon posto per essere precisi nel descrivere le regole di segmento meno ovvie"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "Questo verrà visualizzato nella cronologia delle revisioni di questo segmento per aiutare tutti a ricordare perché le cose sono cambiate"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
-#: frontend/src/metabase/admin/routes.jsx:132
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:215
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
+#: frontend/src/metabase/admin/routes.jsx:137
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
@@ -824,11 +828,11 @@ msgstr "Questo verrà visualizzato nella cronologia delle revisioni di questo se
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase può analizzare i valori per questa tabella in modo da abilitare i filtri delle caselle di controllo nelle 'dashboard' e nelle 'question'. "
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
 msgstr "Riscansiona questa tabella"
 
@@ -842,11 +846,11 @@ msgstr "Aggiungi"
 msgid "Not a valid formatted email address"
 msgstr "Indirizzo email formattato non correttamente"
 
-#: frontend/src/metabase/entities/users/forms.js:12
+#: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
 msgstr "Nome"
 
-#: frontend/src/metabase/entities/users/forms.js:18
+#: frontend/src/metabase/entities/users/forms.js:20
 msgid "Last name"
 msgstr "Cognome"
 
@@ -887,10 +891,10 @@ msgstr "Utenti"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
-#: frontend/src/metabase/admin/settings/selectors.js:120
-#: frontend/src/metabase/entities/users/forms.js:24
+#: frontend/src/metabase/admin/settings/selectors.js:121
+#: frontend/src/metabase/entities/users/forms.js:26
 #: frontend/src/metabase/lib/core.js:146
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:294
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:298
 msgid "Email"
 msgstr "Email"
 
@@ -899,14 +903,14 @@ msgid "A group is only as good as its members."
 msgstr "Un gruppo é tanto buono quanto lo sono i suoi membri."
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
-#: frontend/src/metabase/admin/routes.jsx:52
+#: frontend/src/metabase/admin/routes.jsx:55
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Admin"
 msgstr "Admin"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:241
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:299
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:288
 msgid "and"
 msgstr "e"
 
@@ -958,12 +962,12 @@ msgstr "Rimuovi gruppo"
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:42
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:294
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:397
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:317
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:334
 msgid "Done"
 msgstr "Fatto"
 
@@ -974,8 +978,9 @@ msgstr "Nome del gruppo"
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
-#: frontend/src/metabase/admin/routes.jsx:92
+#: frontend/src/metabase/admin/routes.jsx:97
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Gruppi"
 
@@ -1005,7 +1010,7 @@ msgstr "Disattiva"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:21
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
-#: frontend/src/metabase/admin/routes.jsx:88
+#: frontend/src/metabase/admin/routes.jsx:93
 #: frontend/src/metabase/nav/containers/Navbar.jsx:235
 msgid "People"
 msgstr "Persone"
@@ -1319,25 +1324,25 @@ msgstr "Vedi collezione"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:542
+#: frontend/src/metabase/admin/permissions/selectors.js:558
 msgid "Data Access"
 msgstr "Accesso ai dati"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:667
-#: frontend/src/metabase/admin/permissions/selectors.js:672
+#: frontend/src/metabase/admin/permissions/selectors.js:665
+#: frontend/src/metabase/admin/permissions/selectors.js:670
 msgid "View tables"
 msgstr "Vedi tabelle"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:608
+#: frontend/src/metabase/admin/permissions/selectors.js:606
 msgid "SQL Queries"
 msgstr "SQL query"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:678
+#: frontend/src/metabase/admin/permissions/selectors.js:676
 msgid "View schemas"
 msgstr "Vedi schemi"
 
-#: frontend/src/metabase/admin/routes.jsx:63
+#: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
 msgstr "Modello dei dati"
@@ -1367,20 +1372,24 @@ msgid "Allows users within your LDAP directory to log in to Metabase with their 
 msgstr "Consente agli utenti all'interno della directory LDAP di accedere a Metabase con le proprie credenziali LDAP e consente la mappatura automatica dei gruppi LDAP ai gruppi di metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:19
-#: frontend/src/metabase/admin/settings/selectors.js:167
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
+#: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
 msgstr "Email non valida"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
 msgstr "Intero non valido"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
 msgstr "Modifiche Salvate!"
 
-#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:178
+#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
 msgid "Looks like we ran into some problems"
 msgstr "Mi"
 
@@ -1402,7 +1411,7 @@ msgstr "Pulisci"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:195
+#: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Autenticazione"
 
@@ -1454,15 +1463,15 @@ msgstr "il tuo Google ID"
 msgid "Allow users to sign up on their own if their Google account email address is from:"
 msgstr "Consenti agli utenti di registrarsi da soli se il loro indirizzo email dell'account Google proviene da:"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:242
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:249
 msgid "Answers sent right to your Slack #channels"
 msgstr "Le risposte vengono inviate direttamente ai tuoi #channels di Slack"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:251
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:258
 msgid "Create a Slack Bot User for MetaBot"
 msgstr "Crea un Utente Bot Slack per MetaBot"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:261
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:268
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "Una volta che sei lì, dagli un nome e fai clicca {0}. Quindi copia e incolla il token API Bot nel campo sottostante. Una volta terminato, crea un canale \"metabase_files\" in Slack. Metabase ha bisogno di questo per caricare grafici."
 
@@ -1475,8 +1484,8 @@ msgid "Metabase {0} is available.  You're running {1}"
 msgstr "É disponibile Metabase {0}. La versione in uso é la {1}."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:41
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 msgid "Update"
 msgstr "Aggiornare"
 
@@ -1503,16 +1512,16 @@ msgstr "Cancellare mappa personalizzata"
 #: frontend/src/metabase/containers/Overworld.jsx:293
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:115
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Rimuovere"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:165
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:141
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
 msgstr "Seleziona..."
 
@@ -1697,48 +1706,46 @@ msgid "Generate Key"
 msgstr "Chiave generata"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:87
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:18
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enabled"
 msgstr "Abilitata"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:92
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:19
+#: frontend/src/metabase/admin/settings/selectors.js:93
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Disabilitato"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:112
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:113
 msgid "Unknown setting {0}"
 msgstr "Impostazione sconosciuta {0}"
 
-#: frontend/src/metabase/admin/settings/selectors.js:34
+#: frontend/src/metabase/admin/settings/selectors.js:37
 msgid "Setup"
 msgstr "Imposta"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:207
-#: frontend/src/metabase/admin/settings/selectors.js:39
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:214
+#: frontend/src/metabase/admin/settings/selectors.js:42
 msgid "General"
 msgstr "Generale"
 
-#: frontend/src/metabase/admin/settings/selectors.js:43
+#: frontend/src/metabase/admin/settings/selectors.js:46
 msgid "Site Name"
 msgstr "Nome del Sito"
 
-#: frontend/src/metabase/admin/settings/selectors.js:48
+#: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Site URL"
 msgstr "URL del sito"
 
-#: frontend/src/metabase/admin/settings/selectors.js:53
+#: frontend/src/metabase/admin/settings/selectors.js:64
 msgid "Email Address for Help Requests"
 msgstr "Indirizzo email per richieste di assistenza"
 
-#: frontend/src/metabase/admin/settings/selectors.js:58
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
 msgstr "Segnala fuso orario"
 
-#: frontend/src/metabase/admin/settings/selectors.js:61
+#: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
 msgstr "Database predefinito"
 
@@ -1746,11 +1753,11 @@ msgstr "Database predefinito"
 msgid "Select a timezone"
 msgstr "Seleziona una timezone"
 
-#: frontend/src/metabase/admin/settings/selectors.js:64
+#: frontend/src/metabase/admin/settings/selectors.js:75
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "Non tutti i database supportano i fusi orari, nel qual caso questa impostazione non avrà effetto."
 
-#: frontend/src/metabase/admin/settings/selectors.js:69
+#: frontend/src/metabase/entities/users/forms.js:34
 msgid "Language"
 msgstr "Lingua"
 
@@ -1758,64 +1765,64 @@ msgstr "Lingua"
 msgid "Select a language"
 msgstr "Seleziona una lingua"
 
-#: frontend/src/metabase/admin/settings/selectors.js:79
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
 msgstr "Tracciamento Anonimo"
 
-#: frontend/src/metabase/admin/settings/selectors.js:84
+#: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
 msgstr "Nomi tabelle e campi amichevoli"
 
-#: frontend/src/metabase/admin/settings/selectors.js:90
+#: frontend/src/metabase/admin/settings/selectors.js:91
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Sostituisci solo caratteri di sottolineatura e trattini con spazi"
 
-#: frontend/src/metabase/admin/settings/selectors.js:98
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Enable Nested Queries"
 msgstr "Abilita le query annidate"
 
-#: frontend/src/metabase/admin/settings/selectors.js:109
+#: frontend/src/metabase/admin/settings/selectors.js:110
 msgid "Updates"
 msgstr "Aggiornamenti"
 
-#: frontend/src/metabase/admin/settings/selectors.js:114
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
 msgstr "Controlla Aggiornamenti"
 
-#: frontend/src/metabase/admin/settings/selectors.js:125
+#: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
 msgstr "Host SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:133
+#: frontend/src/metabase/admin/settings/selectors.js:134
 msgid "SMTP Port"
 msgstr "Porta SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:137
+#: frontend/src/metabase/admin/settings/selectors.js:138
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:47
 msgid "That's not a valid port number"
 msgstr "Questo non e' un numero diporta valido"
 
-#: frontend/src/metabase/admin/settings/selectors.js:141
+#: frontend/src/metabase/admin/settings/selectors.js:142
 msgid "SMTP Security"
 msgstr "Tipo sicurezza SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:150
 msgid "SMTP Username"
 msgstr "SMTP Username"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "SMTP Password"
 msgstr "SMTP Password"
 
-#: frontend/src/metabase/admin/settings/selectors.js:163
+#: frontend/src/metabase/admin/settings/selectors.js:164
 msgid "From Address"
 msgstr "\"Da\" Indirizzo"
 
-#: frontend/src/metabase/admin/settings/selectors.js:176
+#: frontend/src/metabase/admin/settings/selectors.js:178
 msgid "Slack API Token"
 msgstr "Slack API Token"
 
-#: frontend/src/metabase/admin/settings/selectors.js:178
+#: frontend/src/metabase/admin/settings/selectors.js:180
 msgid "Enter the token you received from Slack"
 msgstr "Inserisci il token di slack"
 
@@ -1844,8 +1851,10 @@ msgid "Username or DN"
 msgstr "Username o DN"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:43
+#: frontend/src/metabase/entities/databases/forms.js:61
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:64
-#: frontend/src/metabase/user/components/UserSettings.jsx:65
+#: frontend/src/metabase/user/components/UserSettings.jsx:66
+#: src/metabase/driver/common.clj
 msgid "Password"
 msgstr "Password"
 
@@ -1881,79 +1890,79 @@ msgstr "Sincronizza le appartenenze ai gruppi"
 msgid "Group search base"
 msgstr "Ricerca base gruppo"
 
-#: frontend/src/metabase/admin/settings/selectors.js:199
+#: frontend/src/metabase/admin/settings/selectors.js:201
 msgid "Maps"
 msgstr "Mappe"
 
-#: frontend/src/metabase/admin/settings/selectors.js:203
+#: frontend/src/metabase/admin/settings/selectors.js:205
 msgid "Map tile server URL"
 msgstr "URL del MAP TILE SERVER"
 
-#: frontend/src/metabase/admin/settings/selectors.js:204
+#: frontend/src/metabase/admin/settings/selectors.js:206
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Metabase utilizza OpenStreetMaps per impostazione predefinita."
 
-#: frontend/src/metabase/admin/settings/selectors.js:209
+#: frontend/src/metabase/admin/settings/selectors.js:211
 msgid "Custom Maps"
 msgstr "Mappe personalizzate"
 
-#: frontend/src/metabase/admin/settings/selectors.js:210
+#: frontend/src/metabase/admin/settings/selectors.js:212
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Aggiungi i tuoi file GeoJSON per abilitare visualizzazioni di mappe di regioni diverse"
 
-#: frontend/src/metabase/admin/settings/selectors.js:228
+#: frontend/src/metabase/admin/settings/selectors.js:245
 msgid "Public Sharing"
 msgstr "Condivisione pubblica"
 
-#: frontend/src/metabase/admin/settings/selectors.js:232
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "Enable Public Sharing"
 msgstr "Abilita la condivisione pubblica"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:254
 msgid "Shared Dashboards"
 msgstr "'Dashboard' condivise"
 
-#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Shared Questions"
 msgstr "Question condivise"
 
-#: frontend/src/metabase/admin/settings/selectors.js:250
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Embedding in other Applications"
 msgstr "Incorporamento in altre applicazioni"
 
-#: frontend/src/metabase/admin/settings/selectors.js:276
+#: frontend/src/metabase/admin/settings/selectors.js:293
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Abilita incorporamento di Metabase in altre applicazioni"
 
-#: frontend/src/metabase/admin/settings/selectors.js:286
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Embedding secret key"
 msgstr "Chiave segreta incorporata"
 
-#: frontend/src/metabase/admin/settings/selectors.js:292
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Embedded Dashboards"
 msgstr "'Dashboard' incorporate"
 
-#: frontend/src/metabase/admin/settings/selectors.js:298
+#: frontend/src/metabase/admin/settings/selectors.js:315
 msgid "Embedded Questions"
 msgstr "Question incorporate"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:322
 msgid "Caching"
 msgstr "Caching"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:326
 msgid "Enable Caching"
 msgstr "Abilita caching"
 
-#: frontend/src/metabase/admin/settings/selectors.js:314
+#: frontend/src/metabase/admin/settings/selectors.js:331
 msgid "Minimum Query Duration"
 msgstr "Durata minima Query"
 
-#: frontend/src/metabase/admin/settings/selectors.js:321
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Moltiplicatore Time-To-Live (TTL) della cache"
 
-#: frontend/src/metabase/admin/settings/selectors.js:328
+#: frontend/src/metabase/admin/settings/selectors.js:345
 msgid "Max Cache Entry Size"
 msgstr "Dimensione massima della cache"
 
@@ -2121,7 +2130,8 @@ msgstr "Anche le 'dashboard', le collezioni, e i 'pulse' in questa collezione sa
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/routes.jsx:205
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
+#: frontend/src/metabase/routes.jsx:196
 msgid "Archive"
 msgstr "Archivia"
 
@@ -2137,21 +2147,21 @@ msgstr "Vedi l'archivio"
 msgid "Unarchive this {0}"
 msgstr "Annulla questo {0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:39
-#: frontend/src/metabase/components/BrowseApp.jsx:102
-#: frontend/src/metabase/components/BrowseApp.jsx:194
+#: frontend/src/metabase/components/BrowseApp.jsx:46
+#: frontend/src/metabase/components/BrowseApp.jsx:112
+#: frontend/src/metabase/components/BrowseApp.jsx:204
 #: frontend/src/metabase/containers/Overworld.jsx:270
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
 msgstr "I tuoi dati"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:146
+#: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
 msgid "X-ray this table"
 msgstr "Verifica questa tabella"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:161
+#: frontend/src/metabase/components/BrowseApp.jsx:171
 msgid "Learn about this table"
 msgstr "Ulteriori informazioni su questa tabella"
 
@@ -2246,7 +2256,7 @@ msgstr "Fissa"
 msgid "Drag something here to pin it to the top"
 msgstr "Trascina qualcosa qui per fissarlo in cima"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:755
+#: frontend/src/metabase/admin/permissions/selectors.js:753
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2300,7 +2310,7 @@ msgstr "Nuova collezione"
 msgid "Copied!"
 msgstr "Copiato!"
 
-#: frontend/src/metabase/entities/databases/forms.js:12
+#: frontend/src/metabase/entities/databases/forms.js:14
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Usa un tunnel-SSH per le connessioni col database"
 
@@ -2312,7 +2322,7 @@ msgstr "È possibile accedere ad alcune installazioni di database solo collegand
 "Questa opzione fornisce anche un ulteriore livello di sicurezza quando una VPN non è disponibile.\n"
 "Abilitare ciò è di solito più lento rispetto ad una connessione diretta."
 
-#: frontend/src/metabase/entities/databases/forms.js:212
+#: frontend/src/metabase/entities/databases/forms.js:281
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Questo è un database grande, quindi lasciami scegliere quando Metabase deve sincronizzare e scansionare"
 
@@ -2322,17 +2332,17 @@ msgid "By default, Metabase does a lightweight hourly sync and an intensive dail
 msgstr "Come impostazione predefinita, Metabase esegue una sincronizzazione oraria leggera e un'analisi giornaliera intensiva dei valori dei campi.\n"
 "Se si dispone di un database di grandi dimensioni, si consiglia di attivarlo e rivedere quando e con quale frequenza si verificano le scansioni dei valori di campo."
 
-#: frontend/src/metabase/entities/databases/forms.js:78
+#: frontend/src/metabase/entities/databases/forms.js:113
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0} per generare un ID client e un client segreto per il progetto."
 
-#: frontend/src/metabase/entities/databases/forms.js:80
-#: frontend/src/metabase/entities/databases/forms.js:95
-#: frontend/src/metabase/entities/databases/forms.js:131
+#: frontend/src/metabase/entities/databases/forms.js:115
+#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:166
 msgid "Click here"
 msgstr "Clicca qui"
 
-#: frontend/src/metabase/entities/databases/forms.js:83
+#: frontend/src/metabase/entities/databases/forms.js:118
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Scegli \"Altro\" come tipo di applicazione. Chiamalo come preferisci."
 
@@ -2340,19 +2350,19 @@ msgstr "Scegli \"Altro\" come tipo di applicazione. Chiamalo come preferisci."
 msgid "{0} to get an auth code"
 msgstr "{0} per prendere un codice di autenticazione"
 
-#: frontend/src/metabase/entities/databases/forms.js:107
+#: frontend/src/metabase/entities/databases/forms.js:142
 msgid "with Google Drive permissions"
 msgstr "con i permessi di Google Drive"
 
-#: frontend/src/metabase/entities/databases/forms.js:129
+#: frontend/src/metabase/entities/databases/forms.js:164
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "Per usare Metabase con questi dati, devi abilitare l'accesso API nella console degli sviluppatori Google (Google Developers Console)."
 
-#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:165
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} per andare alla console se non lo hai già fatto"
 
-#: frontend/src/metabase/entities/databases/forms.js:196
+#: frontend/src/metabase/entities/databases/forms.js:265
 msgid "How would you like to refer to this database?"
 msgstr "Come vorresti fare riferimento a questo database?"
 
@@ -2361,7 +2371,8 @@ msgstr "Come vorresti fare riferimento a questo database?"
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:143
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:70
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:123
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:96
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:126
 #: frontend/src/metabase/setup/components/UserStep.jsx:93
 msgid "Next"
 msgstr "Successivo"
@@ -2544,7 +2555,7 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Ripristinato a una revisione precedente e {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:290
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "Storia di revisione"
@@ -2590,7 +2601,7 @@ msgid "Questions"
 msgstr "Domande"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:320
+#: frontend/src/metabase/routes.jsx:311
 msgid "Pulses"
 msgstr "Pulse"
 
@@ -2635,15 +2646,16 @@ msgstr "Siamo un po' persi..."
 msgid "Temporary Password"
 msgstr "Password temporanea"
 
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:207
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:481
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
 msgid "Hide"
 msgstr "Nascondi"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:467
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:482
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:471
 msgid "Show"
 msgstr "Mostra"
 
@@ -2753,7 +2765,7 @@ msgstr "Mi spiace, non hai i permessi per vederlo."
 msgid "Unknown error encountered"
 msgstr "C'è stato un errore sconosciuto"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/nav/containers/Navbar.jsx:373
 msgid "Create"
 msgstr "Crea"
@@ -2766,7 +2778,7 @@ msgstr "Crea una dashboard"
 msgid "Table"
 msgstr "Tabella"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
 msgid "Database"
 msgstr "Database"
 
@@ -2786,7 +2798,7 @@ msgstr "Prova ad aggiustare il tuo filtro per trovare ciò che stai cercando."
 msgid "View by"
 msgstr "Visto da"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:122
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:121
 msgid "of"
 msgstr "di"
 
@@ -2813,33 +2825,33 @@ msgstr "La nostra analisi"
 msgid "Browse all items"
 msgstr "Sfoglia tutti gli elementi"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:118
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:117
 msgid "Replace or save as new?"
 msgstr "Sostituisci o salva come nuovo?"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:168
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace original question, \"{0}\""
 msgstr "Sostituisci la richiesta (`question`) originaria, {0}"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:172
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:171
 msgid "Save as new question"
 msgstr "Salva come nuova richiesta (`question`)"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:92
 msgid "First, save your question"
 msgstr "Prima, salva la tua richiesta (`question`)"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:94
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
 msgid "Save question"
 msgstr "Salva la richiesta (`question`)"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:133
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
 msgid "What is the name of your card?"
 msgstr "Quale è il nome della tua card?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
 #: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/entities/questions.js:89
@@ -2855,15 +2867,16 @@ msgstr "Quale è il nome della tua card?"
 msgid "Description"
 msgstr "Descrizione"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
 #: frontend/src/metabase/entities/dashboards.js:150
 #: frontend/src/metabase/entities/questions.js:91
 #: frontend/src/metabase/entities/questions.js:107
+#: frontend/src/metabase/entities/snippets.js:31
 msgid "It's optional but oh, so helpful"
 msgstr "E' opzionale ma oh, così utile"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:148
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "In quale raccolta dovrebbe andare?"
@@ -2880,19 +2893,19 @@ msgstr "elemento"
 msgid "Undo"
 msgstr "Annulla"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:266
 msgid "Applying Question"
 msgstr "Inoltrando Richiesta (`Question`)"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:286
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "That question isn't compatible"
 msgstr "Questa richiesta non è compatibile"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:322
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:309
 msgid "Search for a question"
 msgstr "Cercando la richiesta"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:351
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:343
 msgid "We're not sure if this question is compatible"
 msgstr "Non siamo sicuri che questa richiesta sia compatibile"
 
@@ -2941,25 +2954,23 @@ msgstr "Aggiungi una richiesta (question)"
 msgid "Add a question to this dashboard"
 msgstr "Aggiungi una richiesta (question) alla dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
 msgid "Add a filter"
 msgstr "Aggiungi un filtro"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:256
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "Parametri"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:276
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:280
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
 msgid "Add a text box"
 msgstr "Aggiungi un campo di testo"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:320
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:314
 msgid "Move dashboard"
 msgstr "Sposta la Dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:303
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
 msgid "Edit dashboard"
 msgstr "Modifica la dashboard"
 
@@ -2967,11 +2978,11 @@ msgstr "Modifica la dashboard"
 msgid "Edit Dashboard Layout"
 msgstr "Modifica il layout della dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:371
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:365
 msgid "You are editing a dashboard"
 msgstr "Stai modificando una dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:376
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:370
 msgid "Select the field that should be filtered for each card"
 msgstr "Seleziona il campo che vorresti fosse filtrato per ogni card"
 
@@ -3059,7 +3070,7 @@ msgstr "Questa scheda non ha campi o parametri che possono essere associati a qu
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "I valori in questo campo non si sovrappongono ai valori di altri campi che hai scelto."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:162
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "Nessun campo valido."
@@ -3127,7 +3138,7 @@ msgstr "ricevuti gli ultimi dati da"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:329
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
 msgid "Unknown"
 msgstr "Sconosciuto"
 
@@ -3254,6 +3265,7 @@ msgstr "{0} elementi selezionati"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 msgid "Unarchive"
 msgstr "Non archiviare"
 
@@ -3346,7 +3358,7 @@ msgid "Longitude"
 msgstr "Longitudine"
 
 #: frontend/src/metabase/lib/core.js:43
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:45
 msgid "Number"
 msgstr "Numero"
@@ -3403,7 +3415,7 @@ msgid "User"
 msgstr "Utente"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:211
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
 msgid "Source"
 msgstr "Sorgente"
 
@@ -3444,16 +3456,17 @@ msgid "Score"
 msgstr "Punteggio"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Titolo"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
 msgid "Comment"
 msgstr "Commento"
 
@@ -3505,9 +3518,9 @@ msgstr "Non include"
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
 msgstr "Metabase non recupererà mai questo campo. Utilizzare questo per informazioni sensibili o irrilevanti."
 
-#: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:300
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/query/description.js:77
+#: frontend/src/metabase/lib/query/description.js:262
+#: frontend/src/metabase/lib/schema_metadata.js:476
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
@@ -3522,8 +3535,7 @@ msgstr "Conteggio"
 msgid "CumulativeCount"
 msgstr "Conteggio cumulativo"
 
-#: frontend/src/metabase/lib/expressions/config.js:9
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:485
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3533,7 +3545,6 @@ msgstr "Somma"
 msgid "CumulativeSum"
 msgstr "Somma cumulativa"
 
-#: frontend/src/metabase/lib/expressions/config.js:11
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Distinct"
 msgstr "Distinto"
@@ -3542,25 +3553,22 @@ msgstr "Distinto"
 msgid "StandardDeviation"
 msgstr "DeviazioneStandard"
 
-#: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:494
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Media"
 
-#: frontend/src/metabase/lib/expressions/config.js:14
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:539
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Min"
 
-#: frontend/src/metabase/lib/expressions/config.js:15
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:548
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:503
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:492
 msgid "Max"
 msgstr "Max"
 
@@ -3613,54 +3621,66 @@ msgstr "Cosa hai in mente?"
 msgid "What do you want to find out?"
 msgstr "Cosa vuoi scoprire?"
 
-#: frontend/src/metabase/lib/query.js:298
-#: frontend/src/metabase/lib/schema_metadata.js:466
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:250
+#: frontend/src/metabase/lib/query/description.js:75
+#: frontend/src/metabase/lib/query/description.js:260
+#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Dati grezzi"
 
-#: frontend/src/metabase/lib/query.js:302
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/query/description.js:79
+#: frontend/src/metabase/lib/query/description.js:264
+#: frontend/src/metabase/lib/schema_metadata.js:521
 msgid "Cumulative count"
 msgstr "Conto cumulativo"
 
-#: frontend/src/metabase/lib/query.js:305
+#: frontend/src/metabase/lib/query/description.js:82
+#: frontend/src/metabase/lib/query/description.js:266
 msgid "Average of "
 msgstr "Media di "
 
-#: frontend/src/metabase/lib/query.js:310
+#: frontend/src/metabase/lib/query/description.js:87
+#: frontend/src/metabase/lib/query/description.js:268
 msgid "Distinct values of "
 msgstr "Valori distinti di "
 
-#: frontend/src/metabase/lib/query.js:315
+#: frontend/src/metabase/lib/query/description.js:92
+#: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
 msgstr "Deviazione standard di "
 
-#: frontend/src/metabase/lib/query.js:320
+#: frontend/src/metabase/lib/query/description.js:97
+#: frontend/src/metabase/lib/query/description.js:272
 msgid "Sum of "
 msgstr "Somma di "
 
-#: frontend/src/metabase/lib/query.js:325
+#: frontend/src/metabase/lib/query/description.js:102
+#: frontend/src/metabase/lib/query/description.js:274
 msgid "Cumulative sum of "
 msgstr "Somma cumulativa di "
 
-#: frontend/src/metabase/lib/query.js:330
+#: frontend/src/metabase/lib/query/description.js:107
+#: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
 msgstr "Massimo di "
 
-#: frontend/src/metabase/lib/query.js:335
+#: frontend/src/metabase/lib/query/description.js:112
+#: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
 msgstr "Minimo di "
 
-#: frontend/src/metabase/lib/query.js:349
+#: frontend/src/metabase/lib/query/description.js:126
+#: frontend/src/metabase/lib/query/description.js:286
 msgid "Grouped by "
 msgstr "Raggruppato per "
 
-#: frontend/src/metabase/lib/query.js:363
+#: frontend/src/metabase/lib/query/description.js:140
+#: frontend/src/metabase/lib/query/description.js:295
 msgid "Filtered by "
 msgstr "Filtrato per "
 
-#: frontend/src/metabase/lib/query.js:392
+#: frontend/src/metabase/lib/query/description.js:169
+#: frontend/src/metabase/lib/query/description.js:320
 msgid "Sorted by "
 msgstr "Ordinato per "
 
@@ -3672,55 +3692,45 @@ msgstr "Vero"
 msgid "False"
 msgstr "Falso"
 
-#: frontend/src/metabase/lib/schema_metadata.js:321
+#: frontend/src/metabase/lib/schema_metadata.js:322
 msgid "Select longitude field"
 msgstr "Seleziona il campo longitudine"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:323
 msgid "Enter upper latitude"
 msgstr "Inserisci la latituine superiore"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:324
 msgid "Enter left longitude"
 msgstr "inserisci la longitudine a sinistra"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:325
 msgid "Enter lower latitude"
 msgstr "Inserisci la latitudine inferiore"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:326
 msgid "Enter right longitude"
 msgstr "Inserisci la longitudine a destra"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:539
 #: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:397
-#: frontend/src/metabase/lib/schema_metadata.js:405
-#: frontend/src/metabase/lib/schema_metadata.js:411
-#: frontend/src/metabase/lib/schema_metadata.js:416
-msgid "Is"
-msgstr "E'"
-
 #: frontend/src/metabase/lib/schema_metadata.js:362
 #: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:398
 #: frontend/src/metabase/lib/schema_metadata.js:406
 #: frontend/src/metabase/lib/schema_metadata.js:412
-msgid "Is not"
-msgstr "Non è"
+#: frontend/src/metabase/lib/schema_metadata.js:417
+msgid "Is"
+msgstr "E'"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:417
-msgid "Is empty"
-msgstr "E' vuoto"
+#: frontend/src/metabase/lib/schema_metadata.js:413
+msgid "Is not"
+msgstr "Non è"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:378
@@ -3729,109 +3739,119 @@ msgstr "E' vuoto"
 #: frontend/src/metabase/lib/schema_metadata.js:402
 #: frontend/src/metabase/lib/schema_metadata.js:408
 #: frontend/src/metabase/lib/schema_metadata.js:418
+msgid "Is empty"
+msgstr "E' vuoto"
+
+#: frontend/src/metabase/lib/schema_metadata.js:365
+#: frontend/src/metabase/lib/schema_metadata.js:379
+#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:395
+#: frontend/src/metabase/lib/schema_metadata.js:403
+#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:419
 msgid "Not empty"
 msgstr "Non vuoto"
 
-#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:371
 msgid "Equal to"
 msgstr "Uguale a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:372
 msgid "Not equal to"
 msgstr "Non uguale a "
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Greater than"
 msgstr "Più grande di"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Less than"
 msgstr "Meno di"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Tra"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:376
 msgid "Greater than or equal to"
 msgstr "Più grande o uguale a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Less than or equal to"
 msgstr "Meno di o uguale a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
+#: frontend/src/metabase/lib/schema_metadata.js:384
 msgid "Contains"
 msgstr "Contiene"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:385
 msgid "Does not contain"
 msgstr "Non contiene"
 
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:388
 msgid "Starts with"
 msgstr "Inizia con"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:389
 msgid "Ends with"
 msgstr "Finisce con"
 
-#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:399
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Prima"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:400
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Dopo"
 
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:414
 msgid "Inside"
 msgstr "Dentro"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Solo una tabella con le righe nella risposta, nessuna operazione aggiuntiva."
 
-#: frontend/src/metabase/lib/schema_metadata.js:474
+#: frontend/src/metabase/lib/schema_metadata.js:475
 msgid "Count of rows"
 msgstr "Conteggio di righe"
 
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:477
 msgid "Total number of rows in the answer."
 msgstr "Numero totale di righe nella risposta"
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Sum of ..."
 msgstr "Somma di ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:486
 msgid "Sum of all the values of a column."
 msgstr "Somma di tutti i valori di una colonna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:492
+#: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Average of ..."
 msgstr "Media di ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:495
 msgid "Average of all the values of a column"
 msgstr "Media di tutti i valori di una colonna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:501
+#: frontend/src/metabase/lib/schema_metadata.js:502
 msgid "Number of distinct values of ..."
 msgstr "Numeri di valori distinti di ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:504
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Numero di valori univoci di una colonna tra tutte le righe nella risposta."
 
-#: frontend/src/metabase/lib/schema_metadata.js:510
+#: frontend/src/metabase/lib/schema_metadata.js:511
 msgid "Cumulative sum of ..."
 msgstr "Somma cumulativa di ..."
 
@@ -3839,7 +3859,7 @@ msgstr "Somma cumulativa di ..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Somma additiva di tutti i valori di una colonna. \\\\ ne.x. entrate totali nel tempo."
 
-#: frontend/src/metabase/lib/schema_metadata.js:519
+#: frontend/src/metabase/lib/schema_metadata.js:520
 msgid "Cumulative count of rows"
 msgstr "Conteggio cumulativo di righe"
 
@@ -3847,27 +3867,27 @@ msgstr "Conteggio cumulativo di righe"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Conteggio additivo del numero di righe. \\\\ ne.x. numero totale di vendite nel tempo."
 
-#: frontend/src/metabase/lib/schema_metadata.js:528
+#: frontend/src/metabase/lib/schema_metadata.js:529
 msgid "Standard deviation of ..."
 msgstr "Deviazione standard di ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:531
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Numero che esprime quanto i valori di una colonna variano tra tutte le righe nella risposta."
 
-#: frontend/src/metabase/lib/schema_metadata.js:537
+#: frontend/src/metabase/lib/schema_metadata.js:538
 msgid "Minimum of ..."
 msgstr "Minimo di ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Minimum value of a column"
 msgstr "Minimo valore di una colonna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:546
+#: frontend/src/metabase/lib/schema_metadata.js:547
 msgid "Maximum of ..."
 msgstr "Massimo di ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:549
 msgid "Maximum value of a column"
 msgstr "Massimo valore di una colonna"
 
@@ -4043,7 +4063,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Categoria, Tipo, Valutazione, ecc."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:43
-#: frontend/src/metabase/user/components/UserSettings.jsx:55
+#: frontend/src/metabase/user/components/UserSettings.jsx:56
 msgid "Account settings"
 msgstr "Impostazioni di account"
 
@@ -4055,7 +4075,7 @@ msgstr "Esci da amministratore"
 msgid "Logs"
 msgstr "I log"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:103
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:104
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:22
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:65
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:100
@@ -4095,9 +4115,9 @@ msgid "Metabase Admin"
 msgstr "Amministratore Metabase"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:36
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:36
 msgid "Ask a question"
 msgstr "Poni una domanda"
 
@@ -4118,7 +4138,7 @@ msgstr "Referente"
 msgid "Which metric?"
 msgstr "Quale metrica?"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "Definire metriche comuni per il tuo team rende ancora più facile fare domande"
 
@@ -4130,7 +4150,7 @@ msgstr "Come creare metriche"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Visualizza i dati nel tempo, come una mappa o ruotati per aiutarti a capire tendenze o cambiamenti."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:149
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
 msgid "Custom"
 msgstr "Personalizzato"
 
@@ -4143,13 +4163,13 @@ msgstr "Nuove domande"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Utilizza il semplice generatore di domande per visualizzare tendenze, elenchi di cose o per creare le tue metriche."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:107
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:110
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Query native"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:108
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:111
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Per domande più complicate, puoi scrivere la tua query SQL o nativa."
 
@@ -4254,6 +4274,7 @@ msgid "Enter a default value..."
 msgstr "Inserisci un valore predefinito..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
+#: frontend/src/metabase/containers/Form.jsx:307
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "C'è stato un errore"
@@ -4502,7 +4523,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "Raccomandiamo di mantenere gli impulsi piccoli e concentrati per mantenerli digeribili e utili a tutta la squadra."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:161
-#: frontend/src/metabase/query_builder/components/view/View.jsx:131
+#: frontend/src/metabase/query_builder/components/view/View.jsx:133
 msgid "Pick your data"
 msgstr "Scegli i tuoi dati"
 
@@ -4518,47 +4539,47 @@ msgstr "Email"
 msgid "Slack messages"
 msgstr "Messaggi Slack"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:216
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Spedito"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:217
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} saranno spediti a"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:219
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Messaggi"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:235
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "Spedisci email ora"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:236
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Spedisci {0} ora"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:238
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Invio..."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "Invio fallito"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "Non spedire in quanto pulse non ha risultati"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Pulse ha inviato"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:282
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} deve essere impostato da un amministratore."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:295
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:299
 msgid "Slack"
 msgstr "Slack"
 
@@ -4697,7 +4718,7 @@ msgstr "Ascendente"
 
 #: frontend/src/metabase/modes/components/drill/SortAction.jsx:50
 msgid "Descending"
-msgstr "Discentente"
+msgstr "Discendente"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js:43
 msgid "over time"
@@ -4711,7 +4732,7 @@ msgstr "Media"
 msgid "Distincts"
 msgstr "Distinti"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:55
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "Mostra questo {0}"
@@ -4722,11 +4743,12 @@ msgstr[1] "Mostra questi {0}"
 msgid "Zoom in"
 msgstr "Avvicina"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Espressione custom"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Common Metrics"
 msgstr "Metriche standard"
 
@@ -4923,34 +4945,34 @@ msgstr "solitamente"
 msgid "Pick a segment or table"
 msgstr "Seleziona un segmento o una tabella"
 
-#: frontend/src/metabase/entities/databases/forms.js:191
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
+#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Seleziona un database"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:94
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:85
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:31
 msgid "Select..."
 msgstr "Seleziona..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:134
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
 msgid "Select a table"
 msgstr "Seleziona una tabella"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:819
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:926
 msgid "No tables found in this database."
 msgstr "In questo database non è stata trovata nessuna tabella."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:856
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:901
 msgid "Is a question missing?"
 msgstr "Manca una domanda?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:863
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:909
 msgid "Learn more about nested queries"
 msgstr "Scopri di più sulle query annidate"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:898
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:951
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:40
 msgid "Fields"
 msgstr "Campi"
 
@@ -4984,11 +5006,11 @@ msgstr "Ordina"
 msgid "Row limit"
 msgstr "Limite di righe"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
 msgid "Unknown Field"
 msgstr "Campo sconosciuto"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:75
 msgid "field"
 msgstr "campo"
 
@@ -4996,19 +5018,20 @@ msgstr "campo"
 msgid "Matches"
 msgstr "Combinazioni"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:148
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:156
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:135
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Aggiungi filtri per restringere la tua risposta"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:293
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
 msgstr "Aggiungi un raggruppamento"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:37
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:313
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
-#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:66
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:67
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:89
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:131
@@ -5024,16 +5047,16 @@ msgstr "Aggiungi un raggruppamento"
 msgid "Data"
 msgstr "Dati"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:340
 msgid "Filtered by"
 msgstr "Filtrati per"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:376
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:357
 msgid "View"
 msgstr "Vista"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:393
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:374
 msgid "Grouped By"
 msgstr "Raggruppati per"
 
@@ -5041,7 +5064,7 @@ msgstr "Raggruppati per"
 msgid "None"
 msgstr "Nessuno"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:471
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
 msgid "This question is written in {0}."
 msgstr "Questa domanda è scritta in {0}"
 
@@ -5053,7 +5076,7 @@ msgstr "Nascondi Editor"
 msgid "Hide Query"
 msgstr "Nascondi Query"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:481
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
 msgid "Open Editor"
 msgstr "Apri Editor"
 
@@ -5294,7 +5317,7 @@ msgstr "Tutti i valori che assume {0}"
 msgid "Number of {0} grouped by {1}"
 msgstr "Numero di {0} raggruppato per {1}"
 
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:77
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5353,32 +5376,33 @@ msgstr "Mostra i dati grezzi per {0}"
 msgid "More"
 msgstr "Altro"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:194
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:216
 msgid "Invalid expression"
 msgstr "Espressione non valida"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:269
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:282
 msgid "unknown error"
 msgstr "errore sconosciuto"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:47
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:53
 msgid "Field formula"
 msgstr "Campo formula"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:60
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:64
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Pensa che è come scrivere una formula in un foglio di calcolo: puoi usare numeri, campi in questa tabella, simboli matematici come + e alcune funzioni. Quindi puoi digitare qualcosa come Subtotal - Cost."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:69
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:208
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
 msgid "Learn more"
 msgstr "Scopri di più"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:77
 msgid "Give it a name"
 msgstr "Assegna un nome"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:79
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
 msgid "Something nice and descriptive"
 msgstr "Qualcosa di chiaro e descrittivo"
 
@@ -5458,11 +5482,11 @@ msgid "Enter desired number"
 msgstr "Inserisci il numero desiderato"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:154
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:161
 msgid "Empty"
 msgstr "Vuoto"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:119
 msgid "Find a value"
 msgstr "Trova un valore"
 
@@ -5531,35 +5555,35 @@ msgstr "Leggi la documentazione completa"
 msgid "Filter label"
 msgstr "Etichetta di filtro"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:135
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:134
 msgid "Variable type"
 msgstr "Tipo di variabile"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:143
 msgid "Text"
 msgstr "Testo"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
 msgid "Date"
 msgstr "Data"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:147
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
 msgid "Field Filter"
 msgstr "Filtro per colonna"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Field to map to"
 msgstr "Campo a cui mappare"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:180
 msgid "Filter widget type"
 msgstr "Filtro tipo di widget"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:230
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
 msgid "Required?"
 msgstr "Richiesto?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:240
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
 msgid "Default filter widget value"
 msgstr "Valore di default del widget"
 
@@ -5571,7 +5595,7 @@ msgstr "Archivia questa domanda?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Questa domanda sarà rimossa da ogni dashboard o pulse che la contiene"
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:158
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
 msgid "Question"
 msgstr "Domanda"
 
@@ -5741,7 +5765,7 @@ msgid "Details"
 msgstr "Dettagli"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
-#: frontend/src/metabase/reference/databases/TableList.jsx:116
+#: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
 msgstr "Tabelle in {0}"
 
@@ -5822,24 +5846,24 @@ msgstr "Perchè questa tabella è interessante"
 msgid "Things to be aware of about this table"
 msgstr "Cose di cui essere a conoscenza riguardanti questa tabella"
 
-#: frontend/src/metabase/reference/databases/TableList.jsx:30
+#: frontend/src/metabase/reference/databases/TableList.jsx:29
 msgid "Tables in this database will appear here as they're added"
 msgstr "Le tabelle in questo database appariranno qui man mano verranno aggiunte"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:34
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:33
 msgid "Questions about this table will appear here as they're added"
 msgstr "Le domande su questa tabella appariranno qui man mano verranno aggiunte"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:73
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:77
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:76
 msgid "Questions about {0}"
 msgstr "Domande riguardanti {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
 msgid "Created {0} by {1}"
 msgstr "Creato {0} per {1}"
 
@@ -6028,19 +6052,19 @@ msgstr "Altri campi puoi raggruppare questa metrica per"
 msgid "Fields you can group this metric by"
 msgstr "Campi con cui puoi raggruppare questa metrica"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "Le metriche sono i numeri ufficiali di cui il tuo team si prende cura"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Metrics will appear here once your admins have created some"
 msgstr "Le metriche appariranno qui una volta che i tuoi amministratori ne avranno creati alcuni"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:28
 msgid "Learn how to create metrics"
 msgstr "Scopri come si creano metriche"
 
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:34
 msgid "Questions about this metric will appear here as they're added"
 msgstr "Le 'question' su questa metrica verranno visualizzate qui man mano che vengono aggiunte"
 
@@ -6066,23 +6090,23 @@ msgstr "Perché questo segmento è interessante"
 msgid "Things to be aware of about this Segment"
 msgstr "Cose da sapere su questo segmento"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
 msgid "Segments are interesting subsets of tables"
 msgstr "I segmenti sono sottoinsiemi interessanti di tabelle"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "Definire segmenti comuni per il tuo team rende ancora più facile fare domande"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Segments will appear here once your admins have created some"
 msgstr "I segmenti appariranno qui non appena i tuoi admin ne avranno creati"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
 msgid "Learn how to create segments"
 msgstr "Impara come creare dei segmenti"
 
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:35
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:34
 msgid "Questions about this segment will appear here as they're added"
 msgstr "Le domande su questo segmento appariranno qui non appena saranno aggiunte"
 
@@ -6103,23 +6127,23 @@ msgstr "Domande su questo segmento"
 msgid "X-ray this segment"
 msgstr "Analizza il segmento ai Raggi-X"
 
-#: frontend/src/metabase/routes.jsx:178 frontend/src/metabase/routes.jsx:179
+#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
 msgid "Login"
 msgstr "Accedi"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:303
 #: frontend/src/metabase/containers/ItemPicker.jsx:115
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:204
+#: frontend/src/metabase/routes.jsx:195
 msgid "Search"
 msgstr "Cerca"
 
 #. Usare cruscotto lo trovo agghiacciante
-#: frontend/src/metabase/routes.jsx:223
+#: frontend/src/metabase/routes.jsx:214
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#: frontend/src/metabase/routes.jsx:236
+#: frontend/src/metabase/routes.jsx:227
 msgid "New Question"
 msgstr "Nuova domanda"
 
@@ -6163,63 +6187,63 @@ msgstr "Grazie per averci aiutato a migliorare"
 msgid "We won't collect any usage events"
 msgstr "Non raccoglieremo eventi di utilizzo"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:88
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Per aiutarci a migliorare Metabase, desideriamo raccogliere determinati dati sull'utilizzo tramite Google Analytics."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:90
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Here's a full list of everything we track and why."
 msgstr "Qui trovi la lista completa di cosa tracciamo e perché"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Consenti a Metabase di raccogliere dati anonimi sugli eventi"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:113
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0} reccoglie nulla riguardo i tuoi dati e risultati."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:114
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
 msgid "never"
 msgstr "mai"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:119
 msgid "All collection is completely anonymous."
 msgstr "Tutte le raccolte dati sono completamente anonime."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "La raccolta dati può essere disabilitata in qualsiasi momento dalle impostazioni di amministrazione."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:44
+#: frontend/src/metabase/setup/components/Setup.jsx:59
 msgid "If you feel stuck"
 msgstr "Se ti senti bloccato"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:49
+#: frontend/src/metabase/setup/components/Setup.jsx:64
 msgid "our getting started guide"
 msgstr "la nostra guida rapida"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:50
+#: frontend/src/metabase/setup/components/Setup.jsx:65
 msgid "is just a click away."
 msgstr "ti manca solo un click."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:92
+#: frontend/src/metabase/setup/components/Setup.jsx:111
 msgid "Welcome to Metabase"
 msgstr "Benvenuto in Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:93
+#: frontend/src/metabase/setup/components/Setup.jsx:112
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Sembra che tutto funzioni. Ora ti conosciamo, ti colleghiamo ai tuoi dati e inizi a trovarti delle risposte!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:97
+#: frontend/src/metabase/setup/components/Setup.jsx:116
 msgid "Let's get started"
 msgstr "Iniziamo"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:142
+#: frontend/src/metabase/setup/components/Setup.jsx:166
 msgid "You're all set up!"
 msgstr "Abbiamo impostato tutto!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:153
+#: frontend/src/metabase/setup/components/Setup.jsx:177
 msgid "Take me to Metabase"
 msgstr "Portami su Metabase"
 
@@ -6231,13 +6255,13 @@ msgstr "Come dovremmo chiamarti?"
 msgid "Hi, {0}. nice to meet you!"
 msgstr "Ciao {0}. Piacere di conoscerti!"
 
-#: frontend/src/metabase/entities/users/forms.js:33
+#: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
 msgstr "Crea una password"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:44
-#: frontend/src/metabase/entities/users/forms.js:35
-#: frontend/src/metabase/entities/users/forms.js:82
+#: frontend/src/metabase/entities/users/forms.js:50
+#: frontend/src/metabase/entities/users/forms.js:97
 msgid "Shhh..."
 msgstr "Shhh..."
 
@@ -6245,11 +6269,11 @@ msgstr "Shhh..."
 msgid "Confirm password"
 msgstr "Conferma la password"
 
-#: frontend/src/metabase/entities/users/forms.js:42
+#: frontend/src/metabase/entities/users/forms.js:57
 msgid "Shhh... but one more time so we get it right"
 msgstr "Shhh... un'ultima volta così non sbagliamo"
 
-#: frontend/src/metabase/entities/users/forms.js:70
+#: frontend/src/metabase/entities/users/forms.js:85
 msgid "Your company or team name"
 msgstr "Il nome della tua Società o del tuo team"
 
@@ -6419,7 +6443,7 @@ msgstr "Password aggiornata correttamente!"
 msgid "Account updated successfully!"
 msgstr "Account aggiornato correttamente!"
 
-#: frontend/src/metabase/entities/users/forms.js:81
+#: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
 msgstr "Password attuale"
 
@@ -6431,7 +6455,7 @@ msgstr "Accedi con Google"
 msgid "User Details"
 msgstr "Dettagli utente"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:327
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:344
 msgid "Reset to defaults"
 msgstr "Ripristina i valori di default"
 
@@ -6456,15 +6480,15 @@ msgstr "Quali campi vuoi usare per le coordinate X e Y?"
 msgid "Choose fields"
 msgstr "Scegli i campi"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:217
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:234
 msgid "Save as default view"
 msgstr "Salva come vista di default"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Draw box to filter"
 msgstr "Disegna un box per filtrare"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Cancel filter"
 msgstr "Annulla filtro"
 
@@ -6492,19 +6516,19 @@ msgstr "Impossibile trovare visualizzazione"
 msgid "Could not display this chart with this data."
 msgstr "Impossibile visualizzare questo grafico con questi dati"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:526
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
 msgid "No results!"
 msgstr "Nessun risultato!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:547
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
 msgid "Still Waiting..."
 msgstr "Sto ancora aspettando..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:550
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
 msgid "This usually takes an average of {0}."
 msgstr "Solitamente impiega una media di {0}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:556
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Questo è un po' lungo per una dashboard)"
 
@@ -6663,19 +6687,19 @@ msgstr "Aggiungi regola"
 msgid "Update rule"
 msgstr "Aggiorna regola"
 
-#: frontend/src/metabase/visualizations/index.js:32
+#: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
 msgstr "La visualizzazione è nulla"
 
-#: frontend/src/metabase/visualizations/index.js:37
+#: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
 msgstr "La visualizzazione deve definire una variabile statica 'identificatore':"
 
-#: frontend/src/metabase/visualizations/index.js:43
+#: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
 msgstr "La visualizzazione con quell'identificatore è già registrata"
 
-#: frontend/src/metabase/visualizations/index.js:71
+#: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
 msgstr "Nessuna visualizzazione per {0}"
 
@@ -6701,23 +6725,23 @@ msgid "Doh! The data from your query doesn't fit the chosen display choice. This
 msgstr "Mannaggia! I dati della tua query non ci stanno nella modalità di visualizzazione scelta. La visualizzazione richiede almeno {0} {1} di dati,"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:9
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:117
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:120
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:161
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:169
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:249
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:267
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "colonna"
@@ -6828,83 +6852,83 @@ msgstr "Niente"
 msgid "Linear Interpolated"
 msgstr "Interpolato lineare"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
 msgstr "Scala dell'asse-X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
 msgstr "Serie temporali"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:454
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
 msgid "Linear"
 msgstr "Lineare"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
 msgid "Power"
 msgstr "Esponente"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:428
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:445
 msgid "Log"
 msgstr "Log"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:441
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:430
 msgid "Histogram"
 msgstr "Istogramma"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
 msgstr "Ordinale"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
 msgstr "scala asse Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:462
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
 msgstr "Mostra linea e punti sull'asse X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:360
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:468
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:349
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
 msgid "Compact"
 msgstr "Compatta"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:469
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
 msgid "Rotate 45°"
 msgstr "Ruota di 45°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:459
 msgid "Rotate 90°"
 msgstr "Ruota di 90°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
 msgid "Show y-axis line and marks"
 msgstr "Mostra linea e punti sull'asse X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:489
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Auto y-axis range"
 msgstr "Auto range l'asse Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:533
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:522
 msgid "Use a split y-axis when necessary"
 msgstr "Dividi l'asse Y quando necessario"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:540
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:529
 msgid "Show label on x-axis"
 msgstr "Mostra etichetta sul asse X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:546
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:535
 msgid "X-axis label"
 msgstr "Etichetta asse X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:555
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:544
 msgid "Show label on y-axis"
 msgstr "Mostra etichetta sul asse Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:561
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:550
 msgid "Y-axis label"
 msgstr "Etichetta asse Y"
 
@@ -7030,23 +7054,23 @@ msgstr "Opacità minima"
 msgid "Max Zoom"
 msgstr "Max Zoom"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:231
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:234
 msgid "No relationships found."
 msgstr "Nessuna relazione trovata"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:269
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:272
 msgid "via {0}"
 msgstr "via {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:347
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
 msgid "This {0} is connected to:"
 msgstr "Questo {0} è connesso a:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "Object Detail"
 msgstr "Dettagli oggetto"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:93
 msgid "object"
 msgstr "oggetto"
 
@@ -7435,7 +7459,7 @@ msgstr "Hai molte Question salvate in {0}? Crea collezioni per aiutare a gestirl
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:149 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -7489,8 +7513,8 @@ msgstr[1] "Ore"
 #: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
-msgstr[0] "Quadrimestre"
-msgstr[1] "Quadrimestri"
+msgstr[0] "Trimestre"
+msgstr[1] "Trimestri"
 
 #: src/metabase/api/table.clj
 msgid "Minute of Hour"
@@ -7522,7 +7546,7 @@ msgstr "Mese dell'anno"
 
 #: src/metabase/api/table.clj
 msgid "Quarter of Year"
-msgstr "Quadrimestre dell'anno"
+msgstr "Trimestre dell'anno"
 
 #: src/metabase/api/table.clj
 msgid "10 bins"
@@ -8954,19 +8978,19 @@ msgstr "Puoi modificare questa raccolta e i suoi contenuti"
 msgid "Can view items in this collection"
 msgstr "Può visualizzare gli elementi in questa raccolta"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:767
+#: frontend/src/metabase/admin/permissions/selectors.js:765
 msgid "Collection Access"
 msgstr "Accesso alla raccolta"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:841
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Questo gruppo ha il permesso di vedere almeno una sottoraccolta di questa raccolta."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:848
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Questo gruppo ha il permesso di modificare almeno una sottoraccolta di questa raccolta."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:861
+#: frontend/src/metabase/admin/permissions/selectors.js:859
 msgid "View sub-collections"
 msgstr "Visualizza sotto-raccolte"
 
@@ -8974,7 +8998,7 @@ msgstr "Visualizza sotto-raccolte"
 msgid "Remember Me"
 msgstr "Ricordami"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:63
+#: frontend/src/metabase/components/BrowseApp.jsx:73
 msgid "X-ray this schema"
 msgstr "Raggi X di questo schema"
 
@@ -9035,15 +9059,15 @@ msgstr "Metabase non può trovare nessun risultato per la tua ricerca."
 msgid "No metrics"
 msgstr "Nessuna metrica presente"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:31
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:41
 msgid "Aggregations"
 msgstr "aggregazioni"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:32
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:42
 msgid "Operators"
 msgstr "operatori"
 
-#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:30
+#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:35
 msgid "Custom fields"
 msgstr "campi personalizzati"
 
@@ -9210,7 +9234,7 @@ msgstr "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
 msgid "toucan_sightings"
 msgstr "toucan_sightings"
 
-#: src/metabase/driver/sparksql.clj
+#: src/metabase/models/collection.clj
 msgid "default"
 msgstr "predefinito"
 
@@ -9238,10 +9262,10 @@ msgstr "N/A"
 msgid "Windows domain"
 msgstr "dominio Windows"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:539
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:545
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:554
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:560
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:528
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:534
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:543
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
 msgstr "Etichette"
 
@@ -9276,9 +9300,9 @@ msgstr "Condividi"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:286
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:294
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:302
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:319
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:324
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
@@ -9293,19 +9317,18 @@ msgstr "Condividi"
 msgid "Display"
 msgstr "Display"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:461
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:476
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:502
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:532
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:402
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:465
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:483
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:521
 msgid "Axes"
 msgstr "Assi"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:212
-#: frontend/src/metabase/admin/settings/selectors.js:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:219
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:62
 msgid "Formatting"
@@ -9339,7 +9362,7 @@ msgstr "Raggi-X"
 msgid "Compare to the rest"
 msgstr "Confronta con il resto"
 
-#: frontend/src/metabase/entities/databases/forms.js:16
+#: frontend/src/metabase/entities/databases/forms.js:18
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Usa la timezone di Java Virtual Machine (JVM)"
 
@@ -9368,24 +9391,24 @@ msgstr "Usa Il Time Zone di JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Stiamo analizzando le tabelle e i campi per aiutarti a esplorare i tuoi dati."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
 msgid "Tip: "
 msgstr "Suggerimento: "
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:237
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
 msgstr "Seleziona un tipo di valuta"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:300
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
 msgid "Field Type"
 msgstr "Tipo Campo"
 
-#: frontend/src/metabase/admin/routes.jsx:113
+#: frontend/src/metabase/admin/routes.jsx:118
 #: frontend/src/metabase/nav/containers/Navbar.jsx:267
 msgid "Troubleshooting"
 msgstr "Risoluzione Problemi"
 
-#: frontend/src/metabase/admin/settings/selectors.js:103
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Enable X-ray features"
 msgstr "Abilita funzioni raggi X"
 
@@ -9430,7 +9453,7 @@ msgstr "Durata (ms)"
 msgid "Currency"
 msgstr "Valuta"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
 msgstr "Scegli un utente o un canale..."
 
@@ -9578,7 +9601,7 @@ msgstr "Stile della linea"
 msgid "Show dots on lines"
 msgstr "Mostra i punti sulla linea"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:348
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
@@ -9592,7 +9615,7 @@ msgstr "Quale asse?"
 msgid "Line + Bar"
 msgstr "Linea + Barra"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
 msgid "line and bar chart"
 msgstr "Grafico a barre e linea"
 
@@ -9738,7 +9761,7 @@ msgstr "mese"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "quarter"
-msgstr "quarto"
+msgstr "trimestre"
 
 #: src/metabase/automagic_dashboards/populate.clj
 msgid "Adding {0} cards to dashboard {1}:n{2}"
@@ -10068,7 +10091,7 @@ msgstr "Creato il, per giorno della settimana"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by quarter of the year"
-msgstr "Creato il, per quarto di anno"
+msgstr "Creato il, per trimestre di anno"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per country"
@@ -10387,7 +10410,7 @@ msgstr "[[this]] per [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Quarters when [[this.short-name]] were added"
-msgstr "Quarti quando [[this.short-name]] sono stati aggiunti"
+msgstr "Trimestri quando [[this.short-name]] sono stati aggiunti"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
@@ -10622,7 +10645,7 @@ msgstr "Una panoramica del tuo dato [[this]] da Google Analytics"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Quarters when [[this.short-name]] joined"
-msgstr "Quarti quando [[this.short-name]] si è unito"
+msgstr "Trimestri quando [[this.short-name]] si è unito"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "New [[this.short-name]] in the last 30 days"
@@ -11039,7 +11062,7 @@ msgstr "Come questa metrica è distribuira attraverso numeri differenti"
 msgid "Sessions by page where the session began"
 msgstr "Sessioni per pagina in cui è iniziata la sessione"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:503
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -11408,7 +11431,7 @@ msgstr "Duplica questo elemento"
 msgid "Archive this item"
 msgstr "Archivia questo elemento"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:331
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:325
 msgid "Duplicate dashboard"
 msgstr "Duplica dashboard"
 
@@ -11513,7 +11536,7 @@ msgid_plural "Quarters of year"
 msgstr[0] "Trimestre dell'anno"
 msgstr[1] "Trimestri dell'anno"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
@@ -11529,8 +11552,8 @@ msgstr "[Q]Q"
 msgid "This"
 msgstr "Questo"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:97
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:137
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:136
 msgid "Invalid"
 msgstr "Invalido"
 
@@ -12294,6 +12317,7 @@ msgstr "Ecco le tue {0} carte più recenti:"
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
 msgstr "Potresti essere un po' più specifico o usare l'ID? Ho trovato queste carte con nomi corrispondenti:"
 
+#: src/metabase/driver/common/parameters/values.clj
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
 msgstr "Scheda {0} non trovata."
@@ -12402,11 +12426,11 @@ msgstr "Istruzione per mancata accensione"
 msgid "Archive this?"
 msgstr "Archiviare?"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:243
+#: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
 msgstr "Impara dai nostri dati"
 
-#: frontend/src/metabase/entities/databases/forms.js:20
+#: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
 msgstr "usa DNS SRV quando ti connetti"
 
@@ -12416,7 +12440,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "L'utilizzo di questa opzione richiede che l'host fornito sia un nome di dominio completo. Se ci si connette a un cluster Atlas, potrebbe essere necessario abilitare questa opzione. Se non sai cosa significa, lascialo disabilitato."
 
-#: frontend/src/metabase/entities/databases/forms.js:204
+#: frontend/src/metabase/entities/databases/forms.js:273
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Esegui automaticamente query quando esegui semplici filtri e riepiloghi"
 
@@ -12440,11 +12464,11 @@ msgstr "Tutti i risultati"
 msgid "Our Analytics"
 msgstr "La nostra analisi"
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:513
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
 msgstr "Somma additiva di tutti i valori di una colonna. \\ne.x. entrate totali nel tempo."
 
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
 msgstr "Conteggio additivo di tutti i valori di una riga. \\ne.x. numero totale di vendite nel tempo."
 
@@ -12454,7 +12478,7 @@ msgstr "Conteggio additivo di tutti i valori di una riga. \\ne.x. numero totale 
 msgid "Filter"
 msgstr "Filtro"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:50
 msgid "record"
 msgid_plural "records"
 msgstr[0] "record"
@@ -12468,27 +12492,27 @@ msgstr "Sfoglia i dati"
 msgid "Write SQL"
 msgstr "Scrivi SQL"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:83
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
 msgstr "Domanda semplice"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:84
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:87
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
 msgstr "Raccogli qualche dato, guardalo, e filtra, riepilogalo e visualizzalo facilemnte"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:95
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:98
 msgid "Custom question"
-msgstr "`question` personalizzata"
+msgstr "Domanda personalizzata"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:96
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:99
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Usa l'editor avanzato per notebook per unire i dati, creare colonne personalizzate, fare matematica e altro."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Basic Metrics"
 msgstr "Metriche di base"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:322
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
 msgid "Custom…"
 msgstr "Personalizzato... "
 
@@ -12557,15 +12581,15 @@ msgstr "Scegli la colonna da raggruppare "
 msgid "Pick your starting data"
 msgstr "Scegli una data d'inizio"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select None"
 msgstr "Seleziona nula"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select All"
 msgstr "Seleziona tutto"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:151
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:152
 msgid "Pick a table..."
 msgstr "Scegli una tabela"
 
@@ -12603,7 +12627,7 @@ msgstr "Converti questi domande a SQL"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
 msgid "Get alerts"
-msgstr "Ricevi alerti"
+msgstr "Ricevi avvisi"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
 msgid "{0} breakout"
@@ -12688,15 +12712,15 @@ msgstr "Aggiungi una metrica"
 #: frontend/src/metabase/lib/core.js:137 frontend/src/metabase/lib/core.js:142
 #: frontend/src/metabase/lib/core.js:147 frontend/src/metabase/lib/core.js:152
 #: frontend/src/metabase/lib/core.js:157 frontend/src/metabase/lib/core.js:162
-#: frontend/src/metabase/user/components/UserSettings.jsx:63
+#: frontend/src/metabase/user/components/UserSettings.jsx:64
 msgid "Profile"
 msgstr "Profilo"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:560
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "Questo di solito è piuttosto veloce ma sembra richiedere del tempo proprio ora."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
 msgid "Combo"
 msgstr "Combo"
 
@@ -12712,11 +12736,11 @@ msgstr "Tendenza "
 msgid "Boolean"
 msgstr "Booleano"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:62
 msgid "Unknown Segment"
 msgstr "Segmento sconosciuto"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:73
 msgid "Unknown Filter"
 msgstr "Filtro sconosciuto "
 
@@ -12846,6 +12870,7 @@ msgstr "Usare il classloader APPENA CREATO per contesto condiviso: {0} "
 msgid "Failed to copy file"
 msgstr "Impossibile copiare il file"
 
+#. check that the URL is valid
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
 msgstr "Url non valido: {0}"
@@ -13113,14 +13138,14 @@ msgstr "Scheduling dei task per il Database {0} non riuscita"
 
 #: src/metabase/util/schema.clj
 msgid "All elements must be distinct."
-msgstr "Tutti gli elementi devono essere distinti."
+msgstr "All elements must be distinct."
 
 #:
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Scegli le colonne che desideri includere"
 
-#: frontend/src/metabase/entities/databases/forms.js:205
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Quando questa opzione è attiva, Metabase eseguirà automaticamente query quando l'utente fa semplici esplorazioni con il bottone Riassunto e Filtri mentre osserva una tabella o un grafico. Puoi disattivarla se interrogare il database è lento. Questa impostazione non influisce sui drill-throughs o sulle query SQL."
 
@@ -13158,7 +13183,7 @@ msgstr "Errore nel determinare le colonne previste per la query"
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "Eccezione non gestita, previsto `catch-exception`middleware per gestirla."
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:125
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
 msgid "Diagnostic Info"
 msgstr "Informazioni Diagnostiche"
 
@@ -13182,11 +13207,11 @@ msgstr "Si è verificato un errore loggandosi tramite Google. Si prega di contat
 msgid "Sign in with email"
 msgstr "Loggati con email"
 
-#: frontend/src/metabase/entities/databases/forms.js:21
+#: frontend/src/metabase/entities/databases/forms.js:23
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "Usare questa opzione richiede che l'host fornito sia un FQDN. Se ti connetti ad un cluster Atlas, potresti aver bisogno di abilitare questa opzione. Se non sai cosa significa, lasciala disattivata."
 
-#: frontend/src/metabase/entities/databases/forms.js:213
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Di default, Metabase esegue una sincronizzazione oraria leggera e un'intensa scansione giornaliera dei valori dei campi. Se si dispone di un grande database, si consiglia di attivare questa opzione e rivedere quando e quanto spesso accadono le scansioni del valore del campo."
 
@@ -13254,11 +13279,11 @@ msgstr "Non includere"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "Questo campo non sarà visibile o selezionabile nelle domande create con le interfacce GUI. Sarà comunque accessibile nelle query SQL/native."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:512
 msgid "Cumulative sum"
 msgstr "Somma cumulativa"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Standard deviation"
 msgstr "Deviazione standard"
 
@@ -13270,23 +13295,23 @@ msgstr "deve essere almeno lunga {0} caratteri"
 msgid "Must be at least {0} characters long"
 msgstr "Deve essere almeno lunga {0} caratteri"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:389
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:82
 msgid "Name (required)"
 msgstr "Nome (obbligatorio)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:556
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
 msgid "Run selected text"
 msgstr "Esegui testo selezionato"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:557
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
 msgid "Run query"
 msgstr "Esegui query"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(⌘ + enter)"
 msgstr "(⌘ + invio)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + invio)"
 
@@ -13298,7 +13323,7 @@ msgstr "Qui è dove appariranno i tuoi risultati"
 msgid "You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question."
 msgstr "Non farai alcuna modifica permanente ad una domanda salvata a meno che non fai clic su Salva e scegli di sostituire la domanda originale."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:199
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:200
 msgid "There aren't any filter widgets for this type of field yet."
 msgstr "Non esiste ancora alcun widget filtro per questo tipo di campo."
 
@@ -13334,19 +13359,19 @@ msgstr "Linea obbiettivo"
 msgid "Trend line"
 msgstr "Linea tendenza"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:320
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:317
 msgid "Show values on data points"
 msgstr "Mostra i valori sui data points"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:334
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:325
 msgid "Values to show"
 msgstr "Valori da mostrare"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:342
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:332
 msgid "As many as can fit nicely"
 msgstr "Quanti più si adattano bene"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:343
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
 msgid "All"
 msgstr "Tutti"
 
@@ -13638,31 +13663,31 @@ msgstr "Numeri"
 msgid "No mappable groups"
 msgstr "Nessun gruppo mappabile"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:107
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
 msgstr "Documentazione Metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
 msgstr "Contiene una guida di risoluzione dei problemi"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:112
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
 msgid "Post on the Metabase support forum"
 msgstr "Posta sul forum di supporto di Metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:114
 msgid "A community forum for all things Metabase"
 msgstr "Un forum comunitario per tutte le cose di Metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:117
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
 msgid "File a bug report"
 msgstr "Invia un file di bug report"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:119
 msgid "Create a GitHub issue (includes the diagnostic info below)"
 msgstr "Crea una issue su GitHub (includendo le informazioni di diagnostica riportate sotto)"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:127
 msgid "Please include these details in support requests. Thank you!"
 msgstr "Si prega di includere questi dettagli nelle richieste di supporto. Grazie!"
 
@@ -13690,38 +13715,40 @@ msgstr "Nessuna corrispondenza"
 msgid "Submit"
 msgstr "Invia"
 
-#: frontend/src/metabase/entities/databases/forms.js:13
+#: frontend/src/metabase/entities/databases/forms.js:15
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host. This option also provides an extra layer of security when a VPN is not available. Enabling this is usually slower than a direct connection."
 msgstr "Alcune installazioni di database sono accessibili solo collegandosi tramite un host SSH bastion. Questa opzione fornisce anche un ulteriore livello di sicurezza quando una VPN non è disponibile. Abilitarla è di solito più lenta di una connessione diretta."
 
-#: frontend/src/metabase/entities/databases/forms.js:17
+#: frontend/src/metabase/entities/databases/forms.js:19
 msgid "We suggest you leave this off unless you're doing manual timezone casting in many or most of your queries with this data."
 msgstr "Vi suggeriamo di lasciare disattivata questa opzione a meno che non si sta facendo il fuso orario manuale in molti o nella maggior parte delle vostre domande con questi dati."
 
-#: frontend/src/metabase/entities/databases/forms.js:93
+#: frontend/src/metabase/entities/databases/forms.js:128
 msgid "{0} to get an auth code."
 msgstr "{0} per ottenere un auth code"
 
-#: frontend/src/metabase/entities/databases/forms.js:101
+#: frontend/src/metabase/entities/databases/forms.js:136
+#: src/metabase/models/collection.clj
 msgid "or"
 msgstr "o"
 
-#: frontend/src/metabase/entities/databases/forms.js:159
-#: frontend/src/metabase/entities/databases/forms.js:197
-#: frontend/src/metabase/entities/users/forms.js:44
+#: frontend/src/metabase/entities/databases/forms.js:39
+#: frontend/src/metabase/entities/databases/forms.js:226
+#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "richiesto"
 
-#: frontend/src/metabase/entities/databases/forms.js:188
+#: frontend/src/metabase/entities/databases/forms.js:257
 msgid "Database type"
 msgstr "Tipo database"
 
-#: frontend/src/metabase/entities/databases/forms.js:222
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Questo è un processo leggero che controlla la presenza di aggiornamenti dello schema di questo database. Nella maggior parte dei casi, sarebbe bene lasciare questo settaggio per sincronizzare ogni ora."
 
-#: frontend/src/metabase/entities/databases/forms.js:230
+#: frontend/src/metabase/entities/databases/forms.js:299
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase può scansire i valori presenti in questo campo di questo database per abilitare i filtri checkbox nelle dashboard e nelle query. Questo può essere un processo ad alta intensità di risorse, in particolare se si dispone di un database molto ampio."
 
@@ -13729,15 +13756,15 @@ msgstr "Metabase può scansire i valori presenti in questo campo di questo datab
 msgid "Collection"
 msgstr "Collezione"
 
-#: frontend/src/metabase/entities/users/forms.js:40
+#: frontend/src/metabase/entities/users/forms.js:55
 msgid "Confirm your password"
 msgstr "Conferma la tua password"
 
-#: frontend/src/metabase/entities/users/forms.js:45
+#: frontend/src/metabase/entities/users/forms.js:60
 msgid "passwords do not match"
 msgstr "le password non corrispondono"
 
-#: frontend/src/metabase/entities/users/forms.js:71
+#: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
 msgstr "Dipartimento del Fantastico"
 
@@ -13777,328 +13804,324 @@ msgid "Returns the average of the values in the column."
 msgstr "Ritorna la media dei valori nella colonna."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:18
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
 msgid "The column whose values to average."
 msgstr "La colonna i cui valori medi."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "start"
 msgstr "inizio"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "end"
 msgstr "fine"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
 msgid "Checks a date or numeric column's values to see if they're within the specified range."
 msgstr "Controlla il valore di una colonna con date o numeri per controllare se i valori sono dentro un range specifico."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
 msgstr "Rating"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:24
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:98
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
 msgid "condition"
 msgstr "condizione"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
 msgid "output"
 msgstr "output"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Testa una lista di casi e ritorna il valore della prima corrispondenza, con un valore di default opzionale nel caso non si trovino corrispondenze."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
 msgid "Weight"
 msgstr "Peso"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
 msgid "Large"
 msgstr "Grande"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
 msgid "Medium"
 msgstr "Medio"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
 msgid "Small"
 msgstr "Piccolo"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
 msgid "Something that should evaluate to true or false."
 msgstr "Qualcosa che possa essere espressa come vera o falsa."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:54
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "Il valore che verrà restituito se la condizione precedente è vera."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:62
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "value1"
 msgstr "valore1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:74
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
 msgid "value2"
 msgstr "valore2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Esamina i valori di ogni argomento in ordine e restituisce il primo valore non nullo per ogni riga."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:56
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
 msgid "Comments"
 msgstr "Commenti"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
 msgid "Notes"
 msgstr "Note"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
 msgid "No comments"
 msgstr "Nessun commento"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
 msgid "A column or value."
 msgstr "Una colonna o un valore."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:65
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:77
 msgid "If value1 is empty, value2 gets returned if it's not empty, and so on."
 msgstr "Se valore1 è vuoto, valore2 viene restituito e così via."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 msgid "Combines two or more strings of text together."
 msgstr "Combina due o più stringhe di testo assieme."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
 msgid "Last Name"
 msgstr "Cognome"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 msgid "First Name"
 msgstr "Nome"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
 msgstr "valore2 verrà aggiunto alla fine di questo."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
 msgstr "Questo verrà aggiunto alla fine del valore1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
 msgid "string1"
 msgstr "stringa1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
 msgid "string2"
 msgstr "stringa2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:80
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Verifica se stringa1 contiene al suo interno stringa2."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:284
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
 msgid "Status"
 msgstr "Stato"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 msgid "Pass"
 msgstr "Approvare"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
 msgstr "Il contenuto di questa stringa sarà oggetto di verifica."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
 msgid "The string of text to look for."
 msgstr "La stringa del testo da cercare."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:90
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:116
 msgid "Returns the count of rows in the source data."
 msgstr "Ritorna il numero di righe nei dati sorgente."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Only counts rows where the condition is true."
 msgstr "Conta solo le righe dove la condizione è vera."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:97
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:261
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
 msgid "Subtotal"
 msgstr "Subtotale"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
 msgid "The additive total of rows across a breakout."
 msgstr "L'additivo totale di righe attraverso un breakout."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:110
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
 msgid "The rolling sum of a column across a breakout."
 msgstr "La somma progressiva di una colonna attraverso un breakout."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:113
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:268
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
 msgstr "La colonna da sommare."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
 msgid "The number of distinct values in this column."
 msgstr "Il numero di valori distinti in questa colonna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "The column whose distinct values to count."
 msgstr "La colonna di cui contare i valori distinti."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:128
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:145
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:153
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:201
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:274
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
 msgid "text"
 msgstr "testo"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:130
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:223
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
 msgid "comparison"
 msgstr "comparazione"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Ritorna vero se la fine del testo corrisponde al testo di comparazione."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "Appetite"
 msgstr "Appetito"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "hungry"
 msgstr "affamato"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 msgid "A column or string of text to check."
 msgstr "Una colonna o stringa di testo da verificare."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
 msgid "The string of text that the original text should end with."
 msgstr "La stringa di testo con cui dovrebbe terminare il testo originale."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 msgid "regular_expression"
 msgstr "regular_expression"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:136
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Estrae le sottostringhe corrispondenti secondo un'espressione regolare."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:137
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
 msgid "Address"
 msgstr "Indirizzo"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 msgid "The column or string of text to search though."
 msgstr "La colonna o la stringa di testo da cercare."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
 msgid "The regular expression to match."
 msgstr "L'espressione regolare da corrispondere."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the string of text in all lowercase."
 msgstr "Ritorna la stringa di testa in minuscolo."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:149
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to lowercase."
 msgstr "La colonna con i valori da convertire in minuscolo."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:154
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 msgid "Removes leading whitespace from a string of text."
 msgstr "Rimuove lo spazio bianco iniziale da una stringa di testo."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:157
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column with values you want to trim."
 msgstr "La colonna con i valori su cui vuoi effettuare il trim."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "Returns the largest value found in the column."
 msgstr "Ritorna il valore maggiore trovato nella colonna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
 msgid "Age"
 msgstr "Età"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:165
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
 msgid "The numeric column whose maximum you want to find."
 msgstr "La colonna numerica di cui vuoi trovare il massimo."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:170
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "Returns the smallest value found in the column."
 msgstr "Ritorna il valore minore trovato nella colonna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
 msgid "Salary"
 msgstr "Salario"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:173
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
 msgid "The numeric column whose minimum you want to find."
 msgstr "La colonna numerica di cui vuoi trovare il minimo."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:181
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:242
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
 msgid "position"
 msgstr "posizione"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:194
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
 msgid "length"
 msgstr "lunghezza"
 
@@ -14107,7 +14130,7 @@ msgstr "lunghezza"
 msgid "new_text"
 msgstr "nuovo_testo"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:187
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
 msgid "Replaces a part of the input text with new text."
 msgstr "Sostituisce una parte del testo in input con il nuovo testo."
 
@@ -14119,7 +14142,7 @@ msgstr "ID Ordine"
 msgid "Updated Part of ID"
 msgstr "Parte dell'ID aggiornata"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
 msgid "The text that will be modified."
 msgstr "Il testo che verrà modificato."
 
@@ -14135,87 +14158,87 @@ msgstr "Il numero di caratteri da sostituire."
 msgid "The text to use in the replacement."
 msgstr "Il testo da usare in sostituzione"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Rimuove lo spazio bianco da una stringa di testo."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:210
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Restituisce la percentuale di righe nei dati che corrispondono alla condizione, sottoforma di decimale."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:218
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Restituisce vero se l'inizio del testo corrisponde al testo di confronto."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Course Name"
 msgstr "Nome Corso"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Computer Science"
 msgstr "Scienze Informatiche"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
 msgid "The string of text that the original text should start with."
 msgstr "La stringa di testo con cui dovrebbe cominciare il testo originale."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:229
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
 msgid "Calculates the standard deviation of the column."
 msgstr "Calcola la deviazione standard della colonna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:230
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
 msgid "Population"
 msgstr "Popolazione"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
 msgid "A numeric column."
 msgstr "Una colona numerica."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
 msgid "Returns a portion of the supplied text."
 msgstr "Ritorna una porzione del testo sottoposto."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:241
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:313
 msgid "The text to return a portion of."
 msgstr "Il testo di cui ritornare una porzione."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
 msgid "The position to start copying characters."
 msgstr "La posizione da cui iniziare a copiare i caratteri."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:245
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
 msgid "The number of characters to return."
 msgstr "Il numero di caratteri da ritornare."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
 msgid "Adds up all the values of the column."
 msgstr "Aggiunge tutti i valori della colonna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:253
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
 msgid "The numeric column to sum."
 msgstr "La colonna numerica da sommare"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Somma i valori in una colonna dove le righe corrispondono alla condizione."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
 msgid "Order Status"
 msgstr "Stato Ordine"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
 msgid "Valid"
 msgstr "Valido"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Rimuove spazi bianchi iniziali e finali da una stringa di testo."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
 msgid "Returns the string of text in all upper case."
 msgstr "Ritorna la stringa di testo con tutte lettere maiuscole."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
 msgid "The column with values to convert to upper case."
 msgstr "La colonna i cui valori sono da convertire in maiuscoli."
 
@@ -14275,41 +14298,41 @@ msgstr "Grazie per utilizzare Metabase!"
 
 #: frontend/src/metabase/public/components/LogoBadge.jsx:20
 msgid "Powered by {0}"
-msgstr "Offerto da {0}"
+msgstr "Powered by {0}"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:191
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
 msgid "To:"
 msgstr "A:"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:40
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
 msgstr "Questa domanda non può essere utilizzata perché si basa su di un database differente."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:44
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:43
 msgid "Couldn't find a saved question with that ID number."
 msgstr "Non è stato possibile trovare una domanda salvata con questo numero ID."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:55
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:54
 msgid "Pick a saved question"
 msgstr "Scegli una domanda salvata"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:57
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:56
 msgid "Pick a different question"
 msgstr "Scegli una domanda differente"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:62
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:61
 msgid "Loading…"
 msgstr "Caricamento..."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:79
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:78
 msgid "Question #…"
 msgstr "Domanda #..."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:81
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
 msgstr "Domanda #{0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:115
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
 msgstr "Ultima modifica {0}"
 
@@ -14321,11 +14344,11 @@ msgstr "{0} crea una variabile in questo modello di query chiamata \"variable_na
 msgid "Giving a variable the \"Field Filter\" type allows you to link questions to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "Dare a una variabile del tipo \"Filtro Campo\" consente di collegare le domande a widget filtro dashboard o utilizzare più tipi di widget filtro sulla vostra domanda SQL. Una variabile Filtro Campo inserisce SQL simile a quella generata dal costruttore di query GUI quando si aggiungono filtri su colonne esistenti."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:131
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
 msgstr "Nome variabile"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:217
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:218
 msgid "Filter widget label"
 msgstr "Etichetta widget filtro"
 
@@ -14357,17 +14380,18 @@ msgstr "Nell'intestazione colonna"
 msgid "In every table cell"
 msgstr "In ogni cella della tabella"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:351
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:341
 msgid "Value formatting"
 msgstr "Formattazione del valore"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:361
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
 msgid "Full"
 msgstr "Pieno"
 
+#. nella versione v.0.35 questa traduzione non funziona
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
 msgid "No change from last {0}"
-msgstr "Nessun cambiamento dall'ultimo {0}"
+msgstr "Non variato rispetto al {0} precedente."
 
 #: src/metabase/api/database.clj
 msgid "Connection to ''{0}:{1}'' successful, but could not connect to DB."
@@ -14518,7 +14542,7 @@ msgstr "Errore durante l'impostazione della connessione solo lettura"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting default holdability for connection"
-msgstr "Errore impostando la holdability predefinita per la connessione"
+msgstr "Errore impostando di default il \"set hold\" per la connessione"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting result set fetch direction to FETCH_FORWARD"
@@ -14620,7 +14644,7 @@ msgstr "Risultati memorizzati nella cache per la query."
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Query took {0} to run; miminum for cache eligibility is {1}"
-msgstr "La quary ci ha messo {0} per essere eseguita; il minimo idoneo per la cache è {1}"
+msgstr "La query ci ha messo {0} per essere eseguita; il minimo idoneo per la cache è {1}"
 
 #: src/metabase/query_processor/middleware/cache/impl.clj
 msgid "Results are too large to cache."
@@ -14689,3 +14713,483 @@ msgstr "Errore durante la generazione dell'approfondimento della colonnna:"
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandonment email!"
 msgstr "Sto inviando l'email di abbandono!"
+
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
+msgstr "È possibile creare metriche salvate per aggiungere un'opzione metrica denominata. Le metriche salvate includono il tipo di aggregazione, il campo aggregato e, opzionalmente, qualsiasi filtro aggiunto. Come esempio, si potrebbe usare questo per creare qualcosa di simile ad un modo ufficiale di calcolare il \"Prezzo medio\" per una tabella degli ordini."
+
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:105
+msgid "Select and add filters to create your new segment."
+msgstr "Selezione e aggiungi i filtri per creare il tuo nuovo segmento."
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+msgid "Alphabetical"
+msgstr "Alfabetico"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+msgid "Smart"
+msgstr "Smart"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+msgid "Column order: {0}"
+msgstr "Ordine colonna: {0}"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
+msgid "Unhide all"
+msgstr "Mostra tutto"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:204
+msgid "Hide all"
+msgstr "Nascondi tutto"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:206
+msgid "Unhide"
+msgstr "Mostra"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:22
+msgid "New metric"
+msgstr "Nuova metrica"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:45
+msgid "Create metrics to add them to the Summarize dropdown in the query builder"
+msgstr "Crea metriche per aggiungerle al menu a tendina Riassumere del costruttore delle query"
+
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:22
+msgid "New segment"
+msgstr "Nuovo segmento"
+
+#: frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx:71
+msgid "Filter by table"
+msgstr "Filtra per tabella"
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:64
+msgid "Checking HTTPS..."
+msgstr "Controllo HTTPS..."
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:66
+msgid "It looks like HTTPS is not properly configured"
+msgstr "Sembra che l'HTTPS non sia configurato correttamente"
+
+#: frontend/src/metabase/admin/settings/selectors.js:57
+msgid "Redirect to HTTPS"
+msgstr "Redirect verso HTTPS"
+
+#: frontend/src/metabase/admin/settings/selectors.js:219
+msgid "Localization"
+msgstr "Localizzazione"
+
+#: frontend/src/metabase/admin/settings/selectors.js:222
+msgid "Instance language"
+msgstr "Lingua d'istanza"
+
+#: frontend/src/metabase/admin/settings/selectors.js:237
+msgid "Localization options"
+msgstr "Opzioni di Localizzazione"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:51
+msgid "This database doesn't have any tables."
+msgstr "Questo database non ha tabelle."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
+msgid "This field only accepts a single value because it's used in a SQL query."
+msgstr "Questo campo accetta un valor singolo in quanto è utilizzato in una query SQL."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:17
+msgid "Service Accounts"
+msgstr "Account di servizio"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:26
+msgid "Metabase connects to Big Query via {0}."
+msgstr "Metabase si collega a Big Query con {0}."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:29
+msgid "Continue using an OAuth application to connect"
+msgstr "Prosegui con un'applicazione OAuth per connetterti"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:43
+msgid "We recommend switching to use {0} instead of an OAuth application to connect to BigQuery"
+msgstr "Raccomandiamo di usare {0} invece di un' applicazione OAuth per collegarsi a BigQuery"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:48
+msgid "Connect to a Service Account instead"
+msgstr "Collegati invece a un Account di Servizio"
+
+#: frontend/src/metabase/entities/databases/forms.js:44
+msgid "invalid JSON"
+msgstr "JSON invalido"
+
+#: frontend/src/metabase/entities/databases/forms.js:50
+msgid "SSH private key"
+msgstr "Chiave privata SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:51
+msgid "Paste the contents of your ssh private key here"
+msgstr "Incolla qui il contenuto della tua chiave privata SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:55
+msgid "Passphrase for the SSH private key"
+msgstr "Passphrase per la chiave privata SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:58
+msgid "SSH Authentication"
+msgstr "autenticazione SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:60
+msgid "SSH Key"
+msgstr "chiave SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:65
+msgid "Server SSL certificate chain"
+msgstr "Certificate chain per il server SSL"
+
+#: frontend/src/metabase/entities/databases/forms.js:66
+msgid "Paste the contents of the server's SSL certificate chain here"
+msgstr "Incolla qui il contenuto del certificate chain del server SSL"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:11
+msgid "Paste a connection string"
+msgstr "Incolla la stringa di connessione"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:12
+msgid "Fill out individual fields"
+msgstr "Compilare i singoli campi"
+
+#: frontend/src/metabase/entities/snippets.js:14
+msgid "Enter some SQL here so you can reuse it later"
+msgstr "Inserisci qui del codice SQL che puoi riutilizzare in seguito"
+
+#: frontend/src/metabase/entities/snippets.js:24
+msgid "Give your snippet a name"
+msgstr "Dai un nome al tuo snippet"
+
+#: frontend/src/metabase/entities/snippets.js:25
+msgid "Current Customers"
+msgstr "Clienti Attuali"
+
+#: frontend/src/metabase/entities/snippets.js:30
+msgid "Add a description"
+msgstr "Aggiungi una descrizione"
+
+#: frontend/src/metabase/entities/users/forms.js:37
+msgid "Use site default"
+msgstr "Usa i default del sito"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+msgid "find"
+msgstr "trova"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+msgid "replace"
+msgstr "sostituisci"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+msgid "The text to find."
+msgstr "Il testo da cercare."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "The text to use as the replacement."
+msgstr "Il testo con cui sostituire."
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+msgid "Editing {0}"
+msgstr "Modificando {0}"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+msgid "Create your new snippet"
+msgstr "Crea il tuo nuovo snippet"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+msgid "Archived snippets"
+msgstr "Snippet Archiaviati"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+msgid "Snippets are reusable bits of SQL"
+msgstr "Gli snippet sono pezzi di SQL riutilizzabili"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+msgid "Create a snippet"
+msgstr "Crea uno snippet"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+msgid "Snippets"
+msgstr "Snippet"
+
+#: frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx:15
+msgid "SQL Snippets"
+msgstr "Snippet SQL"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:38
+msgid "Your language is set to {0}"
+msgstr "La tua lingua è impostata su {0}"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:50
+msgid "What's your preferred language?"
+msgstr "Qual è la tua lingua preferita?"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:54
+msgid "This language will be used throughout Metabase and will be the default for new users."
+msgstr "Questa lingua verrà utilizzata in Metabase è sarà il default per i nuovi utenti."
+
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:159
+msgid "We filtered out {0} row(s) containing null values."
+msgstr "Abbiamo filtrato {0} riga/righe contenenti valori null."
+
+#: frontend/src/metabase/visualizations/lib/settings/series.js:133
+msgid "Show values for this series"
+msgstr "Mostra i valori per queste serie"
+
+#: src/metabase/api/card.clj
+msgid "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
+msgstr "Il tempo medio di esecuzione della query è {0}; usando \"magic\" TTL di {1}"
+
+#: src/metabase/api/native_query_snippet.clj
+msgid "A snippet with that name already exists. Please pick a different name."
+msgstr "Esiste già uno snippet con questo nome. Scegli un nome diverso per piacere."
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Metric]"
+msgstr "[Metrica Sconosciuta]"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Segment]"
+msgstr "[Segmento Sconosciuto]"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error writing error to output stream"
+msgstr "Errore di scrittura nel flusso di uscita"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Caught unexpected Exception in streaming response body"
+msgstr "Errore inaspettato nel corpo della risposta"
+
+#: src/metabase/async/streaming_response.clj
+msgid "bound-fn caught unexpected Exception"
+msgstr "Eccezione inaspettata della funzione bound"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error determining whether HTTP request was canceled"
+msgstr "Errore nel determinare se la richiesta HTTP è stata annullata"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Check cancelation status timed out after {0}"
+msgstr "time out del controllo annullamento dopo {0}"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Unexpected exception in do-f-async"
+msgstr "Eccezione non gestita in do-f-async"
+
+#: src/metabase/async/streaming_response.clj src/metabase/server.clj
+msgid "Unexpected exception writing error response"
+msgstr "Eccezione non gestita nella scrittura della risposta d'errore"
+
+#: src/metabase/driver/common.clj
+msgid "Server certificate not trusted - did you specify the correct SSL certificate chain?"
+msgstr "Certificato Server non affidabile - hai utilizzato la certificate chain SSL corretta?"
+
+#: src/metabase/driver/common.clj
+msgid "Server appears to require SSL - please enable SSL above"
+msgstr "Sembra che il server richieda SSL - per favore abilita SSL sopra"
+
+#: src/metabase/driver/common.clj
+msgid "Username"
+msgstr "Nome utente"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Don''t know how to parse parameter of type {0}"
+msgstr "Impossibile fare il parse del parametro di tipo {0}"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Invalid :card parameter: missing `:card-id`"
+msgstr ":card parameter: invalido. ':card-id' mancante"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Unable to resolve Snippet: missing `:snippet-id`"
+msgstr "Impossibile risolvere lo Snippet: ':snippet-id' mancante"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Snippet {0} {1} not found."
+msgstr "Snippet {0} {1} non trovato."
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error determining value for parameter"
+msgstr "Errore nel determinare il valore del parametro"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error building query parameter map"
+msgstr "Errore nella costruzione della mappa dei parametri query"
+
+#: src/metabase/middleware/log.clj
+msgid "ASYNC"
+msgstr "Asincrono"
+
+#: src/metabase/middleware/log.clj
+msgid "{0} ({1} DB calls)"
+msgstr "{0} ({1} Chiamate DB)"
+
+#: src/metabase/middleware/log.clj
+msgid "App DB connections: {0}/{1}"
+msgstr "Connessioni DB App: {0}/{1}"
+
+#: src/metabase/middleware/log.clj
+msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
+msgstr "Threads Jetty: {0}/{1} ({2} inattivo/i, {3} accodato/i)"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} total active threads)"
+msgstr "({0} thread attivi totale/i)"
+
+#: src/metabase/middleware/log.clj
+msgid "Queries in flight: {0}"
+msgstr "Query in partenza: {0}"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} queued)"
+msgstr "({0} accodato/i)"
+
+#: src/metabase/models/collection.clj
+msgid "Collection must be in the same namespace as its parent"
+msgstr "La Collection deve stare assieme alle altre Collection parenti"
+
+#: src/metabase/models/collection.clj
+msgid "Personal Collections must be in the default namespace"
+msgstr "Le Collection personali devono essere nello spazio di default"
+
+#: src/metabase/models/collection.clj
+msgid "You cannot move a Collection to a different namespace once it has been created."
+msgstr "Non puoi spostare una Collection in uno spazio differente una volta che è stata creata."
+
+#: src/metabase/models/collection.clj src/metabase/models/permissions.clj
+msgid "Collection does not exist."
+msgstr "La collezione non esiste."
+
+#: src/metabase/models/collection.clj
+msgid "A {0} can only go in Collections in the {1} namespace."
+msgstr "Un {0} può andare solo in Collezioni {1}"
+
+#: src/metabase/models/database.clj
+msgid "Error sending database deletion notification"
+msgstr "Errore invio notifica cancellazione database"
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "You cannot update the creator_id of a NativeQuerySnippet."
+msgstr "Non puoi aggiornare il creator_id di una NativeQuerySnippet"
+
+#: src/metabase/models/setting.clj
+msgid "Error fetching value of Setting"
+msgstr "Errore recupero Impostazione"
+
+#: src/metabase/public_settings.clj
+msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
+msgstr "Il linguaggio che verrà usato per l'interfaccia utente di Metabase, le e-mail di sistema, i pulses e gli alert."
+
+#: src/metabase/public_settings.clj
+msgid "This is also the default language for all users, which they can change from their own account settings."
+msgstr "Questa è anche la lingua di default per tutti gli utenti, la quale può essere cambiata dagli utenti nelle loro impostazioni account."
+
+#: src/metabase/public_settings.clj
+msgid "Invalid locale {0}"
+msgstr "Località non trovata {0}"
+
+#: src/metabase/public_settings.clj
+msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
+msgstr "Forza tutto il traffico a usare HTTPS con un redirect se il sito utilizza HTTPS"
+
+#: src/metabase/public_settings.clj
+msgid "Cannot redirect requests to HTTPS unless `site-url` is HTTPS."
+msgstr "Impossibile reindirizzare le richieste ad HTTPS finchè 'site-url' non è HTTPS"
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error registering fonts: Metabase will not be able to send Pulses."
+msgstr "Errore registrazione fonts: Metabase non potrà inviare i Pulse"
+
+#: src/metabase/pulse/render/png.clj
+msgid "This is a known issue with certain JVMs. See {0} and for more details."
+msgstr "Questo è un problema noto con alcune Macchine Virtuali Java (JVM). Vedi {0} per maggiori informazioni."
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error rendering Pulse"
+msgstr "Errore nel rendering del Pulse"
+
+#: src/metabase/query_processor/context/default.clj
+msgid "Query timed out after {0}, raising timeout exception."
+msgstr "Timeout query dopo {0}, eccezione timeout inviata"
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "No fields found for table {0}."
+msgstr "Non ci sono campi trovati per la tabella {0}."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Case"
+msgstr "Casistica"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Variance of {0}"
+msgstr "Variazione di {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Median of {0}"
+msgstr "Media di {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "{0}th percentile of {1}"
+msgstr "{0} percentile di {1}"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Not caching results: results are larger than {0} KB"
+msgstr "I risultati non saranno messi in cache: la dimensione dei risultati supera {0} KB"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Cannot cache results: expected byte array, got {0}"
+msgstr "Impossibile mettere in cache i risultati: atteso un array di bi byte, ottenuto {0}"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Request is closed; no one to return cached results to"
+msgstr "La richiesta è chiusa; Impossibile restituire la richiesta cache a qualcuno"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Error attempting to fetch cached results for query with hash {0}"
+msgstr "Errore nel tentativo di recupero dei dati cache per la query con hash {0}"
+
+#: src/metabase/query_processor/middleware/cache_backend/db.clj
+msgid "Error preparing statement to fetch cached query results"
+msgstr "Errore creazione dichiarazione per il recupero dei dati cache della query"
+
+#: src/metabase/query_processor/middleware/catch_exceptions.clj
+msgid "Error processing query: {0}"
+msgstr "Errore elaborazione query: {0}"
+
+#: src/metabase/server.clj
+msgid "Unexpected exception in endpoint"
+msgstr "Eccezione non gestita nella destinazione"
+
+#: src/metabase/server.clj
+msgid "Unexpected Exception in API request handler"
+msgstr "Eccezione non gestita nel gestore delle chiamate API"
+
+#: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+msgid "Error reducing {0}"
+msgstr "Errore nel ridurre {0}"
+
+#: src/metabase/sync/analyze/fingerprint/insights.clj
+msgid "Error generating timeseries insight keyed by: {0}"
+msgstr "Errore nella generazione delle serie temporali con chiave: {0}"
+
+#: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
+msgstr "La posizione {0} del database è cambiata da \"{1}\" a \"{2}\"."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Unscheduling task for Database {0}: trigger: {1}"
+msgstr "Rimuovere programmazione per Database {0}: evento: {1}"
+
+#: src/metabase/util/schema.clj
+msgid "value must be a keyword or string."
+msgstr "il valore deve essere una keyword o una stringa."
+
+#: src/metabase/util/schema.clj
+msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
+msgstr "La stringa deve avere un valore valido \"two-letter ISO\" o \"language-country\".\n"
+"Esempio 'it' o 'it_IT'"

--- a/locales/ja.po
+++ b/locales/ja.po
@@ -30,13 +30,14 @@ msgid "Select a database type"
 msgstr "データベースタイプを選択する"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:411
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:154
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -49,7 +50,7 @@ msgstr "保存"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "効果的に使用するため、Metabaseはデータベースをスキャンします。また、メタデータを最新に保つために定期的に再スキャンします。以下から再スキャンの頻度を設定することができます。"
 
-#: frontend/src/metabase/entities/databases/forms.js:221
+#: frontend/src/metabase/entities/databases/forms.js:290
 msgid "Database syncing"
 msgstr "データベース同期中"
 
@@ -64,7 +65,7 @@ msgstr "データベーススキーマの更新チェックは軽量なプロセ
 msgid "Scan"
 msgstr "スキャン"
 
-#: frontend/src/metabase/entities/databases/forms.js:228
+#: frontend/src/metabase/entities/databases/forms.js:297
 msgid "Scanning for Filter Values"
 msgstr "フィルター値をスキャン中"
 
@@ -76,7 +77,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabaseは、このデータベースの各フィールドの値をスキャンして、ダッシュボードや質問のチェックボックスフィルターを有効にすることができます。 データベースが非常に大きい場合は、ややリソースに負荷がかかる処理となります。"
 
-#: frontend/src/metabase/entities/databases/forms.js:232
+#: frontend/src/metabase/entities/databases/forms.js:301
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "フィールド値のスキャンとキャッシュをいつ行いますか？"
 
@@ -98,6 +99,7 @@ msgid "Never, I'll do this manually if I need to"
 msgstr "自動的に行わず、必要な時に手動設定する"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 msgid "Saving..."
@@ -134,9 +136,9 @@ msgid "in this box:"
 msgstr "このテキストボックスに:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:75
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
@@ -153,18 +155,18 @@ msgstr "このテキストボックスに:"
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:301
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:39
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:90
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:99
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:311
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:328
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "キャンセル"
@@ -181,7 +183,7 @@ msgstr "削除"
 #: frontend/src/metabase/admin/permissions/selectors.js:323
 #: frontend/src/metabase/admin/permissions/selectors.js:330
 #: frontend/src/metabase/admin/permissions/selectors.js:441
-#: frontend/src/metabase/admin/routes.jsx:57
+#: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
@@ -201,9 +203,10 @@ msgid "Scheduling"
 msgstr "スケジューリング"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:71
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
@@ -211,8 +214,8 @@ msgid "Save changes"
 msgstr "変更を保存"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:203
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:35
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
 msgstr "アクション"
 
@@ -224,8 +227,8 @@ msgstr "今すぐデータベーススキーマと同期する"
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:90
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:98
 msgid "Starting…"
 msgstr "開始しています..."
 
@@ -243,13 +246,13 @@ msgstr "今すぐフィールド値を再スキャンする"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
 msgstr "スキャンのスタートに失敗しました"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:92
 msgid "Scan triggered!"
 msgstr "スキャンを開始しました！"
 
@@ -272,15 +275,15 @@ msgid "Add database"
 msgstr "データベースを追加"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:28
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:28
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
 #: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:195
+#: frontend/src/metabase/entities/databases/forms.js:264
 #: frontend/src/metabase/entities/questions.js:86
 #: frontend/src/metabase/entities/questions.js:102
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
@@ -320,6 +323,7 @@ msgstr "保存されました！"
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "編集"
@@ -362,44 +366,43 @@ msgstr "失敗"
 msgid "Success"
 msgstr "成功"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:185
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "プレビュー"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:93
 msgid "No column description yet"
 msgstr "列の説明はまだありません"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:127
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:126
 msgid "Select a field visibility"
-msgstr "フィールドの可視性を選択する"
+msgstr "フィールドの表示・非表示を選択する"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:187
 msgid "No special type"
 msgstr "特別タイプなし"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
 #: frontend/src/metabase/lib/core.js:275
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:44
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:37
 msgid "Other"
 msgstr "その他"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:221
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "特別タイプを選択する"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:255
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:262
 #: frontend/src/metabase/reference/components/Field.jsx:99
 msgid "Select a target"
 msgstr "ターゲットを選択する"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
@@ -407,18 +410,18 @@ msgstr "ターゲットを選択する"
 msgid "Columns"
 msgstr "列"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "列"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:144
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:288
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
 msgid "Visibility"
-msgstr "可視性"
+msgstr "表示・非表示"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
 msgid "Type"
 msgstr "タイプ"
 
@@ -426,7 +429,7 @@ msgstr "タイプ"
 msgid "Current database:"
 msgstr "現在のデータベース:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
 msgid "Show original schema"
 msgstr "元のスキーマを表示する"
 
@@ -447,27 +450,27 @@ msgid "{0} schema"
 msgid_plural "{0} schemas"
 msgstr[0] "{0} スキーマ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:99
 msgid "Why Hide?"
 msgstr "なぜ非表示にしますか？"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:100
 msgid "Technical Data"
 msgstr "テクニカルデータ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
 msgstr "無関係/不正データ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 msgid "Queryable"
 msgstr "利用可能"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:108
 msgid "Hidden"
 msgstr "非表示"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136
 msgid "No table description yet"
 msgstr "テーブルの説明はまだありません"
 
@@ -475,30 +478,31 @@ msgstr "テーブルの説明はまだありません"
 msgid "Metadata Strength"
 msgstr "メタデータ強度"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0} 件の利用可能なテーブル"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:91
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} 非表示のテーブル"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:115
 msgid "Find a table"
 msgstr "テーブルを探す"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:128
 msgid "Schemas"
 msgstr "スキーマ"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:838
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:21
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:43
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:62
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 msgid "Metrics"
 msgstr "メトリクス"
@@ -507,8 +511,8 @@ msgstr "メトリクス"
 msgid "Add a Metric"
 msgstr "メトリクスを追加する"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "定義"
@@ -517,12 +521,12 @@ msgstr "定義"
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "クエリビルダーの表示ドロップダウンにメトリクスを作成し追加する"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:21
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
 #: frontend/src/metabase/home/containers/SearchApp.jsx:72
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:961
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:61
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "セグメント"
@@ -531,35 +535,35 @@ msgstr "セグメント"
 msgid "Add a Segment"
 msgstr "セグメントを追加する"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:51
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:45
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "クエリビルダーのフィルタードロップダウンにセグメントを作成し追加する"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:21
 msgid "created"
 msgstr "作成済み"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "reverted to a previous version"
 msgstr "以前のバージョンに戻す"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:30
 msgid "edited the title"
 msgstr "タイトルを編集する"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:32
 msgid "edited the description"
 msgstr "説明を編集する"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:34
 msgid "edited the "
 msgstr "␣を編集する"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:40
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "made some changes"
 msgstr "変更されました"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
 #: frontend/src/metabase/home/components/Activity.jsx:83
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
@@ -569,84 +573,84 @@ msgstr "あなた"
 msgid "Datamodel"
 msgstr "データモデル"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:41
 msgid " History"
 msgstr "履歴"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
 msgstr "履歴"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:228
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
 msgid "{0} – Field Settings"
 msgstr "{0} - フィールド設定"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:289
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
 msgid "Where this field will appear throughout Metabase"
 msgstr "Metabase上でフィールドが表示される箇所"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:311
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
 msgid "Filtering on this field"
 msgstr "このフィールドでフィルター設定しています"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:312
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "このフィールドでフィルター設定がされている場合、他ユーザーがフィルター設定したい値をどのように入力すればよいですか？"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:437
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
 msgid "No description for this field yet"
 msgstr "このフィールドには説明がまだありません"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
 msgid "Original value"
 msgstr "元の値"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:390
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
 msgid "Mapped value"
 msgstr "マップされた値"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
 msgid "Enter value"
 msgstr "値を入力する"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use original value"
 msgstr "元の値を使う"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Use foreign key"
 msgstr "外部キーを使う"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 msgid "Custom mapping"
 msgstr "カスタムマッピング"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
 msgid "Unrecognized mapping type"
 msgstr "マッピングタイプを識別できません"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "現在のフィールドは外部キーではないか、FKターゲットテーブルのメタデータがありません"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
 msgid "The selected field isn't a foreign key"
 msgstr "選択されたフィールドは外部キーではありません"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:327
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
 msgid "Display values"
 msgstr "値を表示する"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:328
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "データベースから元の値を表示するか、このフィールドに関連する情報またはカスタム情報を表示するかを選択します。"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:278
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
 msgid "Choose a field"
 msgstr "フィールドを選択"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:299
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
 msgid "Please select a column to use for display."
 msgstr "表示に使用する列を選択してください。"
 
@@ -654,16 +658,16 @@ msgstr "表示に使用する列を選択してください。"
 msgid "Tip:"
 msgstr "ヒント:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:443
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "再マッピングの選択と内容が合うようにフィールド名を更新すると良いでしょう。"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:344
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "フィールド値をキャッシュする"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:345
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabaseは、ダッシュボードまたは質問のチェックボックスを有効化するため、このフィールドの値をスキャンします"
 
@@ -672,116 +676,116 @@ msgid "Re-scan this field"
 msgstr "このフィールドを再スキャンする"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
 msgstr "キャッシュしたフィールド値を削除する"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
 msgstr "値の削除に失敗しました"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 msgid "Discard triggered!"
 msgstr "削除されました！"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "テーブルを選択し、スキーマを見てメタデータを追加・編集する"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:36
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "名前が必要です"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:39
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "説明が必要です"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:43
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "履歴メッセージが必要です"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
 msgid "Aggregation is required"
 msgstr "アグリゲーションが必要です"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Edit Your Metric"
 msgstr "メトリクスを編集する"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Create Your Metric"
 msgstr "メトリクスを作成する"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "メトリクスを変更し注釈を加える"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:145
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
-msgstr "保存されたメトリクスを使用して、このテーブルに名前付きメトリクスオプションを追加することができます。 保存されたメトリクスには、集約タイプ、集約フィールド、およびオプションで追加するフィルターが含まれます。 たとえば、これを使用してOrdersテーブルの「平均価格」の公式な計算方法を作成することができます。"
+msgstr "保存されたメトリクスを使用して、このテーブルに名前付きメトリックオプションを追加することができます。 保存されたメトリクスには、集約タイプ、集約フィールド、およびオプションで追加するフィルターが含まれます。 たとえば、これを使用してOrdersテーブルの「平均価格」の公式な計算方法を作成することができます。"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:180
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
 msgid "Result: "
 msgstr "結果: "
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
 msgid "Name Your Metric"
-msgstr "メトリクスに名前を付ける"
+msgstr "メトリックに名前を付ける"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:190
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Give your metric a name to help others find it."
-msgstr "他ユーザーのためにメトリクスに名前を付ける"
+msgstr "他ユーザーのためにメトリックに名前を付ける"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:194
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:152
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "簡単な説明"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:198
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
 msgid "Describe Your Metric"
-msgstr "メトリクスを説明する"
+msgstr "メトリックを説明する"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:199
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Give your metric a description to help others understand what it's about."
-msgstr "他ユーザーのためにメトリクスに説明を加える"
+msgstr "他ユーザーのためにメトリックに説明を加える"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:203
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
 msgid "This is a good place to be more specific about less obvious metric rules"
-msgstr "メトリクスのルールについてより詳細な情報をこちらに記入してください"
+msgstr "分かりにくいメトリクスのルールについてより詳細な情報をこちらに記入してください"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:207
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:165
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "変更理由"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:209
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "変更箇所と変更理由を記入する"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:213
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "他ユーザーにも変更理由がわかるよう、このメトリクスの履歴に表示されます"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
 msgstr "最低1つのフィルターが必要です"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
 msgstr "セグメントを編集する"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
 msgstr "セグメントを作成する"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "セグメントを変更し注釈を加える"
 
@@ -789,33 +793,33 @@ msgstr "セグメントを変更し注釈を加える"
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "{0}テーブルの新しいセグメントを作成するためのフィルターを選択し追加する"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
 msgstr "セグメントに名前を付ける"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:148
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
 msgstr "他ユーザーのためにセグメントを名前を付ける"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:156
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
 msgstr "セグメントを説明する"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "他ユーザーのためにセグメントに説明を加える"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "セグメントのルールについてより詳細な情報をこちらに記入してください"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "他ユーザーにも変更理由がわかるよう、このセグメントの履歴に表示されます"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
-#: frontend/src/metabase/admin/routes.jsx:132
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:215
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
+#: frontend/src/metabase/admin/routes.jsx:137
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
@@ -823,11 +827,11 @@ msgstr "他ユーザーにも変更理由がわかるよう、このセグメン
 msgid "Settings"
 msgstr "設定"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabaseは、ダッシュボードまたは質問のチェックボックスを有効化するため、このテーブルの値をスキャンします"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
 msgstr "このテーブルを再スキャンする"
 
@@ -841,11 +845,11 @@ msgstr "追加"
 msgid "Not a valid formatted email address"
 msgstr "有効なメールアドレスではありません"
 
-#: frontend/src/metabase/entities/users/forms.js:12
+#: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
 msgstr "名"
 
-#: frontend/src/metabase/entities/users/forms.js:18
+#: frontend/src/metabase/entities/users/forms.js:20
 msgid "Last name"
 msgstr "姓"
 
@@ -884,10 +888,10 @@ msgstr "メンバー"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
-#: frontend/src/metabase/admin/settings/selectors.js:120
-#: frontend/src/metabase/entities/users/forms.js:24
+#: frontend/src/metabase/admin/settings/selectors.js:121
+#: frontend/src/metabase/entities/users/forms.js:26
 #: frontend/src/metabase/lib/core.js:146
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:294
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:298
 msgid "Email"
 msgstr "メール"
 
@@ -896,14 +900,14 @@ msgid "A group is only as good as its members."
 msgstr "グループもそのメンバーもどちらも大事です。"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
-#: frontend/src/metabase/admin/routes.jsx:52
+#: frontend/src/metabase/admin/routes.jsx:55
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Admin"
 msgstr "管理者"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:241
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:299
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:288
 msgid "and"
 msgstr "そして"
 
@@ -955,12 +959,12 @@ msgstr "グループを削除する"
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:42
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:294
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:397
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:317
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:334
 msgid "Done"
 msgstr "完了"
 
@@ -971,8 +975,9 @@ msgstr "グループ名"
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
-#: frontend/src/metabase/admin/routes.jsx:92
+#: frontend/src/metabase/admin/routes.jsx:97
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "グループ"
 
@@ -1002,7 +1007,7 @@ msgstr "無効化"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:21
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
-#: frontend/src/metabase/admin/routes.jsx:88
+#: frontend/src/metabase/admin/routes.jsx:93
 #: frontend/src/metabase/nav/containers/Navbar.jsx:235
 msgid "People"
 msgstr "ユーザー"
@@ -1313,25 +1318,25 @@ msgstr "コレクションを見る"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:542
+#: frontend/src/metabase/admin/permissions/selectors.js:558
 msgid "Data Access"
 msgstr "データアクセス"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:667
-#: frontend/src/metabase/admin/permissions/selectors.js:672
+#: frontend/src/metabase/admin/permissions/selectors.js:665
+#: frontend/src/metabase/admin/permissions/selectors.js:670
 msgid "View tables"
 msgstr "テーブルを見る"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:608
+#: frontend/src/metabase/admin/permissions/selectors.js:606
 msgid "SQL Queries"
 msgstr "SQLクエリ"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:678
+#: frontend/src/metabase/admin/permissions/selectors.js:676
 msgid "View schemas"
 msgstr "スキーマを見る"
 
-#: frontend/src/metabase/admin/routes.jsx:63
+#: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
 msgstr "データモデル"
@@ -1361,20 +1366,24 @@ msgid "Allows users within your LDAP directory to log in to Metabase with their 
 msgstr "LDAPディレクトリ内のユーザーに対し、LDAP資格情報によるMetabaseへのログインを許可し、LDAPグループをMetabaseグループに自動的にマッピングできるようにする。"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:19
-#: frontend/src/metabase/admin/settings/selectors.js:167
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
+#: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
 msgstr "有効なメールアドレスではありません"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
 msgstr "有効な整数ではありません"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
 msgstr "変更が保存されました！"
 
-#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:178
+#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
 msgid "Looks like we ran into some problems"
 msgstr "問題が発生したようです"
 
@@ -1396,7 +1405,7 @@ msgstr "クリア"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:195
+#: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "認証"
 
@@ -1448,15 +1457,15 @@ msgstr "GoogleクライアントID"
 msgid "Allow users to sign up on their own if their Google account email address is from:"
 msgstr "Googleアカウントのメールアドレスが以下のものである場合、ユーザーが自分でサインアップできるようにする:"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:242
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:249
 msgid "Answers sent right to your Slack #channels"
 msgstr "Slackに回答が送信されました"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:251
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:258
 msgid "Create a Slack Bot User for MetaBot"
 msgstr "MetaBotのSlack Botユーザーを作成する"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:261
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:268
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "名前を付けて{0}をクリックします。 ボットAPIトークンをコピーし、下のフィールドに貼り付けます。 完了したら、Slackで \"metabase_files\"チャンネルを作成します。 これはMetabaseでグラフをアップロードするために必要な作業です。"
 
@@ -1469,8 +1478,8 @@ msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Metabase {0}が利用可能です。現在{1}を利用中です。"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:41
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 msgid "Update"
 msgstr "アップデートする"
 
@@ -1497,16 +1506,16 @@ msgstr "カスタムマップを削除する"
 #: frontend/src/metabase/containers/Overworld.jsx:293
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:115
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "削除する"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:165
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:141
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
 msgstr "選択..."
 
@@ -1689,48 +1698,46 @@ msgid "Generate Key"
 msgstr "キーを発行する"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:87
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:18
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enabled"
 msgstr "有効"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:92
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:19
+#: frontend/src/metabase/admin/settings/selectors.js:93
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "無効"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:112
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:113
 msgid "Unknown setting {0}"
 msgstr "不明な設定{0}"
 
-#: frontend/src/metabase/admin/settings/selectors.js:34
+#: frontend/src/metabase/admin/settings/selectors.js:37
 msgid "Setup"
 msgstr "設定"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:207
-#: frontend/src/metabase/admin/settings/selectors.js:39
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:214
+#: frontend/src/metabase/admin/settings/selectors.js:42
 msgid "General"
 msgstr "一般"
 
-#: frontend/src/metabase/admin/settings/selectors.js:43
+#: frontend/src/metabase/admin/settings/selectors.js:46
 msgid "Site Name"
 msgstr "サイト名"
 
-#: frontend/src/metabase/admin/settings/selectors.js:48
+#: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Site URL"
 msgstr "サイトのURL"
 
-#: frontend/src/metabase/admin/settings/selectors.js:53
+#: frontend/src/metabase/admin/settings/selectors.js:64
 msgid "Email Address for Help Requests"
 msgstr "ヘルプリクエストのメールアドレス"
 
-#: frontend/src/metabase/admin/settings/selectors.js:58
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
 msgstr "タイムゾーン"
 
-#: frontend/src/metabase/admin/settings/selectors.js:61
+#: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
 msgstr "データベースのデフォルト"
 
@@ -1738,11 +1745,11 @@ msgstr "データベースのデフォルト"
 msgid "Select a timezone"
 msgstr "タイムゾーンを選択する"
 
-#: frontend/src/metabase/admin/settings/selectors.js:64
+#: frontend/src/metabase/admin/settings/selectors.js:75
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "すべてのデータベースがタイムゾーンをサポートしているわけではありません。この場合、この設定は有効になりません。"
 
-#: frontend/src/metabase/admin/settings/selectors.js:69
+#: frontend/src/metabase/entities/users/forms.js:34
 msgid "Language"
 msgstr "言語"
 
@@ -1750,64 +1757,64 @@ msgstr "言語"
 msgid "Select a language"
 msgstr "言語を選択する"
 
-#: frontend/src/metabase/admin/settings/selectors.js:79
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
 msgstr "匿名のトラッキング"
 
-#: frontend/src/metabase/admin/settings/selectors.js:84
+#: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
 msgstr "わかりやすいテーブル名とフィールド名"
 
-#: frontend/src/metabase/admin/settings/selectors.js:90
+#: frontend/src/metabase/admin/settings/selectors.js:91
 msgid "Only replace underscores and dashes with spaces"
 msgstr "アンダースコアとダッシュをスペースに置き換える"
 
-#: frontend/src/metabase/admin/settings/selectors.js:98
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Enable Nested Queries"
 msgstr "ネストしたクエリを有効化する"
 
-#: frontend/src/metabase/admin/settings/selectors.js:109
+#: frontend/src/metabase/admin/settings/selectors.js:110
 msgid "Updates"
 msgstr "アップデート"
 
-#: frontend/src/metabase/admin/settings/selectors.js:114
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
 msgstr "アップデートを確認する"
 
-#: frontend/src/metabase/admin/settings/selectors.js:125
+#: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
 msgstr "SMTPホスト"
 
-#: frontend/src/metabase/admin/settings/selectors.js:133
+#: frontend/src/metabase/admin/settings/selectors.js:134
 msgid "SMTP Port"
 msgstr "SMTPポート"
 
-#: frontend/src/metabase/admin/settings/selectors.js:137
+#: frontend/src/metabase/admin/settings/selectors.js:138
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:47
 msgid "That's not a valid port number"
 msgstr "無効なポート番号です"
 
-#: frontend/src/metabase/admin/settings/selectors.js:141
+#: frontend/src/metabase/admin/settings/selectors.js:142
 msgid "SMTP Security"
 msgstr "SMTPセキュリティ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:150
 msgid "SMTP Username"
 msgstr "SMTPユーザーネーム"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "SMTP Password"
 msgstr "SMTPパスワード"
 
-#: frontend/src/metabase/admin/settings/selectors.js:163
+#: frontend/src/metabase/admin/settings/selectors.js:164
 msgid "From Address"
 msgstr "送信元アドレス"
 
-#: frontend/src/metabase/admin/settings/selectors.js:176
+#: frontend/src/metabase/admin/settings/selectors.js:178
 msgid "Slack API Token"
 msgstr "Slack APIトークン"
 
-#: frontend/src/metabase/admin/settings/selectors.js:178
+#: frontend/src/metabase/admin/settings/selectors.js:180
 msgid "Enter the token you received from Slack"
 msgstr "Slackから受け取ったトークンを入力する"
 
@@ -1836,8 +1843,10 @@ msgid "Username or DN"
 msgstr "ユーザーネームまたはDN"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:43
+#: frontend/src/metabase/entities/databases/forms.js:61
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:64
-#: frontend/src/metabase/user/components/UserSettings.jsx:65
+#: frontend/src/metabase/user/components/UserSettings.jsx:66
+#: src/metabase/driver/common.clj
 msgid "Password"
 msgstr "パスワード"
 
@@ -1873,79 +1882,79 @@ msgstr "グループメンバーを同期する"
 msgid "Group search base"
 msgstr "グループ検索ベース"
 
-#: frontend/src/metabase/admin/settings/selectors.js:199
+#: frontend/src/metabase/admin/settings/selectors.js:201
 msgid "Maps"
 msgstr "マップ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:203
+#: frontend/src/metabase/admin/settings/selectors.js:205
 msgid "Map tile server URL"
 msgstr "マップタイルサーバーのURL"
 
-#: frontend/src/metabase/admin/settings/selectors.js:204
+#: frontend/src/metabase/admin/settings/selectors.js:206
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Metabaseはデフォルト設定でOpenStreetMapsを使用します"
 
-#: frontend/src/metabase/admin/settings/selectors.js:209
+#: frontend/src/metabase/admin/settings/selectors.js:211
 msgid "Custom Maps"
 msgstr "カスタムマップ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:210
+#: frontend/src/metabase/admin/settings/selectors.js:212
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "独自のGeoJSONファイルを追加して、異なるリージョンマップのビジュアライゼーションを可能にする"
 
-#: frontend/src/metabase/admin/settings/selectors.js:228
+#: frontend/src/metabase/admin/settings/selectors.js:245
 msgid "Public Sharing"
 msgstr "公開"
 
-#: frontend/src/metabase/admin/settings/selectors.js:232
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "Enable Public Sharing"
 msgstr "公開を有効化する"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:254
 msgid "Shared Dashboards"
 msgstr "公開されたダッシュボード"
 
-#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Shared Questions"
 msgstr "公開された質問"
 
-#: frontend/src/metabase/admin/settings/selectors.js:250
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Embedding in other Applications"
 msgstr "他アプリケーションに埋め込む"
 
-#: frontend/src/metabase/admin/settings/selectors.js:276
+#: frontend/src/metabase/admin/settings/selectors.js:293
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "他アプリケーションへのMetabaseの埋め込みを有効化する"
 
-#: frontend/src/metabase/admin/settings/selectors.js:286
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Embedding secret key"
 msgstr "秘密キーを埋め込む"
 
-#: frontend/src/metabase/admin/settings/selectors.js:292
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Embedded Dashboards"
 msgstr "埋め込みダッシュボード"
 
-#: frontend/src/metabase/admin/settings/selectors.js:298
+#: frontend/src/metabase/admin/settings/selectors.js:315
 msgid "Embedded Questions"
 msgstr "埋め込み質問"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:322
 msgid "Caching"
 msgstr "キャッシュ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:326
 msgid "Enable Caching"
 msgstr "キャッシュを有効化する"
 
-#: frontend/src/metabase/admin/settings/selectors.js:314
+#: frontend/src/metabase/admin/settings/selectors.js:331
 msgid "Minimum Query Duration"
 msgstr "最低クエリ期間"
 
-#: frontend/src/metabase/admin/settings/selectors.js:321
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "キャッシュTTL乗数"
 
-#: frontend/src/metabase/admin/settings/selectors.js:328
+#: frontend/src/metabase/admin/settings/selectors.js:345
 msgid "Max Cache Entry Size"
 msgstr "最大キャッシュエントリーサイズ"
 
@@ -2112,7 +2121,8 @@ msgstr "このコレクション内のダッシュボード、コレクション
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/routes.jsx:205
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
+#: frontend/src/metabase/routes.jsx:196
 msgid "Archive"
 msgstr "アーカイブ"
 
@@ -2128,21 +2138,21 @@ msgstr "アーカイブを見る"
 msgid "Unarchive this {0}"
 msgstr "この{0}のアーカイブを取り消す"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:39
-#: frontend/src/metabase/components/BrowseApp.jsx:102
-#: frontend/src/metabase/components/BrowseApp.jsx:194
+#: frontend/src/metabase/components/BrowseApp.jsx:46
+#: frontend/src/metabase/components/BrowseApp.jsx:112
+#: frontend/src/metabase/components/BrowseApp.jsx:204
 #: frontend/src/metabase/containers/Overworld.jsx:270
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
 msgstr "データ"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:146
+#: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
 msgid "X-ray this table"
 msgstr "このテーブルを自動探査(X-ray)する"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:161
+#: frontend/src/metabase/components/BrowseApp.jsx:171
 msgid "Learn about this table"
 msgstr "このテーブルについて詳細を見る"
 
@@ -2237,7 +2247,7 @@ msgstr "固定"
 msgid "Drag something here to pin it to the top"
 msgstr "ドラッグしてトップに固定してください"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:755
+#: frontend/src/metabase/admin/permissions/selectors.js:753
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2280,7 +2290,7 @@ msgstr "このコレクションをアーカイブする"
 #: frontend/src/metabase/components/CollectionList.jsx:67
 #: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
-msgstr "個人のコレクション"
+msgstr "パーソナルコレクション"
 
 #: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
@@ -2290,7 +2300,7 @@ msgstr "新しいコレクション"
 msgid "Copied!"
 msgstr "コピーされました"
 
-#: frontend/src/metabase/entities/databases/forms.js:12
+#: frontend/src/metabase/entities/databases/forms.js:14
 msgid "Use an SSH-tunnel for database connections"
 msgstr "データベース接続にSSHトンネルを利用する"
 
@@ -2300,7 +2310,7 @@ msgid "Some database installations can only be accessed by connecting through an
 "Enabling this is usually slower than a direct connection."
 msgstr "一部のデータベースインストールは、SSHホストを介して接続することによってのみアクセスできます。VPNが利用できない場合、このオプションを使用することでセキュリティーレベルを高めることができます。この機能を有効にすると直接接続するよりも動作が遅くなりことがあります。"
 
-#: frontend/src/metabase/entities/databases/forms.js:212
+#: frontend/src/metabase/entities/databases/forms.js:281
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "データベースが大きいため、Metabaseの同期とスキャンのタイミングを選択します"
 
@@ -2309,17 +2319,17 @@ msgid "By default, Metabase does a lightweight hourly sync and an intensive dail
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Metabaseはフィールド値に対し1時間毎のクイックスキャンと毎日のフルスキャンを行うようデフォルトで設定されています。データベースが大きい場合、この設定をオンにし、いつどのようにフィールド値のスキャンをするか確認することをお勧めします。"
 
-#: frontend/src/metabase/entities/databases/forms.js:78
+#: frontend/src/metabase/entities/databases/forms.js:113
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "クライアントIDとクライアントシークレットを作成するには{0}してください"
 
-#: frontend/src/metabase/entities/databases/forms.js:80
-#: frontend/src/metabase/entities/databases/forms.js:95
-#: frontend/src/metabase/entities/databases/forms.js:131
+#: frontend/src/metabase/entities/databases/forms.js:115
+#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:166
 msgid "Click here"
 msgstr "こちらをクリックしてください"
 
-#: frontend/src/metabase/entities/databases/forms.js:83
+#: frontend/src/metabase/entities/databases/forms.js:118
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "アプリケーションタイプは「その他」を選択してください。名前は自由に付けられます。"
 
@@ -2327,19 +2337,19 @@ msgstr "アプリケーションタイプは「その他」を選択してくだ
 msgid "{0} to get an auth code"
 msgstr "認証コードを取得するため{0}"
 
-#: frontend/src/metabase/entities/databases/forms.js:107
+#: frontend/src/metabase/entities/databases/forms.js:142
 msgid "with Google Drive permissions"
 msgstr "Googleドライブ権限で"
 
-#: frontend/src/metabase/entities/databases/forms.js:129
+#: frontend/src/metabase/entities/databases/forms.js:164
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "このデータでMetabaseを利用するには、Google Developers ConsoleのAPIアクセスを有効化する必要があります"
 
-#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:165
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "有効化していない場合は、Consoleで{0}してください"
 
-#: frontend/src/metabase/entities/databases/forms.js:196
+#: frontend/src/metabase/entities/databases/forms.js:265
 msgid "How would you like to refer to this database?"
 msgstr "どのようにこのデータベースを参照しますか？"
 
@@ -2348,7 +2358,8 @@ msgstr "どのようにこのデータベースを参照しますか？"
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:143
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:70
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:123
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:96
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:126
 #: frontend/src/metabase/setup/components/UserStep.jsx:93
 msgid "Next"
 msgstr "次へ"
@@ -2531,7 +2542,7 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "以前の履歴と{0}に戻しました"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:290
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "履歴"
@@ -2577,7 +2588,7 @@ msgid "Questions"
 msgstr "質問"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:320
+#: frontend/src/metabase/routes.jsx:311
 msgid "Pulses"
 msgstr "パルス"
 
@@ -2604,7 +2615,7 @@ msgstr "Metabaseニュースレター"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:81
 msgid "Get infrequent emails about new releases and feature updates."
-msgstr "新しいリリースやアップデートに関するメールの回数を減らす"
+msgstr "新しいリリースやアップデートに関する不定期のメールを購読します"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:99
 msgid "Subscribe"
@@ -2622,15 +2633,16 @@ msgstr "エラーが発生しました..."
 msgid "Temporary Password"
 msgstr "仮パスワード"
 
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:207
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:481
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
 msgid "Hide"
 msgstr "非表示にする"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:467
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:482
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:471
 msgid "Show"
 msgstr "表示する"
 
@@ -2740,7 +2752,7 @@ msgstr "申し訳ありません、閲覧権限がありません"
 msgid "Unknown error encountered"
 msgstr "不明エラーが発生しました"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/nav/containers/Navbar.jsx:373
 msgid "Create"
 msgstr "作成する"
@@ -2753,7 +2765,7 @@ msgstr "ダッシュボードを作成する"
 msgid "Table"
 msgstr "テーブル"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
 msgid "Database"
 msgstr "ダッシュボード"
 
@@ -2773,7 +2785,7 @@ msgstr "お探しのデータを見つけるためフィルターの調整をお
 msgid "View by"
 msgstr "で見る"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:122
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:121
 msgid "of"
 msgstr "の"
 
@@ -2800,33 +2812,33 @@ msgstr "分析"
 msgid "Browse all items"
 msgstr "全データをブラウズする"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:118
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:117
 msgid "Replace or save as new?"
 msgstr "上書きしますか？新しいデータとして保存しますか？"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:168
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace original question, \"{0}\""
 msgstr "元の質問”{0}”を上書きする"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:172
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:171
 msgid "Save as new question"
 msgstr "新しい条件として保存する"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:92
 msgid "First, save your question"
 msgstr "まずは、質問を保存してください"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:94
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
 msgid "Save question"
 msgstr "質問を保存する"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:133
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
 msgid "What is the name of your card?"
 msgstr "カードの名前は？"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
 #: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/entities/questions.js:89
@@ -2842,15 +2854,16 @@ msgstr "カードの名前は？"
 msgid "Description"
 msgstr "説明"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
 #: frontend/src/metabase/entities/dashboards.js:150
 #: frontend/src/metabase/entities/questions.js:91
 #: frontend/src/metabase/entities/questions.js:107
+#: frontend/src/metabase/entities/snippets.js:31
 msgid "It's optional but oh, so helpful"
 msgstr "任意ですが、入力しておくととても便利です"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:148
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "これはどのコレクションに保存しますか？"
@@ -2867,19 +2880,19 @@ msgstr "アイテム"
 msgid "Undo"
 msgstr "やり直す"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:266
 msgid "Applying Question"
 msgstr "質問を適用中"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:286
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "That question isn't compatible"
 msgstr "この質問は互換性がありません"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:322
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:309
 msgid "Search for a question"
 msgstr "質問を検索する"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:351
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:343
 msgid "We're not sure if this question is compatible"
 msgstr "この質問の互換性が不明です"
 
@@ -2928,25 +2941,23 @@ msgstr "質問を追加する"
 msgid "Add a question to this dashboard"
 msgstr "このダッシュボードに質問を追加する"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
 msgid "Add a filter"
 msgstr "フィルターを追加する"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:256
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "パラメーター"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:276
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:280
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
 msgid "Add a text box"
 msgstr "テキストボックスを追加する"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:320
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:314
 msgid "Move dashboard"
 msgstr "ダッシュボードを移動する"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:303
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
 msgid "Edit dashboard"
 msgstr "ダッシュボードを編集する"
 
@@ -2954,11 +2965,11 @@ msgstr "ダッシュボードを編集する"
 msgid "Edit Dashboard Layout"
 msgstr "ダッシュボードのレイアウトを編集する"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:371
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:365
 msgid "You are editing a dashboard"
 msgstr "ダッシュボード編集中"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:376
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:370
 msgid "Select the field that should be filtered for each card"
 msgstr "各カードにフィルタリングするフィールドを選択する"
 
@@ -3046,7 +3057,7 @@ msgstr "このパラメータータイプにマップできるフィールドや
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "このフィールドの値は、選択した他のフィールドの値と重複しません。"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:162
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "有効なフィールドがありません"
@@ -3114,7 +3125,7 @@ msgstr "から最新のデータを受信しました"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:329
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
 msgid "Unknown"
 msgstr "不明"
 
@@ -3241,6 +3252,7 @@ msgstr "{0}アイテムが選択されました"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 msgid "Unarchive"
 msgstr "アーカイブを取り消す"
 
@@ -3333,7 +3345,7 @@ msgid "Longitude"
 msgstr "経度"
 
 #: frontend/src/metabase/lib/core.js:43
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:45
 msgid "Number"
 msgstr "数値"
@@ -3390,7 +3402,7 @@ msgid "User"
 msgstr "ユーザー"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:211
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
 msgid "Source"
 msgstr "ソース"
 
@@ -3431,16 +3443,17 @@ msgid "Score"
 msgstr "スコア"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "タイトル"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
 msgid "Comment"
 msgstr "コメント"
 
@@ -3492,9 +3505,9 @@ msgstr "含まない"
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
 msgstr "Metabaseはこのフィールドを取得しなくなります。取得するとセキュリティ上問題があったり、無関係なフィールドに使いましょう"
 
-#: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:300
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/query/description.js:77
+#: frontend/src/metabase/lib/query/description.js:262
+#: frontend/src/metabase/lib/schema_metadata.js:476
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
@@ -3509,8 +3522,7 @@ msgstr "カウント"
 msgid "CumulativeCount"
 msgstr "累積カウント"
 
-#: frontend/src/metabase/lib/expressions/config.js:9
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:485
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3520,7 +3532,6 @@ msgstr "合計"
 msgid "CumulativeSum"
 msgstr "累積和"
 
-#: frontend/src/metabase/lib/expressions/config.js:11
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Distinct"
 msgstr "ディスティンクト"
@@ -3529,25 +3540,22 @@ msgstr "ディスティンクト"
 msgid "StandardDeviation"
 msgstr "標準偏差"
 
-#: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:494
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "平均"
 
-#: frontend/src/metabase/lib/expressions/config.js:14
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:539
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "最低"
 
-#: frontend/src/metabase/lib/expressions/config.js:15
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:548
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:503
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:492
 msgid "Max"
 msgstr "最高"
 
@@ -3598,54 +3606,66 @@ msgstr "何を知りたいですか？"
 msgid "What do you want to find out?"
 msgstr "何を調べますか？"
 
-#: frontend/src/metabase/lib/query.js:298
-#: frontend/src/metabase/lib/schema_metadata.js:466
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:250
+#: frontend/src/metabase/lib/query/description.js:75
+#: frontend/src/metabase/lib/query/description.js:260
+#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "ローデータ"
 
-#: frontend/src/metabase/lib/query.js:302
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/query/description.js:79
+#: frontend/src/metabase/lib/query/description.js:264
+#: frontend/src/metabase/lib/schema_metadata.js:521
 msgid "Cumulative count"
 msgstr "累積カウント"
 
-#: frontend/src/metabase/lib/query.js:305
+#: frontend/src/metabase/lib/query/description.js:82
+#: frontend/src/metabase/lib/query/description.js:266
 msgid "Average of "
 msgstr "の平均"
 
-#: frontend/src/metabase/lib/query.js:310
+#: frontend/src/metabase/lib/query/description.js:87
+#: frontend/src/metabase/lib/query/description.js:268
 msgid "Distinct values of "
 msgstr "␣の重複を除いた値"
 
-#: frontend/src/metabase/lib/query.js:315
+#: frontend/src/metabase/lib/query/description.js:92
+#: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
 msgstr "の標準偏差"
 
-#: frontend/src/metabase/lib/query.js:320
+#: frontend/src/metabase/lib/query/description.js:97
+#: frontend/src/metabase/lib/query/description.js:272
 msgid "Sum of "
 msgstr "の合計"
 
-#: frontend/src/metabase/lib/query.js:325
+#: frontend/src/metabase/lib/query/description.js:102
+#: frontend/src/metabase/lib/query/description.js:274
 msgid "Cumulative sum of "
 msgstr "の累積和"
 
-#: frontend/src/metabase/lib/query.js:330
+#: frontend/src/metabase/lib/query/description.js:107
+#: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
 msgstr "の最高"
 
-#: frontend/src/metabase/lib/query.js:335
+#: frontend/src/metabase/lib/query/description.js:112
+#: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
 msgstr "の最低"
 
-#: frontend/src/metabase/lib/query.js:349
+#: frontend/src/metabase/lib/query/description.js:126
+#: frontend/src/metabase/lib/query/description.js:286
 msgid "Grouped by "
 msgstr "グループ化された"
 
-#: frontend/src/metabase/lib/query.js:363
+#: frontend/src/metabase/lib/query/description.js:140
+#: frontend/src/metabase/lib/query/description.js:295
 msgid "Filtered by "
 msgstr "フィルターされた"
 
-#: frontend/src/metabase/lib/query.js:392
+#: frontend/src/metabase/lib/query/description.js:169
+#: frontend/src/metabase/lib/query/description.js:320
 msgid "Sorted by "
 msgstr "ソートされた"
 
@@ -3657,55 +3677,45 @@ msgstr "正"
 msgid "False"
 msgstr "誤"
 
-#: frontend/src/metabase/lib/schema_metadata.js:321
+#: frontend/src/metabase/lib/schema_metadata.js:322
 msgid "Select longitude field"
 msgstr "経度フィールドを選択する"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:323
 msgid "Enter upper latitude"
 msgstr "もっと上の緯度を入力する"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:324
 msgid "Enter left longitude"
 msgstr "もっと左の経度を入力する"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:325
 msgid "Enter lower latitude"
 msgstr "もっと下の緯度を入力する"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:326
 msgid "Enter right longitude"
 msgstr "もっと右の経度を入力する"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:539
 #: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:397
-#: frontend/src/metabase/lib/schema_metadata.js:405
-#: frontend/src/metabase/lib/schema_metadata.js:411
-#: frontend/src/metabase/lib/schema_metadata.js:416
-msgid "Is"
-msgstr "である"
-
 #: frontend/src/metabase/lib/schema_metadata.js:362
 #: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:398
 #: frontend/src/metabase/lib/schema_metadata.js:406
 #: frontend/src/metabase/lib/schema_metadata.js:412
-msgid "Is not"
-msgstr "ではない"
+#: frontend/src/metabase/lib/schema_metadata.js:417
+msgid "Is"
+msgstr "である"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:417
-msgid "Is empty"
-msgstr "空"
+#: frontend/src/metabase/lib/schema_metadata.js:413
+msgid "Is not"
+msgstr "ではない"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:378
@@ -3714,109 +3724,119 @@ msgstr "空"
 #: frontend/src/metabase/lib/schema_metadata.js:402
 #: frontend/src/metabase/lib/schema_metadata.js:408
 #: frontend/src/metabase/lib/schema_metadata.js:418
+msgid "Is empty"
+msgstr "空"
+
+#: frontend/src/metabase/lib/schema_metadata.js:365
+#: frontend/src/metabase/lib/schema_metadata.js:379
+#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:395
+#: frontend/src/metabase/lib/schema_metadata.js:403
+#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:419
 msgid "Not empty"
 msgstr "空ではない"
 
-#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:371
 msgid "Equal to"
 msgstr "同等"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:372
 msgid "Not equal to"
 msgstr "同等ではない"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Greater than"
 msgstr "より大きい"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Less than"
 msgstr "より小さい"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "間"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:376
 msgid "Greater than or equal to"
 msgstr "以上"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Less than or equal to"
 msgstr "以下"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
+#: frontend/src/metabase/lib/schema_metadata.js:384
 msgid "Contains"
 msgstr "含む"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:385
 msgid "Does not contain"
 msgstr "含まない"
 
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:388
 msgid "Starts with"
 msgstr "で始まる"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:389
 msgid "Ends with"
 msgstr "で終わる"
 
-#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:399
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "前"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:400
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "後"
 
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:414
 msgid "Inside"
 msgstr "中"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "回答内の行を含むテーブルのみ、他操作なし"
 
-#: frontend/src/metabase/lib/schema_metadata.js:474
+#: frontend/src/metabase/lib/schema_metadata.js:475
 msgid "Count of rows"
 msgstr "行のカウント"
 
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:477
 msgid "Total number of rows in the answer."
 msgstr "回答の全行数"
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Sum of ..."
 msgstr "の合計"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:486
 msgid "Sum of all the values of a column."
 msgstr "列の全値の合計"
 
-#: frontend/src/metabase/lib/schema_metadata.js:492
+#: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Average of ..."
 msgstr "の平均"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:495
 msgid "Average of all the values of a column"
 msgstr "列の全値の平均"
 
-#: frontend/src/metabase/lib/schema_metadata.js:501
+#: frontend/src/metabase/lib/schema_metadata.js:502
 msgid "Number of distinct values of ..."
 msgstr "...の異なる値の数"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:504
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "回答の全行のうちユニーク値の列数"
 
-#: frontend/src/metabase/lib/schema_metadata.js:510
+#: frontend/src/metabase/lib/schema_metadata.js:511
 msgid "Cumulative sum of ..."
 msgstr "累積合計"
 
@@ -3824,7 +3844,7 @@ msgstr "累積合計"
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "列の全値の合計\\\\ne.x. 経年の全収入"
 
-#: frontend/src/metabase/lib/schema_metadata.js:519
+#: frontend/src/metabase/lib/schema_metadata.js:520
 msgid "Cumulative count of rows"
 msgstr "行の累積カウント"
 
@@ -3832,27 +3852,27 @@ msgstr "行の累積カウント"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "行数の合計\\\\ne.x.経年の販売数合計"
 
-#: frontend/src/metabase/lib/schema_metadata.js:528
+#: frontend/src/metabase/lib/schema_metadata.js:529
 msgid "Standard deviation of ..."
 msgstr "...の標準偏差"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:531
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "回答の全行の間で列の値がどれくらい異なるかを表す数値"
 
-#: frontend/src/metabase/lib/schema_metadata.js:537
+#: frontend/src/metabase/lib/schema_metadata.js:538
 msgid "Minimum of ..."
 msgstr "...の最低"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Minimum value of a column"
 msgstr "列の最低値"
 
-#: frontend/src/metabase/lib/schema_metadata.js:546
+#: frontend/src/metabase/lib/schema_metadata.js:547
 msgid "Maximum of ..."
 msgstr "...の最高"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:549
 msgid "Maximum value of a column"
 msgstr "列の最高値"
 
@@ -4028,7 +4048,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "カテゴリー、タイプ、モデル、レーティング等"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:43
-#: frontend/src/metabase/user/components/UserSettings.jsx:55
+#: frontend/src/metabase/user/components/UserSettings.jsx:56
 msgid "Account settings"
 msgstr "アカウント設定"
 
@@ -4040,7 +4060,7 @@ msgstr "管理画面から離れる"
 msgid "Logs"
 msgstr "ログ"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:103
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:104
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:22
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:65
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:100
@@ -4080,9 +4100,9 @@ msgid "Metabase Admin"
 msgstr "Metabase管理者"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:36
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:36
 msgid "Ask a question"
 msgstr "照会する"
 
@@ -4103,7 +4123,7 @@ msgstr "参照"
 msgid "Which metric?"
 msgstr "どのメトリクスですか？"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "チームの共通のメトリクスを定義することで、さらに簡単に質問することができます"
 
@@ -4115,7 +4135,7 @@ msgstr "メトリクスの作成方法"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "経時的なデータをマップとして表示したり、傾向や変化を理解するのに役立つようにピボットしたりできます。"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:149
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
 msgid "Custom"
 msgstr "カスタム"
 
@@ -4128,13 +4148,13 @@ msgstr "新しい条件"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "トレンドやリストを表示したり、独自のメトリクスを作成するには、簡単な質問ビルダーを使用してください。"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:107
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:110
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "ネイティブクエリ"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:108
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:111
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "複雑な質問については、独自のSQLまたはネイティブクエリを記述することができます。"
 
@@ -4239,6 +4259,7 @@ msgid "Enter a default value..."
 msgstr "デフォルト値を入力する..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
+#: frontend/src/metabase/containers/Form.jsx:307
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "エラーが発生しました"
@@ -4486,7 +4507,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "パルスを小さく保ち、チーム全体にとって使いやすく処理することをお勧めします。"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:161
-#: frontend/src/metabase/query_builder/components/view/View.jsx:131
+#: frontend/src/metabase/query_builder/components/view/View.jsx:133
 msgid "Pick your data"
 msgstr "データを選ぶ"
 
@@ -4502,47 +4523,47 @@ msgstr "メール"
 msgid "Slack messages"
 msgstr "Slackメッセージ"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:216
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "送信しました"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:217
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0}が送信されます"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:219
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "メッセージ"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:235
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "今すぐメールを送信する"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:236
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "今すぐ{0}に送信する"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:238
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "送信中..."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "送信に失敗しました"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "パルスの結果が存在しないため送信できませんでした"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "パルスが送信されました"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:282
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0}は管理者が設定する必要があります"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:295
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:299
 msgid "Slack"
 msgstr "Slack"
 
@@ -4695,7 +4716,7 @@ msgstr "平均"
 msgid "Distincts"
 msgstr "Distinct"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:55
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "この{0}を見る"
@@ -4705,11 +4726,12 @@ msgstr[0] "この{0}を見る"
 msgid "Zoom in"
 msgstr "拡大する"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "カスタムエクスプレッション"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Common Metrics"
 msgstr "共通のメトリクス"
 
@@ -4906,34 +4928,34 @@ msgstr "通常"
 msgid "Pick a segment or table"
 msgstr "セグメントまたはテーブルを選ぶ"
 
-#: frontend/src/metabase/entities/databases/forms.js:191
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
+#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "データベースを選択する"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:94
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:85
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:31
 msgid "Select..."
 msgstr "選択する..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:134
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
 msgid "Select a table"
 msgstr "テーブルを選択する"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:819
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:926
 msgid "No tables found in this database."
 msgstr "このデータベースにはテーブルが見つかりませんでした"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:856
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:901
 msgid "Is a question missing?"
 msgstr "質問がありませんか？"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:863
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:909
 msgid "Learn more about nested queries"
 msgstr "ネストしたクエリについてもっと調べる"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:898
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:951
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:40
 msgid "Fields"
 msgstr "フィールド"
 
@@ -4967,11 +4989,11 @@ msgstr "ソート"
 msgid "Row limit"
 msgstr "行数制限"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
 msgid "Unknown Field"
 msgstr "不明なフィールド"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:75
 msgid "field"
 msgstr "フィールド"
 
@@ -4979,19 +5001,20 @@ msgstr "フィールド"
 msgid "Matches"
 msgstr "一致"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:148
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:156
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:135
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "回答を絞るためにフィルターを追加する"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:293
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
 msgstr "グルーピングを追加する"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:37
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:313
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
-#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:66
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:67
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:89
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:131
@@ -5007,16 +5030,16 @@ msgstr "グルーピングを追加する"
 msgid "Data"
 msgstr "データ"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:340
 msgid "Filtered by"
 msgstr "フィルターされた"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:376
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:357
 msgid "View"
 msgstr "閲覧"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:393
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:374
 msgid "Grouped By"
 msgstr "グループ化された"
 
@@ -5024,7 +5047,7 @@ msgstr "グループ化された"
 msgid "None"
 msgstr "なし"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:471
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
 msgid "This question is written in {0}."
 msgstr "この質問は{0}で書かれました"
 
@@ -5036,7 +5059,7 @@ msgstr "エディターを非表示にする"
 msgid "Hide Query"
 msgstr "クエリを非表示にする"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:481
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
 msgid "Open Editor"
 msgstr "エディターを表示する"
 
@@ -5276,7 +5299,7 @@ msgstr "{0}の全ての重複を除いた値"
 msgid "Number of {0} grouped by {1}"
 msgstr "{1}でグループ化された{0}の数"
 
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:77
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5335,32 +5358,33 @@ msgstr "{0}のローデータを見る"
 msgid "More"
 msgstr "さらに"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:194
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:216
 msgid "Invalid expression"
 msgstr "無効な表現"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:269
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:282
 msgid "unknown error"
 msgstr "不明なエラー"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:47
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:53
 msgid "Field formula"
 msgstr "フィールド計算式"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:60
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:64
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "これは、スプレッドシートプログラムで数式を書くようなものだとお考えください。数値、この表のフィールド、+などの数学記号、その他一部の機能を使用できます。そのため、Subtotal - Costのようなものを入力することができます。"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:69
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:208
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
 msgid "Learn more"
 msgstr "詳しく見る"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:77
 msgid "Give it a name"
 msgstr "名前を付ける"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:79
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
 msgid "Something nice and descriptive"
 msgstr "分かりやすい説明"
 
@@ -5440,11 +5464,11 @@ msgid "Enter desired number"
 msgstr "希望の番号を入力する"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:154
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:161
 msgid "Empty"
 msgstr "空"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:119
 msgid "Find a value"
 msgstr "値を探す"
 
@@ -5512,35 +5536,35 @@ msgstr "全文を読む"
 msgid "Filter label"
 msgstr "フィルターラベル"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:135
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:134
 msgid "Variable type"
 msgstr "値タイプ"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:143
 msgid "Text"
 msgstr "テキスト"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
 msgid "Date"
 msgstr "日付"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:147
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
 msgid "Field Filter"
 msgstr "フィールドフィルター"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Field to map to"
 msgstr "マップするためのフィールド"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:180
 msgid "Filter widget type"
 msgstr "フィルターウィジェットタイプ"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:230
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
 msgid "Required?"
 msgstr "必要ですか？"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:240
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
 msgid "Default filter widget value"
 msgstr "デフォルトのフィルターウィジェット値"
 
@@ -5552,7 +5576,7 @@ msgstr "この質問をアーカイブしますか？"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "この質問は関連したダッシュボードやパルスから削除されます"
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:158
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
 msgid "Question"
 msgstr "質問"
 
@@ -5722,7 +5746,7 @@ msgid "Details"
 msgstr "詳細"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
-#: frontend/src/metabase/reference/databases/TableList.jsx:116
+#: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
 msgstr "{0}のテーブル"
 
@@ -5803,24 +5827,24 @@ msgstr "なぜこのテーブルは興味深いですか？"
 msgid "Things to be aware of about this table"
 msgstr "このテーブルに関して知っておくべきこと"
 
-#: frontend/src/metabase/reference/databases/TableList.jsx:30
+#: frontend/src/metabase/reference/databases/TableList.jsx:29
 msgid "Tables in this database will appear here as they're added"
 msgstr "このデータベースのテーブルは追加されるとここに表示れます"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:34
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:33
 msgid "Questions about this table will appear here as they're added"
 msgstr "このテーブルに関する質問は追加されるとここに表示されます"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:73
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:77
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:76
 msgid "Questions about {0}"
 msgstr "{0}に関する質問"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
 msgid "Created {0} by {1}"
 msgstr "{1}で{0}を作成しました"
 
@@ -6009,19 +6033,19 @@ msgstr "このメトリクスをグループ化する他のフィールド"
 msgid "Fields you can group this metric by"
 msgstr "このメトリクスをグループ化するフィールド"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "メトリクスはチームが重視する公式な数値です"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Metrics will appear here once your admins have created some"
 msgstr "メトリクスは管理者が作成次第ここに表示されます"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:28
 msgid "Learn how to create metrics"
 msgstr "メトリクスの作成方法を詳しく見る"
 
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:34
 msgid "Questions about this metric will appear here as they're added"
 msgstr "このメトリクスに関する質問は追加されるとここに表示されます"
 
@@ -6047,23 +6071,23 @@ msgstr "なぜこのセグメントは興味深いですか？"
 msgid "Things to be aware of about this Segment"
 msgstr "このセグメントに関して知っておくべきこと"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
 msgid "Segments are interesting subsets of tables"
 msgstr "セグメントはテーブルのサブセットです"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "共通のセグメントについて定義するとチームがより質問しやすくなります"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Segments will appear here once your admins have created some"
 msgstr "セグメントは管理者が作成次第ここに表示されます"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
 msgid "Learn how to create segments"
 msgstr "セグメントの作成方法について詳しく見る"
 
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:35
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:34
 msgid "Questions about this segment will appear here as they're added"
 msgstr "このセグメントに関する質問は追加されるとここに表示されます"
 
@@ -6083,22 +6107,22 @@ msgstr "このセグメントに関する質問"
 msgid "X-ray this segment"
 msgstr "このセグメントを自動探査(X-ray)する"
 
-#: frontend/src/metabase/routes.jsx:178 frontend/src/metabase/routes.jsx:179
+#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
 msgid "Login"
 msgstr "ログイン"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:303
 #: frontend/src/metabase/containers/ItemPicker.jsx:115
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:204
+#: frontend/src/metabase/routes.jsx:195
 msgid "Search"
 msgstr "検索"
 
-#: frontend/src/metabase/routes.jsx:223
+#: frontend/src/metabase/routes.jsx:214
 msgid "Dashboard"
 msgstr "ダッシュボード"
 
-#: frontend/src/metabase/routes.jsx:236
+#: frontend/src/metabase/routes.jsx:227
 msgid "New Question"
 msgstr "新しい条件"
 
@@ -6142,63 +6166,63 @@ msgstr "ご協力ありがとうございます"
 msgid "We won't collect any usage events"
 msgstr "Usage eventに関する情報は収集いたしません"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:88
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Metabaseサービスを向上させるため、Google Analyticsを通じてデータ使用に関する情報を収集いたします"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:90
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Here's a full list of everything we track and why."
 msgstr "収集する情報とその理由についてはこちらをご確認ください"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Metabaseが匿名の情報収集をすることに同意する"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:113
-msgid "Metabase {0} collects anything about your data or question results."
-msgstr "Metabase {0}はデータや質問結果に関する情報を収集します"
-
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:114
-msgid "never"
-msgstr "しない"
-
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+msgid "Metabase {0} collects anything about your data or question results."
+msgstr "Metabase はデータや質問結果に関する情報を{0}収集しません"
+
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
+msgid "never"
+msgstr "一切"
+
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:119
 msgid "All collection is completely anonymous."
 msgstr "情報収集は全て匿名です"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "情報収集による設定は管理者設定からいつでも変更することができます"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:44
+#: frontend/src/metabase/setup/components/Setup.jsx:59
 msgid "If you feel stuck"
 msgstr "お困りの場合"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:49
+#: frontend/src/metabase/setup/components/Setup.jsx:64
 msgid "our getting started guide"
 msgstr "スタートガイド"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:50
+#: frontend/src/metabase/setup/components/Setup.jsx:65
 msgid "is just a click away."
 msgstr "クリックするだけ"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:92
+#: frontend/src/metabase/setup/components/Setup.jsx:111
 msgid "Welcome to Metabase"
 msgstr "Metabaseへようこそ"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:93
+#: frontend/src/metabase/setup/components/Setup.jsx:112
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "すべて正常に動作しています。使用を開始し、データを接続して回答を探しましょう。"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:97
+#: frontend/src/metabase/setup/components/Setup.jsx:116
 msgid "Let's get started"
 msgstr "開始しましょう"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:142
+#: frontend/src/metabase/setup/components/Setup.jsx:166
 msgid "You're all set up!"
 msgstr "準備ができました！"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:153
+#: frontend/src/metabase/setup/components/Setup.jsx:177
 msgid "Take me to Metabase"
 msgstr "Metabaseを使い始める"
 
@@ -6210,13 +6234,13 @@ msgstr "何とお呼びしましょうか？"
 msgid "Hi, {0}. nice to meet you!"
 msgstr "やあ {0} さん、はじめまして！"
 
-#: frontend/src/metabase/entities/users/forms.js:33
+#: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
-msgstr "パスワードを作成する"
+msgstr "新しいパスワード"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:44
-#: frontend/src/metabase/entities/users/forms.js:35
-#: frontend/src/metabase/entities/users/forms.js:82
+#: frontend/src/metabase/entities/users/forms.js:50
+#: frontend/src/metabase/entities/users/forms.js:97
 msgid "Shhh..."
 msgstr "シーッ"
 
@@ -6224,11 +6248,11 @@ msgstr "シーッ"
 msgid "Confirm password"
 msgstr "パスワード確認"
 
-#: frontend/src/metabase/entities/users/forms.js:42
+#: frontend/src/metabase/entities/users/forms.js:57
 msgid "Shhh... but one more time so we get it right"
 msgstr "もう一度お試しください"
 
-#: frontend/src/metabase/entities/users/forms.js:70
+#: frontend/src/metabase/entities/users/forms.js:85
 msgid "Your company or team name"
 msgstr "企業名またはチーム名"
 
@@ -6397,7 +6421,7 @@ msgstr "パスワードがアップデートされました！"
 msgid "Account updated successfully!"
 msgstr "アカウントがアップデートされました！"
 
-#: frontend/src/metabase/entities/users/forms.js:81
+#: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
 msgstr "現在のパスワード"
 
@@ -6409,7 +6433,7 @@ msgstr "Googleメールアドレスでサインインする"
 msgid "User Details"
 msgstr "ユーザー詳細"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:327
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:344
 msgid "Reset to defaults"
 msgstr "デフォルトに戻す"
 
@@ -6434,15 +6458,15 @@ msgstr "X軸、Y軸にどのフィールドを使用しますか？"
 msgid "Choose fields"
 msgstr "フィールドを選択する"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:217
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:234
 msgid "Save as default view"
 msgstr "デフォルトビューとして保存する"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Draw box to filter"
 msgstr "フィルターにボックスを描く"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Cancel filter"
 msgstr "フィルターをキャンセルする"
 
@@ -6470,19 +6494,19 @@ msgstr "ビジュアライゼーションが見つかりませんでした"
 msgid "Could not display this chart with this data."
 msgstr "このデータではチャートが表示できません"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:526
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
 msgid "No results!"
 msgstr "結果が見つかりませんでした"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:547
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
 msgid "Still Waiting..."
 msgstr "待機中..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:550
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
 msgid "This usually takes an average of {0}."
 msgstr "通常約{0}かかります"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:556
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
 msgid "(This is a bit long for a dashboard)"
 msgstr "（通常のダッシュボード処理より時間がかかっています）"
 
@@ -6641,19 +6665,19 @@ msgstr "ルールを追加する"
 msgid "Update rule"
 msgstr "ルールをアップデートする"
 
-#: frontend/src/metabase/visualizations/index.js:32
+#: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
 msgstr "ビジュアライゼーションはnullです。"
 
-#: frontend/src/metabase/visualizations/index.js:37
+#: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
 msgstr "ビジュアライゼーションでは、'識別子'スタティック変数を定義する必要があります: "
 
-#: frontend/src/metabase/visualizations/index.js:43
+#: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
 msgstr "この識別子を用いたビジュアライゼーションはすでに存在します: "
 
-#: frontend/src/metabase/visualizations/index.js:71
+#: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
 msgstr "{0}のビジュアライゼーションがありません"
 
@@ -6679,23 +6703,23 @@ msgid "Doh! The data from your query doesn't fit the chosen display choice. This
 msgstr "クエリのデータが、選択した表示選択に適合しません。 このビジュアライゼーションには少なくとも{0} {1}のデータが必要です。"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:9
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:117
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:120
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:161
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:169
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:249
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:267
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "列"
@@ -6805,83 +6829,83 @@ msgstr "なし"
 msgid "Linear Interpolated"
 msgstr "線形補間"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
 msgstr "X軸目盛"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
 msgstr "時系列"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:454
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
 msgid "Linear"
 msgstr "線形"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
 msgid "Power"
 msgstr "累乗"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:428
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:445
 msgid "Log"
 msgstr "ログ"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:441
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:430
 msgid "Histogram"
 msgstr "ヒストグラム"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
 msgstr "序数"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
 msgstr "Y軸目盛"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:462
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
 msgstr "X軸線とマークを表示する"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:360
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:468
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:349
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
 msgid "Compact"
 msgstr "コンパクト"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:469
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
 msgid "Rotate 45°"
 msgstr "45°回転"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:459
 msgid "Rotate 90°"
 msgstr "90°回転"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
 msgid "Show y-axis line and marks"
 msgstr "Y軸線とマークを表示する"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:489
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Auto y-axis range"
 msgstr "自動Y軸範囲"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:533
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:522
 msgid "Use a split y-axis when necessary"
 msgstr "必要に応じて分割したY軸を使用する"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:540
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:529
 msgid "Show label on x-axis"
 msgstr "X軸にラベルを表示する"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:546
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:535
 msgid "X-axis label"
 msgstr "X軸ラベル"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:555
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:544
 msgid "Show label on y-axis"
 msgstr "Y軸のラベルを表示する"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:561
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:550
 msgid "Y-axis label"
 msgstr "Y軸ラベル"
 
@@ -7007,23 +7031,23 @@ msgstr "最小不透明度"
 msgid "Max Zoom"
 msgstr "最大ズーム"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:231
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:234
 msgid "No relationships found."
 msgstr "関係は見つかりませんでした"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:269
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:272
 msgid "via {0}"
 msgstr "{0}経由"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:347
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
 msgid "This {0} is connected to:"
 msgstr "この{0}は接続していません:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "Object Detail"
 msgstr "オブジェクト詳細"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:93
 msgid "object"
 msgstr "オブジェクト"
 
@@ -7126,9 +7150,8 @@ msgid "Visible fields"
 msgstr "表示されるフィールド"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
-#, fuzzy
 msgid "Write here, and use Markdown if you'd like"
-msgstr "書き込みをし、ご自由にMarkdownをご利用ください"
+msgstr "こちらに記入してください。マークダウンも利用可能です。"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
 msgid "Vertical Alignment"
@@ -7412,7 +7435,7 @@ msgstr "{0}に保存された質問が多数ありますか？整理するのに
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:149 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -8929,19 +8952,19 @@ msgstr "このコレクションとコンテンツを編集することができ
 msgid "Can view items in this collection"
 msgstr "このコレクション内のアイテムを見ることができます"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:767
+#: frontend/src/metabase/admin/permissions/selectors.js:765
 msgid "Collection Access"
 msgstr "コレクションアクセス"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:841
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "このグループには、コレクション内の最低一つのサブコレクションの閲覧権限があります"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:848
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "このグループは、このコレクションの最低1つのサブコレクションを編集する権限があります"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:861
+#: frontend/src/metabase/admin/permissions/selectors.js:859
 msgid "View sub-collections"
 msgstr "サブコレクションを見る"
 
@@ -8949,7 +8972,7 @@ msgstr "サブコレクションを見る"
 msgid "Remember Me"
 msgstr "記憶する"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:63
+#: frontend/src/metabase/components/BrowseApp.jsx:73
 msgid "X-ray this schema"
 msgstr "このスキーマを自動探査(X-ray)する"
 
@@ -9010,15 +9033,15 @@ msgstr "検索結果が見つかりませんでした"
 msgid "No metrics"
 msgstr "メトリクスがありません"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:31
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:41
 msgid "Aggregations"
 msgstr "集約"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:32
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:42
 msgid "Operators"
 msgstr "オペレーター"
 
-#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:30
+#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:35
 msgid "Custom fields"
 msgstr "カスタムフィールド"
 
@@ -9184,7 +9207,7 @@ msgstr "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
 msgid "toucan_sightings"
 msgstr "toucan_sightings"
 
-#: src/metabase/driver/sparksql.clj
+#: src/metabase/models/collection.clj
 msgid "default"
 msgstr "デフォルト"
 
@@ -9212,10 +9235,10 @@ msgstr "該当なし"
 msgid "Windows domain"
 msgstr "ウィンドウズドメイン"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:539
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:545
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:554
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:560
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:528
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:534
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:543
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
 msgstr "ラベル"
 
@@ -9250,9 +9273,9 @@ msgstr "共有"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:286
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:294
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:302
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:319
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:324
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
@@ -9267,19 +9290,18 @@ msgstr "共有"
 msgid "Display"
 msgstr "表示"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:461
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:476
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:502
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:532
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:402
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:465
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:483
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:521
 msgid "Axes"
 msgstr "軸"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:212
-#: frontend/src/metabase/admin/settings/selectors.js:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:219
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:62
 msgid "Formatting"
@@ -9313,7 +9335,7 @@ msgstr "自動探査(X-ray)"
 msgid "Compare to the rest"
 msgstr "残りと比較する"
 
-#: frontend/src/metabase/entities/databases/forms.js:16
+#: frontend/src/metabase/entities/databases/forms.js:18
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "JVMのタイムゾーンを使う"
 
@@ -9342,24 +9364,24 @@ msgstr "JVMのタイムゾーンを使う"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "あなたがデータ分析を簡単にできるようテーブルとフィールドを解析中です・・"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
 msgid "Tip: "
 msgstr "ヒント: "
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:237
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
 msgstr "通貨単位を選択"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:300
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
 msgid "Field Type"
 msgstr "フィールドタイプ"
 
-#: frontend/src/metabase/admin/routes.jsx:113
+#: frontend/src/metabase/admin/routes.jsx:118
 #: frontend/src/metabase/nav/containers/Navbar.jsx:267
 msgid "Troubleshooting"
 msgstr "トラブルシューティング"
 
-#: frontend/src/metabase/admin/settings/selectors.js:103
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Enable X-ray features"
 msgstr "自動探査(X-ray)機能を有効化"
 
@@ -9404,7 +9426,7 @@ msgstr "実行時間(ms)"
 msgid "Currency"
 msgstr "通貨"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
 msgstr "ユーザーかチャンネルを選ぶ..."
 
@@ -9552,7 +9574,7 @@ msgstr "線の形式"
 msgid "Show dots on lines"
 msgstr "点線で表示"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:348
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
@@ -9566,7 +9588,7 @@ msgstr "どちらの軸？"
 msgid "Line + Bar"
 msgstr "折れ線＋棒"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
 msgid "line and bar chart"
 msgstr "折れ線＋棒グラフ"
 
@@ -9575,12 +9597,10 @@ msgid "Gauge visualization requires a number."
 msgstr "ゲージビジュアライゼーションには数値が必要です"
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:60
-#, fuzzy
 msgid "Gauge"
 msgstr "ゲージ"
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
-#, fuzzy
 msgid "Gauge ranges"
 msgstr "ゲージの範囲"
 
@@ -10812,9 +10832,8 @@ msgid "Total [[this.short-name]]"
 msgstr "合計[[this.short-name]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#, fuzzy
 msgid "Some metrics we found about your transactions."
-msgstr "あなたのトランザクションに関して、あるメトリクスを見つけました。"
+msgstr "あなたのトランザクションに関するメトリクスが見つかりました。"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "How your different products are performing."
@@ -10835,7 +10854,6 @@ msgid "How they compare across time"
 msgstr "時間をかけて比較する方法"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#, fuzzy
 msgid "Average transaction income per month"
 msgstr "月毎の平均トランザクション収益"
 
@@ -10934,7 +10952,7 @@ msgstr "国別セッション"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Some interesting metrics about your GA stats to get you started."
-msgstr "開始するためのGA統計に関する興味深い指標。"
+msgstr "開始するためのGA統計に関する興味深いメトリクス。"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
@@ -11018,7 +11036,7 @@ msgstr "このメトリックが異なる数値にどのように分布してい
 msgid "Sessions by page where the session began"
 msgstr "ページ別の開始されたセッション"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:503
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -11387,7 +11405,7 @@ msgstr "このアイテムを複製する"
 msgid "Archive this item"
 msgstr "このアイテムをアーカイブする"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:331
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:325
 msgid "Duplicate dashboard"
 msgstr "ダッシュボードを複製する"
 
@@ -11492,7 +11510,7 @@ msgid_plural "Quarters of year"
 msgstr[0] "年間四半期数\n"
 "年間四半期数"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
@@ -11508,8 +11526,8 @@ msgstr "[Q]Q"
 msgid "This"
 msgstr "これ"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:97
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:137
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:136
 msgid "Invalid"
 msgstr "無効"
 
@@ -12202,7 +12220,7 @@ msgstr "キープアライブ文字の書き込みで予期しないエラーが
 
 #: src/metabase/async/api_response.clj
 msgid "Unexpected output in async API response"
-msgstr "非同期APIのレスポンスが予想外の出力です"
+msgstr "非同期APIの応答が予想外の出力です"
 
 #: src/metabase/async/api_response.clj
 msgid "starting streaming response"
@@ -12272,6 +12290,7 @@ msgstr "ここにあなたの最新{0}個のカードがあります："
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
 msgstr "もう少し細かく、またはIDを使っていただけますか？私はこれらの名前が一致したカードを見つけました："
 
+#: src/metabase/driver/common/parameters/values.clj
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
 msgstr "カード {0} が見つかりません"
@@ -12380,11 +12399,11 @@ msgstr "ジョブが実行できなかった場合の戦略"
 msgid "Archive this?"
 msgstr "これをアーカイブしますか？"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:243
+#: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
 msgstr "データについて学ぶ"
 
-#: frontend/src/metabase/entities/databases/forms.js:20
+#: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
 msgstr "接続時にDNS SRVを使用する"
 
@@ -12394,7 +12413,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "このオプションを使用するには、提供されたホストがFQDNである必要があります。 Atlasクラスターに接続する場合は、このオプションを有効にする必要があります。 これが何を意味するのかわからない場合は、これを無効のままにします。"
 
-#: frontend/src/metabase/entities/databases/forms.js:204
+#: frontend/src/metabase/entities/databases/forms.js:273
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "簡単なフィルタリングと要約を行うときに自動的にクエリを実行する"
 
@@ -12418,11 +12437,11 @@ msgstr "全ての結果"
 msgid "Our Analytics"
 msgstr "我々の分析"
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:513
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
 msgstr "コラムの全ての値の累積和。\\n例：時間経過ごとの総収入の変化"
 
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
 msgstr "行数の累積和。\\n例：時間経過ごとの売上総数の変化"
 
@@ -12432,7 +12451,7 @@ msgstr "行数の累積和。\\n例：時間経過ごとの売上総数の変化
 msgid "Filter"
 msgstr "フィルター"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:50
 msgid "record"
 msgid_plural "records"
 msgstr[0] "レコード"
@@ -12445,27 +12464,27 @@ msgstr "データを見る"
 msgid "Write SQL"
 msgstr "SQLを書く"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:83
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
 msgstr "簡単な質問"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:84
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:87
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
 msgstr "データを選択し、見て、そして簡単にフィルタリングや集約をし、可視化します。"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:95
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:98
 msgid "Custom question"
 msgstr "カスタム質問"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:96
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:99
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "高度なノートブックエディターを使用して、データの結合、カスタム列の作成、計算などを行います。"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Basic Metrics"
 msgstr "基本的なメトリクス"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:322
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
 msgid "Custom…"
 msgstr "カスタム…"
 
@@ -12534,15 +12553,15 @@ msgstr "集約するためのキー列を選ぶ"
 msgid "Pick your starting data"
 msgstr "開始するデータを選択してください"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select None"
 msgstr "選択解除"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select All"
 msgstr "すべて選択"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:151
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:152
 msgid "Pick a table..."
 msgstr "テーブルを選ぶ..."
 
@@ -12635,7 +12654,7 @@ msgstr "エディターを表示する"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
 msgid "Pick the metric you'd like to see"
-msgstr "あなたの見たい指標を選ぶ"
+msgstr "あなたの見たいメトリクスを選ぶ"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:29
 msgid "{0} options"
@@ -12664,15 +12683,15 @@ msgstr "メトリクスを追加する"
 #: frontend/src/metabase/lib/core.js:137 frontend/src/metabase/lib/core.js:142
 #: frontend/src/metabase/lib/core.js:147 frontend/src/metabase/lib/core.js:152
 #: frontend/src/metabase/lib/core.js:157 frontend/src/metabase/lib/core.js:162
-#: frontend/src/metabase/user/components/UserSettings.jsx:63
+#: frontend/src/metabase/user/components/UserSettings.jsx:64
 msgid "Profile"
 msgstr "プロフィール"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:560
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "これはたいていの場合はとても速いですが、現在は時間がかかっているようです。"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
 msgid "Combo"
 msgstr "コンボ"
 
@@ -12688,11 +12707,11 @@ msgstr "トレンド"
 msgid "Boolean"
 msgstr "真偽値"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:62
 msgid "Unknown Segment"
 msgstr "不明なセグメント"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:73
 msgid "Unknown Filter"
 msgstr "不明なフィルター"
 
@@ -12822,6 +12841,7 @@ msgstr "「新しく作成された」クラスローダーを共有コンテキ
 msgid "Failed to copy file"
 msgstr "ファイルのコピーに失敗しました"
 
+#. check that the URL is valid
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
 msgstr "無効なサイトURL: {0}"
@@ -13091,12 +13111,12 @@ msgstr "データベース{0}に対する定期タスクのスケジューリン
 msgid "All elements must be distinct."
 msgstr "全ての項目が一意でなければなりません"
 
-#: 
+#:
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "含めたい列を選ぶ"
 
-#: frontend/src/metabase/entities/databases/forms.js:205
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "これを有効にすることにより、ユーザーがチャートやテーブルを見るときに要約やフィルターボタンを利用して簡単な探索を行った場合に、Metabaseが自動的にクエリを実行するようになります。このデータベースへのクエリが遅い場合は、この設定を無効にすることができます。この設定によってドリルスルーやSQLクエリが影響を受けることはありません。"
 
@@ -13134,13 +13154,13 @@ msgstr "クエリの予想列の決定エラー"
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "例外がハンドリングされていません。ミドルウェアで`catch-exceptions`を行いハンドリングしてください。"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:125
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
 msgid "Diagnostic Info"
 msgstr "診断情報"
 
 #: frontend/src/metabase/admin/tasks/containers/Logs.jsx:123
 msgid "Select Metabase process:"
-msgstr "メタベースプロセスを選択："
+msgstr "Metabaseプロセスを選択："
 
 #: frontend/src/metabase/admin/tasks/containers/Logs.jsx:133
 msgid "All Metabase processes"
@@ -13158,11 +13178,11 @@ msgstr "Googleへのログインに問題が発生しました。管理者に連
 msgid "Sign in with email"
 msgstr "メールアドレスでサインインする"
 
-#: frontend/src/metabase/entities/databases/forms.js:21
+#: frontend/src/metabase/entities/databases/forms.js:23
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "このオプションを使うには与えられたホスト名がFQDNである必要があります。Atlasクラスタに接続する場合、このオプションを有効にする必要があるでしょう。もしもこれが意味するところが分からない場合は、無効のままにしてください。"
 
-#: frontend/src/metabase/entities/databases/forms.js:213
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "デフォルトでMetabaseはフィールド値を毎時の軽量なバッチと日次の重いスキャンで同期しています。大きなデータベースと接続する場合はこの機能をONとし、いつどのくらいの頻度でフィールド値がスキャンされるのかを確認することをオススメします。"
 
@@ -13230,11 +13250,11 @@ msgstr "含めないでください"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "このフィールドはGUIのインターフェースで作られた質問では見ることも選択することもできません。SQLやネイティブクエリではアクセスすることができます。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:512
 msgid "Cumulative sum"
 msgstr "累積和"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Standard deviation"
 msgstr "標準偏差"
 
@@ -13246,23 +13266,23 @@ msgstr "最低{0}文字でなければなりません"
 msgid "Must be at least {0} characters long"
 msgstr "最低{0}文字でなければなりません"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:389
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:82
 msgid "Name (required)"
 msgstr "名前（必須）"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:556
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
 msgid "Run selected text"
 msgstr "選択されたテキストを実行する"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:557
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
 msgid "Run query"
 msgstr "クエリを実行する"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(⌘ + enter)"
 msgstr "(⌘ + enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + enter)"
 
@@ -13274,7 +13294,7 @@ msgstr "ここにあなたの結果が現れます"
 msgid "You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question."
 msgstr "保存をクリックし、元々の質問を上書きしない限り、保存された質問に対して永続的な変更が行われることはありません。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:199
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:200
 msgid "There aren't any filter widgets for this type of field yet."
 msgstr "このタイプのフィールドのフィルターウィジェットはまだありません。"
 
@@ -13284,15 +13304,15 @@ msgstr "このフィールドを検索"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:218
 msgid "Why this metric is interesting"
-msgstr "この指標が興味深いのは何故か"
+msgstr "このメトリクスが興味深いのは何故か"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:228
 msgid "Things to be aware of about this metric"
-msgstr "この指標について知っていること"
+msgstr "このメトリクスについて知っていること"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "How this metric is calculated"
-msgstr "この指標がどのように計算されたか"
+msgstr "このメトリクスがどのように計算されたか"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:215
 msgid "Table this is based on"
@@ -13310,19 +13330,19 @@ msgstr "目標ライン"
 msgid "Trend line"
 msgstr "傾向線"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:320
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:317
 msgid "Show values on data points"
 msgstr "データ点で値を示す"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:334
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:325
 msgid "Values to show"
 msgstr "表示する値"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:342
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:332
 msgid "As many as can fit nicely"
 msgstr "うまく収まる限り"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:343
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
 msgid "All"
 msgstr "全て"
 
@@ -13495,7 +13515,7 @@ msgstr "メールでアラート（{0}: {1}）を送っています"
 
 #: src/metabase/pulse.clj
 msgid "Metabase alert: {0} has {1}"
-msgstr "メタベースアラート：{0}には{1}があります"
+msgstr "Metabaseアラート：{0}には{1}があります"
 
 #: src/metabase/pulse.clj
 msgid "Sending Alert ({0}: {1}) via Slack"
@@ -13614,31 +13634,31 @@ msgstr "数字"
 msgid "No mappable groups"
 msgstr "マッピング可能なグループはありません"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:107
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
 msgstr "Metabaseのドキュメント"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
 msgstr "トラブルシューティングガイドを含みます"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:112
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
 msgid "Post on the Metabase support forum"
 msgstr "Metabaseのサポートフォーラムにポストする"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:114
 msgid "A community forum for all things Metabase"
-msgstr "メタベースに関するすべてのコミュニティフォーラム"
+msgstr "Metabaseに関するすべてのコミュニティフォーラム"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:117
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
 msgid "File a bug report"
 msgstr "バグレポートを提出する"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:119
 msgid "Create a GitHub issue (includes the diagnostic info below)"
 msgstr "GitHubのIssueを作成する（以下の診断情報を含みます）"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:127
 msgid "Please include these details in support requests. Thank you!"
 msgstr "サポート依頼にはこれらの詳細情報を含めてください。ありがとうございます！"
 
@@ -13648,7 +13668,7 @@ msgstr "youlooknicetoday@email.com"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:50
 msgid "Remember me"
-msgstr "私を覚えてください"
+msgstr "ログイン情報を記憶する"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
@@ -13666,38 +13686,40 @@ msgstr "合致する結果がありません"
 msgid "Submit"
 msgstr "参加する"
 
-#: frontend/src/metabase/entities/databases/forms.js:13
+#: frontend/src/metabase/entities/databases/forms.js:15
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host. This option also provides an extra layer of security when a VPN is not available. Enabling this is usually slower than a direct connection."
 msgstr "一部のデータベースインストールには、SSH踏み台インスタンスを介して接続することによってのみアクセスできます。このオプションは、VPNが利用できない場合のセキュリティの追加レイヤーも提供します。通常、これを有効にすると、直接接続よりも時間がかかります。"
 
-#: frontend/src/metabase/entities/databases/forms.js:17
+#: frontend/src/metabase/entities/databases/forms.js:19
 msgid "We suggest you leave this off unless you're doing manual timezone casting in many or most of your queries with this data."
 msgstr "このデータを使用するクエリの多くまたはほとんどのクエリでタイムゾーンキャストを手動で実行している場合を除いて、これをオフのままにすることをお勧めします。"
 
-#: frontend/src/metabase/entities/databases/forms.js:93
+#: frontend/src/metabase/entities/databases/forms.js:128
 msgid "{0} to get an auth code."
 msgstr "認証コードを取得するための{0}"
 
-#: frontend/src/metabase/entities/databases/forms.js:101
+#: frontend/src/metabase/entities/databases/forms.js:136
+#: src/metabase/models/collection.clj
 msgid "or"
 msgstr "か"
 
-#: frontend/src/metabase/entities/databases/forms.js:159
-#: frontend/src/metabase/entities/databases/forms.js:197
-#: frontend/src/metabase/entities/users/forms.js:44
+#: frontend/src/metabase/entities/databases/forms.js:39
+#: frontend/src/metabase/entities/databases/forms.js:226
+#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
-msgstr "必須の"
+msgstr "必須"
 
-#: frontend/src/metabase/entities/databases/forms.js:188
+#: frontend/src/metabase/entities/databases/forms.js:257
 msgid "Database type"
 msgstr "データベースのタイプ"
 
-#: frontend/src/metabase/entities/databases/forms.js:222
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "これはこのデータベースのスキーマの更新をチェックする軽量なプロセスです。ほとんどの場合この設定を毎時同期のままにしておいて問題がないはずです。"
 
-#: frontend/src/metabase/entities/databases/forms.js:230
+#: frontend/src/metabase/entities/databases/forms.js:299
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabaseはこのデータベースの各フィールドの値をスキャンし、ダッシュボードや質問にチェックボックスのフィルタを有効にすることができます。特にとても大きなデータベースと接続する場合、これはある程度リソースを食う処理になる可能性があります。"
 
@@ -13705,15 +13727,15 @@ msgstr "Metabaseはこのデータベースの各フィールドの値をスキ�
 msgid "Collection"
 msgstr "コレクション"
 
-#: frontend/src/metabase/entities/users/forms.js:40
+#: frontend/src/metabase/entities/users/forms.js:55
 msgid "Confirm your password"
-msgstr "パスワードを確認する"
+msgstr "パスワードを確認"
 
-#: frontend/src/metabase/entities/users/forms.js:45
+#: frontend/src/metabase/entities/users/forms.js:60
 msgid "passwords do not match"
 msgstr "パスワードが一致しません"
 
-#: frontend/src/metabase/entities/users/forms.js:71
+#: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
 msgstr "素晴らしい部門"
 
@@ -13721,7 +13743,7 @@ msgstr "素晴らしい部門"
 #: frontend/src/metabase/lib/core.js:98 frontend/src/metabase/lib/core.js:103
 #: frontend/src/metabase/lib/core.js:108 frontend/src/metabase/lib/core.js:113
 msgid "Financial"
-msgstr "ファイナンシャル"
+msgstr "金融"
 
 #: frontend/src/metabase/lib/core.js:120 frontend/src/metabase/lib/core.js:125
 #: frontend/src/metabase/lib/core.js:130
@@ -13753,328 +13775,324 @@ msgid "Returns the average of the values in the column."
 msgstr "コラムの値の平均値を返す。"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:18
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
 msgid "The column whose values to average."
 msgstr "平均値を計算するコラム。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "start"
 msgstr "開始"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "end"
 msgstr "終わり"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
 msgid "Checks a date or numeric column's values to see if they're within the specified range."
 msgstr "日付や数値型コラムの値が特定の範囲内にあるかをチェックします。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
 msgstr "評価"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:24
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:98
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
 msgid "condition"
 msgstr "条件"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
 msgid "output"
 msgstr "出力"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "ケースのリストをテストし、最初の真のケースの対応する値を返します。他に何も満たされない場合は、オプションのデフォルト値を使用します。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
 msgid "Weight"
 msgstr "重さ"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
 msgid "Large"
 msgstr "大"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
 msgid "Medium"
 msgstr "中"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
 msgid "Small"
 msgstr "小"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
 msgid "Something that should evaluate to true or false."
 msgstr "真または偽に評価されるべきもの。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:54
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "前の条件が真であれば返ってくる値"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:62
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "value1"
 msgstr "値1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:74
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
 msgid "value2"
 msgstr "値2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "各引数の値を順番に調べ、各行の最初のnull以外の値を返します。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:56
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
 msgid "Comments"
 msgstr "コメント"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
 msgid "Notes"
 msgstr "注意"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
 msgid "No comments"
 msgstr "コメントなし"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
 msgid "A column or value."
 msgstr "コラムまたは値。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:65
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:77
 msgid "If value1 is empty, value2 gets returned if it's not empty, and so on."
 msgstr "値1が空であれば、それが空でない場合には値2を返し、以下同様です。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 msgid "Combines two or more strings of text together."
 msgstr "テキストの2つ以上の文字列を結合する。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
 msgid "Last Name"
 msgstr "苗字"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 msgid "First Name"
 msgstr "名前"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
 msgstr "この末尾に値2が追加されます。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
 msgstr "これは値1の末尾に付け足されます。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
 msgid "string1"
 msgstr "文字列1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
 msgid "string2"
 msgstr "文字列2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:80
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "文字列1が内部に文字列2を含むかを確かめる。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:284
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
 msgid "Status"
 msgstr "状態"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 msgid "Pass"
 msgstr "パス"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
 msgstr "この文字列の内容がチェックされます。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
 msgid "The string of text to look for."
 msgstr "探している文字列"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:90
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:116
 msgid "Returns the count of rows in the source data."
 msgstr "ソースのデータにある行数を返す。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Only counts rows where the condition is true."
 msgstr "条件がTrueとなる行のみを数える。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:97
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:261
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
 msgid "Subtotal"
 msgstr "小計"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
 msgid "The additive total of rows across a breakout."
 msgstr "ブレークアウト間の行の累積和。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:110
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
 msgid "The rolling sum of a column across a breakout."
 msgstr "ブレークアウト間のカラムの累積和。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:113
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:268
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
 msgstr "合計処理をするコラム。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
 msgid "The number of distinct values in this column."
 msgstr "このコラムの重複のない値の数。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "The column whose distinct values to count."
 msgstr "重複のない値をカウントするコラム。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:128
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:145
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:153
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:201
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:274
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
 msgid "text"
 msgstr "テキスト"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:130
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:223
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
 msgid "comparison"
 msgstr "比較"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "テキストの末尾が比較対象のテキストと一致する場合にTrueを返します。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "Appetite"
 msgstr "興味"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "hungry"
 msgstr "空腹"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 msgid "A column or string of text to check."
 msgstr "チェックするテキストの列または文字列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
 msgid "The string of text that the original text should end with."
 msgstr "元々のテキストの末端にあるべき文字列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 msgid "regular_expression"
 msgstr "正規表現"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:136
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "正規表現に従って合致する部分文字列を抽出する。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:137
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
 msgid "Address"
 msgstr "住所"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 msgid "The column or string of text to search though."
 msgstr "ただし、検索するテキストの列または文字列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
 msgid "The regular expression to match."
 msgstr "合致する正規表現。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the string of text in all lowercase."
 msgstr "全て小文字であるテキストの文字列を返す。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:149
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to lowercase."
 msgstr "小文字に変換する値のあるコラム。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:154
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 msgid "Removes leading whitespace from a string of text."
 msgstr "文字列やテキストから頭の空白を取り除く。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:157
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column with values you want to trim."
 msgstr "取り除きたい値の入ったコラム。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "Returns the largest value found in the column."
 msgstr "そのコラムで見つかった最大値を返す。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
 msgid "Age"
 msgstr "年齢"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:165
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
 msgid "The numeric column whose maximum you want to find."
 msgstr "最大値を見つけ出したい数値型のコラム。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:170
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "Returns the smallest value found in the column."
 msgstr "そのコラムで見つかった最小値を返す。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
 msgid "Salary"
 msgstr "給与"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:173
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
 msgid "The numeric column whose minimum you want to find."
 msgstr "最小値を見つけ出したい数値型のコラム。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:181
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:242
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
 msgid "position"
 msgstr "位置"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:194
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
 msgid "length"
 msgstr "長さ"
 
@@ -14083,7 +14101,7 @@ msgstr "長さ"
 msgid "new_text"
 msgstr "new_text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:187
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
 msgid "Replaces a part of the input text with new text."
 msgstr "入力されたテキストの一部を新しいテキストに置換します"
 
@@ -14095,7 +14113,7 @@ msgstr "Order ID"
 msgid "Updated Part of ID"
 msgstr "IDの更新された部分"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
 msgid "The text that will be modified."
 msgstr "変更されるテキスト"
 
@@ -14111,87 +14129,87 @@ msgstr "置換される文字数"
 msgid "The text to use in the replacement."
 msgstr "置換で使用するテキスト。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "Removes trailing whitespace from a string of text."
 msgstr "テキストの文字列から末尾の空白を取り除きます。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:210
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "条件を満たすデータの行数の割合を小数で返します。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:218
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "テキストの頭が比較対象のテキストと一致している場合に真を返します。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Course Name"
 msgstr "講座名"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Computer Science"
 msgstr "コンピュータ科学"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
 msgid "The string of text that the original text should start with."
 msgstr "元のテキストの頭にあるべきテキストの文字列"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:229
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
 msgid "Calculates the standard deviation of the column."
 msgstr "コラム値の標準偏差を計算する。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:230
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
 msgid "Population"
 msgstr "人口"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
 msgid "A numeric column."
 msgstr "数値型のコラム。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
 msgid "Returns a portion of the supplied text."
 msgstr "与えられたテキストの一部を返します。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:241
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:313
 msgid "The text to return a portion of."
 msgstr "一部を返されるテキスト"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
 msgid "The position to start copying characters."
 msgstr "文字列のコピーを始める位置"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:245
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
 msgid "The number of characters to return."
 msgstr "返すべき文字の数"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
 msgid "Adds up all the values of the column."
 msgstr "そのカラムの全ての値を足し上げます。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:253
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
 msgid "The numeric column to sum."
 msgstr "合計対象の数値型カラム"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
 msgstr "条件に合う行に対して、コラムの値を合計する。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
 msgid "Order Status"
 msgstr "そのほかの状態"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
 msgid "Valid"
 msgstr "有効"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "テキストの文字列から先頭と末尾の空白を削除する。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
 msgid "Returns the string of text in all upper case."
 msgstr "テキストの文字列をすべて大文字で返します。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
 msgid "The column with values to convert to upper case."
 msgstr "大文字に変換する値のあるコラム。"
 
@@ -14210,8 +14228,7 @@ msgstr "{0}を含めなければならない。"
 #: frontend/src/metabase/lib/settings.js:207
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
-msgstr[0] "最低{0}文字\n"
-"最低{0}文字"
+msgstr[0] "最低{0}文字"
 
 #: frontend/src/metabase/lib/settings.js:216
 msgid "{0} lower case letter"
@@ -14228,8 +14245,7 @@ msgstr[0] "{0}個の大文字\n"
 #: frontend/src/metabase/lib/settings.js:234
 msgid "{0} number"
 msgid_plural "{0} numbers"
-msgstr[0] "{0}個の数\n"
-"{0}個の数"
+msgstr[0] "{0}個の数"
 
 #: frontend/src/metabase/lib/settings.js:239
 msgid "{0} special character"
@@ -14253,39 +14269,39 @@ msgstr "Metabaseを使ってくれてありがとう！"
 msgid "Powered by {0}"
 msgstr "{0}提供"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:191
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
 msgid "To:"
 msgstr "To:"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:40
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
 msgstr "この質問は異なるデータベースに基づくものなので利用することができません。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:44
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:43
 msgid "Couldn't find a saved question with that ID number."
 msgstr "そのID番号では保存された質問を見つけることができませんでした。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:55
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:54
 msgid "Pick a saved question"
 msgstr "保存された質問を選ぶ"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:57
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:56
 msgid "Pick a different question"
 msgstr "違う質問を選ぶ"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:62
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:61
 msgid "Loading…"
 msgstr "ロード中..."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:79
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:78
 msgid "Question #…"
 msgstr "質問 #..."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:81
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
 msgstr "質問 #{0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:115
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
 msgstr "最終編集{0}"
 
@@ -14297,11 +14313,11 @@ msgstr "{0}は、このクエリテンプレートに「variable_name」とい�
 msgid "Giving a variable the \"Field Filter\" type allows you to link questions to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "変数に「フィールドフィルター」タイプを指定すると、質問をダッシュボードフィルターウィジェットにリンクしたり、SQL質問でより多くのタイプのフィルターウィジェットを使用したりできます。フィールドフィルター変数は、既存の列にフィルターを追加するときにGUIクエリビルダーによって生成されるものと同様のSQLを挿入します。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:131
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
 msgstr "変数名"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:217
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:218
 msgid "Filter widget label"
 msgstr "ウィジェットラベルのフィルター"
 
@@ -14333,11 +14349,11 @@ msgstr "列見出し"
 msgid "In every table cell"
 msgstr "すべての表のセル"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:351
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:341
 msgid "Value formatting"
 msgstr "値のフォーマティング"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:361
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
 msgid "Full"
 msgstr "いっぱい"
 
@@ -14666,3 +14682,481 @@ msgstr "コラムに対してインサイトを生成することに失敗しま
 msgid "Sending abandonment email!"
 msgstr "アカウントの剥奪メールを送っています"
 
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
+msgstr "保存されたメトリクスを作成して、名前付きメトリックオプションを追加できます。 保存されたメトリクスには、集計タイプ、集計フィールド、およびオプションで追加したフィルターが含まれます。 例として、これを使用して、Ordersテーブルの「平均価格」を計算する公式の方法のようなものを作成できます。"
+
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:105
+msgid "Select and add filters to create your new segment."
+msgstr "フィルターを選択して追加し、新しいセグメントを作成します。"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+msgid "Alphabetical"
+msgstr "アルファベット順"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+msgid "Smart"
+msgstr "スマート"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+msgid "Column order: {0}"
+msgstr "列の順番"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
+msgid "Unhide all"
+msgstr "すべてを再表示"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:204
+msgid "Hide all"
+msgstr "すべてを隠す"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:206
+msgid "Unhide"
+msgstr "再表示"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:22
+msgid "New metric"
+msgstr "新規メトリクス"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:45
+msgid "Create metrics to add them to the Summarize dropdown in the query builder"
+msgstr "メトリクスを作成して、クエリビルダーの要約ドロップダウンに追加します"
+
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:22
+msgid "New segment"
+msgstr "新規セグメント"
+
+#: frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx:71
+msgid "Filter by table"
+msgstr "テーブルでフィルタ"
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:64
+msgid "Checking HTTPS..."
+msgstr "HTTPSを確認しています..."
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:66
+msgid "It looks like HTTPS is not properly configured"
+msgstr "HTTPSが適切に設定されていないようです"
+
+#: frontend/src/metabase/admin/settings/selectors.js:57
+msgid "Redirect to HTTPS"
+msgstr "HTTPSにリダイレクト"
+
+#: frontend/src/metabase/admin/settings/selectors.js:219
+msgid "Localization"
+msgstr "ローカライゼーション"
+
+#: frontend/src/metabase/admin/settings/selectors.js:222
+msgid "Instance language"
+msgstr "インスタンス言語"
+
+#: frontend/src/metabase/admin/settings/selectors.js:237
+msgid "Localization options"
+msgstr "ローカライゼーションオプション"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:51
+msgid "This database doesn't have any tables."
+msgstr "このデータベースにはテーブルがありません。"
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
+msgid "This field only accepts a single value because it's used in a SQL query."
+msgstr "このフィールドは、SQLクエリで使用されるため、単一の値のみを受け入れます。"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:17
+msgid "Service Accounts"
+msgstr "サービスアカウント"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:26
+msgid "Metabase connects to Big Query via {0}."
+msgstr "Metabaseは{0}を介してBig Queryに接続します。"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:29
+msgid "Continue using an OAuth application to connect"
+msgstr "OAuthアプリケーションを引き続き使用して接続する"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:43
+msgid "We recommend switching to use {0} instead of an OAuth application to connect to BigQuery"
+msgstr "BigQueryへの接続には、OAuthアプリケーションではなく{0}を使用するように切り替えることをお勧めします"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:48
+msgid "Connect to a Service Account instead"
+msgstr "代わりにサービスアカウントに接続してください"
+
+#: frontend/src/metabase/entities/databases/forms.js:44
+msgid "invalid JSON"
+msgstr "無効なJSON"
+
+#: frontend/src/metabase/entities/databases/forms.js:50
+msgid "SSH private key"
+msgstr "SSH秘密鍵"
+
+#: frontend/src/metabase/entities/databases/forms.js:51
+msgid "Paste the contents of your ssh private key here"
+msgstr "ここにSSH秘密鍵の内容を貼り付けます"
+
+#: frontend/src/metabase/entities/databases/forms.js:55
+msgid "Passphrase for the SSH private key"
+msgstr "SSH秘密鍵のパスフレーズ"
+
+#: frontend/src/metabase/entities/databases/forms.js:58
+msgid "SSH Authentication"
+msgstr "SSH認証"
+
+#: frontend/src/metabase/entities/databases/forms.js:60
+msgid "SSH Key"
+msgstr "SSHキー"
+
+#: frontend/src/metabase/entities/databases/forms.js:65
+msgid "Server SSL certificate chain"
+msgstr "サーバーSSL証明書チェーン"
+
+#: frontend/src/metabase/entities/databases/forms.js:66
+msgid "Paste the contents of the server's SSL certificate chain here"
+msgstr "サーバーのSSL証明書チェーンの内容をここに貼り付けます"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:11
+msgid "Paste a connection string"
+msgstr "接続文字列を貼り付けます"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:12
+msgid "Fill out individual fields"
+msgstr "個々のフィールドに入力します"
+
+#: frontend/src/metabase/entities/snippets.js:14
+msgid "Enter some SQL here so you can reuse it later"
+msgstr "ここにSQLを入力して、後で再利用できるようにします"
+
+#: frontend/src/metabase/entities/snippets.js:24
+msgid "Give your snippet a name"
+msgstr "スニペットに名前を付けます"
+
+#: frontend/src/metabase/entities/snippets.js:25
+msgid "Current Customers"
+msgstr "現在の顧客"
+
+#: frontend/src/metabase/entities/snippets.js:30
+msgid "Add a description"
+msgstr "説明を追加"
+
+#: frontend/src/metabase/entities/users/forms.js:37
+msgid "Use site default"
+msgstr "サイトのデフォルトを使用"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+msgid "find"
+msgstr "検索"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+msgid "replace"
+msgstr "置換"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+msgid "The text to find."
+msgstr "検索する文字列"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "The text to use as the replacement."
+msgstr "置換する文字列"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+msgid "Editing {0}"
+msgstr "編集中{0}"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+msgid "Create your new snippet"
+msgstr "新しいスニペットを作成する"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+msgid "Archived snippets"
+msgstr "アーカイブされたスニペット"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+msgid "Snippets are reusable bits of SQL"
+msgstr "スニペットは再利用可能なSQLの断片です"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+msgid "Create a snippet"
+msgstr "スニペットを作成する"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+msgid "Snippets"
+msgstr "スニペット"
+
+#: frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx:15
+msgid "SQL Snippets"
+msgstr "SQLスニペット"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:38
+msgid "Your language is set to {0}"
+msgstr "言語が {0} に設定されました"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:50
+msgid "What's your preferred language?"
+msgstr "あなたの好みの言語は何ですか？"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:54
+msgid "This language will be used throughout Metabase and will be the default for new users."
+msgstr "この言語はMetabase全体で使用され、新しいユーザーのデフォルト設定になります。"
+
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:159
+msgid "We filtered out {0} row(s) containing null values."
+msgstr "空の値を含む{0}列は除外されています。"
+
+#: frontend/src/metabase/visualizations/lib/settings/series.js:133
+msgid "Show values for this series"
+msgstr "このシリーズの値を表示"
+
+#: src/metabase/api/card.clj
+msgid "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
+msgstr "質問の平均実行時間は{0}です。{1} "
+
+#: src/metabase/api/native_query_snippet.clj
+msgid "A snippet with that name already exists. Please pick a different name."
+msgstr "その名前のスニペットはすでに存在しています。別の名前を選択してください。"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Metric]"
+msgstr "[不明なメトリクス]"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Segment]"
+msgstr "[不明なセグメント]"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error writing error to output stream"
+msgstr "出力ストリームへのエラーを書き込み中にエラーが発生しました"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Caught unexpected Exception in streaming response body"
+msgstr "ストリーミング応答本文で予期しない例外をキャッチしました"
+
+#: src/metabase/async/streaming_response.clj
+msgid "bound-fn caught unexpected Exception"
+msgstr "bound-fnが予期しない例外をキャッチしました"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error determining whether HTTP request was canceled"
+msgstr "HTTPリクエストがキャンセルされたかどうかの判別中にエラーが発生しました"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Check cancelation status timed out after {0}"
+msgstr "{0}の後にタイムアウトになるキャンセルステータスを確認してください"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Unexpected exception in do-f-async"
+msgstr "do-f-asyncでの予期しない例外"
+
+#: src/metabase/async/streaming_response.clj src/metabase/server.clj
+msgid "Unexpected exception writing error response"
+msgstr "エラー応答書き込み中の予期しない例外"
+
+#: src/metabase/driver/common.clj
+msgid "Server certificate not trusted - did you specify the correct SSL certificate chain?"
+msgstr "サーバー証明書が信頼されていません - 正しいSSL証明書チェーンを指定しましたか？"
+
+#: src/metabase/driver/common.clj
+msgid "Server appears to require SSL - please enable SSL above"
+msgstr "サーバーはSSLを必要とするようです - 上でSSLを有効にしてください"
+
+#: src/metabase/driver/common.clj
+msgid "Username"
+msgstr "ユーザー名"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Don''t know how to parse parameter of type {0}"
+msgstr "タイプ{0}のパラメーターを解析する方法がわかりません"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Invalid :card parameter: missing `:card-id`"
+msgstr "不正なカードパラメータ: `:card-id`が存在しません"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Unable to resolve Snippet: missing `:snippet-id`"
+msgstr "スニペット `:snippet-id`を解決することができません。"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Snippet {0} {1} not found."
+msgstr "スニペット{0} {1} が見つかりません。"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error determining value for parameter"
+msgstr "パラメータの値を判別中にエラーが発生しました"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error building query parameter map"
+msgstr "クエリパラメータマップの作成中にエラーが発生しました"
+
+#: src/metabase/middleware/log.clj
+msgid "ASYNC"
+msgstr "非同期"
+
+#: src/metabase/middleware/log.clj
+msgid "{0} ({1} DB calls)"
+msgstr "{0} ({1} DB calls)"
+
+#: src/metabase/middleware/log.clj
+msgid "App DB connections: {0}/{1}"
+msgstr "App DBの接続: {0}/{1}"
+
+#: src/metabase/middleware/log.clj
+msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
+msgstr "スレッドが渋滞中: {0}/{1} ({2} idle, {3} queued)"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} total active threads)"
+msgstr "(アクティブなスレッド: {0})"
+
+#: src/metabase/middleware/log.clj
+msgid "Queries in flight: {0}"
+msgstr "実行中のクエリ: {0}"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} queued)"
+msgstr "({0}件が待機中)"
+
+#: src/metabase/models/collection.clj
+msgid "Collection must be in the same namespace as its parent"
+msgstr "コレクションはその親と同じ名前空間にある必要があります"
+
+#: src/metabase/models/collection.clj
+msgid "Personal Collections must be in the default namespace"
+msgstr "個人用コレクションはデフォルトの名前空間にある必要があります"
+
+#: src/metabase/models/collection.clj
+msgid "You cannot move a Collection to a different namespace once it has been created."
+msgstr "作成したコレクションを別の名前空間に移動することはできません。"
+
+#: src/metabase/models/collection.clj src/metabase/models/permissions.clj
+msgid "Collection does not exist."
+msgstr "コレクションは存在しません。"
+
+#: src/metabase/models/collection.clj
+msgid "A {0} can only go in Collections in the {1} namespace."
+msgstr "{0}は{1}名前空間のコレクションにのみ移動することができます。"
+
+#: src/metabase/models/database.clj
+msgid "Error sending database deletion notification"
+msgstr "データベース削除通知の送信中にエラーが発生しました"
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "You cannot update the creator_id of a NativeQuerySnippet."
+msgstr "NativeQuerySnippetのcreator_idは更新できません。"
+
+#: src/metabase/models/setting.clj
+msgid "Error fetching value of Setting"
+msgstr "設定値の取得中にエラーが発生しました"
+
+#: src/metabase/public_settings.clj
+msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
+msgstr "Metabase'sのUI、システムメール、パルス、アラートに使用する言語。"
+
+#: src/metabase/public_settings.clj
+msgid "This is also the default language for all users, which they can change from their own account settings."
+msgstr "これは、すべてのユーザーのデフォルト言語でもあり、ユーザーは自分のアカウント設定から変更できます。"
+
+#: src/metabase/public_settings.clj
+msgid "Invalid locale {0}"
+msgstr "ロケール{0}が不正です"
+
+#: src/metabase/public_settings.clj
+msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
+msgstr "サイトのURLがHTTPSの場合、すべてのトラフィックがリダイレクトを介してHTTPSを使用するように強制する"
+
+#: src/metabase/public_settings.clj
+msgid "Cannot redirect requests to HTTPS unless `site-url` is HTTPS."
+msgstr "`site-urlがHTTPSでない限り、リクエストをHTTPSにリダイレクトできません。"
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error registering fonts: Metabase will not be able to send Pulses."
+msgstr "フォントの登録エラー：Metabaseはパルスを送信できません。"
+
+#: src/metabase/pulse/render/png.clj
+msgid "This is a known issue with certain JVMs. See {0} and for more details."
+msgstr "これは、特定のJVMの既知の問題です。詳細については、 {0} をご覧ください。"
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error rendering Pulse"
+msgstr "パルスのレンダリング中にエラーが発生しました"
+
+#: src/metabase/query_processor/context/default.clj
+msgid "Query timed out after {0}, raising timeout exception."
+msgstr "{0}の後にクエリがタイムアウトし、タイムアウト例外が発生しました。"
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "No fields found for table {0}."
+msgstr "テーブル\"{0}\"にはフィールドがありません。"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Case"
+msgstr "ケース"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Variance of {0}"
+msgstr "{0}の分散"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Median of {0}"
+msgstr "{0}の中央値"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "{0}th percentile of {1}"
+msgstr "{1}の{0}パーセンタイル値"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Not caching results: results are larger than {0} KB"
+msgstr "結果をキャッシュしない：結果が{0}KBを超えています"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Cannot cache results: expected byte array, got {0}"
+msgstr "結果をキャッシュできません：バイト配列を期待していたが、{0}を取得しました"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Request is closed; no one to return cached results to"
+msgstr "リクエストはクローズされています。キャッシュされた結果は返されません"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Error attempting to fetch cached results for query with hash {0}"
+msgstr "ハッシュ{0}を使用してクエリのキャッシュ結果をフェッチしようとしてエラーが発生しました"
+
+#: src/metabase/query_processor/middleware/cache_backend/db.clj
+msgid "Error preparing statement to fetch cached query results"
+msgstr "キャッシュされたクエリ結果をフェッチするためのステートメントの準備中にエラーが発生しました"
+
+#: src/metabase/query_processor/middleware/catch_exceptions.clj
+msgid "Error processing query: {0}"
+msgstr "クエリの実行中にエラーが発生しました: {0}"
+
+#: src/metabase/server.clj
+msgid "Unexpected exception in endpoint"
+msgstr "エンドポイントでの予期しない例外"
+
+#: src/metabase/server.clj
+msgid "Unexpected Exception in API request handler"
+msgstr "APIリクエストハンドラーでの予期しない例外"
+
+#: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+msgid "Error reducing {0}"
+msgstr "Error reducing {0}"
+
+#: src/metabase/sync/analyze/fingerprint/insights.clj
+msgid "Error generating timeseries insight keyed by: {0}"
+msgstr "{0}をキーとする時系列インサイトの生成中にエラーが発生しました"
+
+#: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
+msgstr "{0}のデータベースが '' {1} ''から '' {2} ''に移動されました。"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Unscheduling task for Database {0}: trigger: {1}"
+msgstr "データベース{0}のスケジュール解除タスク：トリガー：{1}"
+
+#: src/metabase/util/schema.clj
+msgid "value must be a keyword or string."
+msgstr "値はキーワードまたは文字列でなければなりません。"
+
+#: src/metabase/util/schema.clj
+msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
+msgstr "文字列は、有効な2文字のISO言語または言語の国コードである必要があります。例えば'en'または'en_US'。"

--- a/locales/nl.po
+++ b/locales/nl.po
@@ -31,13 +31,14 @@ msgstr "Selecteer een type database"
 #. Imperative: Sla op
 #. Verb: Opslaan
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:411
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:154
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -50,7 +51,7 @@ msgstr "Opslaan"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "Metabase moet je database scannen om zijn magie erop los te kunnen laten. We zullen de database ook periodiek opnieuw scannen om de metadata actueel te houden. Je kunt hieronder instellen wanneer de periodieke scans plaatsvinden."
 
-#: frontend/src/metabase/entities/databases/forms.js:221
+#: frontend/src/metabase/entities/databases/forms.js:290
 msgid "Database syncing"
 msgstr "Database synchroniseren"
 
@@ -65,7 +66,7 @@ msgstr "Dit is een licht proces dat nagaat of het database schema gewijzigd is. 
 msgid "Scan"
 msgstr "Scannen"
 
-#: frontend/src/metabase/entities/databases/forms.js:228
+#: frontend/src/metabase/entities/databases/forms.js:297
 msgid "Scanning for Filter Values"
 msgstr "Aan het zoeken naar filterwaarden"
 
@@ -76,7 +77,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase kan de waardes van elk veld in deze database scannen om de checkbox filters in dashboards en vragen weer te geven. Dit is een resource-intensief proces, voornamelijk indien je een grote database hebt."
 
-#: frontend/src/metabase/entities/databases/forms.js:232
+#: frontend/src/metabase/entities/databases/forms.js:301
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Wanneer moet Metabase de waarden van deze velden automatisch scannen en cachen?"
 
@@ -98,6 +99,7 @@ msgid "Never, I'll do this manually if I need to"
 msgstr "Nooit, ik doe het handmatig wanneer nodig"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 msgid "Saving..."
@@ -134,9 +136,9 @@ msgid "in this box:"
 msgstr "in dit kader:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:75
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
@@ -153,18 +155,18 @@ msgstr "in dit kader:"
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:301
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:39
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:90
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:99
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:311
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:328
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "Annuleren"
@@ -181,7 +183,7 @@ msgstr "Verwijder"
 #: frontend/src/metabase/admin/permissions/selectors.js:323
 #: frontend/src/metabase/admin/permissions/selectors.js:330
 #: frontend/src/metabase/admin/permissions/selectors.js:441
-#: frontend/src/metabase/admin/routes.jsx:57
+#: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
@@ -201,9 +203,10 @@ msgid "Scheduling"
 msgstr "Planning"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:71
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
@@ -211,8 +214,8 @@ msgid "Save changes"
 msgstr "Sla wijzigingen op"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:203
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:35
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
 msgstr "Acties"
 
@@ -224,8 +227,8 @@ msgstr "Synchroniseer het databaseschema nu"
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:90
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:98
 msgid "Starting…"
 msgstr "Bezig met starten..."
 
@@ -243,13 +246,13 @@ msgstr "Scan veldwaardes opnieuw"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
 msgstr "Scannen mislukt"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:92
 msgid "Scan triggered!"
 msgstr "Scan gestart!"
 
@@ -272,15 +275,15 @@ msgid "Add database"
 msgstr "Database toevoegen"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:28
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:28
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
 #: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:195
+#: frontend/src/metabase/entities/databases/forms.js:264
 #: frontend/src/metabase/entities/questions.js:86
 #: frontend/src/metabase/entities/questions.js:102
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
@@ -320,6 +323,7 @@ msgstr "Succesvol opgeslagen!"
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Bewerken"
@@ -362,44 +366,43 @@ msgstr "Mislukt"
 msgid "Success"
 msgstr "Succes"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:185
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Voorbeeld"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:93
 msgid "No column description yet"
 msgstr "Nog geen kolombeschrijving"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:127
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:126
 msgid "Select a field visibility"
 msgstr "Selecteer veldzichtbaarheid"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:187
 msgid "No special type"
 msgstr "Geen speciaal type"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
 #: frontend/src/metabase/lib/core.js:275
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:44
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:37
 msgid "Other"
 msgstr "Anders"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:221
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Selecteer een speciaal type"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:255
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:262
 #: frontend/src/metabase/reference/components/Field.jsx:99
 msgid "Select a target"
 msgstr "Selecteer een doel"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
@@ -407,18 +410,18 @@ msgstr "Selecteer een doel"
 msgid "Columns"
 msgstr "Kolommen"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Kolom"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:144
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:288
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
 msgid "Visibility"
 msgstr "Zichtbaarheid"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
 msgid "Type"
 msgstr "Type"
 
@@ -426,7 +429,7 @@ msgstr "Type"
 msgid "Current database:"
 msgstr "Huidige database:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
 msgid "Show original schema"
 msgstr "Toon origineel schema:"
 
@@ -448,28 +451,28 @@ msgid_plural "{0} schemas"
 msgstr[0] "{0} schema"
 msgstr[1] "{0} schema's"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:99
 msgid "Why Hide?"
 msgstr "Waarom verbergen?"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:100
 msgid "Technical Data"
 msgstr "Technische data"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
 msgstr "Onrelevant"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 #, fuzzy
 msgid "Queryable"
 msgstr "Bevraagbaar"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:108
 msgid "Hidden"
 msgstr "Verborgen"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136
 msgid "No table description yet"
 msgstr "Nog geen tabelbeschrijving"
 
@@ -477,32 +480,33 @@ msgstr "Nog geen tabelbeschrijving"
 msgid "Metadata Strength"
 msgstr "Metadata-kwaliteit"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0} bevraagbare tabel"
 msgstr[1] "{0} bevraagbaren tabellen"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:91
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} verborgen tabel"
 msgstr[1] "{0} verborgen tabellen"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:115
 msgid "Find a table"
 msgstr "Zoek een tabel"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:128
 msgid "Schemas"
 msgstr "Schema's"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:838
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:21
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:43
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:62
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 msgid "Metrics"
 msgstr "Metrieken"
@@ -511,8 +515,8 @@ msgstr "Metrieken"
 msgid "Add a Metric"
 msgstr "Voeg een metriek toe"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "Definitie"
@@ -521,12 +525,12 @@ msgstr "Definitie"
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "Maak metrieken aan om deze to te voegen aan de View dropdown in de vraagbouwer"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:21
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
 #: frontend/src/metabase/home/containers/SearchApp.jsx:72
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:961
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:61
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Segmenten"
@@ -535,35 +539,35 @@ msgstr "Segmenten"
 msgid "Add a Segment"
 msgstr "Voeg een segment toe"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:51
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:45
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "Maak segmenten om ze toe te voegen aan het de filter selectie in de query bouwer"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:21
 msgid "created"
 msgstr "aangemaakt"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "reverted to a previous version"
 msgstr "teruggedraaid naar een vorige versie"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:30
 msgid "edited the title"
 msgstr "heeft de titel bewerkt"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:32
 msgid "edited the description"
 msgstr "heeft de omschrijving bewerkt"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:34
 msgid "edited the "
 msgstr "bewerkte de "
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:40
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "made some changes"
 msgstr "heeft wat wijzigingen gemaakt"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
 #: frontend/src/metabase/home/components/Activity.jsx:83
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
@@ -573,87 +577,87 @@ msgstr "U"
 msgid "Datamodel"
 msgstr "Datamodel"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:41
 msgid " History"
 msgstr " geschiedenis"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
 msgstr "Revisiegeschiedenis voor"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:228
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
 msgid "{0} – Field Settings"
 msgstr "{0} - Veldinstellingen"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:289
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
 msgid "Where this field will appear throughout Metabase"
 msgstr "Waar dit veld zichtbaar wordt via Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:311
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
 msgid "Filtering on this field"
 msgstr "Filteren op dit veld"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:312
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Als dit veld wordt gebruikt in een filter, wat moet men gebruiken om te filteren op de waarde die ze hebben ingevoerd?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:437
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
 msgid "No description for this field yet"
 msgstr "Nog geen beschrijving voor dit veld"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
 msgid "Original value"
 msgstr "Originele waarde"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:390
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
 #, fuzzy
 msgid "Mapped value"
 msgstr "Gekoppelde waarde"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
 msgid "Enter value"
 msgstr "Voer een waarde in"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use original value"
 msgstr "Gebruik originele waarde"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Use foreign key"
 msgstr "Gebruik verwijzende sleutel"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 #, fuzzy
 msgid "Custom mapping"
 msgstr "Eigen koppeling"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
 #, fuzzy
 msgid "Unrecognized mapping type"
 msgstr "Type voor koppeling niet herkend"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Het huidige veld is geen verwijzende sleutel of of de metadata van de doeltabel mist"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
 msgid "The selected field isn't a foreign key"
 msgstr "Het geselecteerde veld is geen verwijzende sleutel"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:327
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
 msgid "Display values"
 msgstr "Toon waarden"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:328
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Kies om de originele waarde vanuit de database te zien of toon het veld met verwante of custom informatie."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:278
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
 msgid "Choose a field"
 msgstr "Kies een veld"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:299
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
 msgid "Please select a column to use for display."
 msgstr "Selecteer een kolom om te gebruiken voor weergave"
 
@@ -661,16 +665,16 @@ msgstr "Selecteer een kolom om te gebruiken voor weergave"
 msgid "Tip:"
 msgstr "Tip:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:443
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Je kunt ervoor kiezen om de veldnaam aan te passen, om er zeker van te zijn dat deze nog duidelijk is, baserend op je hermapping keuzes."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:344
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Opgeslagen veldwaarden"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:345
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase kan de waarden voor dit veld scannen om checkbox filters in dashboards en vragen in te schakelen."
 
@@ -679,54 +683,54 @@ msgid "Re-scan this field"
 msgstr "Herscan dit veld"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
 msgstr "Verwijder opgeslagen veldwaarden"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
 msgstr "Verwijderen van opgeslagen veldwaarden is mislukt"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 #, fuzzy
 msgid "Discard triggered!"
 msgstr "Weggooien geactiveerd!"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Selecteer een tabel om het schema te zien en om metadata toe te voegen of te wijzigen."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:36
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "Naam is verplicht"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:39
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "Omschrijving is verplicht"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:43
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Herzieningsbericht is verplicht"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
 msgid "Aggregation is required"
 msgstr "Aggregatie is benodigd"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Edit Your Metric"
 msgstr "Bewerk uw metriek"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Create Your Metric"
 msgstr "Maak uw metriek"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Pas de meetwaarde aan en laat een verklaring achter"
 
@@ -734,62 +738,62 @@ msgstr "Pas de meetwaarde aan en laat een verklaring achter"
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Je kunt opgeslagen metrieken aanmaken om een metriek optie toe tevoegen aan deze tabel. Opgeslagen metrieken omvatten het aggregatietype, het geaggregeerde veld en elk filter dat u toevoegt. Bijvoorbeeld: je kunt deze optie gebruiken voor een standaard manier voor het berekenen van een \"gemiddelde prijs\" for een bestellingen tabel."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:180
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
 msgid "Result: "
 msgstr "Resultaat: "
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
 msgid "Name Your Metric"
 msgstr "Geef uw metriek een naam"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:190
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Give your metric a name to help others find it."
 msgstr "Geef uw metriek een naam om het vindbaar te maken voor anderen."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:194
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:152
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Iets verduidelijkends maar niet te lang"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:198
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
 msgid "Describe Your Metric"
 msgstr "Beschrijf uw metriek"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:199
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Beschrijf uw metriek om het uit te leggen aan anderen."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:203
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Hier kun je preciezer zijn over metriken die minder duidelijk zijn"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:207
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:165
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Reden voor wijzigingen"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:209
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Laat een notitie achter, om de veranderingen uit te leggen en waarom ze nodig waren."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:213
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Dit wordt weergegeven in de revisiegeschiedenis voor deze metriek zodat de reden voor iedereen duidelijk is"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
 msgstr "Er is ten minste één filter benodigd"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
 msgstr "Bewerk uw segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
 msgstr "Maak uw segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Verander je segment en laat een uitleg achter."
 
@@ -797,34 +801,34 @@ msgstr "Verander je segment en laat een uitleg achter."
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "Selecteer en voeg filters toe om een nieuw segment voor de {0} tabel te maken."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
 msgstr "Benoem uw segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:148
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
 msgstr "Geef uw segment een naam om het vindbaar te maken voor anderen."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:156
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
 msgstr "Beschrijf uw segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 #, fuzzy
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Benoem je segment, zodat anderen begrijpen wat het doet."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "Dit is een goede plek om specifieker te zijn over minder voor de hand liggende segment regels."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "Dit wordt getoond in de revisiegeschiedenis, zodat iedereen weet waarom dit segment werd aangepast."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
-#: frontend/src/metabase/admin/routes.jsx:132
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:215
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
+#: frontend/src/metabase/admin/routes.jsx:137
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
@@ -832,11 +836,11 @@ msgstr "Dit wordt getoond in de revisiegeschiedenis, zodat iedereen weet waarom 
 msgid "Settings"
 msgstr "Instellingen"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase kan de waardes van deze tabel scannen om checkbox filters in dashboards en vragen aan te zetten."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
 msgstr "Herscan deze tabel"
 
@@ -850,11 +854,11 @@ msgstr "Toevoegen"
 msgid "Not a valid formatted email address"
 msgstr "Geen valide e-mailadres"
 
-#: frontend/src/metabase/entities/users/forms.js:12
+#: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
 msgstr "Voornaam"
 
-#: frontend/src/metabase/entities/users/forms.js:18
+#: frontend/src/metabase/entities/users/forms.js:20
 msgid "Last name"
 msgstr "Achternaam"
 
@@ -893,10 +897,10 @@ msgstr "Gebruikers"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
-#: frontend/src/metabase/admin/settings/selectors.js:120
-#: frontend/src/metabase/entities/users/forms.js:24
+#: frontend/src/metabase/admin/settings/selectors.js:121
+#: frontend/src/metabase/entities/users/forms.js:26
 #: frontend/src/metabase/lib/core.js:146
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:294
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:298
 msgid "Email"
 msgstr "E-mail"
 
@@ -905,14 +909,14 @@ msgid "A group is only as good as its members."
 msgstr "Een groep is slechts zo goed als zijn leden."
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
-#: frontend/src/metabase/admin/routes.jsx:52
+#: frontend/src/metabase/admin/routes.jsx:55
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Admin"
 msgstr "Beheerder"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:241
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:299
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:288
 msgid "and"
 msgstr "en"
 
@@ -965,12 +969,12 @@ msgstr "Verwijder groep"
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:42
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:294
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:397
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:317
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:334
 msgid "Done"
 msgstr "Klaar"
 
@@ -981,8 +985,9 @@ msgstr "Groepsnaam"
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
-#: frontend/src/metabase/admin/routes.jsx:92
+#: frontend/src/metabase/admin/routes.jsx:97
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Groepen"
 
@@ -1012,7 +1017,7 @@ msgstr "Deactiveer"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:21
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
-#: frontend/src/metabase/admin/routes.jsx:88
+#: frontend/src/metabase/admin/routes.jsx:93
 #: frontend/src/metabase/nav/containers/Navbar.jsx:235
 msgid "People"
 msgstr "Mensen"
@@ -1324,25 +1329,25 @@ msgstr "Toon verzamelingen"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:542
+#: frontend/src/metabase/admin/permissions/selectors.js:558
 msgid "Data Access"
 msgstr "Datatoegang"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:667
-#: frontend/src/metabase/admin/permissions/selectors.js:672
+#: frontend/src/metabase/admin/permissions/selectors.js:665
+#: frontend/src/metabase/admin/permissions/selectors.js:670
 msgid "View tables"
 msgstr "Toon tabellen"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:608
+#: frontend/src/metabase/admin/permissions/selectors.js:606
 msgid "SQL Queries"
 msgstr "SQL Queries"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:678
+#: frontend/src/metabase/admin/permissions/selectors.js:676
 msgid "View schemas"
 msgstr "Toon schema's"
 
-#: frontend/src/metabase/admin/routes.jsx:63
+#: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
 msgstr "Datamodel"
@@ -1372,20 +1377,24 @@ msgid "Allows users within your LDAP directory to log in to Metabase with their 
 msgstr "Hiermee kunnen gebruikers in uw LDAP-directory zich aanmelden bij Metabase met hun LDAP-inloggegevens en kunnen LDAP-groepen automatisch worden toegewezen aan Metabase-groepen."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:19
-#: frontend/src/metabase/admin/settings/selectors.js:167
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
+#: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
 msgstr "Dat is geen valide e-mailadres"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
 msgstr "Dat is geen geldig getal"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
 msgstr "Wijzigingen opgeslagen!"
 
-#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:178
+#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
 msgid "Looks like we ran into some problems"
 msgstr "Het lijkt er op dat we tegen een probleem zijn aangelopen"
 
@@ -1407,7 +1416,7 @@ msgstr "Leeg"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:195
+#: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Authenticatie"
 
@@ -1459,15 +1468,15 @@ msgstr "Je Google client ID"
 msgid "Allow users to sign up on their own if their Google account email address is from:"
 msgstr "Sta gebruikers toe om te registeren via een Google account e-mailadres van:"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:242
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:249
 msgid "Answers sent right to your Slack #channels"
 msgstr "Stuur antwoorden direct naar Slack #channels"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:251
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:258
 msgid "Create a Slack Bot User for MetaBot"
 msgstr "Maak een Slack Bot account aan voor MetaBot"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:261
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:268
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "Volg de stappen, geef het een naam en klik op {0}. Kopieer en plak de Bot API token in het onderstaande veld. Wanneer dit voltooid is kun je een \"metabase_files\" channel aanmaken in Slack. Metabase heeft dit nodig om afbeeldingen te uploaden."
 
@@ -1480,8 +1489,8 @@ msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Metabase {0} is beschikbaar. U draait nu {1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:41
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 msgid "Update"
 msgstr "Update"
 
@@ -1508,16 +1517,16 @@ msgstr "Verwijder aangepaste kaart"
 #: frontend/src/metabase/containers/Overworld.jsx:293
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:115
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Verwijderen"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:165
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:141
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
 msgstr "Selecteer..."
 
@@ -1701,48 +1710,46 @@ msgid "Generate Key"
 msgstr "Genereer sleutel"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:87
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:18
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enabled"
 msgstr "Aangezet"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:92
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:19
+#: frontend/src/metabase/admin/settings/selectors.js:93
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Uitgezet"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:112
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:113
 msgid "Unknown setting {0}"
 msgstr "Onbekende instelling {0}"
 
-#: frontend/src/metabase/admin/settings/selectors.js:34
+#: frontend/src/metabase/admin/settings/selectors.js:37
 msgid "Setup"
 msgstr "Setup"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:207
-#: frontend/src/metabase/admin/settings/selectors.js:39
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:214
+#: frontend/src/metabase/admin/settings/selectors.js:42
 msgid "General"
 msgstr "Algemeen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:43
+#: frontend/src/metabase/admin/settings/selectors.js:46
 msgid "Site Name"
 msgstr "Sitenaam"
 
-#: frontend/src/metabase/admin/settings/selectors.js:48
+#: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Site URL"
 msgstr "URL van de site"
 
-#: frontend/src/metabase/admin/settings/selectors.js:53
+#: frontend/src/metabase/admin/settings/selectors.js:64
 msgid "Email Address for Help Requests"
 msgstr "E-mailadres voor hulpverzoeken"
 
-#: frontend/src/metabase/admin/settings/selectors.js:58
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
 msgstr "Rapport tijdzone"
 
-#: frontend/src/metabase/admin/settings/selectors.js:61
+#: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
 msgstr "Standaard database"
 
@@ -1750,11 +1757,11 @@ msgstr "Standaard database"
 msgid "Select a timezone"
 msgstr "Selecteer een tijdzone"
 
-#: frontend/src/metabase/admin/settings/selectors.js:64
+#: frontend/src/metabase/admin/settings/selectors.js:75
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "Niet alle database ondersteunen tijdzones, in die gevallen heeft deze instelling geen effect."
 
-#: frontend/src/metabase/admin/settings/selectors.js:69
+#: frontend/src/metabase/entities/users/forms.js:34
 msgid "Language"
 msgstr "Taal"
 
@@ -1762,64 +1769,64 @@ msgstr "Taal"
 msgid "Select a language"
 msgstr "Selecteer een taal"
 
-#: frontend/src/metabase/admin/settings/selectors.js:79
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
 msgstr "Anoniem volgen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:84
+#: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
 msgstr "Vriendelijke tabel- en veldnamen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:90
+#: frontend/src/metabase/admin/settings/selectors.js:91
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Alleen liggende streepjes en strepen vervangen door spaties"
 
-#: frontend/src/metabase/admin/settings/selectors.js:98
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Enable Nested Queries"
 msgstr "Geneste vragen inschakelen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:109
+#: frontend/src/metabase/admin/settings/selectors.js:110
 msgid "Updates"
 msgstr "Updates"
 
-#: frontend/src/metabase/admin/settings/selectors.js:114
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
 msgstr "Controleer op updates"
 
-#: frontend/src/metabase/admin/settings/selectors.js:125
+#: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
 msgstr "SMTP host"
 
-#: frontend/src/metabase/admin/settings/selectors.js:133
+#: frontend/src/metabase/admin/settings/selectors.js:134
 msgid "SMTP Port"
 msgstr "SMTP poort"
 
-#: frontend/src/metabase/admin/settings/selectors.js:137
+#: frontend/src/metabase/admin/settings/selectors.js:138
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:47
 msgid "That's not a valid port number"
 msgstr "Dat is geen valide poortnummer"
 
-#: frontend/src/metabase/admin/settings/selectors.js:141
+#: frontend/src/metabase/admin/settings/selectors.js:142
 msgid "SMTP Security"
 msgstr "SMTP-beveiliging"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:150
 msgid "SMTP Username"
 msgstr "SMTP-gebruikersnaam"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "SMTP Password"
 msgstr "SMTP wachtwoord"
 
-#: frontend/src/metabase/admin/settings/selectors.js:163
+#: frontend/src/metabase/admin/settings/selectors.js:164
 msgid "From Address"
 msgstr "Van adres"
 
-#: frontend/src/metabase/admin/settings/selectors.js:176
+#: frontend/src/metabase/admin/settings/selectors.js:178
 msgid "Slack API Token"
 msgstr "Slack API token"
 
-#: frontend/src/metabase/admin/settings/selectors.js:178
+#: frontend/src/metabase/admin/settings/selectors.js:180
 msgid "Enter the token you received from Slack"
 msgstr "Voer de token in die je hebt gekregen van Slack"
 
@@ -1848,8 +1855,10 @@ msgid "Username or DN"
 msgstr "Gebruikersnaam of DN"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:43
+#: frontend/src/metabase/entities/databases/forms.js:61
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:64
-#: frontend/src/metabase/user/components/UserSettings.jsx:65
+#: frontend/src/metabase/user/components/UserSettings.jsx:66
+#: src/metabase/driver/common.clj
 msgid "Password"
 msgstr "Wachtwoord"
 
@@ -1885,79 +1894,79 @@ msgstr "Groepslidmaatschappen synchroniseren"
 msgid "Group search base"
 msgstr "Groep zoekbasis"
 
-#: frontend/src/metabase/admin/settings/selectors.js:199
+#: frontend/src/metabase/admin/settings/selectors.js:201
 msgid "Maps"
 msgstr "Kaarten"
 
-#: frontend/src/metabase/admin/settings/selectors.js:203
+#: frontend/src/metabase/admin/settings/selectors.js:205
 msgid "Map tile server URL"
 msgstr "URL van kaarttegelserver (Maps)"
 
-#: frontend/src/metabase/admin/settings/selectors.js:204
+#: frontend/src/metabase/admin/settings/selectors.js:206
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Metabase gebruikt standaard OpenStreetMaps."
 
-#: frontend/src/metabase/admin/settings/selectors.js:209
+#: frontend/src/metabase/admin/settings/selectors.js:211
 msgid "Custom Maps"
 msgstr "Aangepaste kaarten"
 
-#: frontend/src/metabase/admin/settings/selectors.js:210
+#: frontend/src/metabase/admin/settings/selectors.js:212
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Voeg je eigen GeoJSON bestanden toe om andere regio visualisaties in te schakelen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:228
+#: frontend/src/metabase/admin/settings/selectors.js:245
 msgid "Public Sharing"
 msgstr "Publiek delen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:232
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "Enable Public Sharing"
 msgstr "Schakel publiek delen in"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:254
 msgid "Shared Dashboards"
 msgstr "Gedeelde dashboards"
 
-#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Shared Questions"
 msgstr "Gedeelde vragen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:250
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Embedding in other Applications"
 msgstr "Embedden in andere applicaties"
 
-#: frontend/src/metabase/admin/settings/selectors.js:276
+#: frontend/src/metabase/admin/settings/selectors.js:293
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Embedden van Metabase in andere applicaties inschakelen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:286
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Embedding secret key"
 msgstr "Embedding secret key"
 
-#: frontend/src/metabase/admin/settings/selectors.js:292
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Embedded Dashboards"
 msgstr "Embedded Dashboards"
 
-#: frontend/src/metabase/admin/settings/selectors.js:298
+#: frontend/src/metabase/admin/settings/selectors.js:315
 msgid "Embedded Questions"
 msgstr "Embedded Vragen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:322
 msgid "Caching"
 msgstr "Caching"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:326
 msgid "Enable Caching"
 msgstr "Schakel caching in"
 
-#: frontend/src/metabase/admin/settings/selectors.js:314
+#: frontend/src/metabase/admin/settings/selectors.js:331
 msgid "Minimum Query Duration"
 msgstr "minimale query duur"
 
-#: frontend/src/metabase/admin/settings/selectors.js:321
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "cache levensduur (TTL) vermenigvuldiging"
 
-#: frontend/src/metabase/admin/settings/selectors.js:328
+#: frontend/src/metabase/admin/settings/selectors.js:345
 msgid "Max Cache Entry Size"
 msgstr "Maximale cachegrootte"
 
@@ -2125,7 +2134,8 @@ msgstr "De dashboards, collecties en pulsen in deze collectie zullen ook gearchi
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/routes.jsx:205
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
+#: frontend/src/metabase/routes.jsx:196
 msgid "Archive"
 msgstr "Archief"
 
@@ -2141,21 +2151,21 @@ msgstr "Toon het archief"
 msgid "Unarchive this {0}"
 msgstr "Dearchiveer dit {0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:39
-#: frontend/src/metabase/components/BrowseApp.jsx:102
-#: frontend/src/metabase/components/BrowseApp.jsx:194
+#: frontend/src/metabase/components/BrowseApp.jsx:46
+#: frontend/src/metabase/components/BrowseApp.jsx:112
+#: frontend/src/metabase/components/BrowseApp.jsx:204
 #: frontend/src/metabase/containers/Overworld.jsx:270
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
 msgstr "Onze data"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:146
+#: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
 msgid "X-ray this table"
 msgstr "X-ray deze tabel"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:161
+#: frontend/src/metabase/components/BrowseApp.jsx:171
 msgid "Learn about this table"
 msgstr "Leer over deze tabel"
 
@@ -2250,7 +2260,7 @@ msgstr "Pins"
 msgid "Drag something here to pin it to the top"
 msgstr "Sleep iets hier om het bovenaan vast te zetten"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:755
+#: frontend/src/metabase/admin/permissions/selectors.js:753
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2304,7 +2314,7 @@ msgstr "Nieuwe verzameling"
 msgid "Copied!"
 msgstr "Gekopiëerd!"
 
-#: frontend/src/metabase/entities/databases/forms.js:12
+#: frontend/src/metabase/entities/databases/forms.js:14
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Gebruik een SSH-tunnel voor databaseverbindingen"
 
@@ -2314,7 +2324,7 @@ msgid "Some database installations can only be accessed by connecting through an
 "Enabling this is usually slower than a direct connection."
 msgstr "Sommige database-installaties kunnen alleen benaderd worden met een SSH verbinding. Deze optie zorgt ook voor een extra beveiliging wanneer een VPN niet beschikbaar is. Het inschakelen van deze optie is vaak langzamer dan een directe verbinding."
 
-#: frontend/src/metabase/entities/databases/forms.js:212
+#: frontend/src/metabase/entities/databases/forms.js:281
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Dit is een grote database, laat mij kiezen wat Metabase moet synchroniseren en scannen."
 
@@ -2323,17 +2333,17 @@ msgid "By default, Metabase does a lightweight hourly sync and an intensive dail
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Metabase voert standaard een lichte synchronisatie uit en dagelijks een volledige scan van de velden. Wanneer je een grote database hebt adviseren we deze optie aan te zetten zodat je zelf kan bepalen wat en hoe de velden gescand moeten worden."
 
-#: frontend/src/metabase/entities/databases/forms.js:78
+#: frontend/src/metabase/entities/databases/forms.js:113
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0} om een Client ID en Client Secret te genereren voor je project."
 
-#: frontend/src/metabase/entities/databases/forms.js:80
-#: frontend/src/metabase/entities/databases/forms.js:95
-#: frontend/src/metabase/entities/databases/forms.js:131
+#: frontend/src/metabase/entities/databases/forms.js:115
+#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:166
 msgid "Click here"
 msgstr "Klik hier"
 
-#: frontend/src/metabase/entities/databases/forms.js:83
+#: frontend/src/metabase/entities/databases/forms.js:118
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Kies \"Anders\" als applicatie type. Noem het zoals je wilt."
 
@@ -2341,19 +2351,19 @@ msgstr "Kies \"Anders\" als applicatie type. Noem het zoals je wilt."
 msgid "{0} to get an auth code"
 msgstr "{0} om een auth code te verkrijgen"
 
-#: frontend/src/metabase/entities/databases/forms.js:107
+#: frontend/src/metabase/entities/databases/forms.js:142
 msgid "with Google Drive permissions"
 msgstr "met Google Drive rechten"
 
-#: frontend/src/metabase/entities/databases/forms.js:129
+#: frontend/src/metabase/entities/databases/forms.js:164
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "Om Metabase te gebruiken met deze data moet je de API toegang inschakelen in de Google Developers Console."
 
-#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:165
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} om naar het console te gaan, wanneer je dit nog niet gedaan hebt."
 
-#: frontend/src/metabase/entities/databases/forms.js:196
+#: frontend/src/metabase/entities/databases/forms.js:265
 msgid "How would you like to refer to this database?"
 msgstr "Hoe wil je naar deze database verwijzen?"
 
@@ -2362,7 +2372,8 @@ msgstr "Hoe wil je naar deze database verwijzen?"
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:143
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:70
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:123
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:96
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:126
 #: frontend/src/metabase/setup/components/UserStep.jsx:93
 msgid "Next"
 msgstr "Volgende"
@@ -2545,7 +2556,7 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Teruggezet naar een eerdere revisie en {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:290
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "Revisiegeschiedenis"
@@ -2591,7 +2602,7 @@ msgid "Questions"
 msgstr "Vragen"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:320
+#: frontend/src/metabase/routes.jsx:311
 msgid "Pulses"
 msgstr "Pulsen"
 
@@ -2636,15 +2647,16 @@ msgstr "Wij zijn een beetje verdwaald..."
 msgid "Temporary Password"
 msgstr "Tijdelijk wachtwoord"
 
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:207
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:481
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
 msgid "Hide"
 msgstr "Verbergen"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:467
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:482
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:471
 msgid "Show"
 msgstr "Toon"
 
@@ -2754,7 +2766,7 @@ msgstr "Sorry, u hebt geen rechten om dat te zien."
 msgid "Unknown error encountered"
 msgstr "Onbekende fout"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/nav/containers/Navbar.jsx:373
 msgid "Create"
 msgstr "Aanmaken"
@@ -2767,7 +2779,7 @@ msgstr "Maak dashboard aan"
 msgid "Table"
 msgstr "Tabel"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
 msgid "Database"
 msgstr "Database"
 
@@ -2787,7 +2799,7 @@ msgstr "Pas het filter aan om te vinden waar je naar zoekt."
 msgid "View by"
 msgstr "Bekijk als"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:122
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:121
 msgid "of"
 msgstr "van"
 
@@ -2814,33 +2826,33 @@ msgstr "Onze analyse"
 msgid "Browse all items"
 msgstr "Bekijk alle items"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:118
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:117
 msgid "Replace or save as new?"
 msgstr "Vervangen of als nieuwe vraag opslaan?"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:168
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace original question, \"{0}\""
 msgstr "Vervang de originele vraag, \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:172
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:171
 msgid "Save as new question"
 msgstr "Sla op als nieuwe vraag"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:92
 msgid "First, save your question"
 msgstr "Sla eerst uw vraag op"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:94
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
 msgid "Save question"
 msgstr "Sla vraag op"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:133
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
 msgid "What is the name of your card?"
 msgstr "Wat is de naam van uw kaart?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
 #: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/entities/questions.js:89
@@ -2856,15 +2868,16 @@ msgstr "Wat is de naam van uw kaart?"
 msgid "Description"
 msgstr "Omschrijving"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
 #: frontend/src/metabase/entities/dashboards.js:150
 #: frontend/src/metabase/entities/questions.js:91
 #: frontend/src/metabase/entities/questions.js:107
+#: frontend/src/metabase/entities/snippets.js:31
 msgid "It's optional but oh, so helpful"
 msgstr "Het optioneel, maar oh zo handig"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:148
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "In welke collectie moet dit komen?"
@@ -2881,19 +2894,19 @@ msgstr "item"
 msgid "Undo"
 msgstr "Ongedaan maken"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:266
 msgid "Applying Question"
 msgstr "Vraag toepassen"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:286
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "That question isn't compatible"
 msgstr "Die vraag is niet compatibel"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:322
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:309
 msgid "Search for a question"
 msgstr "Een vraag opzoeken"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:351
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:343
 msgid "We're not sure if this question is compatible"
 msgstr "We weten niet zeker of deze vraag compatibel is"
 
@@ -2942,25 +2955,23 @@ msgstr "Voeg een vraag toe"
 msgid "Add a question to this dashboard"
 msgstr "Voeg een vraag toe aan dit dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
 msgid "Add a filter"
 msgstr "Voeg een filter toe"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:256
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "Parameters"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:276
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:280
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
 msgid "Add a text box"
 msgstr "Voeg een tekstveld toe"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:320
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:314
 msgid "Move dashboard"
 msgstr "Verplaats dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:303
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
 msgid "Edit dashboard"
 msgstr "Bewerk dashboard"
 
@@ -2968,11 +2979,11 @@ msgstr "Bewerk dashboard"
 msgid "Edit Dashboard Layout"
 msgstr "Pas dashboard layout aan"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:371
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:365
 msgid "You are editing a dashboard"
 msgstr "U bent een dashboard aan het bewerken"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:376
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:370
 msgid "Select the field that should be filtered for each card"
 msgstr "Selecteer het veld dat voor elke kaart moet worden gefilterd"
 
@@ -3060,7 +3071,7 @@ msgstr "Deze kaart heeft geen velden of parameters die kunnen worden toegewezen 
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "De waarden in dit veld overlappen niet met de waarden van andere velden die je hebt gekozen."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:162
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "Geen valide velden"
@@ -3128,7 +3139,7 @@ msgstr "heeft de laatste data ontvangen van"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:329
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
 msgid "Unknown"
 msgstr "Onbekend"
 
@@ -3255,6 +3266,7 @@ msgstr "{0} items geselecteerd"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 msgid "Unarchive"
 msgstr "Dearchiveer"
 
@@ -3347,7 +3359,7 @@ msgid "Longitude"
 msgstr "Lengtegraad"
 
 #: frontend/src/metabase/lib/core.js:43
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:45
 msgid "Number"
 msgstr "Nummer"
@@ -3404,7 +3416,7 @@ msgid "User"
 msgstr "Gebruiker"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:211
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
 msgid "Source"
 msgstr "Bron"
 
@@ -3445,16 +3457,17 @@ msgid "Score"
 msgstr "Score"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Titel"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
 msgid "Comment"
 msgstr "Commentaar"
 
@@ -3506,9 +3519,9 @@ msgstr "Voeg niet toe"
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
 msgstr "Metabase haalt dit veld nooit op. Gebruik dit voor gevoelige of irrelevante informatie."
 
-#: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:300
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/query/description.js:77
+#: frontend/src/metabase/lib/query/description.js:262
+#: frontend/src/metabase/lib/schema_metadata.js:476
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
@@ -3523,8 +3536,7 @@ msgstr "Aantal"
 msgid "CumulativeCount"
 msgstr "CumulatiefAantal"
 
-#: frontend/src/metabase/lib/expressions/config.js:9
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:485
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3534,7 +3546,6 @@ msgstr "Som"
 msgid "CumulativeSum"
 msgstr "CumulatiefSom"
 
-#: frontend/src/metabase/lib/expressions/config.js:11
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Distinct"
 msgstr "Uniek"
@@ -3543,25 +3554,22 @@ msgstr "Uniek"
 msgid "StandardDeviation"
 msgstr "StandaardDeviatie"
 
-#: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:494
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Gemiddelde"
 
-#: frontend/src/metabase/lib/expressions/config.js:14
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:539
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Min"
 
-#: frontend/src/metabase/lib/expressions/config.js:15
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:548
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:503
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:492
 msgid "Max"
 msgstr "Max"
 
@@ -3614,54 +3622,66 @@ msgstr "Waar denk je aan?"
 msgid "What do you want to find out?"
 msgstr "Waar ben je naar op zoek?"
 
-#: frontend/src/metabase/lib/query.js:298
-#: frontend/src/metabase/lib/schema_metadata.js:466
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:250
+#: frontend/src/metabase/lib/query/description.js:75
+#: frontend/src/metabase/lib/query/description.js:260
+#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Rauwe data"
 
-#: frontend/src/metabase/lib/query.js:302
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/query/description.js:79
+#: frontend/src/metabase/lib/query/description.js:264
+#: frontend/src/metabase/lib/schema_metadata.js:521
 msgid "Cumulative count"
 msgstr "Cumulatief aantal"
 
-#: frontend/src/metabase/lib/query.js:305
+#: frontend/src/metabase/lib/query/description.js:82
+#: frontend/src/metabase/lib/query/description.js:266
 msgid "Average of "
 msgstr "Gemiddelde van "
 
-#: frontend/src/metabase/lib/query.js:310
+#: frontend/src/metabase/lib/query/description.js:87
+#: frontend/src/metabase/lib/query/description.js:268
 msgid "Distinct values of "
 msgstr "Verschillende waarden van "
 
-#: frontend/src/metabase/lib/query.js:315
+#: frontend/src/metabase/lib/query/description.js:92
+#: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
 msgstr "Standaardafwijking van "
 
-#: frontend/src/metabase/lib/query.js:320
+#: frontend/src/metabase/lib/query/description.js:97
+#: frontend/src/metabase/lib/query/description.js:272
 msgid "Sum of "
 msgstr "Som van "
 
-#: frontend/src/metabase/lib/query.js:325
+#: frontend/src/metabase/lib/query/description.js:102
+#: frontend/src/metabase/lib/query/description.js:274
 msgid "Cumulative sum of "
 msgstr "Cumulatieve som van "
 
-#: frontend/src/metabase/lib/query.js:330
+#: frontend/src/metabase/lib/query/description.js:107
+#: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
 msgstr "Maximum van"
 
-#: frontend/src/metabase/lib/query.js:335
+#: frontend/src/metabase/lib/query/description.js:112
+#: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
 msgstr "Minimum van"
 
-#: frontend/src/metabase/lib/query.js:349
+#: frontend/src/metabase/lib/query/description.js:126
+#: frontend/src/metabase/lib/query/description.js:286
 msgid "Grouped by "
 msgstr "Groeperen bij "
 
-#: frontend/src/metabase/lib/query.js:363
+#: frontend/src/metabase/lib/query/description.js:140
+#: frontend/src/metabase/lib/query/description.js:295
 msgid "Filtered by "
 msgstr "Filteren bij "
 
-#: frontend/src/metabase/lib/query.js:392
+#: frontend/src/metabase/lib/query/description.js:169
+#: frontend/src/metabase/lib/query/description.js:320
 msgid "Sorted by "
 msgstr "Sorteren bij "
 
@@ -3673,55 +3693,45 @@ msgstr "Waar"
 msgid "False"
 msgstr "Niet waar"
 
-#: frontend/src/metabase/lib/schema_metadata.js:321
+#: frontend/src/metabase/lib/schema_metadata.js:322
 msgid "Select longitude field"
 msgstr "Selecteer longitude"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:323
 msgid "Enter upper latitude"
 msgstr "Vul hoogste latitude in"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:324
 msgid "Enter left longitude"
 msgstr "Vul longitude (links) in"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:325
 msgid "Enter lower latitude"
 msgstr "Vul laagste latitude in"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:326
 msgid "Enter right longitude"
 msgstr "Vul longitude (rechts) in"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:539
 #: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:397
-#: frontend/src/metabase/lib/schema_metadata.js:405
-#: frontend/src/metabase/lib/schema_metadata.js:411
-#: frontend/src/metabase/lib/schema_metadata.js:416
-msgid "Is"
-msgstr "Is"
-
 #: frontend/src/metabase/lib/schema_metadata.js:362
 #: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:398
 #: frontend/src/metabase/lib/schema_metadata.js:406
 #: frontend/src/metabase/lib/schema_metadata.js:412
-msgid "Is not"
-msgstr "Is niet"
+#: frontend/src/metabase/lib/schema_metadata.js:417
+msgid "Is"
+msgstr "Is"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:417
-msgid "Is empty"
-msgstr "Is leeg"
+#: frontend/src/metabase/lib/schema_metadata.js:413
+msgid "Is not"
+msgstr "Is niet"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:378
@@ -3730,109 +3740,119 @@ msgstr "Is leeg"
 #: frontend/src/metabase/lib/schema_metadata.js:402
 #: frontend/src/metabase/lib/schema_metadata.js:408
 #: frontend/src/metabase/lib/schema_metadata.js:418
+msgid "Is empty"
+msgstr "Is leeg"
+
+#: frontend/src/metabase/lib/schema_metadata.js:365
+#: frontend/src/metabase/lib/schema_metadata.js:379
+#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:395
+#: frontend/src/metabase/lib/schema_metadata.js:403
+#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:419
 msgid "Not empty"
 msgstr "Is niet leeg"
 
-#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:371
 msgid "Equal to"
 msgstr "Gelijk aan"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:372
 msgid "Not equal to"
 msgstr "Niet gelijk aan"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Greater than"
 msgstr "Groter dan"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Less than"
 msgstr "Kleiner dan"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Tussen"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:376
 msgid "Greater than or equal to"
 msgstr "Groter dan of gelijk aan"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Less than or equal to"
 msgstr "Kleiner dan of gelijk aan"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
+#: frontend/src/metabase/lib/schema_metadata.js:384
 msgid "Contains"
 msgstr "Bevat"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:385
 msgid "Does not contain"
 msgstr "Bevat geen"
 
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:388
 msgid "Starts with"
 msgstr "Begint met"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:389
 msgid "Ends with"
 msgstr "Eindigt met"
 
-#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:399
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Voor"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:400
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Na"
 
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:414
 msgid "Inside"
 msgstr "Binnen"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Gewoon een tabel met de rijen in het antwoord, geen extra bewerkingen."
 
-#: frontend/src/metabase/lib/schema_metadata.js:474
+#: frontend/src/metabase/lib/schema_metadata.js:475
 msgid "Count of rows"
 msgstr "Aantal rijen"
 
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:477
 msgid "Total number of rows in the answer."
 msgstr "Totaal aantal rijen in het antwoord."
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Sum of ..."
 msgstr "Som van ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:486
 msgid "Sum of all the values of a column."
 msgstr "Som van alle waarden van een kolom."
 
-#: frontend/src/metabase/lib/schema_metadata.js:492
+#: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Average of ..."
 msgstr "Gemiddelde van ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:495
 msgid "Average of all the values of a column"
 msgstr "Gemiddelde van alle waarden van een kolom"
 
-#: frontend/src/metabase/lib/schema_metadata.js:501
+#: frontend/src/metabase/lib/schema_metadata.js:502
 msgid "Number of distinct values of ..."
 msgstr "Aantal verschillende waarden van ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:504
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Aantal unieke waarden van een kolom tussen alle rijen in het antwoord."
 
-#: frontend/src/metabase/lib/schema_metadata.js:510
+#: frontend/src/metabase/lib/schema_metadata.js:511
 msgid "Cumulative sum of ..."
 msgstr "Cumulatieve som van ..."
 
@@ -3840,7 +3860,7 @@ msgstr "Cumulatieve som van ..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Additieve som van alle waarden van een kolom. \\\\ Voorbeeld: totale omzet in de loop van de tijd."
 
-#: frontend/src/metabase/lib/schema_metadata.js:519
+#: frontend/src/metabase/lib/schema_metadata.js:520
 msgid "Cumulative count of rows"
 msgstr "Cumulatief aantal rijen"
 
@@ -3848,27 +3868,27 @@ msgstr "Cumulatief aantal rijen"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Optelling van het aantal rijen. \\\\ Voorbeeld: totaal aantal verkopen in de loop van de tijd."
 
-#: frontend/src/metabase/lib/schema_metadata.js:528
+#: frontend/src/metabase/lib/schema_metadata.js:529
 msgid "Standard deviation of ..."
 msgstr "Standaardafwijking van ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:531
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Getal dat aangeeft hoeveel de waarden van een kolom variëren tussen alle rijen in het antwoord."
 
-#: frontend/src/metabase/lib/schema_metadata.js:537
+#: frontend/src/metabase/lib/schema_metadata.js:538
 msgid "Minimum of ..."
 msgstr "Minimum van ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Minimum value of a column"
 msgstr "Minimale waarde van een kolom"
 
-#: frontend/src/metabase/lib/schema_metadata.js:546
+#: frontend/src/metabase/lib/schema_metadata.js:547
 msgid "Maximum of ..."
 msgstr "Maximum van ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:549
 msgid "Maximum value of a column"
 msgstr "Maximale waarde van een kolom"
 
@@ -4044,7 +4064,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Categorie, Type, Model, Beoordeling, etc."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:43
-#: frontend/src/metabase/user/components/UserSettings.jsx:55
+#: frontend/src/metabase/user/components/UserSettings.jsx:56
 msgid "Account settings"
 msgstr "Account instellingen"
 
@@ -4056,7 +4076,7 @@ msgstr "Admin afsluiten"
 msgid "Logs"
 msgstr "Logs"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:103
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:104
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:22
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:65
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:100
@@ -4096,9 +4116,9 @@ msgid "Metabase Admin"
 msgstr "Metabase administrator"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:36
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:36
 msgid "Ask a question"
 msgstr "Een vraag stellen"
 
@@ -4119,7 +4139,7 @@ msgstr "Referentie"
 msgid "Which metric?"
 msgstr "Welke metriek?"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "Door gemeenschappelijke statistieken voor je team te definiëren, kun je nog eenvoudiger vragen stellen"
 
@@ -4131,7 +4151,7 @@ msgstr "Hoe maak je metrieken"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Bekijk gegevens in de loop van de tijd of als een kaart om trends of veranderingen beter te kunnen begrijpen."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:149
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
 msgid "Custom"
 msgstr "Aangepast"
 
@@ -4144,13 +4164,13 @@ msgstr "Nieuwe vraag"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Gebruik de eenvoudige vragenmaker om trends, lijsten met dingen te bekijken of om je eigen statistieken te maken."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:107
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:110
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Native query"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:108
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:111
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Voor meer gecompliceerde vragen kunt u uw eigen SQL- of native query schrijven."
 
@@ -4255,6 +4275,7 @@ msgid "Enter a default value..."
 msgstr "Voer een standaard waarde in..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
+#: frontend/src/metabase/containers/Form.jsx:307
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Een fout is opgetreden"
@@ -4503,7 +4524,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "We raden aan om pulsen klein en geconcentreerd te houden om ze relevant en nuttig te houden voor het hele team."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:161
-#: frontend/src/metabase/query_builder/components/view/View.jsx:131
+#: frontend/src/metabase/query_builder/components/view/View.jsx:133
 msgid "Pick your data"
 msgstr "Kies je gegevens"
 
@@ -4519,47 +4540,47 @@ msgstr "E-mails"
 msgid "Slack messages"
 msgstr "Slack berichten"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:216
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Verstuurd"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:217
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} wordt verzonden om"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:219
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Berichten"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:235
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "Verstuur e-mail nu"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:236
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Verstuur nu naar {0}"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:238
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Versturen..."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "Versturen mislukt"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "Niet verzonden omdat de puls geen resultaten heeft."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Pulse verstuurd"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:282
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} moet worden ingesteld door een beheerder."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:295
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:299
 msgid "Slack"
 msgstr "Slack"
 
@@ -4712,7 +4733,7 @@ msgstr "Gemiddeld"
 msgid "Distincts"
 msgstr "Uniek"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:55
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "Bekijk deze {0}"
@@ -4723,11 +4744,12 @@ msgstr[1] "Bekijk deze {0}"
 msgid "Zoom in"
 msgstr "Inzoomen"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Aangepaste expressie"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Common Metrics"
 msgstr "Populaire statistieken"
 
@@ -4924,34 +4946,34 @@ msgstr "doorgaans"
 msgid "Pick a segment or table"
 msgstr "Kies een segment of tabel"
 
-#: frontend/src/metabase/entities/databases/forms.js:191
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
+#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Selecteer een database"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:94
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:85
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:31
 msgid "Select..."
 msgstr "Selecteer..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:134
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
 msgid "Select a table"
 msgstr "Selecteer een tabel"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:819
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:926
 msgid "No tables found in this database."
 msgstr "Geen tabellen gevonden in deze database"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:856
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:901
 msgid "Is a question missing?"
 msgstr "Mist er een vraag?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:863
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:909
 msgid "Learn more about nested queries"
 msgstr "Meer informatie over geneste zoekopdrachten"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:898
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:951
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:40
 msgid "Fields"
 msgstr "Velden"
 
@@ -4985,11 +5007,11 @@ msgstr "Sorteer"
 msgid "Row limit"
 msgstr "Rij limiet"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
 msgid "Unknown Field"
 msgstr "Onbekend veld"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:75
 msgid "field"
 msgstr "veld"
 
@@ -4997,19 +5019,20 @@ msgstr "veld"
 msgid "Matches"
 msgstr "Matcht"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:148
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:156
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:135
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Voeg filters toe om je antwoord te verfijnen"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:293
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
 msgstr "Groepering toevoegen"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:37
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:313
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
-#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:66
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:67
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:89
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:131
@@ -5025,16 +5048,16 @@ msgstr "Groepering toevoegen"
 msgid "Data"
 msgstr "Data"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:340
 msgid "Filtered by"
 msgstr "Gefilterd op"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:376
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:357
 msgid "View"
 msgstr "Bekijk"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:393
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:374
 msgid "Grouped By"
 msgstr "Gegroepeerd op"
 
@@ -5042,7 +5065,7 @@ msgstr "Gegroepeerd op"
 msgid "None"
 msgstr "Geen"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:471
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
 msgid "This question is written in {0}."
 msgstr "Deze vraag is geschreven in {0}."
 
@@ -5054,7 +5077,7 @@ msgstr "Verberg editor"
 msgid "Hide Query"
 msgstr "Query verbergen"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:481
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
 msgid "Open Editor"
 msgstr "Editor openen"
 
@@ -5295,7 +5318,7 @@ msgstr "Alle unieke waardes van {0}"
 msgid "Number of {0} grouped by {1}"
 msgstr "Aantal van {0} per {1}"
 
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:77
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5354,32 +5377,33 @@ msgstr "Bekijk de onbewerkte resultaten voor {0}"
 msgid "More"
 msgstr "Meer"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:194
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:216
 msgid "Invalid expression"
 msgstr "Ongeldige expressie"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:269
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:282
 msgid "unknown error"
 msgstr "Onbekende foutmelding"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:47
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:53
 msgid "Field formula"
 msgstr "Veld formule"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:60
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:64
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Zie dit als het schrijven van een formule in een spreadsheetprogramma: je kunt getallen, velden in deze tabel, wiskundige symbolen zoals + en sommige functies gebruiken. Dus je zou iets kunnen typen als Subtotaal - Kosten."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:69
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:208
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
 msgid "Learn more"
 msgstr "Lees meer"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:77
 msgid "Give it a name"
 msgstr "Geef het een naam"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:79
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
 msgid "Something nice and descriptive"
 msgstr "Iets moois en omschrijvend"
 
@@ -5459,11 +5483,11 @@ msgid "Enter desired number"
 msgstr "Voer het gewenste getal in"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:154
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:161
 msgid "Empty"
 msgstr "Leeg"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:119
 msgid "Find a value"
 msgstr "Vind een waarde"
 
@@ -5531,35 +5555,35 @@ msgstr "Lees de volledige documentatie"
 msgid "Filter label"
 msgstr "Filter label"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:135
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:134
 msgid "Variable type"
 msgstr "Variabel type"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:143
 msgid "Text"
 msgstr "Tekst"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
 msgid "Date"
 msgstr "Datum"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:147
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
 msgid "Field Filter"
 msgstr "Veld filter"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Field to map to"
 msgstr "Veld om te koppelen"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:180
 msgid "Filter widget type"
 msgstr "Filter widget type"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:230
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
 msgid "Required?"
 msgstr "Verplicht?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:240
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
 msgid "Default filter widget value"
 msgstr "Standaard filter widget waarde"
 
@@ -5571,7 +5595,7 @@ msgstr "Deze vraag archiveren?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Deze vraag zal verwijderd worden van elk dashboard of puls waar deze gebruikt wordt."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:158
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
 msgid "Question"
 msgstr "Vraag"
 
@@ -5741,7 +5765,7 @@ msgid "Details"
 msgstr "Details"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
-#: frontend/src/metabase/reference/databases/TableList.jsx:116
+#: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
 msgstr "Tabellen in {0}"
 
@@ -5822,24 +5846,24 @@ msgstr "Waarom is deze tabel interessant"
 msgid "Things to be aware of about this table"
 msgstr "Dingen waar je op moet letten bij deze tabel"
 
-#: frontend/src/metabase/reference/databases/TableList.jsx:30
+#: frontend/src/metabase/reference/databases/TableList.jsx:29
 msgid "Tables in this database will appear here as they're added"
 msgstr "Tabellen in de database worden hier weergegeven zodra deze zijn toegevoegd"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:34
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:33
 msgid "Questions about this table will appear here as they're added"
 msgstr "Vragen m.b.t deze tabel worden hier weergegeven zodra deze zijn toegevoegd"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:73
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:77
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:76
 msgid "Questions about {0}"
 msgstr "Vragen met betrekking tot {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
 msgid "Created {0} by {1}"
 msgstr "Toegevoegd {0} door {1}"
 
@@ -6028,19 +6052,19 @@ msgstr "Andere velden die gegroepeerd kunnen worden bij deze metriek"
 msgid "Fields you can group this metric by"
 msgstr "Velden waarop je dit metriek kunt groeperen"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "Metrieken zijn de officiële cijfers waar je team om geeft"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Metrics will appear here once your admins have created some"
 msgstr "Metrieken worden hier weergegeven zodra je beheerder er een paar hebben aangemaakt"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:28
 msgid "Learn how to create metrics"
 msgstr "Leer meer over het aanmaken van metrieken"
 
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:34
 msgid "Questions about this metric will appear here as they're added"
 msgstr "Vragen met betrekking tot deze metriek komen hier te staan zodra ze zijn toegevoegd"
 
@@ -6066,23 +6090,23 @@ msgstr "Waarom is dit segment interessant"
 msgid "Things to be aware of about this Segment"
 msgstr "Dingen waarop je moet letten bij dit segment"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
 msgid "Segments are interesting subsets of tables"
 msgstr "Segmenten zijn interessante subsets van tabellen"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "Het definiëren van veel gebruikte segmenten helpt je team om nog gemakkelijker nieuwe vragen aan te maken"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Segments will appear here once your admins have created some"
 msgstr "Segmenten worden hier getoond zodra je beheerders er een paar hebben aangemaakt."
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
 msgid "Learn how to create segments"
 msgstr "Leer meer over het aanmaken van segmenten"
 
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:35
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:34
 msgid "Questions about this segment will appear here as they're added"
 msgstr "Vragen over dit segment worden hier getoond zodra deze zijn toegevoegd"
 
@@ -6102,22 +6126,22 @@ msgstr "Vragen over dit segment"
 msgid "X-ray this segment"
 msgstr "X-ray dit segment"
 
-#: frontend/src/metabase/routes.jsx:178 frontend/src/metabase/routes.jsx:179
+#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
 msgid "Login"
 msgstr "Inloggen"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:303
 #: frontend/src/metabase/containers/ItemPicker.jsx:115
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:204
+#: frontend/src/metabase/routes.jsx:195
 msgid "Search"
 msgstr "Zoeken"
 
-#: frontend/src/metabase/routes.jsx:223
+#: frontend/src/metabase/routes.jsx:214
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#: frontend/src/metabase/routes.jsx:236
+#: frontend/src/metabase/routes.jsx:227
 msgid "New Question"
 msgstr "Nieuwe vraag"
 
@@ -6161,63 +6185,63 @@ msgstr "Bedankt dat je ons helpt te verbeteren"
 msgid "We won't collect any usage events"
 msgstr "We verzamelen geen gebruiker interacties"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:88
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Om ons te helpen Metabase te verbeteren, willen we bepaalde gegevens over het gebruik verzamelen via Google Analytics."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:90
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Here's a full list of everything we track and why."
 msgstr "Hier is een volledige lijst van alles wat we bijhouden en waarom."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Laat Metabase anoniem gebruiksgebeurtenissen verzamelen"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:113
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase verzamelt {0} je gegevens of vraagresultaten."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:114
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
 msgid "never"
 msgstr "nooit"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:119
 msgid "All collection is completely anonymous."
 msgstr "Alle collecties zijn volledig anoniem"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Verzameling kan op elk moment in je beheerdersinstellingen worden uitgeschakeld."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:44
+#: frontend/src/metabase/setup/components/Setup.jsx:59
 msgid "If you feel stuck"
 msgstr "Als je er niet uitkomt"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:49
+#: frontend/src/metabase/setup/components/Setup.jsx:64
 msgid "our getting started guide"
 msgstr "onze beknopte handleiding"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:50
+#: frontend/src/metabase/setup/components/Setup.jsx:65
 msgid "is just a click away."
 msgstr "is slechts een klik verwijderd."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:92
+#: frontend/src/metabase/setup/components/Setup.jsx:111
 msgid "Welcome to Metabase"
 msgstr "Welkom bij Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:93
+#: frontend/src/metabase/setup/components/Setup.jsx:112
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Het lijkt er op dat alles werkt. Laten we kennis maken, verbinding maken met je data en starten met het vinden van wat antwoorden!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:97
+#: frontend/src/metabase/setup/components/Setup.jsx:116
 msgid "Let's get started"
 msgstr "Laten we starten"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:142
+#: frontend/src/metabase/setup/components/Setup.jsx:166
 msgid "You're all set up!"
 msgstr "Je bent er helemaal klaar voor!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:153
+#: frontend/src/metabase/setup/components/Setup.jsx:177
 msgid "Take me to Metabase"
 msgstr "Breng me naar Metabase"
 
@@ -6229,13 +6253,13 @@ msgstr "Hoe moeten we je noemen?"
 msgid "Hi, {0}. nice to meet you!"
 msgstr "Hi {0}. leuk om je te ontmoeten!"
 
-#: frontend/src/metabase/entities/users/forms.js:33
+#: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
 msgstr "Maak een wachtwoord"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:44
-#: frontend/src/metabase/entities/users/forms.js:35
-#: frontend/src/metabase/entities/users/forms.js:82
+#: frontend/src/metabase/entities/users/forms.js:50
+#: frontend/src/metabase/entities/users/forms.js:97
 msgid "Shhh..."
 msgstr "Sssssst..."
 
@@ -6243,11 +6267,11 @@ msgstr "Sssssst..."
 msgid "Confirm password"
 msgstr "Bevestig wachtwoord"
 
-#: frontend/src/metabase/entities/users/forms.js:42
+#: frontend/src/metabase/entities/users/forms.js:57
 msgid "Shhh... but one more time so we get it right"
 msgstr "Sssssst... maar nog een keer zodat we het zeker weten"
 
-#: frontend/src/metabase/entities/users/forms.js:70
+#: frontend/src/metabase/entities/users/forms.js:85
 msgid "Your company or team name"
 msgstr "Je bedrijfsnaam of team naam"
 
@@ -6416,7 +6440,7 @@ msgstr "Wachtwoord succesvol bijgewerkt!"
 msgid "Account updated successfully!"
 msgstr "Account succesvol bijgewerkt!"
 
-#: frontend/src/metabase/entities/users/forms.js:81
+#: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
 msgstr "Huidig wachtwoord"
 
@@ -6428,7 +6452,7 @@ msgstr "Log in met je Google E-mailadres"
 msgid "User Details"
 msgstr "Gebruikersdetails"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:327
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:344
 msgid "Reset to defaults"
 msgstr "Terugzetten naar standaard waardes"
 
@@ -6453,15 +6477,15 @@ msgstr "Welke velden wil je gebruiken voor de X- en Y-assen?"
 msgid "Choose fields"
 msgstr "Velden kiezen"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:217
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:234
 msgid "Save as default view"
 msgstr "Opslaan als standaard weergave"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Draw box to filter"
 msgstr "Teken een box om te filteren"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Cancel filter"
 msgstr "Annuleer filter"
 
@@ -6489,19 +6513,19 @@ msgstr "Kan visualisatie niet vinden"
 msgid "Could not display this chart with this data."
 msgstr "Kan deze grafiek niet met deze gegevens weergeven."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:526
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
 msgid "No results!"
 msgstr "Geen resultaten"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:547
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
 msgid "Still Waiting..."
 msgstr "Nog steeds bezig met wachten..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:550
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
 msgid "This usually takes an average of {0}."
 msgstr "Dit duurt meestal gemiddeld {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:556
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Dit is een beetje lang voor een dashboard)"
 
@@ -6660,19 +6684,19 @@ msgstr "Regel toevoegen"
 msgid "Update rule"
 msgstr "Regel bewerken"
 
-#: frontend/src/metabase/visualizations/index.js:32
+#: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
 msgstr "Visualisatie is leeg"
 
-#: frontend/src/metabase/visualizations/index.js:37
+#: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
 msgstr "Visualisatie moet een statische variabele 'identifier' definiëren:"
 
-#: frontend/src/metabase/visualizations/index.js:43
+#: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
 msgstr "Visualisatie met deze identificatie is al geregistreerd:"
 
-#: frontend/src/metabase/visualizations/index.js:71
+#: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
 msgstr "Geen visualisatie voor {0}"
 
@@ -6698,23 +6722,23 @@ msgid "Doh! The data from your query doesn't fit the chosen display choice. This
 msgstr "Doh! De gegevens van je zoekopdracht passen niet in de gekozen weergave. Deze visualisatie vereist ten minste {0} {1} aan gegevens."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:9
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:117
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:120
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:161
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:169
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:249
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:267
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "Kolom"
@@ -6825,83 +6849,83 @@ msgstr "Niks"
 msgid "Linear Interpolated"
 msgstr "Lineaire geïnterpoleerd"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
 msgstr "X-as schaal"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
 msgstr "Tijdreeksen"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:454
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
 msgid "Linear"
 msgstr "Lineair"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
 msgid "Power"
 msgstr "machtsverheffen"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:428
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:445
 msgid "Log"
 msgstr "logaritmisch"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:441
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:430
 msgid "Histogram"
 msgstr "Histogram"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
 msgstr "Rangschikkend"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
 msgstr "Y-as schaal"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:462
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
 msgstr "X-aslijn en markeringen weergeven"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:360
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:468
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:349
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
 msgid "Compact"
 msgstr "Compact"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:469
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
 msgid "Rotate 45°"
 msgstr "Roteer 45°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:459
 msgid "Rotate 90°"
 msgstr "Roteer 90°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
 msgid "Show y-axis line and marks"
 msgstr "Y-aslijn en markeringen weergeven"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:489
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Auto y-axis range"
 msgstr "Automatisch Y-as bereik"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:533
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:522
 msgid "Use a split y-axis when necessary"
 msgstr "Gebruik indien nodig een gesplitste Y-as"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:540
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:529
 msgid "Show label on x-axis"
 msgstr "Labels weergeven op X-as"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:546
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:535
 msgid "X-axis label"
 msgstr "X-as label"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:555
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:544
 msgid "Show label on y-axis"
 msgstr "Label weergeven op Y-as"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:561
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:550
 msgid "Y-axis label"
 msgstr "Y-as label"
 
@@ -7027,23 +7051,23 @@ msgstr "Minimale doorzichtigheid"
 msgid "Max Zoom"
 msgstr "Maximale zoom"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:231
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:234
 msgid "No relationships found."
 msgstr "Geen relaties gevonden"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:269
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:272
 msgid "via {0}"
 msgstr "via {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:347
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
 msgid "This {0} is connected to:"
 msgstr "Deze {0} is verbonden aan"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "Object Detail"
 msgstr "Object detail"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:93
 msgid "object"
 msgstr "object"
 
@@ -7432,7 +7456,7 @@ msgstr "Heb je veel vragen opgeslagen in {0}? Maak collecties om ze te helpen be
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:149 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -8952,19 +8976,19 @@ msgstr "Kan deze verzameling en de inhoud ervan bewerken"
 msgid "Can view items in this collection"
 msgstr "Kan items in deze collectie bekijken"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:767
+#: frontend/src/metabase/admin/permissions/selectors.js:765
 msgid "Collection Access"
 msgstr "Verzamelingstoegang"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:841
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Deze groep heeft toestemming om ten minste één deelcollectie van deze verzameling te bekijken."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:848
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Deze groep heeft toestemming om ten minste één subcollectie van deze verzameling te bewerken."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:861
+#: frontend/src/metabase/admin/permissions/selectors.js:859
 msgid "View sub-collections"
 msgstr "Toon subverzamelingen"
 
@@ -8972,7 +8996,7 @@ msgstr "Toon subverzamelingen"
 msgid "Remember Me"
 msgstr "Onthoud mij"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:63
+#: frontend/src/metabase/components/BrowseApp.jsx:73
 msgid "X-ray this schema"
 msgstr "X-ray dit schema"
 
@@ -9033,15 +9057,15 @@ msgstr "Metabase kon geen resultaten vinden voor uw zoekopdracht."
 msgid "No metrics"
 msgstr "Geen metrieken"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:31
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:41
 msgid "Aggregations"
 msgstr "Aggregaties"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:32
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:42
 msgid "Operators"
 msgstr "operators"
 
-#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:30
+#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:35
 msgid "Custom fields"
 msgstr "Aangepaste velden"
 
@@ -9208,7 +9232,7 @@ msgstr "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
 msgid "toucan_sightings"
 msgstr "toucan_sightings"
 
-#: src/metabase/driver/sparksql.clj
+#: src/metabase/models/collection.clj
 msgid "default"
 msgstr "standaard"
 
@@ -9236,10 +9260,10 @@ msgstr "N/B"
 msgid "Windows domain"
 msgstr "Windows domein"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:539
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:545
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:554
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:560
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:528
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:534
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:543
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
 msgstr "Labels"
 
@@ -9274,9 +9298,9 @@ msgstr "Delen"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:286
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:294
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:302
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:319
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:324
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
@@ -9291,19 +9315,18 @@ msgstr "Delen"
 msgid "Display"
 msgstr "Weergave"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:461
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:476
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:502
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:532
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:402
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:465
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:483
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:521
 msgid "Axes"
 msgstr "Assen"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:212
-#: frontend/src/metabase/admin/settings/selectors.js:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:219
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:62
 msgid "Formatting"
@@ -9337,7 +9360,7 @@ msgstr "X-ray"
 msgid "Compare to the rest"
 msgstr "Vergelijk met de rest"
 
-#: frontend/src/metabase/entities/databases/forms.js:16
+#: frontend/src/metabase/entities/databases/forms.js:18
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Gebruik de Java Virtual Machine (JVM) tijdzone"
 
@@ -9367,24 +9390,24 @@ msgstr "Gebruik JVM tijdzone"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "We analyseren momenteel de tabellen en velden om je te helpen met het verkennen van je gegevens."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
 msgid "Tip: "
 msgstr "Tip:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:237
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
 msgstr "Selecteer een valutatype"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:300
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
 msgid "Field Type"
 msgstr "Ved type"
 
-#: frontend/src/metabase/admin/routes.jsx:113
+#: frontend/src/metabase/admin/routes.jsx:118
 #: frontend/src/metabase/nav/containers/Navbar.jsx:267
 msgid "Troubleshooting"
 msgstr "Probleemoplossen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:103
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Enable X-ray features"
 msgstr "X-ray functionaliteit inschakelen"
 
@@ -9429,7 +9452,7 @@ msgstr "Duur (ms)"
 msgid "Currency"
 msgstr "Valuta"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
 msgstr "Kies een gebruiker of kanaal ..."
 
@@ -9577,7 +9600,7 @@ msgstr "Lijn stijl"
 msgid "Show dots on lines"
 msgstr "Punten en lijnen weergeven"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:348
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
@@ -9591,7 +9614,7 @@ msgstr "Welke assen?"
 msgid "Line + Bar"
 msgstr "Lijn en staaf"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
 msgid "line and bar chart"
 msgstr "Lijn en staaf grafiek"
 
@@ -11038,7 +11061,7 @@ msgstr "Hoe deze metriek verdeeld is over verschillende nummers"
 msgid "Sessions by page where the session began"
 msgstr "Sessies per pagina wanneer de sessie begon"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:503
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -11407,7 +11430,7 @@ msgstr "Dit item dupliceren"
 msgid "Archive this item"
 msgstr "Dit item archiveren"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:331
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:325
 msgid "Duplicate dashboard"
 msgstr "Dashboard dupliceren"
 
@@ -11512,7 +11535,7 @@ msgid_plural "Quarters of year"
 msgstr[0] "Kwartaal van het jaar"
 msgstr[1] "Kwartalen van het jaar"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
@@ -11528,8 +11551,8 @@ msgstr "[Q]Q"
 msgid "This"
 msgstr "Deze"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:97
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:137
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:136
 msgid "Invalid"
 msgstr "Ongeldig"
 
@@ -12292,6 +12315,7 @@ msgstr "Hier zijn je {0} meest recente kaarten:"
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
 msgstr "Zou je wat specifieker kunnen zijn, of de ID gebruiken? Ik vond deze kaarten met overeenkomende namen:"
 
+#: src/metabase/driver/common/parameters/values.clj
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
 msgstr "Kaart {0} niet gevonden."
@@ -12400,11 +12424,11 @@ msgstr "Misfire instructie"
 msgid "Archive this?"
 msgstr "Dit archiveren?"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:243
+#: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
 msgstr "Leer meer over je data"
 
-#: frontend/src/metabase/entities/databases/forms.js:20
+#: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
 msgstr "Gebruik DNS SRV bij het verbinden"
 
@@ -12416,7 +12440,7 @@ msgstr "Als je deze optie gebruikt, moet de geleverde host een FQDN zijn. Als u 
 "een Atlas-cluster, moet u deze optie mogelijk inschakelen. Als je niet weet wat dit betekent,\n"
 "laat dit uitgeschakeld."
 
-#: frontend/src/metabase/entities/databases/forms.js:204
+#: frontend/src/metabase/entities/databases/forms.js:273
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Voer automatisch query's uit wanneer u eenvoudig filtert en samenvat"
 
@@ -12440,11 +12464,11 @@ msgstr "Alle resultaten"
 msgid "Our Analytics"
 msgstr "Onze analyse"
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:513
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
 msgstr "Additieve som van alle waarden van een kolom. \\ Bijvoorbeeld totale omzet in de loop van de tijd."
 
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
 msgstr "Optelling van het aantal rijen. \\ Bijvoorbeeld totaal aantal verkopen in de loop van de tijd."
 
@@ -12454,7 +12478,7 @@ msgstr "Optelling van het aantal rijen. \\ Bijvoorbeeld totaal aantal verkopen i
 msgid "Filter"
 msgstr "Filter"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:50
 msgid "record"
 msgid_plural "records"
 msgstr[0] "resultaat"
@@ -12468,27 +12492,27 @@ msgstr "Browsen door data"
 msgid "Write SQL"
 msgstr "SQL schrijven"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:83
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
 msgstr "Simpele vraag"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:84
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:87
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
 msgstr "Kies een aantal gegevens, bekijk deze en filter, vat samen en visualiseer deze eenvoudig."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:95
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:98
 msgid "Custom question"
 msgstr "Aangepaste vraag"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:96
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:99
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Gebruik de geavanceerde notebookeditor om gegevens samen te voegen, aangepaste kolommen te maken, wiskunde uit te voeren en meer."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Basic Metrics"
 msgstr "Basisstatistieken"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:322
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
 msgid "Custom…"
 msgstr "Aangepast.."
 
@@ -12557,15 +12581,15 @@ msgstr "Kies een kolom om op te groeperen"
 msgid "Pick your starting data"
 msgstr "Kies je startgegevens"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select None"
 msgstr "Niets selecteren"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select All"
 msgstr "Alles selecteren"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:151
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:152
 msgid "Pick a table..."
 msgstr "Kies een tabel..."
 
@@ -12688,15 +12712,15 @@ msgstr "Voeg een metriek toe"
 #: frontend/src/metabase/lib/core.js:137 frontend/src/metabase/lib/core.js:142
 #: frontend/src/metabase/lib/core.js:147 frontend/src/metabase/lib/core.js:152
 #: frontend/src/metabase/lib/core.js:157 frontend/src/metabase/lib/core.js:162
-#: frontend/src/metabase/user/components/UserSettings.jsx:63
+#: frontend/src/metabase/user/components/UserSettings.jsx:64
 msgid "Profile"
 msgstr "Profiel"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:560
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "Dit is meestal vrij snel, maar lijkt nu even te duren."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
 msgid "Combo"
 msgstr "Combinatie"
 
@@ -12712,11 +12736,11 @@ msgstr "Trend"
 msgid "Boolean"
 msgstr "Boolean"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:62
 msgid "Unknown Segment"
 msgstr "Onbekende segment"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:73
 msgid "Unknown Filter"
 msgstr "Onbekende filter"
 
@@ -12846,6 +12870,7 @@ msgstr "Using NEWLY CREATED classloader as shared context classloader: {0}"
 msgid "Failed to copy file"
 msgstr "Fout bij het kopiëren van bestand"
 
+#. check that the URL is valid
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
 msgstr "Ongeldige site-URL: {0}"
@@ -13120,7 +13145,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Kies de kolommen die je mee wilt nemen"
 
-#: frontend/src/metabase/entities/databases/forms.js:205
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Wanneer dit is ingeschakeld, voert Metabase automatisch query's uit wanneer gebruikers eenvoudige verkenningen doen met de knoppen Samenvatting en Filter bij het bekijken van een tabel of diagram. Je kunt dit uitschakelen als het opvragen van deze database lang duurt. Deze instelling heeft geen invloed op drill-throughs of SQL-query's."
 
@@ -13158,7 +13183,7 @@ msgstr "Fout bij het bepalen van verwachte kolommen voor query"
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "Onbehandelde exceptie, `catch-exceptions` middleware werd verwacht om dit af te handelen."
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:125
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
 msgid "Diagnostic Info"
 msgstr "Diagnostische informatie"
 
@@ -13182,11 +13207,11 @@ msgstr "Er is iets fout gegaan met het inloggen met Google. Neem contact op met 
 msgid "Sign in with email"
 msgstr "Log in via e-mail"
 
-#: frontend/src/metabase/entities/databases/forms.js:21
+#: frontend/src/metabase/entities/databases/forms.js:23
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "Deze optie stelt verplicht dat de ingestelde host een FQDN is. Wanneer je verbinding probeert te maken met een Atlas kluster wil je deze optie misschien inschakelen. Wanneer je niet precies weet wat dit betekend kun je deze optie beter uitgeschakeld laten."
 
-#: frontend/src/metabase/entities/databases/forms.js:213
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Standaard voert Metabase een lichte uurlijke synchronisatie uit en een dagelijkse uitgebreide scan voor veldwaardes. Wanneer je een grote database heeft bevelen we aan om deze optie aan te zetten en te bekijken wanneer en hoe vaak de veldwaarde scans uitgevoerd worden."
 
@@ -13254,11 +13279,11 @@ msgstr "Voeg niet toe"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "Dit veld is niet zichtbaar of selecteerbaar in vragen die met de GUI-interfaces zijn gemaakt. Het blijft toegankelijk voor SQL / native query's."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:512
 msgid "Cumulative sum"
 msgstr "Cumulatieve som"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Standard deviation"
 msgstr "Standaardafwijking"
 
@@ -13270,23 +13295,23 @@ msgstr "moet minimaal {0} tekens lang zijn"
 msgid "Must be at least {0} characters long"
 msgstr "Moet ten minste {0} tekens lang zijn"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:389
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:82
 msgid "Name (required)"
 msgstr "Naam (verplicht)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:556
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
 msgid "Run selected text"
 msgstr "Voer geselecteerde tekst uit"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:557
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
 msgid "Run query"
 msgstr "Voer query uit"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(⌘ + enter)"
 msgstr "(⌘ + enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + enter)"
 
@@ -13298,7 +13323,7 @@ msgstr "Hier worden de resultaten weergegeven"
 msgid "You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question."
 msgstr "Je zal geen permanente wijzigingen aanbrengen in een opgeslagen vraag tenzij je op Opslaan klikt en ervoor kiest om de oorspronkelijke vraag te vervangen."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:199
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:200
 msgid "There aren't any filter widgets for this type of field yet."
 msgstr "Er zijn nog geen filterwidgets voor dit type veld."
 
@@ -13334,19 +13359,19 @@ msgstr "Doel lijn"
 msgid "Trend line"
 msgstr "Trend lijn"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:320
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:317
 msgid "Show values on data points"
 msgstr "Toon waarden op gegevenspunten"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:334
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:325
 msgid "Values to show"
 msgstr "Waardes om te tonen"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:342
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:332
 msgid "As many as can fit nicely"
 msgstr "Zo veel als passen"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:343
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
 msgid "All"
 msgstr "Alles"
 
@@ -13640,31 +13665,31 @@ msgstr "Nummers"
 msgid "No mappable groups"
 msgstr "Geen toewijsbare groepen"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:107
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
 msgstr "Metabase documentatie"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
 msgstr "Bevat een gids voor probleemoplossing"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:112
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
 msgid "Post on the Metabase support forum"
 msgstr "Plaats bericht op het Metabase support forum"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:114
 msgid "A community forum for all things Metabase"
 msgstr "Een community forum voor alle dingen van Metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:117
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
 msgid "File a bug report"
 msgstr "Een bug rapporteren"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:119
 msgid "Create a GitHub issue (includes the diagnostic info below)"
 msgstr "Maak een GitHub issue aan (voeg de onderstaande diagnostische gegevens toe)"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:127
 msgid "Please include these details in support requests. Thank you!"
 msgstr "Voeg deze gegevens toe aan je verzoek. Bedankt!"
 
@@ -13692,38 +13717,40 @@ msgstr "Geen overeenkomende resultaten"
 msgid "Submit"
 msgstr "Versturen"
 
-#: frontend/src/metabase/entities/databases/forms.js:13
+#: frontend/src/metabase/entities/databases/forms.js:15
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host. This option also provides an extra layer of security when a VPN is not available. Enabling this is usually slower than a direct connection."
 msgstr "Sommige database-installaties zijn alleen toegankelijk via een SSH-bastionhost. Deze optie biedt ook een extra beveiligingslaag wanneer een VPN niet beschikbaar is. Het inschakelen hiervan is meestal langzamer dan een directe verbinding."
 
-#: frontend/src/metabase/entities/databases/forms.js:17
+#: frontend/src/metabase/entities/databases/forms.js:19
 msgid "We suggest you leave this off unless you're doing manual timezone casting in many or most of your queries with this data."
 msgstr "We raden aan dit uit te schakelen, tenzij je bij veel (of de meeste) vragen met deze gegevens handmatig tijdzone cast."
 
-#: frontend/src/metabase/entities/databases/forms.js:93
+#: frontend/src/metabase/entities/databases/forms.js:128
 msgid "{0} to get an auth code."
 msgstr "{} om een auth code te verkrijgen."
 
-#: frontend/src/metabase/entities/databases/forms.js:101
+#: frontend/src/metabase/entities/databases/forms.js:136
+#: src/metabase/models/collection.clj
 msgid "or"
 msgstr "of"
 
-#: frontend/src/metabase/entities/databases/forms.js:159
-#: frontend/src/metabase/entities/databases/forms.js:197
-#: frontend/src/metabase/entities/users/forms.js:44
+#: frontend/src/metabase/entities/databases/forms.js:39
+#: frontend/src/metabase/entities/databases/forms.js:226
+#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "Verplicht"
 
-#: frontend/src/metabase/entities/databases/forms.js:188
+#: frontend/src/metabase/entities/databases/forms.js:257
 msgid "Database type"
 msgstr "Database type"
 
-#: frontend/src/metabase/entities/databases/forms.js:222
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Dit is een lichtgewichtproces dat controleert op updates van het schema van deze database. In de meeste gevallen zou het goed moeten zijn als deze set elk uur wordt gesynchroniseerd."
 
-#: frontend/src/metabase/entities/databases/forms.js:230
+#: frontend/src/metabase/entities/databases/forms.js:299
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase kan de waarden in elk veld in deze database scannen om selectievakjesfilters in dashboards en vragen in te schakelen. Dit kan een ietwat resource-intensief proces zijn, vooral bij een zeer grote database."
 
@@ -13731,15 +13758,15 @@ msgstr "Metabase kan de waarden in elk veld in deze database scannen om selectie
 msgid "Collection"
 msgstr "Collectie"
 
-#: frontend/src/metabase/entities/users/forms.js:40
+#: frontend/src/metabase/entities/users/forms.js:55
 msgid "Confirm your password"
 msgstr "Bevestig je wachtwoord"
 
-#: frontend/src/metabase/entities/users/forms.js:45
+#: frontend/src/metabase/entities/users/forms.js:60
 msgid "passwords do not match"
 msgstr "wachtwoorden komen niet overeen"
 
-#: frontend/src/metabase/entities/users/forms.js:71
+#: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
 msgstr "Geweldige afdeling"
 
@@ -13779,328 +13806,324 @@ msgid "Returns the average of the values in the column."
 msgstr "Retourneert het gemiddelde van de waarden in de kolom."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:18
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
 msgid "The column whose values to average."
 msgstr "De kolom waarvan de gemiddelde waarden gebruikt moeten worden."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "start"
 msgstr "begin"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "end"
 msgstr "einde"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
 msgid "Checks a date or numeric column's values to see if they're within the specified range."
 msgstr "Controleert de waarden van een datum of numerieke kolom om te zien of deze binnen het opgegeven bereik liggen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
 msgstr "Beoordeling"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:24
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:98
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
 msgid "condition"
 msgstr "conditie"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
 msgid "output"
 msgstr "uitvoer"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Test een lijst met cases en retourneert de bijbehorende waarde van de eerste echte case, met een optionele standaardwaarde als aan niets anders wordt voldaan."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
 msgid "Weight"
 msgstr "Gewicht"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
 msgid "Large"
 msgstr "Groot"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
 msgid "Medium"
 msgstr "Medium"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
 msgid "Small"
 msgstr "Klein"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
 msgid "Something that should evaluate to true or false."
 msgstr "Iets dat moet evalueren als waar of onwaar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:54
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "De waarde die wordt geretourneerd als de voorgaande voorwaarde waar is."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:62
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "value1"
 msgstr "waarde1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:74
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
 msgid "value2"
 msgstr "waarde2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Bekijkt de waarden in elk argument in volgorde en retourneert de eerste niet-nulwaarde voor elke rij."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:56
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
 msgid "Comments"
 msgstr "Opmerkingen"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
 msgid "Notes"
 msgstr "Notities"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
 msgid "No comments"
 msgstr "Geen opmerkingen"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
 msgid "A column or value."
 msgstr "Een kolom of waarde"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:65
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:77
 msgid "If value1 is empty, value2 gets returned if it's not empty, and so on."
 msgstr "Als waarde1 leeg is, wordt waarde2 geretourneerd als deze niet leeg is, enzovoort."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 msgid "Combines two or more strings of text together."
 msgstr "Combineert twee of meer strings samen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
 msgid "Last Name"
 msgstr "Achternaam"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 msgid "First Name"
 msgstr "Voornaam"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
 msgstr "waarde 2 wordt aan het einde hiervan toegevoegd."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
 msgstr "Dit wordt toegevoegd aan het einde van waarde1."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
 msgid "string1"
 msgstr "string1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
 msgid "string2"
 msgstr "string2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:80
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Controleert of string1 string2 bevat."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:284
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
 msgid "Status"
 msgstr "Status"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 msgid "Pass"
 msgstr "Overslaan"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
 msgstr "De inhoud van deze string wordt gecontroleerd."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
 msgid "The string of text to look for."
 msgstr "De string waarnaar moet worden gezocht."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:90
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:116
 msgid "Returns the count of rows in the source data."
 msgstr "Retourneert het aantal rijen in de brongegevens."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Only counts rows where the condition is true."
 msgstr "Telt alleen rijen waar de voorwaarde waar is."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:97
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:261
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
 msgid "Subtotal"
 msgstr "Subtotaal"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
 msgid "The additive total of rows across a breakout."
 msgstr "Het additieve totaal van rijen over een breakout."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:110
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
 msgid "The rolling sum of a column across a breakout."
 msgstr "De rollende som van een kolom over een breakout."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:113
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:268
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
 msgstr "De kolom die moet worden opgeteld."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
 msgid "The number of distinct values in this column."
 msgstr "Het aantal verschillende waarden in deze kolom."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "The column whose distinct values to count."
 msgstr "De kolom waarvan het aantal verschillende waarden moeten worden geteld."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:128
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:145
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:153
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:201
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:274
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
 msgid "text"
 msgstr "tekst"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:130
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:223
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
 msgid "comparison"
 msgstr "vergelijking"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Retourneert true als het einde van de tekst overeenkomt met de vergelijkingstekst."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "Appetite"
 msgstr "Eetlust"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "hungry"
 msgstr "hongerig"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 msgid "A column or string of text to check."
 msgstr "Een kolom of string om te controleren."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
 msgid "The string of text that the original text should end with."
 msgstr "De string waarmee de oorspronkelijke tekst moet eindigen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 msgid "regular_expression"
 msgstr "reguliere_expressie"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:136
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Pakt overeenkomende substrings volgens een reguliere expressie."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:137
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
 msgid "Address"
 msgstr "Adres"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 msgid "The column or string of text to search though."
 msgstr "De kolom of tekenreeks om te zoeken."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
 msgid "The regular expression to match."
 msgstr "De reguliere expressie om te vinden."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the string of text in all lowercase."
 msgstr "Retourneert de tekenreeks in kleine letters."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:149
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to lowercase."
 msgstr "De kolom met waarden die naar kleine letters moeten worden geconverteerd."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:154
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 msgid "Removes leading whitespace from a string of text."
 msgstr "Hiermee wordt witte ruimtes uit een string verwijderd."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:157
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column with values you want to trim."
 msgstr "De kolom met waarden die je wilt trimmen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "Returns the largest value found in the column."
 msgstr "Retourneert de grootste waarde die in de kolom is gevonden."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
 msgid "Age"
 msgstr "Leeftijd"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:165
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
 msgid "The numeric column whose maximum you want to find."
 msgstr "De numerieke kolom waarvan je het maximum wilt vinden."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:170
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "Returns the smallest value found in the column."
 msgstr "Retourneert de kleinste waarde die in de kolom is gevonden."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
 msgid "Salary"
 msgstr "Salaris"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:173
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
 msgid "The numeric column whose minimum you want to find."
 msgstr "De numerieke kolom waarvan je het minimum wilt vinden."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:181
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:242
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
 msgid "position"
 msgstr "positie"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:194
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
 msgid "length"
 msgstr "lengte"
 
@@ -14109,7 +14132,7 @@ msgstr "lengte"
 msgid "new_text"
 msgstr "nieuwe_tekst"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:187
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
 msgid "Replaces a part of the input text with new text."
 msgstr "Vervangt een deel van de invoertekst door nieuwe tekst."
 
@@ -14121,7 +14144,7 @@ msgstr "Bestellingnummer"
 msgid "Updated Part of ID"
 msgstr "Bijgewerkte deel van ID"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
 msgid "The text that will be modified."
 msgstr "De tekst dat bewerkt gaat worden."
 
@@ -14137,87 +14160,87 @@ msgstr "Het aantal tekens dat moet worden vervangen."
 msgid "The text to use in the replacement."
 msgstr "De tekst die moet worden gebruikt bij de vervanging."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Hiermee wordt witruimte aan het einde van een string verwijderd."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:210
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Retourneert het percentage rijen in de gegevens die overeenkomen met de voorwaarde, als een decimaal."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:218
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Retourneert true als het begin van de tekst overeenkomt met de vergelijkingstekst."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Course Name"
 msgstr "Naam van vak"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Computer Science"
 msgstr "Computer wetenschappen"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
 msgid "The string of text that the original text should start with."
 msgstr "De string waarmee de originele tekst moet beginnen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:229
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
 msgid "Calculates the standard deviation of the column."
 msgstr "Berekent de standaarddeviatie van de kolom."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:230
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
 msgid "Population"
 msgstr "Populatie"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
 msgid "A numeric column."
 msgstr "Een numerieke kolom."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
 msgid "Returns a portion of the supplied text."
 msgstr "Retourneert een gedeelte van de opgegeven tekst."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:241
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:313
 msgid "The text to return a portion of."
 msgstr "De tekst om een deel van te retourneren."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
 msgid "The position to start copying characters."
 msgstr "De startpositie om tekens te kopiëren."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:245
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
 msgid "The number of characters to return."
 msgstr "Het aantal karakters wat wordt teruggegeven."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
 msgid "Adds up all the values of the column."
 msgstr "Telt alle waardes bij elkaar op voor de kolom."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:253
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
 msgid "The numeric column to sum."
 msgstr "De numerieke kolom voor het optellen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Vat waarden samen in een kolom waar rijen overeenkomen met de voorwaarde."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
 msgid "Order Status"
 msgstr "Bestelling status"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
 msgid "Valid"
 msgstr "Geldig"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Verwijdert witruimtes aan het begin en einde van een string."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
 msgid "Returns the string of text in all upper case."
 msgstr "Retourneert de string in hoofdletters."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
 msgid "The column with values to convert to upper case."
 msgstr "De kolom met waarden die naar hoofdletters moeten worden geconverteerd."
 
@@ -14279,39 +14302,39 @@ msgstr "Bedankt voor het gebruik van Metabase!"
 msgid "Powered by {0}"
 msgstr "Aangedreven door {0}"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:191
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
 msgid "To:"
 msgstr "Naar:"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:40
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
 msgstr "Deze vraag kan niet worden gebruikt omdat dit gebaseerd is op een andere database."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:44
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:43
 msgid "Couldn't find a saved question with that ID number."
 msgstr "Kon geen opgeslagen vraag vinden met dat ID nummer."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:55
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:54
 msgid "Pick a saved question"
 msgstr "Kies een opgeslagen vraag"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:57
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:56
 msgid "Pick a different question"
 msgstr "Kies een andere vraag"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:62
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:61
 msgid "Loading…"
 msgstr "Laden..."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:79
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:78
 msgid "Question #…"
 msgstr "Vraag #..."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:81
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
 msgstr "Vraag #{0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:115
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
 msgstr "Laatst bewerkt {0}"
 
@@ -14323,11 +14346,11 @@ msgstr "{0} maakt in deze vraagsjabloon een variabele onder de naam \"variable_n
 msgid "Giving a variable the \"Field Filter\" type allows you to link questions to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "Door een variabele het type \"Veldfilter\" te geven, kunt u vragen aan dashboardfilters koppelen of andere filtertypes in uw SQL-vraag gebruiken. Een variabele van het type \"Veldfilter\" voegt soortgelijke SQL toe als de query-editor wanneer u op bestaande kolommen filtert."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:131
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
 msgstr "Variabel naam"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:217
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:218
 msgid "Filter widget label"
 msgstr "Filter widget label"
 
@@ -14359,11 +14382,11 @@ msgstr "In de kolomkop"
 msgid "In every table cell"
 msgstr "In elke tabel cel"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:351
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:341
 msgid "Value formatting"
 msgstr "Waarde opmaak"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:361
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
 msgid "Full"
 msgstr "Vol"
 
@@ -14691,3 +14714,482 @@ msgstr "Fout bij het genereren van inzichten voor kolom:"
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandonment email!"
 msgstr "Verlaten e-mail verzenden!"
+
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
+msgstr "Je kunt opgeslagen metrische gegevens maken om een genaamde metrieke optie toe te voegen. Opgeslagen metrieken bevatten onder meer het aggregatietype, het geaggregeerde veld en optioneel de filter(s) die je toevoegt. Je kunt dit bijvoorbeeld gebruiken om een officiële manier vast te leggen voor de \"Gemiddelde prijs\" van een Orders-tabel (feit)."
+
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:105
+msgid "Select and add filters to create your new segment."
+msgstr "Selecteer en voeg filters toe om een nieuw segment te maken."
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+msgid "Alphabetical"
+msgstr "Alfabetisch"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+msgid "Smart"
+msgstr "Slim"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+msgid "Column order: {0}"
+msgstr "Kolommenvolgorde: {0}"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
+msgid "Unhide all"
+msgstr "Alles tonen"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:204
+msgid "Hide all"
+msgstr "Alles verbergen"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:206
+msgid "Unhide"
+msgstr "Tonen"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:22
+msgid "New metric"
+msgstr "Nieuwe metriek"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:45
+msgid "Create metrics to add them to the Summarize dropdown in the query builder"
+msgstr "Maak een metriek aan om deze aan de samenvatting drop-down in de query editor toe te voegen"
+
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:22
+msgid "New segment"
+msgstr "Nieuw segment"
+
+#: frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx:71
+msgid "Filter by table"
+msgstr "Op tabel filteren"
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:64
+msgid "Checking HTTPS..."
+msgstr "HTTPS controleren..."
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:66
+msgid "It looks like HTTPS is not properly configured"
+msgstr "HTTPS lijkt niet goed te zijn ingesteld"
+
+#: frontend/src/metabase/admin/settings/selectors.js:57
+msgid "Redirect to HTTPS"
+msgstr "Naar HTTPS doorsturen"
+
+#: frontend/src/metabase/admin/settings/selectors.js:219
+msgid "Localization"
+msgstr "Localisatie"
+
+#: frontend/src/metabase/admin/settings/selectors.js:222
+msgid "Instance language"
+msgstr "Taal van deze installatie"
+
+#: frontend/src/metabase/admin/settings/selectors.js:237
+msgid "Localization options"
+msgstr "Localisatieopties"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:51
+msgid "This database doesn't have any tables."
+msgstr "Deze database bevat geen tabellen."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
+msgid "This field only accepts a single value because it's used in a SQL query."
+msgstr "Dit veld kan slechts een enkele waarde aannemen, omdat het in aan SQL-query gebruikt wordt."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:17
+msgid "Service Accounts"
+msgstr "Service Accounts"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:26
+msgid "Metabase connects to Big Query via {0}."
+msgstr "Metabase maakt verbinding met Big Query via {0}."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:29
+msgid "Continue using an OAuth application to connect"
+msgstr "OAuth-applicatie blijven gebruiken om te verbinden"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:43
+msgid "We recommend switching to use {0} instead of an OAuth application to connect to BigQuery"
+msgstr "We bevelen aan in plaats van een OAuth-applicatie {0} te gebruiken om met Big Query verbinding te maken."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:48
+msgid "Connect to a Service Account instead"
+msgstr "Met een Service Account verbinding maken"
+
+#: frontend/src/metabase/entities/databases/forms.js:44
+msgid "invalid JSON"
+msgstr "invalide JSON"
+
+#: frontend/src/metabase/entities/databases/forms.js:50
+msgid "SSH private key"
+msgstr "SSH-privésleutel"
+
+#: frontend/src/metabase/entities/databases/forms.js:51
+msgid "Paste the contents of your ssh private key here"
+msgstr "Plak de inhoud van je SSH-privésleutel hier"
+
+#: frontend/src/metabase/entities/databases/forms.js:55
+msgid "Passphrase for the SSH private key"
+msgstr "Wachtwoord voor de SSH-privésleutel"
+
+#: frontend/src/metabase/entities/databases/forms.js:58
+msgid "SSH Authentication"
+msgstr "SSH-authenticatie"
+
+#: frontend/src/metabase/entities/databases/forms.js:60
+msgid "SSH Key"
+msgstr "SSH-sleutel"
+
+#: frontend/src/metabase/entities/databases/forms.js:65
+msgid "Server SSL certificate chain"
+msgstr "SSL-certificatenketen van de server"
+
+#: frontend/src/metabase/entities/databases/forms.js:66
+msgid "Paste the contents of the server's SSL certificate chain here"
+msgstr "Plak de inhoud van de SSL-certificatenketen van de server hier"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:11
+msgid "Paste a connection string"
+msgstr "Plak de verbindingsstring"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:12
+msgid "Fill out individual fields"
+msgstr "Afzonderlijke velden invullen"
+
+#: frontend/src/metabase/entities/snippets.js:14
+msgid "Enter some SQL here so you can reuse it later"
+msgstr "SQL invoeren om later te hergebruiken"
+
+#: frontend/src/metabase/entities/snippets.js:24
+msgid "Give your snippet a name"
+msgstr "Geef je snippet een naam"
+
+#: frontend/src/metabase/entities/snippets.js:25
+msgid "Current Customers"
+msgstr "Huidige klanten"
+
+#: frontend/src/metabase/entities/snippets.js:30
+msgid "Add a description"
+msgstr "Beschrijving toevoegen"
+
+#: frontend/src/metabase/entities/users/forms.js:37
+msgid "Use site default"
+msgstr "Standaard gebruiken"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+msgid "find"
+msgstr "vinden"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+msgid "replace"
+msgstr "vervangen"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+msgid "The text to find."
+msgstr "Tekst om te vinden."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "The text to use as the replacement."
+msgstr "Tekst om mee te vervangen."
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+msgid "Editing {0}"
+msgstr "{0} wijzigen"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+msgid "Create your new snippet"
+msgstr "Maak je nieuwe snippet"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+msgid "Archived snippets"
+msgstr "Gearchiveerde snippets"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+msgid "Snippets are reusable bits of SQL"
+msgstr "Snippets zijn herbruikbare stukjes SQL code"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+msgid "Create a snippet"
+msgstr "Nieuwe snippet"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+msgid "Snippets"
+msgstr "Snippets"
+
+#: frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx:15
+msgid "SQL Snippets"
+msgstr "SQL Snippets"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:38
+msgid "Your language is set to {0}"
+msgstr "Uw taal is ingesteld op {0}"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:50
+msgid "What's your preferred language?"
+msgstr "Wat is uw voorkeurstaal?"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:54
+msgid "This language will be used throughout Metabase and will be the default for new users."
+msgstr "Deze taal zal overal in Metabase worden gebruikt en voor nieuwe gebruikers als standaard worden ingesteld."
+
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:159
+msgid "We filtered out {0} row(s) containing null values."
+msgstr "We hebben {0} rij(-en) met nul-waardes weggefilterd."
+
+#: frontend/src/metabase/visualizations/lib/settings/series.js:133
+msgid "Show values for this series"
+msgstr "Toon waardes van deze serie"
+
+#: src/metabase/api/card.clj
+msgid "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
+msgstr "De gemiddelde uitvoertijd van deze vraag is {0}, gebruik makend van magic TTL van {1}"
+
+#: src/metabase/api/native_query_snippet.clj
+msgid "A snippet with that name already exists. Please pick a different name."
+msgstr "Er bestaat al een snippet met deze naam, kies een andere naam."
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Metric]"
+msgstr "[Onbekende metriek]"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Segment]"
+msgstr "[Onbekend segment]"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error writing error to output stream"
+msgstr "Fout bij het wegschrijven van een foutmelding"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Caught unexpected Exception in streaming response body"
+msgstr "Onverwachte uitzondering bij het wegschrijven van het respons"
+
+#: src/metabase/async/streaming_response.clj
+msgid "bound-fn caught unexpected Exception"
+msgstr "Onverwachte uitzondering in bound-fn"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error determining whether HTTP request was canceled"
+msgstr "Fout bij het bepalen of HTTP-aanvraag geannuleerd was"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Check cancelation status timed out after {0}"
+msgstr "Timout van het bepalen van annuleringsstatus na {0}"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Unexpected exception in do-f-async"
+msgstr "Onverwachte uitzondering in do-f-async"
+
+#: src/metabase/async/streaming_response.clj src/metabase/server.clj
+msgid "Unexpected exception writing error response"
+msgstr "Onverwachte uitzondering bij het schrijven van foutrespons"
+
+#: src/metabase/driver/common.clj
+msgid "Server certificate not trusted - did you specify the correct SSL certificate chain?"
+msgstr "Het servercertificaat kan niet worden vertrouwd: heeft u de goede SSL-certificatenketen aangegeven?"
+
+#: src/metabase/driver/common.clj
+msgid "Server appears to require SSL - please enable SSL above"
+msgstr "De server lijkt SSL te benodigen, zet SSL aan hierboven"
+
+#: src/metabase/driver/common.clj
+msgid "Username"
+msgstr "Gebruikersnaam"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Don''t know how to parse parameter of type {0}"
+msgstr "Geen idee hoe parameter van type {0} behandeld moet worden"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Invalid :card parameter: missing `:card-id`"
+msgstr "Ongeldig :card paramter: mist `:card-id`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Unable to resolve Snippet: missing `:snippet-id`"
+msgstr "Kon snippet niet gebruiken: mist `:snippet-id`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Snippet {0} {1} not found."
+msgstr "Snippet {0} {1} niet gevonden."
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error determining value for parameter"
+msgstr "Fout bij het bepalen van parameterwaarde"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error building query parameter map"
+msgstr "Fout tijdens bouwen van query parameter map"
+
+#: src/metabase/middleware/log.clj
+msgid "ASYNC"
+msgstr "ASYNC"
+
+#: src/metabase/middleware/log.clj
+msgid "{0} ({1} DB calls)"
+msgstr "{0} ({1} DB-aanroepen)"
+
+#: src/metabase/middleware/log.clj
+msgid "App DB connections: {0}/{1}"
+msgstr "Applicatieverbindingen met DB: {0}/{1}"
+
+#: src/metabase/middleware/log.clj
+msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
+msgstr "Jetty-threads: {0}/{1} ({2} wachtend, {3} in wachtrij)"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} total active threads)"
+msgstr "({0} totaal actieve threads)"
+
+#: src/metabase/middleware/log.clj
+msgid "Queries in flight: {0}"
+msgstr "Query's actief nu: {0}"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} queued)"
+msgstr "({0} in wachtrij)"
+
+#: src/metabase/models/collection.clj
+msgid "Collection must be in the same namespace as its parent"
+msgstr "Collectie moet onderdeel zijn van dezelde bovenloggende namespace "
+
+#: src/metabase/models/collection.clj
+msgid "Personal Collections must be in the default namespace"
+msgstr "Persoonlijke collecties moeten zich in de standaard namespace bevinden"
+
+#: src/metabase/models/collection.clj
+msgid "You cannot move a Collection to a different namespace once it has been created."
+msgstr "Je kunt een collectie niet verplaatsen naar een andere namespace nadat deze is gemaakt."
+
+#: src/metabase/models/collection.clj src/metabase/models/permissions.clj
+msgid "Collection does not exist."
+msgstr "Collectie bestaat niet."
+
+#: src/metabase/models/collection.clj
+msgid "A {0} can only go in Collections in the {1} namespace."
+msgstr "Een {0} mag alleen in Collecties in de namespace {1}."
+
+#: src/metabase/models/database.clj
+msgid "Error sending database deletion notification"
+msgstr "Fout bij versturen van database verwijdering notificatie"
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "You cannot update the creator_id of a NativeQuerySnippet."
+msgstr "Je kunt de creator_id van een NativeQuerySnippet niet bijwerken."
+
+#: src/metabase/models/setting.clj
+msgid "Error fetching value of Setting"
+msgstr "Fout bij ophalen van waarde van instelling"
+
+#: src/metabase/public_settings.clj
+msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
+msgstr "De taal die moet worden gebruikt voor de gebruikersinterface van Metabase, systeem-e-mails, pulsen en waarschuwingen."
+
+#: src/metabase/public_settings.clj
+msgid "This is also the default language for all users, which they can change from their own account settings."
+msgstr "Dit is ook de standaardtaal voor alle gebruikers, die ze kunnen wijzigen vanuit hun eigen accountinstellingen."
+
+#: src/metabase/public_settings.clj
+msgid "Invalid locale {0}"
+msgstr "Ongeldige landinstelling {0}"
+
+#: src/metabase/public_settings.clj
+msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
+msgstr "Alle verkeer verplicht via HTTPS (indien URL met \"https\" begint)"
+
+#: src/metabase/public_settings.clj
+msgid "Cannot redirect requests to HTTPS unless `site-url` is HTTPS."
+msgstr "Kan niet naar HTTPS doorsturen indien URL niet met \"https\" begint."
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error registering fonts: Metabase will not be able to send Pulses."
+msgstr "Fout bij het registreren van fonts: Metabase zal geen Pulses kunnen verzenden."
+
+#: src/metabase/pulse/render/png.clj
+msgid "This is a known issue with certain JVMs. See {0} and for more details."
+msgstr "Dit is een bekend probleem met bepaalde JVM's. Zie {0} voor meer details."
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error rendering Pulse"
+msgstr "Fout bij het weergeven van een Pulse"
+
+#: src/metabase/query_processor/context/default.clj
+msgid "Query timed out after {0}, raising timeout exception."
+msgstr "Query-timeout na {0}, timeout-uitzondering activeren."
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "No fields found for table {0}."
+msgstr "Geen velden voor tabel {0} gevonden."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Case"
+msgstr "Zaak"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Variance of {0}"
+msgstr "Variantie van {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Median of {0}"
+msgstr "Mediaan van {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "{0}th percentile of {1}"
+msgstr "{0}(st)e percentiel van {1}"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Not caching results: results are larger than {0} KB"
+msgstr "Resultaten worden niet gecachet: groter dan {0} KB"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Cannot cache results: expected byte array, got {0}"
+msgstr "Kan resultaten niet cachen: byte-array verwacht, {0} ontvangen"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Request is closed; no one to return cached results to"
+msgstr "Aanvraag is afgesloten; kan cacheresultaten aan niemand retourneren"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Error attempting to fetch cached results for query with hash {0}"
+msgstr "Fout bij het ophalen van gecachte resultaten voor zoekopdracht met hash {0}"
+
+#: src/metabase/query_processor/middleware/cache_backend/db.clj
+msgid "Error preparing statement to fetch cached query results"
+msgstr "Fout bij het voorbereiden van instructie om queryresultaten in cache op te halen"
+
+#: src/metabase/query_processor/middleware/catch_exceptions.clj
+msgid "Error processing query: {0}"
+msgstr "Fout bij het afhandelen van query: {0}"
+
+#: src/metabase/server.clj
+msgid "Unexpected exception in endpoint"
+msgstr "Niet-opgevangen uitzondering binnen een eindpoint"
+
+#: src/metabase/server.clj
+msgid "Unexpected Exception in API request handler"
+msgstr "Niet-opgevangen uitzondering binnen API request handler"
+
+#: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+msgid "Error reducing {0}"
+msgstr "Fout bij het reduceren van {0}"
+
+#: src/metabase/sync/analyze/fingerprint/insights.clj
+msgid "Error generating timeseries insight keyed by: {0}"
+msgstr "Fout bij het genereren van inzicht in tijdseries, ingegeven door: {0}"
+
+#: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
+msgstr "Databasepositie van {0} is van \"{1}\" in \"{2}\" veranderd."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Unscheduling task for Database {0}: trigger: {1}"
+msgstr "Taak ongedaan maken voor database {0}: trigger: {1}"
+
+#: src/metabase/util/schema.clj
+msgid "value must be a keyword or string."
+msgstr "waarde moet een trefwoord of tekenreeks zijn."
+
+#: src/metabase/util/schema.clj
+msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
+msgstr "String moet een geldige tweeletterige ISO-taal of taal-landcode zijn, bijv. 'nl' of 'nl_NL'."

--- a/locales/pl.po
+++ b/locales/pl.po
@@ -29,13 +29,14 @@ msgid "Select a database type"
 msgstr "Wybierz typ bazy danych"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:411
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:154
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -46,9 +47,9 @@ msgstr "Zapisz"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:122
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
-msgstr "Aby wykonać niektóre z jego magii, Metabase musi skanować bazę danych. Będziemy również przeskanować go okresowo, aby zachować aktualne metadane. Można kontrolować, kiedy okresowe skanowanie odbywa się poniżej."
+msgstr "Aby wykonać część z jego magii, Metabase musi przeskanować Twoją bazę danych. Będzie również skanować ją regularnie, aby zachować aktualne metadane. Możesz ustawić poniżej, kiedy ma się odbywać regularne skanowanie."
 
-#: frontend/src/metabase/entities/databases/forms.js:221
+#: frontend/src/metabase/entities/databases/forms.js:290
 msgid "Database syncing"
 msgstr "Synchronizacja bazy danych"
 
@@ -57,14 +58,14 @@ msgid "This is a lightweight process that checks for\n"
 "updates to this database’s schema. In most cases, you should be fine leaving this\n"
 "set to sync hourly."
 msgstr "Jest to lekki proces, który sprawdza aktualizacje schematu tej bazy danych.\n"
-"W większości przypadków powinno być dobrze pozostawiając ten zestaw do synchronizacji godzinowej."
+"W większości przypadków powinno być poprawnie, jeśli pozostawisz ustawienie synchronizacji co godzinę."
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:42
 #: frontend/src/metabase/admin/databases/components/widgets/MetadataSyncScheduleWidget.jsx:22
 msgid "Scan"
 msgstr "Skanuj"
 
-#: frontend/src/metabase/entities/databases/forms.js:228
+#: frontend/src/metabase/entities/databases/forms.js:297
 msgid "Scanning for Filter Values"
 msgstr "Skanowanie w poszukiwaniu wartości filtrów"
 
@@ -75,9 +76,9 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase  może skanować wartości znajdujące się w każdym z pól w tej bazie danych,\n"
 " aby włączyć filtry pól wyboru w pulpitach nawigacyjnych i zapytaniach.\n"
-" Może to być proces nieco intensywnie korzystający z zasobów, szczególnie jeśli masz bardzo dużą bazę danych."
+" Może to być proces dość intensywnie korzystający z zasobów, szczególnie jeśli masz bardzo dużą bazę danych."
 
-#: frontend/src/metabase/entities/databases/forms.js:232
+#: frontend/src/metabase/entities/databases/forms.js:301
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Kiedy Metabase powinien automatycznie skanować i buforować wartości pól?"
 
@@ -97,9 +98,10 @@ msgstr "Gdy użytkownik doda nowy filtr do pulpitu nawigacyjnego lub zapytania S
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:62
 msgid "Never, I'll do this manually if I need to"
-msgstr "Nigdy, Zrobię to ręcznie jeżeli będzie potrzeba"
+msgstr "Nigdy, zrobię to ręcznie jeżeli będzie potrzeba"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 msgid "Saving..."
@@ -116,7 +118,7 @@ msgstr "Usunąć bazę danych?"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
-msgstr "Wszystkie zapisane zapytania, metryki i segmenty, które opierają się na tej bazie danych zostaną utracone."
+msgstr "Wszystkie zapisane zapytania, metryki i segmenty oparte na tej bazie danych zostaną utracone."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
@@ -136,9 +138,9 @@ msgid "in this box:"
 msgstr "w tym polu:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:75
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
@@ -155,18 +157,18 @@ msgstr "w tym polu:"
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:301
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:39
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:90
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:99
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:311
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:328
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "Anuluj"
@@ -176,14 +178,14 @@ msgstr "Anuluj"
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
-msgstr "Uusń"
+msgstr "Usuń"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
 #: frontend/src/metabase/admin/permissions/selectors.js:323
 #: frontend/src/metabase/admin/permissions/selectors.js:330
 #: frontend/src/metabase/admin/permissions/selectors.js:441
-#: frontend/src/metabase/admin/routes.jsx:57
+#: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
@@ -203,9 +205,10 @@ msgid "Scheduling"
 msgstr "Planowanie"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:71
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
@@ -213,8 +216,8 @@ msgid "Save changes"
 msgstr "Zapisz zmiany"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:203
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:35
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
 msgstr "Akcje"
 
@@ -226,8 +229,8 @@ msgstr "Synchronizuj teraz schemat bazy danych"
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:90
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:98
 msgid "Starting…"
 msgstr "Uruchamianie..."
 
@@ -245,13 +248,13 @@ msgstr "Ponowne skanowanie wartości pól teraz"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
 msgstr "Nie można uruchomić skanowania"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:92
 msgid "Scan triggered!"
 msgstr "Rozpoczęto skanowanie!"
 
@@ -274,15 +277,15 @@ msgid "Add database"
 msgstr "Dodaj bazę danych"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:28
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:28
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
 #: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:195
+#: frontend/src/metabase/entities/databases/forms.js:264
 #: frontend/src/metabase/entities/questions.js:86
 #: frontend/src/metabase/entities/questions.js:102
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
@@ -308,7 +311,7 @@ msgstr "Przywróć przykładowy zestaw danych"
 
 #: frontend/src/metabase/admin/databases/database.js:167
 msgid "Couldn't connect to the database. Please check the connection details."
-msgstr "Nie można połączyć się z bazą danych. Proszę sprawdzić szczegóły połączenia."
+msgstr "Nie można połączyć się z bazą danych. Proszę sprawdzić ustawienia połączenia."
 
 #: frontend/src/metabase/admin/databases/database.js:384
 msgid "Successfully created!"
@@ -322,6 +325,7 @@ msgstr "Pomyślnie zapisane!"
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Edycja"
@@ -332,11 +336,11 @@ msgstr "Historia weryfikacji"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
-msgstr "Ponów próbę {0}"
+msgstr "Ponowić próbę {0}?"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
-msgstr "Zapisane zapytania i inne elementy, które zależą od tego elementu {0}, będą nadal działać, ale ten element {1} nie będzie już można wybrać z konstruktora zapytań."
+msgstr "Zapisane zapytania i inne elementy, które zależą od tego elementu {0}, będą nadal działać, ale ten element {1} nie będzie już wybieralny z konstruktora zapytań."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
@@ -364,44 +368,43 @@ msgstr "Niepowodzenie"
 msgid "Success"
 msgstr "Sukces"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:185
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Podgląd"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:93
 msgid "No column description yet"
 msgstr "Brak opisu kolumny"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:127
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:126
 msgid "Select a field visibility"
 msgstr "Wybierz widoczność pola"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:187
 msgid "No special type"
 msgstr "Brak specjalnego typu"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
 #: frontend/src/metabase/lib/core.js:275
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:44
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:37
 msgid "Other"
 msgstr "Inne"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:221
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Wybierz specjalny typ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:255
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:262
 #: frontend/src/metabase/reference/components/Field.jsx:99
 msgid "Select a target"
 msgstr "Wyznacz cel"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
@@ -409,18 +412,18 @@ msgstr "Wyznacz cel"
 msgid "Columns"
 msgstr "Kolumny"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Kolumn"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:144
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:288
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
 msgid "Visibility"
 msgstr "Widoczność"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
 msgid "Type"
 msgstr "Typ"
 
@@ -428,7 +431,7 @@ msgstr "Typ"
 msgid "Current database:"
 msgstr "Aktualna baza danych"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
 msgid "Show original schema"
 msgstr "Pokaż oryginalny schemat"
 
@@ -452,27 +455,27 @@ msgstr[1] "{0} schematy"
 msgstr[2] "{0} schematów"
 msgstr[3] "{0} schematów"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:99
 msgid "Why Hide?"
 msgstr "Dlaczego ukryć?"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:100
 msgid "Technical Data"
 msgstr "Dane techniczne"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
 msgstr "Bez znaczenia"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 msgid "Queryable"
 msgstr "Odpytywalne"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:108
 msgid "Hidden"
 msgstr "Ukryty"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136
 msgid "No table description yet"
 msgstr "Brak opisu tabeli"
 
@@ -480,7 +483,7 @@ msgstr "Brak opisu tabeli"
 msgid "Metadata Strength"
 msgstr "Siła meta danych"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0} tabela do zapytań"
@@ -488,7 +491,7 @@ msgstr[1] "{0} tabele do zapytań"
 msgstr[2] "{0} tabel do zapytań"
 msgstr[3] "{0} tabel do zapytań"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:91
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} tabela ukryta"
@@ -496,20 +499,21 @@ msgstr[1] "{0} tabele ukryte"
 msgstr[2] "{0} tabel ukrytych"
 msgstr[3] "{0} tabel ukrytych"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:115
 msgid "Find a table"
 msgstr "Szukaj tabeli"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:128
 msgid "Schemas"
 msgstr "Schematy"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:838
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:21
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:43
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:62
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 msgid "Metrics"
 msgstr "Metryki"
@@ -518,8 +522,8 @@ msgstr "Metryki"
 msgid "Add a Metric"
 msgstr "Dodaj metrykę"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "Definicja"
@@ -528,12 +532,12 @@ msgstr "Definicja"
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "Stwórz metryki, aby dodać je do listy rozwijanej widoku w konstruktorze zapytań"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:21
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
 #: frontend/src/metabase/home/containers/SearchApp.jsx:72
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:961
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:61
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Segmenty"
@@ -542,35 +546,35 @@ msgstr "Segmenty"
 msgid "Add a Segment"
 msgstr "Dodaj segment"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:51
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:45
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "Stwórz segmenty w celu dodania ich do Filtru w konstruktorze zapytań"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:21
 msgid "created"
 msgstr "utworzone"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "reverted to a previous version"
 msgstr "przywróć poprzednią wersję"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:30
 msgid "edited the title"
 msgstr "edytuj tytuł"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:32
 msgid "edited the description"
 msgstr "edytuj opis"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:34
 msgid "edited the "
 msgstr "modyfikował(a) "
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:40
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "made some changes"
 msgstr "zrobiłem kilka zmian"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
 #: frontend/src/metabase/home/components/Activity.jsx:83
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
@@ -580,84 +584,84 @@ msgstr "Ty"
 msgid "Datamodel"
 msgstr "Model danych"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:41
 msgid " History"
 msgstr "Historia"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
 msgstr "Historia wersji dla"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:228
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
 msgid "{0} – Field Settings"
 msgstr "{0} — ustawienia pól"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:289
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
 msgid "Where this field will appear throughout Metabase"
 msgstr "Gdzie to pole pojawi się w Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:311
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
 msgid "Filtering on this field"
 msgstr "Filtrowanie w tym polu"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:312
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Kiedy to pole jest używane w filtrze, jakie osoby powinny używać do wprowadzania wartości, którą chce filtrować?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:437
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
 msgid "No description for this field yet"
 msgstr "Brak opisu dla pola"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
 msgid "Original value"
 msgstr "Wartość oryginalna"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:390
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
 msgid "Mapped value"
 msgstr "Mapowane wartości"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
 msgid "Enter value"
 msgstr "Wpisz wartość"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use original value"
 msgstr "Użyj oryginalnej wartości"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Use foreign key"
 msgstr "Użyj klucza obcego"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 msgid "Custom mapping"
 msgstr "Mapowanie niestandardowe"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
 msgid "Unrecognized mapping type"
 msgstr "Nierozpoznany typ mapowania"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Bieżące pole nie jest kluczem obcym lub brak jest tabeli docelowej"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
 msgid "The selected field isn't a foreign key"
 msgstr "Wybrane pole nie jest kluczem obcym"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:327
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
 msgid "Display values"
 msgstr "Wyświetl wartości"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:328
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Wybierz aby pokazać oryginalną wartość z bazy danych lub wyświetlić pole skojarzone lub niestandardowe informacje."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:278
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
 msgid "Choose a field"
 msgstr "Wybierz pole"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:299
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
 msgid "Please select a column to use for display."
 msgstr "Wybierz kolumnę, której chcesz użyć do wyświetlenia."
 
@@ -665,16 +669,16 @@ msgstr "Wybierz kolumnę, której chcesz użyć do wyświetlenia."
 msgid "Tip:"
 msgstr "Porada:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:443
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Możesz zaktualizować nazwę pola, aby upewnić się, że nadal ma sens na podstawie opcji ponownego mapowania."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:344
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Buforowane wartości pola"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:345
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase może skanować wartości tego pola, aby włączyć filtry pól wyboru w pulpitach nawigacyjnych i zapytaniach."
 
@@ -683,53 +687,53 @@ msgid "Re-scan this field"
 msgstr "Ponownie przeskanuj to pole"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
 msgstr "Odrzuć buforowane wartości pola"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
 msgstr "Nie można odrzucić wartości"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 msgid "Discard triggered!"
 msgstr "Odrzuć wywołane!"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Wybierz dowolną tabelę, aby zobaczyć jej schemat i dodać lub edytować metadane."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:36
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "Nazwa jest wymagana"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:39
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "Opis jest wymagany"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:43
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Wymagany jest komunikat poprawki"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
 msgid "Aggregation is required"
 msgstr "Agregacja jest wymagana"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Edit Your Metric"
 msgstr "Edytuj metryki"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Create Your Metric"
 msgstr "Utwórz metryki"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Wprowadź zmiany w metrykę i pozostaw notatkę wyjaśniającą."
 
@@ -737,62 +741,62 @@ msgstr "Wprowadź zmiany w metrykę i pozostaw notatkę wyjaśniającą."
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Można utworzyć zapisane metryki, aby dodać do tej tabeli opcję o nazwie metryki. Zapisane metryki obejmują typ agregacji, pole zagregowane i opcjonalnie dowolny dodany filtr. Na przykład, można użyć tego, aby utworzyć coś jak oficjalny sposób obliczania \"Średnia cena\" dla tabeli zamówienia."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:180
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
 msgid "Result: "
 msgstr "Wynik:"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
 msgid "Name Your Metric"
 msgstr "Nazwij swoje metryki"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:190
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Give your metric a name to help others find it."
 msgstr "Nadaj metrykom nazwę aby ułatwić innym znalezienie jej"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:194
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:152
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Coś opisowego, ale nie za długie"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:198
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
 msgid "Describe Your Metric"
 msgstr "Opisz swoje metryki"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:199
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Opisz swoje metryki aby ułatwić ich zrozumienie dla innych"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:203
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Jest to dobre miejsce, aby być bardziej szczegółowe o mniej oczywiste reguły metryczne"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:207
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:165
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Powód do zmian"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:209
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Zostaw notatkę, aby wyjaśnić, jakie zmiany zostały wprowadzone i dlaczego były wymagane."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:213
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "To pojawi się w historii zmian dla tej metryki, aby pomóc wszystkim pamiętać, dlaczego rzeczy zmienił"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
 msgstr "Co najmniej jeden filtr jest wymagany"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
 msgstr "Edytuj segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
 msgstr "Utwórz swój segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Wprowadź zmiany w segmencie i pozostaw notatkę wyjaśniającą."
 
@@ -800,33 +804,33 @@ msgstr "Wprowadź zmiany w segmencie i pozostaw notatkę wyjaśniającą."
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "Wybieranie i Dodawanie filtrów w celu utworzenia nowego segmentu dla tabeli {0}"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
 msgstr "Nadaj nazwę segmentowi"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:148
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
 msgstr "Nadaj swojemu segmentowi nazwę, aby pomóc innym w jego znalezieniu."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:156
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
 msgstr "Opisanie segmentu"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Nadaj segmentowi opis, aby pomóc innym w zrozumieniu jego informacji."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "Jest to dobre miejsce, aby być bardziej szczegółowe o mniej oczywiste reguły segmentu"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "Będzie to widoczne w historii zmian dla tego segmentu, aby pomóc wszystkim pamiętać, dlaczego rzeczy zmienił"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
-#: frontend/src/metabase/admin/routes.jsx:132
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:215
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
+#: frontend/src/metabase/admin/routes.jsx:137
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
@@ -834,11 +838,11 @@ msgstr "Będzie to widoczne w historii zmian dla tego segmentu, aby pomóc wszys
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase może skanować wartości w tej tabeli, aby włączyć filtry CheckBox w pulpitach nawigacyjnych i zapytaniach."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
 msgstr "Skanuj ponownie tabele"
 
@@ -852,11 +856,11 @@ msgstr "Dodaj"
 msgid "Not a valid formatted email address"
 msgstr "Niepoprawny adres email"
 
-#: frontend/src/metabase/entities/users/forms.js:12
+#: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
 msgstr "Imię"
 
-#: frontend/src/metabase/entities/users/forms.js:18
+#: frontend/src/metabase/entities/users/forms.js:20
 msgid "Last name"
 msgstr "Nazwisko"
 
@@ -896,10 +900,10 @@ msgstr "Członkowie"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
-#: frontend/src/metabase/admin/settings/selectors.js:120
-#: frontend/src/metabase/entities/users/forms.js:24
+#: frontend/src/metabase/admin/settings/selectors.js:121
+#: frontend/src/metabase/entities/users/forms.js:26
 #: frontend/src/metabase/lib/core.js:146
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:294
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:298
 msgid "Email"
 msgstr "Email"
 
@@ -908,14 +912,14 @@ msgid "A group is only as good as its members."
 msgstr "Grupa jest tak dobra jak jej członkowie"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
-#: frontend/src/metabase/admin/routes.jsx:52
+#: frontend/src/metabase/admin/routes.jsx:55
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Admin"
 msgstr "Admin"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:241
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:299
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:288
 msgid "and"
 msgstr "i"
 
@@ -970,12 +974,12 @@ msgstr "Usuń grupę"
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:42
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:294
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:397
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:317
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:334
 msgid "Done"
 msgstr "Gotowe"
 
@@ -986,8 +990,9 @@ msgstr "Nazwa grupy"
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
-#: frontend/src/metabase/admin/routes.jsx:92
+#: frontend/src/metabase/admin/routes.jsx:97
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Grupy"
 
@@ -1017,7 +1022,7 @@ msgstr "Deaktywuj"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:21
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
-#: frontend/src/metabase/admin/routes.jsx:88
+#: frontend/src/metabase/admin/routes.jsx:93
 #: frontend/src/metabase/nav/containers/Navbar.jsx:235
 msgid "People"
 msgstr "Ludzie"
@@ -1331,25 +1336,25 @@ msgstr "Zobacz kolekcję"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:542
+#: frontend/src/metabase/admin/permissions/selectors.js:558
 msgid "Data Access"
 msgstr "Dostęp do danych"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:667
-#: frontend/src/metabase/admin/permissions/selectors.js:672
+#: frontend/src/metabase/admin/permissions/selectors.js:665
+#: frontend/src/metabase/admin/permissions/selectors.js:670
 msgid "View tables"
 msgstr "Wyświetl tabele"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:608
+#: frontend/src/metabase/admin/permissions/selectors.js:606
 msgid "SQL Queries"
 msgstr "Zapytania SQL"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:678
+#: frontend/src/metabase/admin/permissions/selectors.js:676
 msgid "View schemas"
 msgstr "Wyświetl schematy"
 
-#: frontend/src/metabase/admin/routes.jsx:63
+#: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
 msgstr "Model danych"
@@ -1379,20 +1384,24 @@ msgid "Allows users within your LDAP directory to log in to Metabase with their 
 msgstr "Umożliwia użytkownikom w katalogu LDAP zalogować się do Metabase przy użyciu poświadczeń LDAP i umożliwia automatyczne mapowanie grup LDAP na grupy Metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:19
-#: frontend/src/metabase/admin/settings/selectors.js:167
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
+#: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
 msgstr "Niepoprawy adres email"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
 msgstr "Niepoprawna wartość liczbowa"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
 msgstr "Zmiany zapisane!"
 
-#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:178
+#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
 msgid "Looks like we ran into some problems"
 msgstr "Natrafiliśmy na problem"
 
@@ -1414,7 +1423,7 @@ msgstr "Wyczyść"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:195
+#: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Uwierzytelnianie"
 
@@ -1466,15 +1475,15 @@ msgstr "ID klienta Google"
 msgid "Allow users to sign up on their own if their Google account email address is from:"
 msgstr "Zezwalaj użytkownikom na samodzielne logowanie, jeśli ich adres e-mail konta Google to:"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:242
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:249
 msgid "Answers sent right to your Slack #channels"
 msgstr "Odpowiedz wysłana na kanał Slacka"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:251
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:258
 msgid "Create a Slack Bot User for MetaBot"
 msgstr "Tworzenie użytkownika Slack bot dla MetaBot"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:261
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:268
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "Gdy już tam jesteś, nadaj mu nazwę i kliknij {0}. Następnie skopiuj i wklej token API bota w polu poniżej. Gdy skończysz, utworzyć \"metabase_files\" kanał w Slack. Metabase wymaga tego, aby przesyłać wykresy."
 
@@ -1487,8 +1496,8 @@ msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Dostępny jest Metabase {0}.  Używasz {1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:41
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 msgid "Update"
 msgstr "Aktualizuj"
 
@@ -1515,16 +1524,16 @@ msgstr "Usuń niestandardową mapę"
 #: frontend/src/metabase/containers/Overworld.jsx:293
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:115
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Usuń"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:165
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:141
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
 msgstr "Pobierz..."
 
@@ -1707,48 +1716,46 @@ msgid "Generate Key"
 msgstr "Wygeneruj klucz"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:87
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:18
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enabled"
 msgstr "Włącz"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:92
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:19
+#: frontend/src/metabase/admin/settings/selectors.js:93
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Zablokowany"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:112
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:113
 msgid "Unknown setting {0}"
 msgstr "Nieznane ustawienie {0}"
 
-#: frontend/src/metabase/admin/settings/selectors.js:34
+#: frontend/src/metabase/admin/settings/selectors.js:37
 msgid "Setup"
 msgstr "Ustawienia"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:207
-#: frontend/src/metabase/admin/settings/selectors.js:39
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:214
+#: frontend/src/metabase/admin/settings/selectors.js:42
 msgid "General"
 msgstr "Ogólny"
 
-#: frontend/src/metabase/admin/settings/selectors.js:43
+#: frontend/src/metabase/admin/settings/selectors.js:46
 msgid "Site Name"
 msgstr "Nazwa strony"
 
-#: frontend/src/metabase/admin/settings/selectors.js:48
+#: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Site URL"
 msgstr "Adres strony"
 
-#: frontend/src/metabase/admin/settings/selectors.js:53
+#: frontend/src/metabase/admin/settings/selectors.js:64
 msgid "Email Address for Help Requests"
 msgstr "Adres e-mail dla żądań pomocy"
 
-#: frontend/src/metabase/admin/settings/selectors.js:58
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
 msgstr "Strefa czasowa raportu"
 
-#: frontend/src/metabase/admin/settings/selectors.js:61
+#: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
 msgstr "Domyślna baza danych"
 
@@ -1756,11 +1763,11 @@ msgstr "Domyślna baza danych"
 msgid "Select a timezone"
 msgstr "Wybierz strefę czasową"
 
-#: frontend/src/metabase/admin/settings/selectors.js:64
+#: frontend/src/metabase/admin/settings/selectors.js:75
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "Nie wszystkie bazy danych obsługują strefy czasowe, w którym to przypadku to ustawienie nie zostanie uwzględnione."
 
-#: frontend/src/metabase/admin/settings/selectors.js:69
+#: frontend/src/metabase/entities/users/forms.js:34
 msgid "Language"
 msgstr "Język"
 
@@ -1768,64 +1775,64 @@ msgstr "Język"
 msgid "Select a language"
 msgstr "Wybierz język"
 
-#: frontend/src/metabase/admin/settings/selectors.js:79
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
 msgstr "Anonimowe śledzenie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:84
+#: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
 msgstr "Przyjazne nazwy tabel i pól"
 
-#: frontend/src/metabase/admin/settings/selectors.js:90
+#: frontend/src/metabase/admin/settings/selectors.js:91
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Zastępowanie spacjami podkreśleń i myślników"
 
-#: frontend/src/metabase/admin/settings/selectors.js:98
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Enable Nested Queries"
 msgstr "Włącz kwerendy zagnieżdżone"
 
-#: frontend/src/metabase/admin/settings/selectors.js:109
+#: frontend/src/metabase/admin/settings/selectors.js:110
 msgid "Updates"
 msgstr "Aktualizacje"
 
-#: frontend/src/metabase/admin/settings/selectors.js:114
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
 msgstr "Sprawdz aktualizację"
 
-#: frontend/src/metabase/admin/settings/selectors.js:125
+#: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
 msgstr "SMTP Host"
 
-#: frontend/src/metabase/admin/settings/selectors.js:133
+#: frontend/src/metabase/admin/settings/selectors.js:134
 msgid "SMTP Port"
 msgstr "SMTP Port"
 
-#: frontend/src/metabase/admin/settings/selectors.js:137
+#: frontend/src/metabase/admin/settings/selectors.js:138
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:47
 msgid "That's not a valid port number"
 msgstr "Niepoprawny numer portu"
 
-#: frontend/src/metabase/admin/settings/selectors.js:141
+#: frontend/src/metabase/admin/settings/selectors.js:142
 msgid "SMTP Security"
 msgstr "Zabezpieczenia SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:150
 msgid "SMTP Username"
 msgstr "Użytkownik SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "SMTP Password"
 msgstr "Hasło SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:163
+#: frontend/src/metabase/admin/settings/selectors.js:164
 msgid "From Address"
 msgstr "Z adresu"
 
-#: frontend/src/metabase/admin/settings/selectors.js:176
+#: frontend/src/metabase/admin/settings/selectors.js:178
 msgid "Slack API Token"
 msgstr "Slack API Token"
 
-#: frontend/src/metabase/admin/settings/selectors.js:178
+#: frontend/src/metabase/admin/settings/selectors.js:180
 msgid "Enter the token you received from Slack"
 msgstr "Wpisz token który otrzymałeś na Slacku"
 
@@ -1854,8 +1861,10 @@ msgid "Username or DN"
 msgstr "Użytkownik lub DN"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:43
+#: frontend/src/metabase/entities/databases/forms.js:61
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:64
-#: frontend/src/metabase/user/components/UserSettings.jsx:65
+#: frontend/src/metabase/user/components/UserSettings.jsx:66
+#: src/metabase/driver/common.clj
 msgid "Password"
 msgstr "Hasło"
 
@@ -1891,79 +1900,79 @@ msgstr "Synchronizowanie członkostwa w grupach"
 msgid "Group search base"
 msgstr "Baza wyszukiwania grupowego"
 
-#: frontend/src/metabase/admin/settings/selectors.js:199
+#: frontend/src/metabase/admin/settings/selectors.js:201
 msgid "Maps"
 msgstr "Mapy"
 
-#: frontend/src/metabase/admin/settings/selectors.js:203
+#: frontend/src/metabase/admin/settings/selectors.js:205
 msgid "Map tile server URL"
 msgstr "Adres URL serwera kafelków mapy"
 
-#: frontend/src/metabase/admin/settings/selectors.js:204
+#: frontend/src/metabase/admin/settings/selectors.js:206
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Domyślnie Metabase korzysta z OpenStreetMaps."
 
-#: frontend/src/metabase/admin/settings/selectors.js:209
+#: frontend/src/metabase/admin/settings/selectors.js:211
 msgid "Custom Maps"
 msgstr "Dodatkowe mapy"
 
-#: frontend/src/metabase/admin/settings/selectors.js:210
+#: frontend/src/metabase/admin/settings/selectors.js:212
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Dodawanie własnych plików GeoJSON w celu włączenia różnych wizualizacji map regionu"
 
-#: frontend/src/metabase/admin/settings/selectors.js:228
+#: frontend/src/metabase/admin/settings/selectors.js:245
 msgid "Public Sharing"
 msgstr "Udostępnianie publiczne"
 
-#: frontend/src/metabase/admin/settings/selectors.js:232
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "Enable Public Sharing"
 msgstr "Włącz udostępnianie publiczne"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:254
 msgid "Shared Dashboards"
 msgstr "Udostępnione pulpity nawigacyjne"
 
-#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Shared Questions"
 msgstr "Wspólne zapytania"
 
-#: frontend/src/metabase/admin/settings/selectors.js:250
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Embedding in other Applications"
 msgstr "Osadzanie w innych aplikacjach"
 
-#: frontend/src/metabase/admin/settings/selectors.js:276
+#: frontend/src/metabase/admin/settings/selectors.js:293
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Włącz osadzanie Metabase w innych aplikacjach"
 
-#: frontend/src/metabase/admin/settings/selectors.js:286
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Embedding secret key"
 msgstr "Osadzanie klucza tajnego"
 
-#: frontend/src/metabase/admin/settings/selectors.js:292
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Embedded Dashboards"
 msgstr "Osadzone pulpity nawigacyjne"
 
-#: frontend/src/metabase/admin/settings/selectors.js:298
+#: frontend/src/metabase/admin/settings/selectors.js:315
 msgid "Embedded Questions"
 msgstr "Osadzone zapytania"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:322
 msgid "Caching"
 msgstr "Buforowanie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:326
 msgid "Enable Caching"
 msgstr "Włącz buforowanie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:314
+#: frontend/src/metabase/admin/settings/selectors.js:331
 msgid "Minimum Query Duration"
 msgstr "Minimalny czas trwania kwerendy"
 
-#: frontend/src/metabase/admin/settings/selectors.js:321
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Mnożnik czasu wygaśnięcia (TTL) pamięci podręcznej"
 
-#: frontend/src/metabase/admin/settings/selectors.js:328
+#: frontend/src/metabase/admin/settings/selectors.js:345
 msgid "Max Cache Entry Size"
 msgstr "Maksymalny rozmiar wpisu w pamięci podręcznej"
 
@@ -2130,7 +2139,8 @@ msgstr "Pulpity nawigacyjne, kolekcje i pulsy w tej kolekcji również zostaną 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/routes.jsx:205
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
+#: frontend/src/metabase/routes.jsx:196
 msgid "Archive"
 msgstr "Archiwum"
 
@@ -2146,21 +2156,21 @@ msgstr "Wyświetl archiwum"
 msgid "Unarchive this {0}"
 msgstr "Przywróć to {0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:39
-#: frontend/src/metabase/components/BrowseApp.jsx:102
-#: frontend/src/metabase/components/BrowseApp.jsx:194
+#: frontend/src/metabase/components/BrowseApp.jsx:46
+#: frontend/src/metabase/components/BrowseApp.jsx:112
+#: frontend/src/metabase/components/BrowseApp.jsx:204
 #: frontend/src/metabase/containers/Overworld.jsx:270
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
 msgstr "Nasze dane"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:146
+#: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
 msgid "X-ray this table"
 msgstr "Prześwietl X-ray ta tabelę"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:161
+#: frontend/src/metabase/components/BrowseApp.jsx:171
 msgid "Learn about this table"
 msgstr "Dowiedz się więcej"
 
@@ -2255,7 +2265,7 @@ msgstr "Przypięcia"
 msgid "Drag something here to pin it to the top"
 msgstr "Przeciągnij coś tutaj, aby przypiąć go do góry"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:755
+#: frontend/src/metabase/admin/permissions/selectors.js:753
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2311,7 +2321,7 @@ msgstr "Nowa kolekcja"
 msgid "Copied!"
 msgstr "Skopiiowane!"
 
-#: frontend/src/metabase/entities/databases/forms.js:12
+#: frontend/src/metabase/entities/databases/forms.js:14
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Użyj tunelu SSH dla tego połączenia z bazą danych"
 
@@ -2323,7 +2333,7 @@ msgstr "Do niektórych instalacji baz danych można uzyskać dostęp tylko poprz
 "Ta opcja zapewnia również dodatkową warstwę zabezpieczeń, gdy sieć VPN nie jest dostępna.\n"
 "Włączenie tego jest zwykle wolniejsze niż bezpośrednie połączenie."
 
-#: frontend/src/metabase/entities/databases/forms.js:212
+#: frontend/src/metabase/entities/databases/forms.js:281
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Jest to duża baza danych, więc pozwól mi wybrać, kiedy Metabase synchronizuje i skanuje"
 
@@ -2333,17 +2343,17 @@ msgid "By default, Metabase does a lightweight hourly sync and an intensive dail
 msgstr "Domyślnie Metabase wykonuje lekką synchronizację godzinową i intensywnie codziennie skanuje wartości pól.\n"
 "W przypadku dużej bazy danych zaleca się włączenie tej funkcji i sprawdzenie, kiedy i jak często ma miejsce skanowanie wartości pola."
 
-#: frontend/src/metabase/entities/databases/forms.js:78
+#: frontend/src/metabase/entities/databases/forms.js:113
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0}, aby wygenerować identyfikator klienta i klucz tajny klienta dla projektu."
 
-#: frontend/src/metabase/entities/databases/forms.js:80
-#: frontend/src/metabase/entities/databases/forms.js:95
-#: frontend/src/metabase/entities/databases/forms.js:131
+#: frontend/src/metabase/entities/databases/forms.js:115
+#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:166
 msgid "Click here"
 msgstr "Kliknij tutaj"
 
-#: frontend/src/metabase/entities/databases/forms.js:83
+#: frontend/src/metabase/entities/databases/forms.js:118
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Wybierz \"Other\" jako typ aplikacji. Nazwij to, co chcesz."
 
@@ -2351,19 +2361,19 @@ msgstr "Wybierz \"Other\" jako typ aplikacji. Nazwij to, co chcesz."
 msgid "{0} to get an auth code"
 msgstr "{0} w celu uzyskania kodu autoryzacji"
 
-#: frontend/src/metabase/entities/databases/forms.js:107
+#: frontend/src/metabase/entities/databases/forms.js:142
 msgid "with Google Drive permissions"
 msgstr "z uprawnieniami dysku Google"
 
-#: frontend/src/metabase/entities/databases/forms.js:129
+#: frontend/src/metabase/entities/databases/forms.js:164
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "Aby użyć Metabase z tymi danymi, należy włączyć dostęp do interfejsu API w konsoli programisty Google."
 
-#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:165
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0}, aby przejść do konsoli, jeśli jeszcze tego nie zrobiono."
 
-#: frontend/src/metabase/entities/databases/forms.js:196
+#: frontend/src/metabase/entities/databases/forms.js:265
 msgid "How would you like to refer to this database?"
 msgstr "Jak chcesz referować do tej bazy?"
 
@@ -2372,7 +2382,8 @@ msgstr "Jak chcesz referować do tej bazy?"
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:143
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:70
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:123
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:96
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:126
 #: frontend/src/metabase/setup/components/UserStep.jsx:93
 msgid "Next"
 msgstr "Następny"
@@ -2555,7 +2566,7 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Przywrócono wcześniejszą wersję i {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:290
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "Historia zmian"
@@ -2601,7 +2612,7 @@ msgid "Questions"
 msgstr "Pytanie"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:320
+#: frontend/src/metabase/routes.jsx:311
 msgid "Pulses"
 msgstr "Pulsy"
 
@@ -2646,15 +2657,16 @@ msgstr "Chyba się zgubiliśmy..."
 msgid "Temporary Password"
 msgstr "Hasło tymczasowe"
 
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:207
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:481
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
 msgid "Hide"
 msgstr "Ukryj"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:467
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:482
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:471
 msgid "Show"
 msgstr "Pokaż"
 
@@ -2764,7 +2776,7 @@ msgstr "Przepraszamy, nie masz uprawnień do wyświetlania"
 msgid "Unknown error encountered"
 msgstr "Napotkano nieznany błąd"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/nav/containers/Navbar.jsx:373
 msgid "Create"
 msgstr "Utwórz"
@@ -2777,7 +2789,7 @@ msgstr "Utwórz panel"
 msgid "Table"
 msgstr "Tabela"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
 msgid "Database"
 msgstr "Baza danych"
 
@@ -2797,7 +2809,7 @@ msgstr "Spróbuj dostosować filtr, tak aby znaleźć to, czego szukasz."
 msgid "View by"
 msgstr "Wyświetlone przez"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:122
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:121
 msgid "of"
 msgstr "z"
 
@@ -2824,33 +2836,33 @@ msgstr "Nasze analizy"
 msgid "Browse all items"
 msgstr "Przeglądaj elementy"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:118
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:117
 msgid "Replace or save as new?"
 msgstr "Zamienić lub zapisz jako nowe?"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:168
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace original question, \"{0}\""
 msgstr "Zastąp oryginalne zapytanie \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:172
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:171
 msgid "Save as new question"
 msgstr "Zapisz jako nowe pytanie"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:92
 msgid "First, save your question"
 msgstr "Najpierw zapisz swoje zapytanie"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:94
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
 msgid "Save question"
 msgstr "Zapisz pytanie"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:133
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
 msgid "What is the name of your card?"
 msgstr "Jaka jest nazwa Twojej zakładki?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
 #: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/entities/questions.js:89
@@ -2866,15 +2878,16 @@ msgstr "Jaka jest nazwa Twojej zakładki?"
 msgid "Description"
 msgstr "Opis"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
 #: frontend/src/metabase/entities/dashboards.js:150
 #: frontend/src/metabase/entities/questions.js:91
 #: frontend/src/metabase/entities/questions.js:107
+#: frontend/src/metabase/entities/snippets.js:31
 msgid "It's optional but oh, so helpful"
 msgstr "Jest to opcjonalne, ale jakże pomocne"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:148
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "Której kolekcja powinna to trafić?"
@@ -2891,19 +2904,19 @@ msgstr "element"
 msgid "Undo"
 msgstr "Cofnij"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:266
 msgid "Applying Question"
 msgstr "Aplikacja zapytania"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:286
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "That question isn't compatible"
 msgstr "To zapytanie nie jest zgodne"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:322
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:309
 msgid "Search for a question"
 msgstr "Wyszukaj zapytanie"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:351
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:343
 msgid "We're not sure if this question is compatible"
 msgstr "Nie jesteśmy pewni, czy to zapytanie jest zgodne"
 
@@ -2952,25 +2965,23 @@ msgstr "Dodaj pytanie"
 msgid "Add a question to this dashboard"
 msgstr "Dodaj zapytanie do tego pulpitu"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
 msgid "Add a filter"
 msgstr "Dodaj filtr"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:256
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "Parametry"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:276
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:280
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
 msgid "Add a text box"
 msgstr "Dodaj pole tekstowe"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:320
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:314
 msgid "Move dashboard"
 msgstr "Przenieś pulpit"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:303
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
 msgid "Edit dashboard"
 msgstr "Edytuj pulpit"
 
@@ -2978,11 +2989,11 @@ msgstr "Edytuj pulpit"
 msgid "Edit Dashboard Layout"
 msgstr "Zmień układ pulpitu"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:371
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:365
 msgid "You are editing a dashboard"
 msgstr "Modyfikujesz pulpit"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:376
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:370
 msgid "Select the field that should be filtered for each card"
 msgstr "Wybierz pole, które ma być filtrowane dla każdej zakładki"
 
@@ -3070,7 +3081,7 @@ msgstr "Ta zakładka nie ma żadnych pól lub parametrów, które mogą być map
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Wartości w tym polu nie pokrywają się z wartościami pozostałych wybranych pól."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:162
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "Brak prawidłowych pól"
@@ -3138,7 +3149,7 @@ msgstr "odebrano najnowsze dane z"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:329
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
 msgid "Unknown"
 msgstr "Nieznany"
 
@@ -3265,6 +3276,7 @@ msgstr "{0} wybrane elementy"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 msgid "Unarchive"
 msgstr "Przywróć"
 
@@ -3357,7 +3369,7 @@ msgid "Longitude"
 msgstr "Szerokość"
 
 #: frontend/src/metabase/lib/core.js:43
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:45
 msgid "Number"
 msgstr "Numer"
@@ -3414,7 +3426,7 @@ msgid "User"
 msgstr "Użytkownik"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:211
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
 msgid "Source"
 msgstr "Źródło"
 
@@ -3455,16 +3467,17 @@ msgid "Score"
 msgstr "Wynik"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Tytuł"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
 msgid "Comment"
 msgstr "Komentarz"
 
@@ -3516,9 +3529,9 @@ msgstr "Nie zawiera"
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
 msgstr "Metabase nigdy nie będzie pobierać tego pola. Użyj tego dla informacji poufnych lub nieistotnych."
 
-#: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:300
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/query/description.js:77
+#: frontend/src/metabase/lib/query/description.js:262
+#: frontend/src/metabase/lib/schema_metadata.js:476
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
@@ -3533,8 +3546,7 @@ msgstr "Count"
 msgid "CumulativeCount"
 msgstr "LicznikŁączny"
 
-#: frontend/src/metabase/lib/expressions/config.js:9
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:485
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3544,7 +3556,6 @@ msgstr "Sum"
 msgid "CumulativeSum"
 msgstr "SumaŁączna"
 
-#: frontend/src/metabase/lib/expressions/config.js:11
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Distinct"
 msgstr "Distinct"
@@ -3553,25 +3564,22 @@ msgstr "Distinct"
 msgid "StandardDeviation"
 msgstr "OdchyleniaStandardowe"
 
-#: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:494
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Average"
 
-#: frontend/src/metabase/lib/expressions/config.js:14
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:539
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Min"
 
-#: frontend/src/metabase/lib/expressions/config.js:15
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:548
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:503
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:492
 msgid "Max"
 msgstr "Max"
 
@@ -3628,54 +3636,66 @@ msgstr "Co masz na myśli?"
 msgid "What do you want to find out?"
 msgstr "Co byś się chciał dowiedzieć?"
 
-#: frontend/src/metabase/lib/query.js:298
-#: frontend/src/metabase/lib/schema_metadata.js:466
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:250
+#: frontend/src/metabase/lib/query/description.js:75
+#: frontend/src/metabase/lib/query/description.js:260
+#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Dane"
 
-#: frontend/src/metabase/lib/query.js:302
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/query/description.js:79
+#: frontend/src/metabase/lib/query/description.js:264
+#: frontend/src/metabase/lib/schema_metadata.js:521
 msgid "Cumulative count"
 msgstr "Skumulowany licznik"
 
-#: frontend/src/metabase/lib/query.js:305
+#: frontend/src/metabase/lib/query/description.js:82
+#: frontend/src/metabase/lib/query/description.js:266
 msgid "Average of "
 msgstr "Średnia z"
 
-#: frontend/src/metabase/lib/query.js:310
+#: frontend/src/metabase/lib/query/description.js:87
+#: frontend/src/metabase/lib/query/description.js:268
 msgid "Distinct values of "
 msgstr "Różne wartości z "
 
-#: frontend/src/metabase/lib/query.js:315
+#: frontend/src/metabase/lib/query/description.js:92
+#: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
 msgstr "Odchylenie standardowe z "
 
-#: frontend/src/metabase/lib/query.js:320
+#: frontend/src/metabase/lib/query/description.js:97
+#: frontend/src/metabase/lib/query/description.js:272
 msgid "Sum of "
 msgstr "Suma z "
 
-#: frontend/src/metabase/lib/query.js:325
+#: frontend/src/metabase/lib/query/description.js:102
+#: frontend/src/metabase/lib/query/description.js:274
 msgid "Cumulative sum of "
 msgstr "Skumulowana suma z "
 
-#: frontend/src/metabase/lib/query.js:330
+#: frontend/src/metabase/lib/query/description.js:107
+#: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
 msgstr "Maksimum z "
 
-#: frontend/src/metabase/lib/query.js:335
+#: frontend/src/metabase/lib/query/description.js:112
+#: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
 msgstr "Minimum z "
 
-#: frontend/src/metabase/lib/query.js:349
+#: frontend/src/metabase/lib/query/description.js:126
+#: frontend/src/metabase/lib/query/description.js:286
 msgid "Grouped by "
 msgstr "Pogrupowane według "
 
-#: frontend/src/metabase/lib/query.js:363
+#: frontend/src/metabase/lib/query/description.js:140
+#: frontend/src/metabase/lib/query/description.js:295
 msgid "Filtered by "
 msgstr "Filtrowane po "
 
-#: frontend/src/metabase/lib/query.js:392
+#: frontend/src/metabase/lib/query/description.js:169
+#: frontend/src/metabase/lib/query/description.js:320
 msgid "Sorted by "
 msgstr "Uporządkowane po "
 
@@ -3687,55 +3707,45 @@ msgstr "Prawda"
 msgid "False"
 msgstr "Fałsz"
 
-#: frontend/src/metabase/lib/schema_metadata.js:321
+#: frontend/src/metabase/lib/schema_metadata.js:322
 msgid "Select longitude field"
 msgstr "Wybierz pole długości geograficznej"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:323
 msgid "Enter upper latitude"
 msgstr "Podaj górną granicę szerokości geograficznej"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:324
 msgid "Enter left longitude"
 msgstr "Podaj lewą granicę długości geograficznej"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:325
 msgid "Enter lower latitude"
 msgstr "Podaj dolną granicę szerokości geograficznej"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:326
 msgid "Enter right longitude"
 msgstr "Podaj prawą granicę długości geograficznej"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:539
 #: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:397
-#: frontend/src/metabase/lib/schema_metadata.js:405
-#: frontend/src/metabase/lib/schema_metadata.js:411
-#: frontend/src/metabase/lib/schema_metadata.js:416
-msgid "Is"
-msgstr "Jest"
-
 #: frontend/src/metabase/lib/schema_metadata.js:362
 #: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:398
 #: frontend/src/metabase/lib/schema_metadata.js:406
 #: frontend/src/metabase/lib/schema_metadata.js:412
-msgid "Is not"
-msgstr "Nie jest"
+#: frontend/src/metabase/lib/schema_metadata.js:417
+msgid "Is"
+msgstr "Jest"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:417
-msgid "Is empty"
-msgstr "Jest puste"
+#: frontend/src/metabase/lib/schema_metadata.js:413
+msgid "Is not"
+msgstr "Nie jest"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:378
@@ -3744,109 +3754,119 @@ msgstr "Jest puste"
 #: frontend/src/metabase/lib/schema_metadata.js:402
 #: frontend/src/metabase/lib/schema_metadata.js:408
 #: frontend/src/metabase/lib/schema_metadata.js:418
+msgid "Is empty"
+msgstr "Jest puste"
+
+#: frontend/src/metabase/lib/schema_metadata.js:365
+#: frontend/src/metabase/lib/schema_metadata.js:379
+#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:395
+#: frontend/src/metabase/lib/schema_metadata.js:403
+#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:419
 msgid "Not empty"
 msgstr "Nie jest puste"
 
-#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:371
 msgid "Equal to"
 msgstr "Równa się"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:372
 msgid "Not equal to"
 msgstr "Nie równa się"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Greater than"
 msgstr "Większe od"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Less than"
 msgstr "Mniejsze od"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Pomiędzy"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:376
 msgid "Greater than or equal to"
 msgstr "Większe lub równe"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Less than or equal to"
 msgstr "Mniejsze lub równe"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
+#: frontend/src/metabase/lib/schema_metadata.js:384
 msgid "Contains"
 msgstr "Zawiera"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:385
 msgid "Does not contain"
 msgstr "Nie zawiera"
 
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:388
 msgid "Starts with"
 msgstr "Zaczyna się od"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:389
 msgid "Ends with"
 msgstr "Kończy się"
 
-#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:399
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Przed"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:400
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Po"
 
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:414
 msgid "Inside"
 msgstr "W"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Tylko tabela z wierszami, bez dodatkowych operacji."
 
-#: frontend/src/metabase/lib/schema_metadata.js:474
+#: frontend/src/metabase/lib/schema_metadata.js:475
 msgid "Count of rows"
 msgstr "Ilość wierszy"
 
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:477
 msgid "Total number of rows in the answer."
 msgstr "Całkowita liczba wierszy."
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Sum of ..."
 msgstr "Suma z "
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:486
 msgid "Sum of all the values of a column."
 msgstr "Suma wszystkich wartości kolumny."
 
-#: frontend/src/metabase/lib/schema_metadata.js:492
+#: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Average of ..."
 msgstr "Średnia z…"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:495
 msgid "Average of all the values of a column"
 msgstr "Średnia wszystkich wartości kolumny"
 
-#: frontend/src/metabase/lib/schema_metadata.js:501
+#: frontend/src/metabase/lib/schema_metadata.js:502
 msgid "Number of distinct values of ..."
 msgstr "Liczba różnych wartości..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:504
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Liczba unikatowych wartości w kolumnie ze wszystkich wierszy odpowiedzi."
 
-#: frontend/src/metabase/lib/schema_metadata.js:510
+#: frontend/src/metabase/lib/schema_metadata.js:511
 msgid "Cumulative sum of ..."
 msgstr "Skumulowana suma..."
 
@@ -3854,7 +3874,7 @@ msgstr "Skumulowana suma..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Addytywna suma wszystkich wartości kolumny. \\\\nnp. całkowity przychód w czasie."
 
-#: frontend/src/metabase/lib/schema_metadata.js:519
+#: frontend/src/metabase/lib/schema_metadata.js:520
 msgid "Cumulative count of rows"
 msgstr "Skumulowana liczba wierszy"
 
@@ -3862,27 +3882,27 @@ msgstr "Skumulowana liczba wierszy"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Addytywna liczba wierszy.\\\\nnp. łączna ilość transakcji w czasie."
 
-#: frontend/src/metabase/lib/schema_metadata.js:528
+#: frontend/src/metabase/lib/schema_metadata.js:529
 msgid "Standard deviation of ..."
 msgstr "Odchylenie standardowe…"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:531
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Numer, który pokazuje jak bardzo wartości danej kolumny różnią się między sobą."
 
-#: frontend/src/metabase/lib/schema_metadata.js:537
+#: frontend/src/metabase/lib/schema_metadata.js:538
 msgid "Minimum of ..."
 msgstr "Minimum..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Minimum value of a column"
 msgstr "Minimalna wartość dla kolumny"
 
-#: frontend/src/metabase/lib/schema_metadata.js:546
+#: frontend/src/metabase/lib/schema_metadata.js:547
 msgid "Maximum of ..."
 msgstr "Maksimum..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:549
 msgid "Maximum value of a column"
 msgstr "Maksymalna wartość dla kolumny"
 
@@ -4058,7 +4078,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Kategoria, Typ, Model, Ocena itd."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:43
-#: frontend/src/metabase/user/components/UserSettings.jsx:55
+#: frontend/src/metabase/user/components/UserSettings.jsx:56
 msgid "Account settings"
 msgstr "Ustawienia konta"
 
@@ -4070,7 +4090,7 @@ msgstr "Zamknij panel administracyjny"
 msgid "Logs"
 msgstr "Logi"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:103
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:104
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:22
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:65
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:100
@@ -4110,9 +4130,9 @@ msgid "Metabase Admin"
 msgstr "Metabase Admin"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:36
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:36
 msgid "Ask a question"
 msgstr "Zadaj pytanie"
 
@@ -4133,7 +4153,7 @@ msgstr "Referencje"
 msgid "Which metric?"
 msgstr "Które metryki?"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "Definiowanie wspólnych metryk, upraszcza zadawanie pytań Tobie i Twojemu zespołowi"
 
@@ -4145,7 +4165,7 @@ msgstr "Jak utworzyć metryki"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Wyświetlanie danych w czasie, jako mapę lub z tabelę przestawną by ułatwić Ci analizę trendów lub zmian."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:149
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
 msgid "Custom"
 msgstr "Własny"
 
@@ -4158,13 +4178,13 @@ msgstr "Nowe pytanie"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Użyj tego prostego konstruktora zapytań by zobaczyć trendy, listy lub utworzyć własną metrykęwłasnych metryk."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:107
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:110
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Zapytanie natywne"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:108
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:111
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "W przypadku bardziej skomplikowanych zapytań można użyć własnej kwerendę w SQL lub natywnych zapytaniach."
 
@@ -4275,6 +4295,7 @@ msgid "Enter a default value..."
 msgstr "Wpisz wartość domyślną.."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
+#: frontend/src/metabase/containers/Form.jsx:307
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Wystąpił błąd"
@@ -4526,7 +4547,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "Zalecamy utrzymanie małych pulsów i skoncentrowanie się na tym, aby zapewnić ich strawność i użyteczność dla całego zespołu."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:161
-#: frontend/src/metabase/query_builder/components/view/View.jsx:131
+#: frontend/src/metabase/query_builder/components/view/View.jsx:133
 msgid "Pick your data"
 msgstr "Wybierz swoje dane"
 
@@ -4542,47 +4563,47 @@ msgstr "Emaile"
 msgid "Slack messages"
 msgstr "Widomości Slack"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:216
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Wysłane"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:217
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} zostanie wysłane w"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:219
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Wiadomości"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:235
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "Wyśij teraz wiadomość"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:236
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Wyślij teraz do {0}"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:238
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Wysyłanie..."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "Wysyłanie się niepowiodło"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "Nie wysłano, ponieważ puls nie ma wyników."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Puls wysłany"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:282
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} musi zostać skonfigurowany przez administratora."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:295
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:299
 msgid "Slack"
 msgstr "Slack"
 
@@ -4735,7 +4756,7 @@ msgstr "Śr"
 msgid "Distincts"
 msgstr "Różne"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:55
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "Pokaż {0}"
@@ -4748,11 +4769,12 @@ msgstr[3] "Pokaż {0}"
 msgid "Zoom in"
 msgstr "Przybliż"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Wyrażenia niestandardowe"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Common Metrics"
 msgstr "Wspólne metryki"
 
@@ -4949,34 +4971,34 @@ msgstr "zazwyczaj"
 msgid "Pick a segment or table"
 msgstr "Wybierz segment lub tabelę"
 
-#: frontend/src/metabase/entities/databases/forms.js:191
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
+#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Wybierz bazę danych"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:94
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:85
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:31
 msgid "Select..."
 msgstr "Wybieranie.."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:134
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
 msgid "Select a table"
 msgstr "Wybierz tabele"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:819
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:926
 msgid "No tables found in this database."
 msgstr "Brak tabel w tej bazie danych"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:856
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:901
 msgid "Is a question missing?"
 msgstr "Brakuje zapytania?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:863
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:909
 msgid "Learn more about nested queries"
 msgstr "Dowiedz się więcej o kwerendach zagnieżdżonych"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:898
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:951
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:40
 msgid "Fields"
 msgstr "Pola"
 
@@ -5010,11 +5032,11 @@ msgstr "Sortuj"
 msgid "Row limit"
 msgstr "Limit wierszy"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
 msgid "Unknown Field"
 msgstr "Nieznane pole"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:75
 msgid "field"
 msgstr "pole"
 
@@ -5022,19 +5044,20 @@ msgstr "pole"
 msgid "Matches"
 msgstr "Pasuje"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:148
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:156
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:135
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Dodawanie filtrów w celu zawężenia odpowiedzi"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:293
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
 msgstr "Dodaj grupowanie"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:37
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:313
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
-#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:66
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:67
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:89
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:131
@@ -5050,16 +5073,16 @@ msgstr "Dodaj grupowanie"
 msgid "Data"
 msgstr "Dane"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:340
 msgid "Filtered by"
 msgstr "Filtrowane po"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:376
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:357
 msgid "View"
 msgstr "Wyświetl"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:393
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:374
 msgid "Grouped By"
 msgstr "Pogrupowane po"
 
@@ -5067,7 +5090,7 @@ msgstr "Pogrupowane po"
 msgid "None"
 msgstr "Żadne"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:471
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
 msgid "This question is written in {0}."
 msgstr "To zapytanie jest napisane w {0}."
 
@@ -5079,7 +5102,7 @@ msgstr "Ukryj Edytor"
 msgid "Hide Query"
 msgstr "Ukryj kwerendę"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:481
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
 msgid "Open Editor"
 msgstr "Otwórz Edytor"
 
@@ -5322,7 +5345,7 @@ msgstr "Wszystkie różne wartości z {0}"
 msgid "Number of {0} grouped by {1}"
 msgstr "Liczba elementów {0} zgrupowanych według {1}"
 
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:77
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5381,32 +5404,33 @@ msgstr "Zobacz dane dla {0}"
 msgid "More"
 msgstr "Więcej"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:194
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:216
 msgid "Invalid expression"
 msgstr "Nieprawidłowe wyrażenie"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:269
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:282
 msgid "unknown error"
 msgstr "nieznany błąd"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:47
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:53
 msgid "Field formula"
 msgstr "Pole formuły"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:60
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:64
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Pomyśl o tym jako o rodzaju jak pisanie formuły w programie arkusza kalkulacyjnego: można użyć liczby, pola w tabeli, symbole matematyczne jak +, i niektóre funkcje. Więc można wpisać coś w stylu podsumy kosztów."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:69
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:208
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
 msgid "Learn more"
 msgstr "Dowiedz się więcej"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:77
 msgid "Give it a name"
 msgstr "Nadaj mu nazwę"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:79
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
 msgid "Something nice and descriptive"
 msgstr "Coś miłego i opisowego"
 
@@ -5486,11 +5510,11 @@ msgid "Enter desired number"
 msgstr "Wprowadź żądaną liczbę"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:154
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:161
 msgid "Empty"
 msgstr "Puste"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:119
 msgid "Find a value"
 msgstr "Znajdz wartość"
 
@@ -5558,35 +5582,35 @@ msgstr "Przeczytaj pełną dokumentację"
 msgid "Filter label"
 msgstr "Etykieta filtra"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:135
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:134
 msgid "Variable type"
 msgstr "Typ zmiennej"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:143
 msgid "Text"
 msgstr "Tekst"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
 msgid "Date"
 msgstr "Data"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:147
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
 msgid "Field Filter"
 msgstr "Filtr pola"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Field to map to"
 msgstr "Pole do mapowania na"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:180
 msgid "Filter widget type"
 msgstr "Typ widżetu Filtruj"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:230
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
 msgid "Required?"
 msgstr "Wymagane?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:240
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
 msgid "Default filter widget value"
 msgstr "Domyślna wartość widżetu filtr"
 
@@ -5598,7 +5622,7 @@ msgstr "Archiwizować to zapytanie?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "To zapytanie zostanie usunięte z wszelkich pulpitów nawigacyjnych lub pulsów, używając go."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:158
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
 msgid "Question"
 msgstr "Pytanie"
 
@@ -5768,7 +5792,7 @@ msgid "Details"
 msgstr "Szczegóły"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
-#: frontend/src/metabase/reference/databases/TableList.jsx:116
+#: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
 msgstr "Tabele w {0}"
 
@@ -5849,24 +5873,24 @@ msgstr "Dlaczego ta tabela jest interesująca"
 msgid "Things to be aware of about this table"
 msgstr "Co należy wiedzieć o tej tabeli"
 
-#: frontend/src/metabase/reference/databases/TableList.jsx:30
+#: frontend/src/metabase/reference/databases/TableList.jsx:29
 msgid "Tables in this database will appear here as they're added"
 msgstr "Tabele w tej bazie danych pojawią się w tym miejscu, gdy są dodawane"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:34
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:33
 msgid "Questions about this table will appear here as they're added"
 msgstr "Zaytania dotyczące tej tabeli pojawią się tutaj, jak są dodawane"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:73
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:77
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:76
 msgid "Questions about {0}"
 msgstr "Pytania o {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
 msgid "Created {0} by {1}"
 msgstr "Utworzone {0} przez {1}"
 
@@ -6055,19 +6079,19 @@ msgstr "Inne pola, po których możesz grupować tę metrykę"
 msgid "Fields you can group this metric by"
 msgstr "Pola, po których możesz grupować tę metrykę"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "Metryki są oficjalnymi numerami, o które dba twój zespół"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Metrics will appear here once your admins have created some"
 msgstr "Metryki pojawią się tutaj, gdy Twoi Administratorzy utworzyli kilka"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:28
 msgid "Learn how to create metrics"
 msgstr "Dowiedz się, jak tworzyć metryki"
 
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:34
 msgid "Questions about this metric will appear here as they're added"
 msgstr "Zapytania dotyczące tej metryki pojawią się tutaj, jak są dodawane"
 
@@ -6093,23 +6117,23 @@ msgstr "Dlaczego ten segment jest interesujący"
 msgid "Things to be aware of about this Segment"
 msgstr "Co należy wiedzieć o tym segmencie"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
 msgid "Segments are interesting subsets of tables"
 msgstr "Segmenty to interesujące podzbiory tabel"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "Definiowanie wspólnych segmentów zespołu ułatwia jeszcze łatwiejsze zadawanie pytań"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Segments will appear here once your admins have created some"
 msgstr "Segmenty pojawią się tutaj, gdy Twoi Administratorzy utworzyli kilka"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
 msgid "Learn how to create segments"
 msgstr "Dowiedz się, jak tworzyć segmenty"
 
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:35
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:34
 msgid "Questions about this segment will appear here as they're added"
 msgstr "Zapytania dotyczące tego segmentu pojawią się w miarę ich dodawania"
 
@@ -6129,22 +6153,22 @@ msgstr "Zapytania dotyczące tego segmentu"
 msgid "X-ray this segment"
 msgstr "Prześwietl X-ray ten segment"
 
-#: frontend/src/metabase/routes.jsx:178 frontend/src/metabase/routes.jsx:179
+#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
 msgid "Login"
 msgstr "Zaloguj się"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:303
 #: frontend/src/metabase/containers/ItemPicker.jsx:115
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:204
+#: frontend/src/metabase/routes.jsx:195
 msgid "Search"
 msgstr "Szukaj"
 
-#: frontend/src/metabase/routes.jsx:223
+#: frontend/src/metabase/routes.jsx:214
 msgid "Dashboard"
 msgstr "Kokpit"
 
-#: frontend/src/metabase/routes.jsx:236
+#: frontend/src/metabase/routes.jsx:227
 msgid "New Question"
 msgstr "Nowe zapytanie"
 
@@ -6188,63 +6212,63 @@ msgstr "Dzięki za pomoc w usprawnianiu nas"
 msgid "We won't collect any usage events"
 msgstr "Nie będziemy zbierać żadnych zdarzeń użycia"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:88
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Aby pomóc w ulepszaniu Metabase, chcielibyśmy zebrać pewne dane dotyczące użycia w Google Analytics."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:90
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Here's a full list of everything we track and why."
 msgstr "Oto pełna lista wszystkiego, co śledzimy i dlaczego."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Zezwalaj na anonimowe zbieranie zdarzeń użycia Metabase"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:113
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0} gromadzi wszelkie informacje na temat wyników danych lub pytań."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:114
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
 msgid "never"
 msgstr "nigdy"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:119
 msgid "All collection is completely anonymous."
 msgstr "Cała kolekcja jest całkowicie anonimowa."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Kolekcja może być wyłączona w dowolnym momencie w ustawieniach administratora."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:44
+#: frontend/src/metabase/setup/components/Setup.jsx:59
 msgid "If you feel stuck"
 msgstr "Jeśli czujesz że utknąłeś"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:49
+#: frontend/src/metabase/setup/components/Setup.jsx:64
 msgid "our getting started guide"
 msgstr "nasz przewodnik dla początkujących"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:50
+#: frontend/src/metabase/setup/components/Setup.jsx:65
 msgid "is just a click away."
 msgstr "znajduje się zaledwie kilka kliknięć stąd."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:92
+#: frontend/src/metabase/setup/components/Setup.jsx:111
 msgid "Welcome to Metabase"
 msgstr "Witamy w Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:93
+#: frontend/src/metabase/setup/components/Setup.jsx:112
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Wygląda na to, że wszystko działa. Teraz niech cię poznać, połączyć się z danymi, i zacząć znaleźć kilka odpowiedzi!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:97
+#: frontend/src/metabase/setup/components/Setup.jsx:116
 msgid "Let's get started"
 msgstr "Zacznijmy"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:142
+#: frontend/src/metabase/setup/components/Setup.jsx:166
 msgid "You're all set up!"
 msgstr "Wszystko ustawione!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:153
+#: frontend/src/metabase/setup/components/Setup.jsx:177
 msgid "Take me to Metabase"
 msgstr "Zabierz mnie do Metabase"
 
@@ -6256,13 +6280,13 @@ msgstr "Jak powinniśmy Cie nazywać?"
 msgid "Hi, {0}. nice to meet you!"
 msgstr "Cześć, {0} miło Cię poznać!"
 
-#: frontend/src/metabase/entities/users/forms.js:33
+#: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
 msgstr "Stwórz hasło"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:44
-#: frontend/src/metabase/entities/users/forms.js:35
-#: frontend/src/metabase/entities/users/forms.js:82
+#: frontend/src/metabase/entities/users/forms.js:50
+#: frontend/src/metabase/entities/users/forms.js:97
 msgid "Shhh..."
 msgstr "Szzz..."
 
@@ -6270,11 +6294,11 @@ msgstr "Szzz..."
 msgid "Confirm password"
 msgstr "Potwierdz hasło"
 
-#: frontend/src/metabase/entities/users/forms.js:42
+#: frontend/src/metabase/entities/users/forms.js:57
 msgid "Shhh... but one more time so we get it right"
 msgstr "Shhh... więc jeszcze raz aby to prawidłowo zadziałało"
 
-#: frontend/src/metabase/entities/users/forms.js:70
+#: frontend/src/metabase/entities/users/forms.js:85
 msgid "Your company or team name"
 msgstr "Nazwa firmy lub nazwa zespołu"
 
@@ -6443,7 +6467,7 @@ msgstr "Hasło zostało pomyślnie zaktualizowane!"
 msgid "Account updated successfully!"
 msgstr "Konto zostało zaktualizowane pomyślnie!"
 
-#: frontend/src/metabase/entities/users/forms.js:81
+#: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
 msgstr "Aktualne hasło"
 
@@ -6455,7 +6479,7 @@ msgstr "Zaloguj się za pomocą e-mail Google"
 msgid "User Details"
 msgstr "Szczegóły użytkownika"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:327
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:344
 msgid "Reset to defaults"
 msgstr "Powróć do ustawień fabrycznych"
 
@@ -6480,15 +6504,15 @@ msgstr "Które pola chcesz użyć dla osi X i Y?"
 msgid "Choose fields"
 msgstr "Wybierz pola"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:217
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:234
 msgid "Save as default view"
 msgstr "Zapisz jako domyślny widok"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Draw box to filter"
 msgstr "Zaznacz prostokąt aby filtrować"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Cancel filter"
 msgstr "Anuluj filtr"
 
@@ -6516,19 +6540,19 @@ msgstr "Nie można odnaleźć wizualizacji"
 msgid "Could not display this chart with this data."
 msgstr "Nie można wyświetlić tego wykresu z tymi danymi."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:526
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
 msgid "No results!"
 msgstr "Brak wyników!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:547
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
 msgid "Still Waiting..."
 msgstr "Wciąż czekam..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:550
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
 msgid "This usually takes an average of {0}."
 msgstr "Zazwyczaj trwa to średnio {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:556
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
 msgid "(This is a bit long for a dashboard)"
 msgstr "(jest to trochę za dużo dla pulpitu)"
 
@@ -6687,19 +6711,19 @@ msgstr "Dodaj regułę"
 msgid "Update rule"
 msgstr "Aktualizuj regułę"
 
-#: frontend/src/metabase/visualizations/index.js:32
+#: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
 msgstr "Wizualizacja jest pusta"
 
-#: frontend/src/metabase/visualizations/index.js:37
+#: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
 msgstr "Wizualizacja musi definiować statyczną zmienną ‘identifier’: "
 
-#: frontend/src/metabase/visualizations/index.js:43
+#: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
 msgstr "Wizualizacja z tym identyfikatorem jest już zarejestrowana: "
 
-#: frontend/src/metabase/visualizations/index.js:71
+#: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
 msgstr "Brak wizualizacji dla {0}"
 
@@ -6725,23 +6749,23 @@ msgid "Doh! The data from your query doesn't fit the chosen display choice. This
 msgstr "Doh! Dane z zapytania nie pasują do wybranego wyboru wyświetlania. Ta Wizualizacja wymaga co najmniej {0} {1} danych."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:9
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:117
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:120
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:161
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:169
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:249
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:267
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "kolumna"
@@ -6854,83 +6878,83 @@ msgstr "Nic"
 msgid "Linear Interpolated"
 msgstr "Interpolacja liniowa"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
 msgstr "Skala osi X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
 msgstr "Seria czasu"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:454
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
 msgid "Linear"
 msgstr "Liniowa"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
 msgid "Power"
 msgstr "Moc silnika"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:428
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:445
 msgid "Log"
 msgstr "Log"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:441
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:430
 msgid "Histogram"
 msgstr "Histogram"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
 msgstr "Porządkowa"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
 msgstr "Skala osi Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:462
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
 msgstr "Pokaż oś x linii i znaczników"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:360
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:468
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:349
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
 msgid "Compact"
 msgstr "Kompaktowy"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:469
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
 msgid "Rotate 45°"
 msgstr "Obróć o 45 stopni"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:459
 msgid "Rotate 90°"
 msgstr "Obróć o 90 stopni"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
 msgid "Show y-axis line and marks"
 msgstr "Pokaż linię i znaczniki osi y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:489
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Auto y-axis range"
 msgstr "Automatyczny zakres osi y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:533
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:522
 msgid "Use a split y-axis when necessary"
 msgstr "W razie potrzeby użyj podzielonej osi y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:540
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:529
 msgid "Show label on x-axis"
 msgstr "Pokaż etykietę na osi x"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:546
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:535
 msgid "X-axis label"
 msgstr "Etykieta osi X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:555
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:544
 msgid "Show label on y-axis"
 msgstr "Pokaż etykietę na osi y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:561
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:550
 msgid "Y-axis label"
 msgstr "Etykieta osi Y"
 
@@ -7056,23 +7080,23 @@ msgstr "Min. krycie"
 msgid "Max Zoom"
 msgstr "Max powiększenie"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:231
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:234
 msgid "No relationships found."
 msgstr "Nie znaleziono relacji."
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:269
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:272
 msgid "via {0}"
 msgstr "przez {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:347
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
 msgid "This {0} is connected to:"
 msgstr "Obiekt {0} jest połączony z:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "Object Detail"
 msgstr "Szczegóły obiektu"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:93
 msgid "object"
 msgstr "element"
 
@@ -7177,7 +7201,7 @@ msgstr "Pola widoczne"
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
 #, fuzzy
 msgid "Write here, and use Markdown if you'd like"
-msgstr "Napisz tutaj, i jeśli chcesz użyj składni Markdown"
+msgstr "Pisz tutaj, możesz użyć składni Markdown"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
 msgid "Vertical Alignment"
@@ -7464,7 +7488,7 @@ msgstr "Masz dużo zapisanych zapytań w {0}? Twórz kolekcje, aby ułatwić zar
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:149 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -8993,19 +9017,19 @@ msgstr "Można edytować tej kolekcji i jej zawartość"
 msgid "Can view items in this collection"
 msgstr "Można przeglądać elementy w tej kolekcji"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:767
+#: frontend/src/metabase/admin/permissions/selectors.js:765
 msgid "Collection Access"
 msgstr "Dostęp do kolekcji"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:841
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Ta grupa ma uprawnienia do wyświetlania co najmniej jeden podzbiór tej kolekcji."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:848
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Ta grupa ma uprawnienia do edytowania co najmniej jeden podzbiór tej kolekcji."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:861
+#: frontend/src/metabase/admin/permissions/selectors.js:859
 msgid "View sub-collections"
 msgstr "Wyświetl kolekcje podrzędne"
 
@@ -9013,7 +9037,7 @@ msgstr "Wyświetl kolekcje podrzędne"
 msgid "Remember Me"
 msgstr "Zapamiętaj mnie"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:63
+#: frontend/src/metabase/components/BrowseApp.jsx:73
 msgid "X-ray this schema"
 msgstr "Prześwietl X-ray ten schemat"
 
@@ -9074,15 +9098,15 @@ msgstr "Metabase nie może znaleźć żadnych wyników wyszukiwania."
 msgid "No metrics"
 msgstr "Brak metryk"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:31
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:41
 msgid "Aggregations"
 msgstr "Agregacje"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:32
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:42
 msgid "Operators"
 msgstr "Prowadzący"
 
-#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:30
+#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:35
 msgid "Custom fields"
 msgstr "Własne Pola"
 
@@ -9249,7 +9273,7 @@ msgstr "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
 msgid "toucan_sightings"
 msgstr "toucan_sightings"
 
-#: src/metabase/driver/sparksql.clj
+#: src/metabase/models/collection.clj
 msgid "default"
 msgstr "domyślne"
 
@@ -9277,10 +9301,10 @@ msgstr "N/A"
 msgid "Windows domain"
 msgstr "Domena systemu Windows"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:539
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:545
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:554
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:560
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:528
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:534
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:543
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
 msgstr "Etykiety"
 
@@ -9315,9 +9339,9 @@ msgstr "Udostępnianie"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:286
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:294
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:302
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:319
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:324
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
@@ -9332,19 +9356,18 @@ msgstr "Udostępnianie"
 msgid "Display"
 msgstr "Wyświetl"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:461
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:476
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:502
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:532
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:402
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:465
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:483
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:521
 msgid "Axes"
 msgstr "Osie"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:212
-#: frontend/src/metabase/admin/settings/selectors.js:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:219
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:62
 msgid "Formatting"
@@ -9378,7 +9401,7 @@ msgstr "RTG"
 msgid "Compare to the rest"
 msgstr "Porównaj z resztą"
 
-#: frontend/src/metabase/entities/databases/forms.js:16
+#: frontend/src/metabase/entities/databases/forms.js:18
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Korzystanie z timezone wirtualnej maszyny Java (JVM)"
 
@@ -9408,24 +9431,24 @@ msgstr "Użyj strefy czasowej JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Obecnie analizujemy tabele i pola aby pomóc ci w analizie twoich danych"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
 msgid "Tip: "
 msgstr "Wskazówka:␣"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:237
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
 msgstr "Wybierz typ waluty"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:300
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
 msgid "Field Type"
 msgstr "Typ Pola"
 
-#: frontend/src/metabase/admin/routes.jsx:113
+#: frontend/src/metabase/admin/routes.jsx:118
 #: frontend/src/metabase/nav/containers/Navbar.jsx:267
 msgid "Troubleshooting"
 msgstr "Kłopoty"
 
-#: frontend/src/metabase/admin/settings/selectors.js:103
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Enable X-ray features"
 msgstr "Włącz funkcję X-ray"
 
@@ -9470,7 +9493,7 @@ msgstr "Czas trwania (ms)"
 msgid "Currency"
 msgstr "waluta"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
 msgstr "Wybierze użytkownika lub kanał..."
 
@@ -9618,7 +9641,7 @@ msgstr "Styl linii"
 msgid "Show dots on lines"
 msgstr "Pokazuj kropki na liniach"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:348
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
@@ -9632,7 +9655,7 @@ msgstr "Która oś?"
 msgid "Line + Bar"
 msgstr "Linia + Słupek"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
 msgid "line and bar chart"
 msgstr "wykres słupkowo-liniowy"
 
@@ -11080,7 +11103,7 @@ msgstr "W jaki sposób dane są rozłożone na różne liczby"
 msgid "Sessions by page where the session began"
 msgstr "Sesje według strony, na której rozpoczęła się sesja"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:503
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -11449,7 +11472,7 @@ msgstr "Powiel ten element"
 msgid "Archive this item"
 msgstr "Zarchiwizuj ten element"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:331
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:325
 msgid "Duplicate dashboard"
 msgstr "Powiel pulpit"
 
@@ -11572,7 +11595,7 @@ msgstr[1] "Kwartały roku"
 msgstr[2] "Kwartałów roku"
 msgstr[3] "Kwartałów roku"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
@@ -11590,8 +11613,8 @@ msgstr "[Q]Q"
 msgid "This"
 msgstr "To"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:97
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:137
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:136
 msgid "Invalid"
 msgstr "Niepoprawne"
 
@@ -12355,6 +12378,7 @@ msgstr "Oto twoje {0} najnowsze karty:"
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
 msgstr "Czy możesz być trochę bardziej szczegółowy lub użyć ID? Znalazłem te karty o dopasowanych nazwach:"
 
+#: src/metabase/driver/common/parameters/values.clj
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
 msgstr "Nie znaleziono karty {0}."
@@ -12463,11 +12487,11 @@ msgstr "Instrukcja niewypału"
 msgid "Archive this?"
 msgstr "Zarchiwizować to?"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:243
+#: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
 msgstr "Dowiedz się o naszych danych"
 
-#: frontend/src/metabase/entities/databases/forms.js:20
+#: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
 msgstr "Użyj  przy połączeniu DNS SRV"
 
@@ -12478,7 +12502,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 msgstr "Korzystanie z tej opcji wymaga, aby podany host był nazwą FQDN. Jeśli łączysz się z Atlas Cluster, może być konieczne włączenie tej opcji. Jeśli nie wiesz co to znaczy,\n"
 "pozostaw to wyłączone."
 
-#: frontend/src/metabase/entities/databases/forms.js:204
+#: frontend/src/metabase/entities/databases/forms.js:273
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Automatycznie uruchamiaj zapytania podczas prostego filtrowania i podsumowywania"
 
@@ -12502,11 +12526,11 @@ msgstr "Wszystkie wyniki"
 msgid "Our Analytics"
 msgstr "Nasze Analizy"
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:513
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
 msgstr "Całkowita suma wszystkich wartości kolumny. \\ne.x. przychody ogółem w czasie."
 
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
 msgstr "Całkowita liczba wierszy. \\ne.x. łączna liczba sprzedaży w czasie."
 
@@ -12516,7 +12540,7 @@ msgstr "Całkowita liczba wierszy. \\ne.x. łączna liczba sprzedaży w czasie."
 msgid "Filter"
 msgstr "Filtr"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:50
 msgid "record"
 msgid_plural "records"
 msgstr[0] "rekord"
@@ -12532,27 +12556,27 @@ msgstr "Przeglądaj Dane"
 msgid "Write SQL"
 msgstr "Napisz SQL"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:83
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
 msgstr "Proste pytanie"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:84
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:87
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
 msgstr "Wybierz niektóre dane, wyświetl je i łatwo filtruj, podsumowuj i wizualizuj."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:95
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:98
 msgid "Custom question"
 msgstr "Niestandardowe zapytanie"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:96
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:99
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Korzystaj z zaawansowanego edytora notatników, aby łączyć dane, tworzyć niestandardowe kolumny, wykonywać matematykę i wykonywać inne czynności."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Basic Metrics"
 msgstr "Podstawowe Metryki"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:322
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
 msgid "Custom…"
 msgstr "Własne..."
 
@@ -12621,15 +12645,15 @@ msgstr "Wybierz kolumnę grupowania"
 msgid "Pick your starting data"
 msgstr "Wybierz początkowe dane"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select None"
 msgstr "Wybierz Brak"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select All"
 msgstr "Zaznacz wszystko"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:151
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:152
 msgid "Pick a table..."
 msgstr "Wybierz tabelę..."
 
@@ -12756,15 +12780,15 @@ msgstr "Dodaj metrykę"
 #: frontend/src/metabase/lib/core.js:137 frontend/src/metabase/lib/core.js:142
 #: frontend/src/metabase/lib/core.js:147 frontend/src/metabase/lib/core.js:152
 #: frontend/src/metabase/lib/core.js:157 frontend/src/metabase/lib/core.js:162
-#: frontend/src/metabase/user/components/UserSettings.jsx:63
+#: frontend/src/metabase/user/components/UserSettings.jsx:64
 msgid "Profile"
 msgstr "Profil"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:560
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "Zazwyczaj jest to dość szybkie, ale wydaje się, że zajmuje to teraz trochę czasu."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
 msgid "Combo"
 msgstr "Combo"
 
@@ -12780,11 +12804,11 @@ msgstr "Trend"
 msgid "Boolean"
 msgstr "Boolean"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:62
 msgid "Unknown Segment"
 msgstr "Nieznany Segment"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:73
 msgid "Unknown Filter"
 msgstr "Nieznany Filtr"
 
@@ -12914,6 +12938,7 @@ msgstr "Używanie NOWO TWORZONEGO modułu ładującego klasy jako modułu wspó�
 msgid "Failed to copy file"
 msgstr "Nie udało się skopiować pliku"
 
+#. check that the URL is valid
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
 msgstr "Nieprawidłowy adres URL witryny: {0}"
@@ -13188,7 +13213,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Wybierz kolumny, które chcesz uwzględnić"
 
-#: frontend/src/metabase/entities/databases/forms.js:205
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Gdy ta opcja jest włączona, Metabase automatycznie uruchamia zapytania, gdy użytkownicy wykonują proste eksploracje za pomocą przycisków Podsumuj i Filtruj podczas przeglądania tabeli lub wykresu. Możesz to wyłączyć, jeśli odpytywanie tej bazy danych jest powolne. To ustawienie nie wpływa na drążenie wszerz lub zapytania SQL."
 
@@ -13226,7 +13251,7 @@ msgstr "Błąd podczas określania oczekiwanych kolumn dla zapytania"
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "Nieobsługiwany wyjątek, oczekiwane oprogramowanie pośredniczące `catch-exceptions`  do obsługi."
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:125
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
 msgid "Diagnostic Info"
 msgstr "Informacje diagnostyczne"
 
@@ -13251,11 +13276,11 @@ msgstr "Podczas logowania w Google wystąpił problem. Skontaktuj się z adminis
 msgid "Sign in with email"
 msgstr "Zaloguj się przez e-mail"
 
-#: frontend/src/metabase/entities/databases/forms.js:21
+#: frontend/src/metabase/entities/databases/forms.js:23
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "Korzystanie z tej opcji wymaga, aby podany host był nazwą FQDN. W przypadku łączenia się z klastrem Atlas może być konieczne włączenie tej opcji. Jeśli nie wiesz, co to oznacza, pozostaw to wyłączone."
 
-#: frontend/src/metabase/entities/databases/forms.js:213
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Domyślnie Metabase wykonuje lekką synchronizację godzinową i intensywny codzienny skan wartości pól. Jeśli masz dużą bazę danych, zalecamy włączenie tej opcji i sprawdzenie, kiedy i jak często skanowane są wartości pola."
 
@@ -13323,11 +13348,11 @@ msgstr "Nie zawiera"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "To pole nie będzie widoczne ani możliwe do wyboru w pytaniach utworzonych za pomocą interfejsów użytkownika GUI. Będzie nadal dostępny w zapytaniach SQL."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:512
 msgid "Cumulative sum"
 msgstr "Skumulowana suma"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Standard deviation"
 msgstr "Odchylenie standardowe"
 
@@ -13339,23 +13364,23 @@ msgstr "musi mieć co najmniej {0} znaków"
 msgid "Must be at least {0} characters long"
 msgstr "Musi mieć co najmniej {0} znaków"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:389
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:82
 msgid "Name (required)"
 msgstr "Nazwa (wymagane)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:556
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
 msgid "Run selected text"
 msgstr "Uruchom zaznaczony tekst"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:557
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
 msgid "Run query"
 msgstr "Uruchom zapytanie"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(⌘ + enter)"
 msgstr "(⌘ + enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + enter)"
 
@@ -13367,7 +13392,7 @@ msgstr "Oto, gdzie pojawią się Twoje wyniki"
 msgid "You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question."
 msgstr "Nie wprowadzisz żadnych trwałych zmian w zapisanym pytaniu, chyba że klikniesz Zapisz i zdecydujesz się zastąpić oryginalne pytanie."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:199
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:200
 msgid "There aren't any filter widgets for this type of field yet."
 msgstr "Nie ma jeszcze widżetów filtrów dla tego typu pól."
 
@@ -13403,19 +13428,19 @@ msgstr "Linia docelowa"
 msgid "Trend line"
 msgstr "Linia trendu"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:320
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:317
 msgid "Show values on data points"
 msgstr "Pokaż wartości w punktach danych"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:334
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:325
 msgid "Values to show"
 msgstr "Wartości do pokazania"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:342
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:332
 msgid "As many as can fit nicely"
 msgstr "Tyle, ile można ładnie zmieścić"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:343
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
 msgid "All"
 msgstr "Wszystko"
 
@@ -13707,31 +13732,31 @@ msgstr "Numery"
 msgid "No mappable groups"
 msgstr "Brak grup, które można zmapować"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:107
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
 msgstr "Dokumentacja  Metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
 msgstr "Zawiera przewodnik rozwiązywania problemów"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:112
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
 msgid "Post on the Metabase support forum"
 msgstr "Publikuj na forum wsparcia Metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:114
 msgid "A community forum for all things Metabase"
 msgstr "Forum społeczności dla Matabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:117
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
 msgid "File a bug report"
 msgstr "Zgłoś raport o błędzie"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:119
 msgid "Create a GitHub issue (includes the diagnostic info below)"
 msgstr "Utwórz problem w GitHub (dodajac informacje diagnostyczne)"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:127
 msgid "Please include these details in support requests. Thank you!"
 msgstr "Podaj te szczegóły w prośbach o wsparcie. Dziękujemy!"
 
@@ -13759,38 +13784,40 @@ msgstr "Brak pasujących wyników"
 msgid "Submit"
 msgstr "Zatwierdź"
 
-#: frontend/src/metabase/entities/databases/forms.js:13
+#: frontend/src/metabase/entities/databases/forms.js:15
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host. This option also provides an extra layer of security when a VPN is not available. Enabling this is usually slower than a direct connection."
 msgstr "Dostęp do niektórych instalacji baz danych można uzyskać tylko poprzez połączenie SSH. Ta opcja zapewnia również dodatkową warstwę bezpieczeństwa, gdy sieć VPN nie jest dostępna. Włączenie tego jest zwykle wolniejsze niż bezpośrednie połączenie."
 
-#: frontend/src/metabase/entities/databases/forms.js:17
+#: frontend/src/metabase/entities/databases/forms.js:19
 msgid "We suggest you leave this off unless you're doing manual timezone casting in many or most of your queries with this data."
 msgstr "Sugerujemy pozostawienie tej opcji wyłączoną, chyba że wykonujesz ręczne wskazywanie stref czasowych w wielu lub większości zapytań z tymi danymi."
 
-#: frontend/src/metabase/entities/databases/forms.js:93
+#: frontend/src/metabase/entities/databases/forms.js:128
 msgid "{0} to get an auth code."
 msgstr "{0}, aby uzyskać kod autoryzacyjny."
 
-#: frontend/src/metabase/entities/databases/forms.js:101
+#: frontend/src/metabase/entities/databases/forms.js:136
+#: src/metabase/models/collection.clj
 msgid "or"
 msgstr "lub"
 
-#: frontend/src/metabase/entities/databases/forms.js:159
-#: frontend/src/metabase/entities/databases/forms.js:197
-#: frontend/src/metabase/entities/users/forms.js:44
+#: frontend/src/metabase/entities/databases/forms.js:39
+#: frontend/src/metabase/entities/databases/forms.js:226
+#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "wymagany"
 
-#: frontend/src/metabase/entities/databases/forms.js:188
+#: frontend/src/metabase/entities/databases/forms.js:257
 msgid "Database type"
 msgstr "Typ bazy danych"
 
-#: frontend/src/metabase/entities/databases/forms.js:222
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Jest to proces, który sprawdza dostępność aktualizacji schematu tej bazy danych. W większości przypadków powinieneś pozostawić ten zestaw do synchronizacji co godzinę."
 
-#: frontend/src/metabase/entities/databases/forms.js:230
+#: frontend/src/metabase/entities/databases/forms.js:299
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase może skanować wartości obecne w każdym polu w tej bazie danych, aby włączyć filtry pól wyboru w pulpitach nawigacyjnych i pytaniach. Może to być proces bardzo obciążający zasoby, szczególnie jeśli masz bardzo dużą bazę danych."
 
@@ -13798,15 +13825,15 @@ msgstr "Metabase może skanować wartości obecne w każdym polu w tej bazie dan
 msgid "Collection"
 msgstr "Kolekcja"
 
-#: frontend/src/metabase/entities/users/forms.js:40
+#: frontend/src/metabase/entities/users/forms.js:55
 msgid "Confirm your password"
 msgstr "Potwierdź swoje hasło"
 
-#: frontend/src/metabase/entities/users/forms.js:45
+#: frontend/src/metabase/entities/users/forms.js:60
 msgid "passwords do not match"
 msgstr "Hasła nie pasują do siebie"
 
-#: frontend/src/metabase/entities/users/forms.js:71
+#: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
 msgstr "Departament Niesamowitości"
 
@@ -13846,328 +13873,324 @@ msgid "Returns the average of the values in the column."
 msgstr "Zwraca średnią wartości z kolumny."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:18
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
 msgid "The column whose values to average."
 msgstr "Kolumna, której wartości mają być uśrednione."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "start"
 msgstr "start"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "end"
 msgstr "koniec"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
 msgid "Checks a date or numeric column's values to see if they're within the specified range."
 msgstr "Sprawdza wartości daty lub wartości liczbowych kolumn, aby sprawdzić, czy mieszczą się w określonym zakresie."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
 msgstr "Ocena"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:24
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:98
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
 msgid "condition"
 msgstr "warunek"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
 msgid "output"
 msgstr "wynik"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Testuje listę przypadków i zwraca odpowiednią wartość pierwszego prawdziwego przypadku, z opcjonalną wartością domyślną, jeśli nic więcej nie jest spełnione."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
 msgid "Weight"
 msgstr "Waga"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
 msgid "Large"
 msgstr "Duży"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
 msgid "Medium"
 msgstr "Średni"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
 msgid "Small"
 msgstr "Mały"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
 msgid "Something that should evaluate to true or false."
 msgstr "Coś, co powinno być ocenione na prawdziwe lub fałszywe."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:54
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "Wartość, która zostanie zwrócona, jeśli powyższy warunek jest spełniony."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:62
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "value1"
 msgstr "wartość1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:74
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
 msgid "value2"
 msgstr "wartość2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Sprawdza wartości w każdym argumencie w kolejności i zwraca pierwszą wartość inną niż null dla każdego wiersza."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:56
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
 msgid "Comments"
 msgstr "Komentarze"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
 msgid "Notes"
 msgstr "Notatki"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
 msgid "No comments"
 msgstr "Bez komentarza"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
 msgid "A column or value."
 msgstr "Kolumna lub wartość."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:65
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:77
 msgid "If value1 is empty, value2 gets returned if it's not empty, and so on."
 msgstr "Jeśli wartość1 jest pusta, zwracana jest wartość2 , jeśli nie jest pusta,  itd."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 msgid "Combines two or more strings of text together."
 msgstr "Łączy dwa lub więcej ciągów tekstu razem."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
 msgid "Last Name"
 msgstr "Nazwisko"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 msgid "First Name"
 msgstr "Imię"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
 msgstr "wartość2 zostanie dodana na końcu tego."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
 msgstr "Zostanie to dodane na końcu wartości 1."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
 msgid "string1"
 msgstr "ciąg1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
 msgid "string2"
 msgstr "ciąg2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:80
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Sprawdza, czy ciąg1 zawiera w sobie ciąg2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:284
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
 msgid "Status"
 msgstr "Status"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 msgid "Pass"
 msgstr "Zdane"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
 msgstr "Zawartość tego ciągu zostanie sprawdzona."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
 msgid "The string of text to look for."
 msgstr "Ciąg tekstu do wyszukania."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:90
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:116
 msgid "Returns the count of rows in the source data."
 msgstr "Zwraca liczbę wierszy w danych źródłowych."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Only counts rows where the condition is true."
 msgstr "Liczy tylko wiersze, w których warunek jest spełniony."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:97
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:261
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
 msgid "Subtotal"
 msgstr "Suma częściowa"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
 msgid "The additive total of rows across a breakout."
 msgstr "Łączna suma wierszy w rozbiciu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:110
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
 msgid "The rolling sum of a column across a breakout."
 msgstr "Łączna suma kolumny w rozbiciu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:113
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:268
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
 msgstr "Kolumna do zsumowania."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
 msgid "The number of distinct values in this column."
 msgstr "Liczba różnych wartości w tej kolumnie."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "The column whose distinct values to count."
 msgstr "Kolumna, której odrębne wartości należy policzyć."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:128
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:145
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:153
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:201
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:274
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
 msgid "text"
 msgstr "tekst"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:130
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:223
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
 msgid "comparison"
 msgstr "porównanie"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Zwraca prawkę, jeśli koniec tekstu pasuje do tekstu porównawczego."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "Appetite"
 msgstr "Apetyt"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "hungry"
 msgstr "głodny"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 msgid "A column or string of text to check."
 msgstr "Kolumna lub ciąg tekstu do sprawdzenia."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
 msgid "The string of text that the original text should end with."
 msgstr "Ciąg tekstu, którym powinien kończyć się tekst oryginalny."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 msgid "regular_expression"
 msgstr "wyrażenie_regularne"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:136
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Wyodrębnia pasujące podciągi zgodnie z wyrażeniem regularnym."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:137
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
 msgid "Address"
 msgstr "Adres"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 msgid "The column or string of text to search though."
 msgstr "Jednak kolumna lub ciąg tekstu do wyszukiwania."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
 msgid "The regular expression to match."
 msgstr "Dopasowane wyrażenie regularne."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the string of text in all lowercase."
 msgstr "Zwraca ciąg tekstu małymi literami."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:149
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to lowercase."
 msgstr "Kolumna z wartościami do konwersji na małe litery."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:154
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 msgid "Removes leading whitespace from a string of text."
 msgstr "Usuwa wiodące białe znaki z ciągu tekstu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:157
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column with values you want to trim."
 msgstr "Kolumna z wartościami, które chcesz przyciąć."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "Returns the largest value found in the column."
 msgstr "Zwraca największą wartość znalezioną w kolumnie."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
 msgid "Age"
 msgstr "Wiek"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:165
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
 msgid "The numeric column whose maximum you want to find."
 msgstr "Kolumna numeryczna, której maksimum chcesz znaleźć."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:170
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "Returns the smallest value found in the column."
 msgstr "Zwraca najmniejszą wartość znalezioną w kolumnie."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
 msgid "Salary"
 msgstr "Wynagrodzenie"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:173
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
 msgid "The numeric column whose minimum you want to find."
 msgstr "Kolumna numeryczna, której minimum chcesz znaleźć."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:181
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:242
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
 msgid "position"
 msgstr "pozycja"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:194
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
 msgid "length"
 msgstr "długość"
 
@@ -14176,7 +14199,7 @@ msgstr "długość"
 msgid "new_text"
 msgstr "nowy_tekst"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:187
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
 msgid "Replaces a part of the input text with new text."
 msgstr "Zamienia część tekstu wejściowego na nowy tekst."
 
@@ -14188,7 +14211,7 @@ msgstr "Order ID"
 msgid "Updated Part of ID"
 msgstr "Zaktualizowana Cześć ID"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
 msgid "The text that will be modified."
 msgstr "Tekst, który zostanie zmodyfikowany."
 
@@ -14204,87 +14227,87 @@ msgstr "Liczba znaków do zastąpienia."
 msgid "The text to use in the replacement."
 msgstr "Tekst używany w zamianie."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Usuwa końcowe puste znaki z ciągu tekstu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:210
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Zwraca procent wierszy w danych, które pasują do warunku, w postaci dziesiętnej."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:218
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Zwraca prawdę, jeśli początek tekstu pasuje do tekstu porównawczego."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Course Name"
 msgstr "Nazwa kursu"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Computer Science"
 msgstr "Informatyka"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
 msgid "The string of text that the original text should start with."
 msgstr "Ciąg tekstu, od którego powinien zaczynać się tekst oryginalny."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:229
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
 msgid "Calculates the standard deviation of the column."
 msgstr "Oblicza odchylenie standardowe kolumny."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:230
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
 msgid "Population"
 msgstr "Populacja"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
 msgid "A numeric column."
 msgstr "Kolumna numeryczna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
 msgid "Returns a portion of the supplied text."
 msgstr "Zwraca część dostarczonego tekstu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:241
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:313
 msgid "The text to return a portion of."
 msgstr "Tekst do zwrócenia części."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
 msgid "The position to start copying characters."
 msgstr "Miejsce do rozpoczęcia kopiowania znaków."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:245
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
 msgid "The number of characters to return."
 msgstr "Liczba znaków do zwrócenia."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
 msgid "Adds up all the values of the column."
 msgstr "Dodaje wszystkie wartości kolumny."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:253
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
 msgid "The numeric column to sum."
 msgstr "Kolumna numeryczna do zsumowania."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Sumuje wartości w kolumnie, w której wiersze odpowiadają warunkowi."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
 msgid "Order Status"
 msgstr "Status zamówienia"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
 msgid "Valid"
 msgstr "Poprawny"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Usuwa początkowe i końcowe puste spacje z ciągu tekstu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
 msgid "Returns the string of text in all upper case."
 msgstr "Zwraca ciąg tekstu wielkimi literami."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
 msgid "The column with values to convert to upper case."
 msgstr "Kolumna z wartościami do konwersji na wielkie litery."
 
@@ -14356,39 +14379,39 @@ msgstr "Dziękujemy za korzystanie z Metabase!"
 msgid "Powered by {0}"
 msgstr "Obsługiwane przez {0}"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:191
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
 msgid "To:"
 msgstr "Do:"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:40
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
 msgstr "Nie można użyć tego pytania, ponieważ jest ono oparte na innej bazie danych."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:44
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:43
 msgid "Couldn't find a saved question with that ID number."
 msgstr "Nie można znaleźć zapisanego pytania o tym numerze id."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:55
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:54
 msgid "Pick a saved question"
 msgstr "Wybierz zapisane zapytanie"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:57
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:56
 msgid "Pick a different question"
 msgstr "Wybierz inne zapytanie"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:62
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:61
 msgid "Loading…"
 msgstr "Ładowanie…"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:79
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:78
 msgid "Question #…"
 msgstr "Pytanie nr…"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:81
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
 msgstr "Pytanie nr {0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:115
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
 msgstr "Ostatnio edytowane {0}"
 
@@ -14400,11 +14423,11 @@ msgstr "{0} tworzy zmienną w tym szablonie zapytania o nazwie „nazwa_zmiennej
 msgid "Giving a variable the \"Field Filter\" type allows you to link questions to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "Podanie zmiennej typu „Filtr pola” pozwala łączyć pytania z widżetami filtrów pulpitu nawigacyjnego lub używać więcej typów widżetów filtrów w zapytaniu SQL. Zmienna Filtr pola wstawia SQL podobny do tego generowanego przez konstruktora zapytań GUI podczas dodawania filtrów do istniejących kolumn."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:131
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
 msgstr "Nazwa zmiennej"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:217
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:218
 msgid "Filter widget label"
 msgstr "Filtruj etykietę widżetu"
 
@@ -14436,11 +14459,11 @@ msgstr "W nagłówku kolumny"
 msgid "In every table cell"
 msgstr "W każdej komórce tabeli"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:351
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:341
 msgid "Value formatting"
 msgstr "Formatowanie wartości"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:361
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
 msgid "Full"
 msgstr "Pełny"
 
@@ -14540,7 +14563,7 @@ msgstr "Wyłącz auto-commit..."
 
 #: src/metabase/db.clj
 msgid "Set default db connection with connection pool..."
-msgstr "Ustaw domyślne połączenie db z pulą połączeń ..."
+msgstr "Ustaw domyślne połączenie db z pulą połączeń..."
 
 #: src/metabase/db.clj
 msgid "Successfully verified {0} {1} application database connection."
@@ -14768,3 +14791,482 @@ msgstr "Błąd podczas generowania statystyk dla kolumny:"
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandonment email!"
 msgstr "Wysyłanie wiadomości e-mail o rezygnacji!"
+
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
+msgstr "Możesz utworzyć zapisane metryki, aby dodać nazwaną opcję metryki. Zapisane dane obejmują typ agregacji, pole agregacji i opcjonalnie każdy dodany filtr. Jako przykład możesz użyć tego do stworzenia czegoś w rodzaju oficjalnego sposobu obliczania „średniej ceny” dla tabeli zamówień."
+
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:105
+msgid "Select and add filters to create your new segment."
+msgstr "Wybierz i dodaj filtry, aby utworzyć nowy segment."
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+msgid "Alphabetical"
+msgstr "Alfabetycznie"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+msgid "Smart"
+msgstr "Inteligentne"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+msgid "Column order: {0}"
+msgstr "Kolejność kolumn: {0}"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
+msgid "Unhide all"
+msgstr "Pokaż wszystko"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:204
+msgid "Hide all"
+msgstr "Ukryj wszystko"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:206
+msgid "Unhide"
+msgstr "Pokaż"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:22
+msgid "New metric"
+msgstr "Nowa metryka"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:45
+msgid "Create metrics to add them to the Summarize dropdown in the query builder"
+msgstr "Utwórz metryki, aby dodać je do menu Podsumowanie w narzędziu do tworzenia zapytań"
+
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:22
+msgid "New segment"
+msgstr "Nowy segment"
+
+#: frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx:71
+msgid "Filter by table"
+msgstr "Filtruj według tabeli"
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:64
+msgid "Checking HTTPS..."
+msgstr "Sprawdzanie HTTPS..."
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:66
+msgid "It looks like HTTPS is not properly configured"
+msgstr "HTTPS nie jest prawidłowo skonfigurowany"
+
+#: frontend/src/metabase/admin/settings/selectors.js:57
+msgid "Redirect to HTTPS"
+msgstr "Przekierowanie na HTTPS"
+
+#: frontend/src/metabase/admin/settings/selectors.js:219
+msgid "Localization"
+msgstr "Lokalizacja"
+
+#: frontend/src/metabase/admin/settings/selectors.js:222
+msgid "Instance language"
+msgstr "Język instancji"
+
+#: frontend/src/metabase/admin/settings/selectors.js:237
+msgid "Localization options"
+msgstr "Opcje lokalizacji"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:51
+msgid "This database doesn't have any tables."
+msgstr "Baza danych nie zawiera żadnych tabel"
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
+msgid "This field only accepts a single value because it's used in a SQL query."
+msgstr "To pole przyjmuje tylko jedną zmienną ponieważ jest użyte w zapytaniu SQL."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:17
+msgid "Service Accounts"
+msgstr "Service Accounts"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:26
+msgid "Metabase connects to Big Query via {0}."
+msgstr "Metabase łączy się z Big Query poprzez {0}."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:29
+msgid "Continue using an OAuth application to connect"
+msgstr "Kontynuuj użycie OAuth do połączenia"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:43
+msgid "We recommend switching to use {0} instead of an OAuth application to connect to BigQuery"
+msgstr "Rekomendujemy użycie {0} zamiast OAuth w celu połączenia się z BigQuery"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:48
+msgid "Connect to a Service Account instead"
+msgstr "Zamiast tego połącz się z Service Account"
+
+#: frontend/src/metabase/entities/databases/forms.js:44
+msgid "invalid JSON"
+msgstr "Nieprawidłowy JSON"
+
+#: frontend/src/metabase/entities/databases/forms.js:50
+msgid "SSH private key"
+msgstr "Klucz prywatny SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:51
+msgid "Paste the contents of your ssh private key here"
+msgstr "Wklej tutaj zawartość klucza prywatnego SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:55
+msgid "Passphrase for the SSH private key"
+msgstr "Hasło do klucza SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:58
+msgid "SSH Authentication"
+msgstr "Autentykacja SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:60
+msgid "SSH Key"
+msgstr "Klucz SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:65
+msgid "Server SSL certificate chain"
+msgstr "Łańcuch certyfikatów SSL serwera"
+
+#: frontend/src/metabase/entities/databases/forms.js:66
+msgid "Paste the contents of the server's SSL certificate chain here"
+msgstr "Wklej tutaj zawartość łańcucha certyfikatów SSL"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:11
+msgid "Paste a connection string"
+msgstr "Wklej string połączenia"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:12
+msgid "Fill out individual fields"
+msgstr "Wypełnij wszystkie pola"
+
+#: frontend/src/metabase/entities/snippets.js:14
+msgid "Enter some SQL here so you can reuse it later"
+msgstr "Wpisz tutaj SQL aby móc go użyć później ponownie"
+
+#: frontend/src/metabase/entities/snippets.js:24
+msgid "Give your snippet a name"
+msgstr "Nadaj swojemu fragmentowi nazwę"
+
+#: frontend/src/metabase/entities/snippets.js:25
+msgid "Current Customers"
+msgstr "Obecni Klienci"
+
+#: frontend/src/metabase/entities/snippets.js:30
+msgid "Add a description"
+msgstr "Dodaj opis"
+
+#: frontend/src/metabase/entities/users/forms.js:37
+msgid "Use site default"
+msgstr "Użyj domyślnych"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+msgid "find"
+msgstr "szukaj"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+msgid "replace"
+msgstr "zamień"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+msgid "The text to find."
+msgstr "Wyszukiwany tekst"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "The text to use as the replacement."
+msgstr "Tekst używany do zamiany"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+msgid "Editing {0}"
+msgstr "Edytowanie {0}"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+msgid "Create your new snippet"
+msgstr "Utwórz nowy fragment"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+msgid "Archived snippets"
+msgstr "Archiwalne fragmenty"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+msgid "Snippets are reusable bits of SQL"
+msgstr "Fragmenty to reużywalne cząstki SQL"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+msgid "Create a snippet"
+msgstr "Utwórz fragment"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+msgid "Snippets"
+msgstr "Fragmenty"
+
+#: frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx:15
+msgid "SQL Snippets"
+msgstr "Fragmenty SQL"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:38
+msgid "Your language is set to {0}"
+msgstr "Język ustawiony na {0}"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:50
+msgid "What's your preferred language?"
+msgstr "Jaki jest Twój preferowany język?"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:54
+msgid "This language will be used throughout Metabase and will be the default for new users."
+msgstr "Ten język będzie używany w całym Metabase oraz ustawiony wszystkim nowym użytkownikom jako domyślny."
+
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:159
+msgid "We filtered out {0} row(s) containing null values."
+msgstr "Odfiltrowanych zostało {0} wierszy zawierających wartości null."
+
+#: frontend/src/metabase/visualizations/lib/settings/series.js:133
+msgid "Show values for this series"
+msgstr "Pokaż wartości dla tej serii"
+
+#: src/metabase/api/card.clj
+msgid "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
+msgstr "Średnie trwanie zapytania wynosi {0}; używając \"magicznego\" TTL wynoszącego {1}"
+
+#: src/metabase/api/native_query_snippet.clj
+msgid "A snippet with that name already exists. Please pick a different name."
+msgstr "Fragment o tej nazwie już istnieje. Proszę wybrać inną nazwę."
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Metric]"
+msgstr "[Nieznana Metryka]"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Segment]"
+msgstr "[Nieznany Segment]"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error writing error to output stream"
+msgstr "Błąd wydruku błędu na strumień wyjściowy"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Caught unexpected Exception in streaming response body"
+msgstr "Wychwycono nieoczekiwany wyjątek w treści odpowiedzi przesyłania strumieniowego"
+
+#: src/metabase/async/streaming_response.clj
+msgid "bound-fn caught unexpected Exception"
+msgstr "funkcja łączona napotkała nieoczekiwany wyjątek"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error determining whether HTTP request was canceled"
+msgstr "Błąd określania, czy żądanie HTTP zostało anulowane"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Check cancelation status timed out after {0}"
+msgstr "Upłynął limit czasu anulowania po {0}"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Unexpected exception in do-f-async"
+msgstr "Nieoczekiwany wyjątek w do-f-async"
+
+#: src/metabase/async/streaming_response.clj src/metabase/server.clj
+msgid "Unexpected exception writing error response"
+msgstr "Nieoczekiwany błąd zapisu odpowiedzi wyjątku"
+
+#: src/metabase/driver/common.clj
+msgid "Server certificate not trusted - did you specify the correct SSL certificate chain?"
+msgstr "Certyfikat serwera nie jest zaufany - czy podałeś prawidłowy łańcuch certyfikatów SSL?"
+
+#: src/metabase/driver/common.clj
+msgid "Server appears to require SSL - please enable SSL above"
+msgstr "Serwer wydaje się wymagać SSL - włącz SSL powyżej"
+
+#: src/metabase/driver/common.clj
+msgid "Username"
+msgstr "Nazwa użytkownika"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Don''t know how to parse parameter of type {0}"
+msgstr "Nie wiem, jak przeanalizować parametr typu {0}"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Invalid :card parameter: missing `:card-id`"
+msgstr "Nieprawidłowy parametr :card - brakuje `:card-id`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Unable to resolve Snippet: missing `:snippet-id`"
+msgstr "Nie można znaleźć Fragmentu - brakuje `:snippet-id`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Snippet {0} {1} not found."
+msgstr "Fragment {0} {1} nie znaleziony"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error determining value for parameter"
+msgstr "Błąd podczas określania wartości parametru"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error building query parameter map"
+msgstr "Błąd podczas budowania mapy parametrów zapytania"
+
+#: src/metabase/middleware/log.clj
+msgid "ASYNC"
+msgstr "ASYNC"
+
+#: src/metabase/middleware/log.clj
+msgid "{0} ({1} DB calls)"
+msgstr "{0} ({1} zapytań BD)"
+
+#: src/metabase/middleware/log.clj
+msgid "App DB connections: {0}/{1}"
+msgstr "Zapytań aplikacji do BD: {0}/{1}"
+
+#: src/metabase/middleware/log.clj
+msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
+msgstr "Wątki pomostowe: {0}/{1} ({2} bezczynny, {3} w kolejce)"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} total active threads)"
+msgstr " ({0} aktywnych wątków) "
+
+#: src/metabase/middleware/log.clj
+msgid "Queries in flight: {0}"
+msgstr "Zapytania w locie: {0}"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} queued)"
+msgstr "({0} w kolejce)"
+
+#: src/metabase/models/collection.clj
+msgid "Collection must be in the same namespace as its parent"
+msgstr "Kolekcja musi znajdować się w tej samej przestrzeni nazw co jej rodzic"
+
+#: src/metabase/models/collection.clj
+msgid "Personal Collections must be in the default namespace"
+msgstr "Kolekcje osobiste muszą znajdować się domyślnej przestrzeni nazw"
+
+#: src/metabase/models/collection.clj
+msgid "You cannot move a Collection to a different namespace once it has been created."
+msgstr "Nie można przenieść kolekcji do innej przestrzeni nazw po jej utworzeniu."
+
+#: src/metabase/models/collection.clj src/metabase/models/permissions.clj
+msgid "Collection does not exist."
+msgstr "Kolekcja nie istnieje."
+
+#: src/metabase/models/collection.clj
+msgid "A {0} can only go in Collections in the {1} namespace."
+msgstr "{0} może zostać zapisany tylko do kolekcji {1}"
+
+#: src/metabase/models/database.clj
+msgid "Error sending database deletion notification"
+msgstr "Błąd w wysłaniu prośby o usunięcie bazy danych"
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "You cannot update the creator_id of a NativeQuerySnippet."
+msgstr "Nie można zmienić creator_id w NativeQuerySnippet."
+
+#: src/metabase/models/setting.clj
+msgid "Error fetching value of Setting"
+msgstr "Błąd w pobieraniu wartości Ustawienia"
+
+#: src/metabase/public_settings.clj
+msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
+msgstr "Język który zostanie użyty w UI Metabase, mailach systemowych, pulsach oraz alertach."
+
+#: src/metabase/public_settings.clj
+msgid "This is also the default language for all users, which they can change from their own account settings."
+msgstr "To jest również domyślny język użytkowników, którzy mają możliwość jego zmiany z poziomu ustawień swojego konta."
+
+#: src/metabase/public_settings.clj
+msgid "Invalid locale {0}"
+msgstr "Nieprawidłowa lokalizacja {0}"
+
+#: src/metabase/public_settings.clj
+msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
+msgstr "Wymuś użycie HTTPS poprzez przekierowanie dla całego ruchu, jeśli URL strony zawiera HTTPS"
+
+#: src/metabase/public_settings.clj
+msgid "Cannot redirect requests to HTTPS unless `site-url` is HTTPS."
+msgstr "Nie można przekierować zapytań na HTTPS dopóki `site-url` nie będzie zawierał HTTPS."
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error registering fonts: Metabase will not be able to send Pulses."
+msgstr "Błąd w rejestracji czcionek: Metabase nie będzie mógł wysyłać Pulsów."
+
+#: src/metabase/pulse/render/png.clj
+msgid "This is a known issue with certain JVMs. See {0} and for more details."
+msgstr "To jest znany błąd z niektórymi JVMami. Zobacz {0} aby dowiedzieć się więcej."
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error rendering Pulse"
+msgstr "Błąd w renderowaniu Pulsu"
+
+#: src/metabase/query_processor/context/default.clj
+msgid "Query timed out after {0}, raising timeout exception."
+msgstr "Zapytanie przekroczyło czas oczekiwania po {0}, wysyłanie wyjątku."
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "No fields found for table {0}."
+msgstr "Tabela {0} nie zawiera pól."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Case"
+msgstr "Stan"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Variance of {0}"
+msgstr "Wariancja {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Median of {0}"
+msgstr "Mediana z {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "{0}th percentile of {1}"
+msgstr "{0} percentyl z {1)"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Not caching results: results are larger than {0} KB"
+msgstr "Rezultat nie zostanie zapisany w pamięci podręcznej: większy od {0} KB"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Cannot cache results: expected byte array, got {0}"
+msgstr "Nie można zapisać rezultatu do pamięci podręczniej: spodziewano się byte array, mamy {0}"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Request is closed; no one to return cached results to"
+msgstr "Zapytanie zamknięte; nikt nie zwraca wyników z cache"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Error attempting to fetch cached results for query with hash {0}"
+msgstr "Błąd w pobieraniu zapytania z hashem {0} z cache"
+
+#: src/metabase/query_processor/middleware/cache_backend/db.clj
+msgid "Error preparing statement to fetch cached query results"
+msgstr "Błąd przygotowania instrukcji do pobrania wyników zapytania z pamięci podręcznej"
+
+#: src/metabase/query_processor/middleware/catch_exceptions.clj
+msgid "Error processing query: {0}"
+msgstr "Błąd w przetwarzaniu zapytania: {0}"
+
+#: src/metabase/server.clj
+msgid "Unexpected exception in endpoint"
+msgstr "Niespodziewany wyjątek"
+
+#: src/metabase/server.clj
+msgid "Unexpected Exception in API request handler"
+msgstr "Niespodziewany wyjątek w zapytaniu API"
+
+#: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+msgid "Error reducing {0}"
+msgstr "Błąd przy redukcji {0}"
+
+#: src/metabase/sync/analyze/fingerprint/insights.clj
+msgid "Error generating timeseries insight keyed by: {0}"
+msgstr "Błąd podczas generowania wglądu w serie danych opisane kluczem: {0}"
+
+#: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
+msgstr "Pozycja bazy danych {0} została zmieniona z \"{1}\" na \"{2}\"."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Unscheduling task for Database {0}: trigger: {1}"
+msgstr "Usuwanie zaplanowanych zadań dla bazy {0}: wyzwalacz: {1}"
+
+#: src/metabase/util/schema.clj
+msgid "value must be a keyword or string."
+msgstr "wartość musi być słowem kluczowym lub stringiem"
+
+#: src/metabase/util/schema.clj
+msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
+msgstr "Łańcuch musi być poprawnym dwuliterowym językiem ISO lub kodem języka kraju, np. „en” lub „en_US”."

--- a/locales/pt.po
+++ b/locales/pt.po
@@ -29,13 +29,14 @@ msgid "Select a database type"
 msgstr "Selecione um tipo de banco de dados"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:411
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:154
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -48,7 +49,7 @@ msgstr "Salvar"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "Para fazer um pouco de sua mágica, o Metabase precisa varrer o seu banco de dados. Faremos isso periodicamente para manter os metadados atualizados. Você pode controlar quando as revisões periódicas são feitas a seguir."
 
-#: frontend/src/metabase/entities/databases/forms.js:221
+#: frontend/src/metabase/entities/databases/forms.js:290
 msgid "Database syncing"
 msgstr "Sincronizando Banco de Dados"
 
@@ -63,7 +64,7 @@ msgstr "Este é um processo rápido que procura atualizações no esquema deste 
 msgid "Scan"
 msgstr "Escanear"
 
-#: frontend/src/metabase/entities/databases/forms.js:228
+#: frontend/src/metabase/entities/databases/forms.js:297
 msgid "Scanning for Filter Values"
 msgstr "Procurando por Valores de Filtro"
 
@@ -75,7 +76,7 @@ msgid "Metabase can scan the values present in each\n"
 msgstr "Metabase pode varrer os valores presentes em cada \n"
 "campo neste banco de dados para ativar filtros checkbox em painéis e perguntas. Isso pode ser um processo que consome muitos recursos, especialmente se você tiver um banco de dados grande."
 
-#: frontend/src/metabase/entities/databases/forms.js:232
+#: frontend/src/metabase/entities/databases/forms.js:301
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Quando o Metabase deve verificar e armazenar automaticamente os valores dos campos?"
 
@@ -97,6 +98,7 @@ msgid "Never, I'll do this manually if I need to"
 msgstr "Nunca, eu farei isto manualmente se precisar"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 msgid "Saving..."
@@ -134,9 +136,9 @@ msgid "in this box:"
 msgstr "nesta caixa:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:75
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
@@ -153,18 +155,18 @@ msgstr "nesta caixa:"
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:301
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:39
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:90
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:99
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:311
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:328
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "Cancelar"
@@ -182,7 +184,7 @@ msgstr "Excluir"
 #: frontend/src/metabase/admin/permissions/selectors.js:323
 #: frontend/src/metabase/admin/permissions/selectors.js:330
 #: frontend/src/metabase/admin/permissions/selectors.js:441
-#: frontend/src/metabase/admin/routes.jsx:57
+#: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
@@ -202,9 +204,10 @@ msgid "Scheduling"
 msgstr "Agendamento"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:71
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
@@ -212,8 +215,8 @@ msgid "Save changes"
 msgstr "Salvar alterações"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:203
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:35
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
 msgstr "Ações"
 
@@ -225,8 +228,8 @@ msgstr "Sincronize o esquema do banco de dados agora"
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:90
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:98
 msgid "Starting…"
 msgstr "Iniciando..."
 
@@ -244,13 +247,13 @@ msgstr "Verificar novamente os valores do campo agora"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
 msgstr "A verificação não pôde ser iniciada"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:92
 msgid "Scan triggered!"
 msgstr "Verificação começou!"
 
@@ -273,15 +276,15 @@ msgid "Add database"
 msgstr "Adicionar banco de dados"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:28
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:28
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
 #: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:195
+#: frontend/src/metabase/entities/databases/forms.js:264
 #: frontend/src/metabase/entities/questions.js:86
 #: frontend/src/metabase/entities/questions.js:102
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
@@ -321,6 +324,7 @@ msgstr "Salvo com sucesso!"
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Editar"
@@ -364,45 +368,44 @@ msgstr "Falhou"
 msgid "Success"
 msgstr "Sucesso"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:185
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Pré-visualizar"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:93
 msgid "No column description yet"
 msgstr "Não há descrição da coluna"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:127
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:126
 msgid "Select a field visibility"
 msgstr "Selecione uma visibilidade de campo"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:187
 msgid "No special type"
 msgstr "Sem tipo especial"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
 #: frontend/src/metabase/lib/core.js:275
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:44
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:37
 #, fuzzy
 msgid "Other"
 msgstr "Outro"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:221
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Selecione um tipo especial"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:255
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:262
 #: frontend/src/metabase/reference/components/Field.jsx:99
 msgid "Select a target"
 msgstr "Selecione uma referência"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
@@ -410,18 +413,18 @@ msgstr "Selecione uma referência"
 msgid "Columns"
 msgstr "Colunas"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Coluna"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:144
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:288
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
 msgid "Visibility"
 msgstr "Visibilidade"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
 msgid "Type"
 msgstr "Tipo"
 
@@ -429,7 +432,7 @@ msgstr "Tipo"
 msgid "Current database:"
 msgstr "Banco de dados atual:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
 msgid "Show original schema"
 msgstr "Mostrar esquema original"
 
@@ -451,27 +454,27 @@ msgid_plural "{0} schemas"
 msgstr[0] "{0} esquema"
 msgstr[1] "{0} esquemas"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:99
 msgid "Why Hide?"
 msgstr "Por que esconder isso?"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:100
 msgid "Technical Data"
 msgstr "Dados técnicos"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
 msgstr "Irrelevante"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 msgid "Queryable"
 msgstr "Consultável"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:108
 msgid "Hidden"
 msgstr "Oculto"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136
 msgid "No table description yet"
 msgstr "Não há descrição da tabela"
 
@@ -479,32 +482,33 @@ msgstr "Não há descrição da tabela"
 msgid "Metadata Strength"
 msgstr "Força dos metadados"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0} Tabela Consultável"
 msgstr[1] "{0} Tabelas Consultáveis"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:91
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} Tabela Escondida"
 msgstr[1] "{0} Tabelas Escondidas"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:115
 msgid "Find a table"
 msgstr "Encontre uma tabela"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:128
 msgid "Schemas"
 msgstr "Esquemas"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:838
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:21
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:43
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:62
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 msgid "Metrics"
 msgstr "Métricas"
@@ -513,8 +517,8 @@ msgstr "Métricas"
 msgid "Add a Metric"
 msgstr "Adicione uma métrica"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "Definição"
@@ -523,12 +527,12 @@ msgstr "Definição"
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "Crie métricas para adicionar ao menu Visualizar no editor de consultas"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:21
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
 #: frontend/src/metabase/home/containers/SearchApp.jsx:72
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:961
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:61
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Segmentos"
@@ -537,35 +541,35 @@ msgstr "Segmentos"
 msgid "Add a Segment"
 msgstr "Adicionar um segmento"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:51
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:45
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "Criar segmentos para adicionar ao menu Filtro no editor de consultas"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:21
 msgid "created"
 msgstr "criado"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "reverted to a previous version"
 msgstr "revertido para uma versão anterior"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:30
 msgid "edited the title"
 msgstr "editou o título"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:32
 msgid "edited the description"
 msgstr "editou a descrição"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:34
 msgid "edited the "
 msgstr "editado em "
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:40
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "made some changes"
 msgstr "fez algumas alterações"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
 #: frontend/src/metabase/home/components/Activity.jsx:83
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
@@ -575,84 +579,84 @@ msgstr "Você"
 msgid "Datamodel"
 msgstr "Modelo de dados"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:41
 msgid " History"
 msgstr " História"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
 msgstr "Histórico de revisão para"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:228
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
 msgid "{0} – Field Settings"
 msgstr "{0} - configuração"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:289
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
 msgid "Where this field will appear throughout Metabase"
 msgstr "Onde este campo aparecerá no Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:311
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
 msgid "Filtering on this field"
 msgstr "Filtrando neste campo"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:312
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Quando esse campo é usado em um filtro, quais valores ele deve aceitar?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:437
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
 msgid "No description for this field yet"
 msgstr "Ainda não há descrição para este campo"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
 msgid "Original value"
 msgstr "Valor original"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:390
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
 msgid "Mapped value"
 msgstr "Valor atribuído"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
 msgid "Enter value"
 msgstr "Insira um valor"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use original value"
 msgstr "Usar o valor original"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Use foreign key"
 msgstr "Usar chave estrangeira"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 msgid "Custom mapping"
 msgstr "Mapeamento personalizado"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
 msgid "Unrecognized mapping type"
 msgstr "Tipo de mapeamento não reconhecido"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "O campo atual não é uma chave estrangeira ou os metadados principais estão ausentes idioma estrangeiro na tabela de destino"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
 msgid "The selected field isn't a foreign key"
 msgstr "O campo selecionado não é uma chave estrangeira"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:327
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
 msgid "Display values"
 msgstr "Valores exibidos"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:328
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Escolha se você deseja mostrar o valor original do banco de dados ou mostrar informações associadas ou personalizadas."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:278
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
 msgid "Choose a field"
 msgstr "Escolha um campo"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:299
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
 msgid "Please select a column to use for display."
 msgstr "Selecione uma coluna para mostrar"
 
@@ -660,16 +664,16 @@ msgstr "Selecione uma coluna para mostrar"
 msgid "Tip:"
 msgstr "Conselho:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:443
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Você pode querer atualizar o nome do campo para ter certeza de que ainda tem significado dependendo das opções de alocação."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:344
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Valores de campo no cache"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:345
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "o Metabase pode digitalizar os valores nesse campo para habilitar Filtros da caixa de seleção em painéis e perguntas."
 
@@ -678,53 +682,53 @@ msgid "Re-scan this field"
 msgstr "Reexaminar este campo"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
 msgstr "Descartar valores de campo em cache"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
 msgstr "Erro ao descartar valores"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 msgid "Discard triggered!"
 msgstr "Limpeza iniciada!"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Selecione qualquer tabela para ver seu esquema e adicionar ou editar metadados."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:36
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "Nome é obrigatório"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:39
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "Descrição é obrigatória"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:43
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Mensagem da revisão é obrigatória"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
 msgid "Aggregation is required"
 msgstr "A agregação é obrigatória"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Edit Your Metric"
 msgstr "Edite sua métrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Create Your Metric"
 msgstr "Crie sua métrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Faça alterações na sua métrica e deixe uma nota explicativa."
 
@@ -732,62 +736,62 @@ msgstr "Faça alterações na sua métrica e deixe uma nota explicativa."
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Você pode criar métricas e salvá-las como um campo calculado nessa tabela. As métricas salvas incluem o tipo de agregação, o campo agregado e opcionalmente, qualquer filtro que você adicionar. Por exemplo, você pode usar esse para definir a forma oficial de calcular o \"Preço Médio\" para una Tabela Pedidos."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:180
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
 msgid "Result: "
 msgstr "Resultado: "
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
 msgid "Name Your Metric"
 msgstr "Nomeie sua métrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:190
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Give your metric a name to help others find it."
 msgstr "Dê um nome à sua métrica para ajudar outras pessoas a encontrarem."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:194
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:152
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Algo descritivo, mas não muito longo"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:198
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
 msgid "Describe Your Metric"
 msgstr "Descreva sua métrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:199
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Dê uma descrição à sua métrica para ajudar os outros a entender o que é tente"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:203
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Este é um bom lugar para ser mais específico sobre as regras de métrica menos óbvio"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:207
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:165
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Razão para alterações"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:209
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Deixe uma nota para explicar que alterações você fez e por que elas foram necessário."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:213
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Isso aparecerá no histórico de revisão dessa métrica para ajudar todos para lembrar por que a mudança foi feita"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
 msgstr "Pelo menos um filtro é necessário"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
 msgstr "Edite seu segmento"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
 msgstr "Crie seu segmento"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Faça alterações no seu segmento e deixe uma nota explicativa."
 
@@ -795,33 +799,33 @@ msgstr "Faça alterações no seu segmento e deixe uma nota explicativa."
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "Selecione e adicione filtros para criar um novo segmento para a tabela {0}"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
 msgstr "Nomeie seu segmento"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:148
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
 msgstr "Dê um nome ao seu segmento para ajudar outras pessoas a encontrá-lo."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:156
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
 msgstr "Descreva seu segmento"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Dê ao seu segmento uma descrição para ajudar os outros a entender o que é tente"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "Este é um bom lugar para ser mais específico sobre as regras de segmentação menos óbvia"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "Isso aparecerá no histórico de revisão deste segmento para ajudar todos para lembrar por que a mudança foi feita"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
-#: frontend/src/metabase/admin/routes.jsx:132
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:215
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
+#: frontend/src/metabase/admin/routes.jsx:137
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
@@ -829,11 +833,11 @@ msgstr "Isso aparecerá no histórico de revisão deste segmento para ajudar tod
 msgid "Settings"
 msgstr "Configuração"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "o Metabase pode ler os valores nesta tabela para ativar filtros caixas de seleção em painéis e perguntas."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
 msgstr "Releia esta tabela"
 
@@ -847,11 +851,11 @@ msgstr "Adicionar"
 msgid "Not a valid formatted email address"
 msgstr "Formato do e-mail incorreto"
 
-#: frontend/src/metabase/entities/users/forms.js:12
+#: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
 msgstr "Nome"
 
-#: frontend/src/metabase/entities/users/forms.js:18
+#: frontend/src/metabase/entities/users/forms.js:20
 msgid "Last name"
 msgstr "Sobrenome"
 
@@ -890,10 +894,10 @@ msgstr "Membros"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
-#: frontend/src/metabase/admin/settings/selectors.js:120
-#: frontend/src/metabase/entities/users/forms.js:24
+#: frontend/src/metabase/admin/settings/selectors.js:121
+#: frontend/src/metabase/entities/users/forms.js:26
 #: frontend/src/metabase/lib/core.js:146
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:294
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:298
 msgid "Email"
 msgstr "E-mail"
 
@@ -902,14 +906,14 @@ msgid "A group is only as good as its members."
 msgstr "Um grupo vale apenas o que seus membros valem."
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
-#: frontend/src/metabase/admin/routes.jsx:52
+#: frontend/src/metabase/admin/routes.jsx:55
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Admin"
 msgstr "Administrador"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:241
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:299
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:288
 msgid "and"
 msgstr "e"
 
@@ -962,12 +966,12 @@ msgstr "Excluir grupo"
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:42
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:294
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:397
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:317
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:334
 msgid "Done"
 msgstr "Feito"
 
@@ -978,8 +982,9 @@ msgstr "Nome do Grupo"
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
-#: frontend/src/metabase/admin/routes.jsx:92
+#: frontend/src/metabase/admin/routes.jsx:97
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Grupos"
 
@@ -1009,7 +1014,7 @@ msgstr "Desativar"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:21
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
-#: frontend/src/metabase/admin/routes.jsx:88
+#: frontend/src/metabase/admin/routes.jsx:93
 #: frontend/src/metabase/nav/containers/Navbar.jsx:235
 msgid "People"
 msgstr "Pessoas"
@@ -1322,25 +1327,25 @@ msgstr "Ver coleção"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:542
+#: frontend/src/metabase/admin/permissions/selectors.js:558
 msgid "Data Access"
 msgstr "Acesso aos dados"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:667
-#: frontend/src/metabase/admin/permissions/selectors.js:672
+#: frontend/src/metabase/admin/permissions/selectors.js:665
+#: frontend/src/metabase/admin/permissions/selectors.js:670
 msgid "View tables"
 msgstr "Veja as tabelas"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:608
+#: frontend/src/metabase/admin/permissions/selectors.js:606
 msgid "SQL Queries"
 msgstr "Consultas SQL"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:678
+#: frontend/src/metabase/admin/permissions/selectors.js:676
 msgid "View schemas"
 msgstr "Veja esquemas"
 
-#: frontend/src/metabase/admin/routes.jsx:63
+#: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
 msgstr "Modelo de dados"
@@ -1370,20 +1375,24 @@ msgid "Allows users within your LDAP directory to log in to Metabase with their 
 msgstr "Permitir que usuários do seu diretório LDAP efetuem login no Metabase com suas credenciais LDAP e permite o mapeamento automático de grupos LDAP nos grupos do Metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:19
-#: frontend/src/metabase/admin/settings/selectors.js:167
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
+#: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
 msgstr "Esse não é um endereço de e-mail válido"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
 msgstr "Isso não é um inteiro válido"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
 msgstr "Alterações salvas!"
 
-#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:178
+#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
 msgid "Looks like we ran into some problems"
 msgstr "Parece que temos alguns problemas"
 
@@ -1405,7 +1414,7 @@ msgstr "Limpar"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:195
+#: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Autenticação"
 
@@ -1457,15 +1466,15 @@ msgstr "O seu ID de cliente do Google"
 msgid "Allow users to sign up on their own if their Google account email address is from:"
 msgstr "Permite que os usuários se registrem sozinhos se o endereço de e-mail conta eletrônica da sua conta do Google é:"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:242
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:249
 msgid "Answers sent right to your Slack #channels"
 msgstr "Respostas enviadas diretamente para seus #canais no Slack"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:251
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:258
 msgid "Create a Slack Bot User for MetaBot"
 msgstr "Crie um usuário do Slack Bot para o MetaBot"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:261
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:268
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "Quando estiver lá, dê um nome e clique em {0}. Então, copie e cole a API do Token do Bot no campo abaixo. Assim que você tiver terminado, crie um canal \"metabase_files\" no Slack. O Metabase precisa disso para fazer upload de gráficos."
 
@@ -1478,8 +1487,8 @@ msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Metabase {0} está disponivel. Você está executando {1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:41
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 msgid "Update"
 msgstr "Atualizar"
 
@@ -1506,16 +1515,16 @@ msgstr "Remover mapa personalizado"
 #: frontend/src/metabase/containers/Overworld.jsx:293
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:115
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Excluir"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:165
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:141
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
 msgstr "Selecione..."
 
@@ -1698,48 +1707,46 @@ msgid "Generate Key"
 msgstr "Gerar chave"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:87
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:18
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enabled"
 msgstr "Habilitado"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:92
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:19
+#: frontend/src/metabase/admin/settings/selectors.js:93
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Desativado"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:112
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:113
 msgid "Unknown setting {0}"
 msgstr "A diretiva de configuração {0} é desconhecida"
 
-#: frontend/src/metabase/admin/settings/selectors.js:34
+#: frontend/src/metabase/admin/settings/selectors.js:37
 msgid "Setup"
 msgstr "Configurar"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:207
-#: frontend/src/metabase/admin/settings/selectors.js:39
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:214
+#: frontend/src/metabase/admin/settings/selectors.js:42
 msgid "General"
 msgstr "Geral"
 
-#: frontend/src/metabase/admin/settings/selectors.js:43
+#: frontend/src/metabase/admin/settings/selectors.js:46
 msgid "Site Name"
 msgstr "Nome do site"
 
-#: frontend/src/metabase/admin/settings/selectors.js:48
+#: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Site URL"
 msgstr "URL do site"
 
-#: frontend/src/metabase/admin/settings/selectors.js:53
+#: frontend/src/metabase/admin/settings/selectors.js:64
 msgid "Email Address for Help Requests"
 msgstr "Endereço de e-mail para solicitações de ajuda"
 
-#: frontend/src/metabase/admin/settings/selectors.js:58
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
 msgstr "Fuso horário do relatório"
 
-#: frontend/src/metabase/admin/settings/selectors.js:61
+#: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
 msgstr "Padrão do banco de dados"
 
@@ -1747,11 +1754,11 @@ msgstr "Padrão do banco de dados"
 msgid "Select a timezone"
 msgstr "Selecione um fuso horário"
 
-#: frontend/src/metabase/admin/settings/selectors.js:64
+#: frontend/src/metabase/admin/settings/selectors.js:75
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "Nem todos os bancos de dados suportam fusos horários, nesses casos a configuração não terá efeito."
 
-#: frontend/src/metabase/admin/settings/selectors.js:69
+#: frontend/src/metabase/entities/users/forms.js:34
 msgid "Language"
 msgstr "Idioma"
 
@@ -1759,64 +1766,64 @@ msgstr "Idioma"
 msgid "Select a language"
 msgstr "Selecione um idioma"
 
-#: frontend/src/metabase/admin/settings/selectors.js:79
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
 msgstr "Acompanhamento anônimo"
 
-#: frontend/src/metabase/admin/settings/selectors.js:84
+#: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
 msgstr "Nomes de tabelas e campos amigáveis"
 
-#: frontend/src/metabase/admin/settings/selectors.js:90
+#: frontend/src/metabase/admin/settings/selectors.js:91
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Apenas substitui sublinhados e hífens por espaços"
 
-#: frontend/src/metabase/admin/settings/selectors.js:98
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Enable Nested Queries"
 msgstr "Ativar consultas aninhadas"
 
-#: frontend/src/metabase/admin/settings/selectors.js:109
+#: frontend/src/metabase/admin/settings/selectors.js:110
 msgid "Updates"
 msgstr "Atualizações"
 
-#: frontend/src/metabase/admin/settings/selectors.js:114
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
 msgstr "Verificar atualizações"
 
-#: frontend/src/metabase/admin/settings/selectors.js:125
+#: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
 msgstr "Servidor SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:133
+#: frontend/src/metabase/admin/settings/selectors.js:134
 msgid "SMTP Port"
 msgstr "Porta SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:137
+#: frontend/src/metabase/admin/settings/selectors.js:138
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:47
 msgid "That's not a valid port number"
 msgstr "Esse não é um número de porta válido"
 
-#: frontend/src/metabase/admin/settings/selectors.js:141
+#: frontend/src/metabase/admin/settings/selectors.js:142
 msgid "SMTP Security"
 msgstr "Segurança SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:150
 msgid "SMTP Username"
 msgstr "Usuário SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "SMTP Password"
 msgstr "Senha SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:163
+#: frontend/src/metabase/admin/settings/selectors.js:164
 msgid "From Address"
 msgstr "E-mail do remetente"
 
-#: frontend/src/metabase/admin/settings/selectors.js:176
+#: frontend/src/metabase/admin/settings/selectors.js:178
 msgid "Slack API Token"
 msgstr "Slack API Token"
 
-#: frontend/src/metabase/admin/settings/selectors.js:178
+#: frontend/src/metabase/admin/settings/selectors.js:180
 msgid "Enter the token you received from Slack"
 msgstr "Digite o token que você recebeu do Slack"
 
@@ -1845,8 +1852,10 @@ msgid "Username or DN"
 msgstr "Nome de usuário ou DN"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:43
+#: frontend/src/metabase/entities/databases/forms.js:61
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:64
-#: frontend/src/metabase/user/components/UserSettings.jsx:65
+#: frontend/src/metabase/user/components/UserSettings.jsx:66
+#: src/metabase/driver/common.clj
 msgid "Password"
 msgstr "Senha"
 
@@ -1882,79 +1891,79 @@ msgstr "Sincronizar membros do grupo"
 msgid "Group search base"
 msgstr "Base de pesquisa de grupo"
 
-#: frontend/src/metabase/admin/settings/selectors.js:199
+#: frontend/src/metabase/admin/settings/selectors.js:201
 msgid "Maps"
 msgstr "Mapas"
 
-#: frontend/src/metabase/admin/settings/selectors.js:203
+#: frontend/src/metabase/admin/settings/selectors.js:205
 msgid "Map tile server URL"
 msgstr "URL do servidor da camada de mapa"
 
-#: frontend/src/metabase/admin/settings/selectors.js:204
+#: frontend/src/metabase/admin/settings/selectors.js:206
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "O Metabase usa o OpenStreetMaps por padrão."
 
-#: frontend/src/metabase/admin/settings/selectors.js:209
+#: frontend/src/metabase/admin/settings/selectors.js:211
 msgid "Custom Maps"
 msgstr "Mapas personalizados"
 
-#: frontend/src/metabase/admin/settings/selectors.js:210
+#: frontend/src/metabase/admin/settings/selectors.js:212
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Adicione seus próprios arquivos GeoJSON para permitir diferentes visualizações de mapas da região"
 
-#: frontend/src/metabase/admin/settings/selectors.js:228
+#: frontend/src/metabase/admin/settings/selectors.js:245
 msgid "Public Sharing"
 msgstr "Compartilhamento público"
 
-#: frontend/src/metabase/admin/settings/selectors.js:232
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "Enable Public Sharing"
 msgstr "Ativar o compartilhamento público"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:254
 msgid "Shared Dashboards"
 msgstr "Painéis compartilhados"
 
-#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Shared Questions"
 msgstr "Perguntas compartilhadas"
 
-#: frontend/src/metabase/admin/settings/selectors.js:250
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Embedding in other Applications"
 msgstr "Incorporar em outras aplicações"
 
-#: frontend/src/metabase/admin/settings/selectors.js:276
+#: frontend/src/metabase/admin/settings/selectors.js:293
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Habilitar incorporação do Metabase em outros aplicativos"
 
-#: frontend/src/metabase/admin/settings/selectors.js:286
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Embedding secret key"
 msgstr "Chave secreta de incorporação"
 
-#: frontend/src/metabase/admin/settings/selectors.js:292
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Embedded Dashboards"
 msgstr "Painéis embutidos"
 
-#: frontend/src/metabase/admin/settings/selectors.js:298
+#: frontend/src/metabase/admin/settings/selectors.js:315
 msgid "Embedded Questions"
 msgstr "Perguntas incorporadas"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:322
 msgid "Caching"
 msgstr "Cache"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:326
 msgid "Enable Caching"
 msgstr "Ativar cache"
 
-#: frontend/src/metabase/admin/settings/selectors.js:314
+#: frontend/src/metabase/admin/settings/selectors.js:331
 msgid "Minimum Query Duration"
 msgstr "Duração mínima da consulta"
 
-#: frontend/src/metabase/admin/settings/selectors.js:321
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Cache do Time-to-Live Multiplier (TTL)"
 
-#: frontend/src/metabase/admin/settings/selectors.js:328
+#: frontend/src/metabase/admin/settings/selectors.js:345
 msgid "Max Cache Entry Size"
 msgstr "Tamanho máximo de entrada de cache"
 
@@ -2122,7 +2131,8 @@ msgstr "Os painéis, coleções e notificações nesta coleção também serão 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/routes.jsx:205
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
+#: frontend/src/metabase/routes.jsx:196
 msgid "Archive"
 msgstr "Arquivo"
 
@@ -2138,21 +2148,21 @@ msgstr "Veja o arquivo"
 msgid "Unarchive this {0}"
 msgstr "Desarquivar este {0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:39
-#: frontend/src/metabase/components/BrowseApp.jsx:102
-#: frontend/src/metabase/components/BrowseApp.jsx:194
+#: frontend/src/metabase/components/BrowseApp.jsx:46
+#: frontend/src/metabase/components/BrowseApp.jsx:112
+#: frontend/src/metabase/components/BrowseApp.jsx:204
 #: frontend/src/metabase/containers/Overworld.jsx:270
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
 msgstr "Nossos dados"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:146
+#: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
 msgid "X-ray this table"
 msgstr "Aplique raio-X nesta tabela"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:161
+#: frontend/src/metabase/components/BrowseApp.jsx:171
 msgid "Learn about this table"
 msgstr "Aprenda mais sobre essa tabela"
 
@@ -2247,7 +2257,7 @@ msgstr "Fixados"
 msgid "Drag something here to pin it to the top"
 msgstr "Arraste algo aqui para fixar no topo da página."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:755
+#: frontend/src/metabase/admin/permissions/selectors.js:753
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2301,7 +2311,7 @@ msgstr "Coleção nova"
 msgid "Copied!"
 msgstr "Copiado!"
 
-#: frontend/src/metabase/entities/databases/forms.js:12
+#: frontend/src/metabase/entities/databases/forms.js:14
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Usa um túnel SSH para conexões com o banco de dados"
 
@@ -2313,7 +2323,7 @@ msgstr "Algumas instalações de banco de dados só podem ser acessadas conectan
 "Esta opção também fornece uma camada adicional de segurança quando não você tem uma VPN. \n"
 "Isso geralmente é mais lento que uma conexão direta."
 
-#: frontend/src/metabase/entities/databases/forms.js:212
+#: frontend/src/metabase/entities/databases/forms.js:281
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Este é um grande banco de dados, então deixe-me escolher quando o Metabase sincronizar e digitalizar"
 
@@ -2323,17 +2333,17 @@ msgid "By default, Metabase does a lightweight hourly sync and an intensive dail
 msgstr "Por padrão, o Metabase executa uma sincronização leve de hora em hora, e uma análise diária intensiva dos valores do campo.\n"
 "Se você tem um banco de dados grande, recomendamos ativá-lo e verificar quando e com que frequência as varreduras de valores de campo ocorrem."
 
-#: frontend/src/metabase/entities/databases/forms.js:78
+#: frontend/src/metabase/entities/databases/forms.js:113
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0} para gerar um ID e uma chave secreta do cliente para seu projeto."
 
-#: frontend/src/metabase/entities/databases/forms.js:80
-#: frontend/src/metabase/entities/databases/forms.js:95
-#: frontend/src/metabase/entities/databases/forms.js:131
+#: frontend/src/metabase/entities/databases/forms.js:115
+#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:166
 msgid "Click here"
 msgstr "Clique aqui"
 
-#: frontend/src/metabase/entities/databases/forms.js:83
+#: frontend/src/metabase/entities/databases/forms.js:118
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Escolhe \"Outro\" como tipo de aplicação. Nomeie-o como quiser"
 
@@ -2341,19 +2351,19 @@ msgstr "Escolhe \"Outro\" como tipo de aplicação. Nomeie-o como quiser"
 msgid "{0} to get an auth code"
 msgstr "{0} para obter um código de autenticação"
 
-#: frontend/src/metabase/entities/databases/forms.js:107
+#: frontend/src/metabase/entities/databases/forms.js:142
 msgid "with Google Drive permissions"
 msgstr "com permissões do Google Drive"
 
-#: frontend/src/metabase/entities/databases/forms.js:129
+#: frontend/src/metabase/entities/databases/forms.js:164
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "Para usar o Metabase com esses dados, você deve ativar o acesso à API em Google Developers Console."
 
-#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:165
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} para ir ao console, se você ainda não fez isso."
 
-#: frontend/src/metabase/entities/databases/forms.js:196
+#: frontend/src/metabase/entities/databases/forms.js:265
 msgid "How would you like to refer to this database?"
 msgstr "Como você gostaria de chamar esse banco de dados?"
 
@@ -2362,7 +2372,8 @@ msgstr "Como você gostaria de chamar esse banco de dados?"
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:143
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:70
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:123
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:96
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:126
 #: frontend/src/metabase/setup/components/UserStep.jsx:93
 msgid "Next"
 msgstr "Próximo"
@@ -2547,7 +2558,7 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Revertido para uma revisão anterior e {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:290
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "Histórico de revisão"
@@ -2593,7 +2604,7 @@ msgid "Questions"
 msgstr "Perguntas"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:320
+#: frontend/src/metabase/routes.jsx:311
 msgid "Pulses"
 msgstr "Notificações"
 
@@ -2638,15 +2649,16 @@ msgstr "Estamos um pouco perdidos..."
 msgid "Temporary Password"
 msgstr "Senha Temporária"
 
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:207
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:481
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
 msgid "Hide"
 msgstr "Esconder"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:467
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:482
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:471
 msgid "Show"
 msgstr "Mostrar"
 
@@ -2756,7 +2768,7 @@ msgstr "Desculpe, você não tem permissão para ver isso."
 msgid "Unknown error encountered"
 msgstr "Erro desconhecido encontrado"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/nav/containers/Navbar.jsx:373
 msgid "Create"
 msgstr "Criar"
@@ -2769,7 +2781,7 @@ msgstr "Criar um painel"
 msgid "Table"
 msgstr "Tabela"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
 msgid "Database"
 msgstr "Banco de dados"
 
@@ -2789,7 +2801,7 @@ msgstr "Tente ajustar seu filtro para encontrar o que você está procurando."
 msgid "View by"
 msgstr "Veja por"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:122
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:121
 msgid "of"
 msgstr "de"
 
@@ -2816,33 +2828,33 @@ msgstr "Nossas análises"
 msgid "Browse all items"
 msgstr "Exibir todos os itens"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:118
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:117
 msgid "Replace or save as new?"
 msgstr "Substituir ou salvar como novo?"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:168
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace original question, \"{0}\""
 msgstr "Substituir a pergunta original, \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:172
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:171
 msgid "Save as new question"
 msgstr "Salvar como uma nova pergunta"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:92
 msgid "First, save your question"
 msgstr "Primeiro, salve sua pergunta"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:94
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
 msgid "Save question"
 msgstr "Salvar a pergunta"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:133
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
 msgid "What is the name of your card?"
 msgstr "Qual é o nome do seu cartão?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
 #: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/entities/questions.js:89
@@ -2858,15 +2870,16 @@ msgstr "Qual é o nome do seu cartão?"
 msgid "Description"
 msgstr "Descrição"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
 #: frontend/src/metabase/entities/dashboards.js:150
 #: frontend/src/metabase/entities/questions.js:91
 #: frontend/src/metabase/entities/questions.js:107
+#: frontend/src/metabase/entities/snippets.js:31
 msgid "It's optional but oh, so helpful"
 msgstr "É opcional, mas tão útil"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:148
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "Em que coleção isso deveria ir?"
@@ -2883,19 +2896,19 @@ msgstr "item"
 msgid "Undo"
 msgstr "Desfazer"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:266
 msgid "Applying Question"
 msgstr "Aplicando Pergunta"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:286
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "That question isn't compatible"
 msgstr "Essa pergunta não é compatível"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:322
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:309
 msgid "Search for a question"
 msgstr "Pesquisar uma pergunta"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:351
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:343
 msgid "We're not sure if this question is compatible"
 msgstr "Não temos certeza se essa pergunta é compatível"
 
@@ -2944,25 +2957,23 @@ msgstr "Adicione uma pergunta"
 msgid "Add a question to this dashboard"
 msgstr "Adicione uma pergunta a este painel"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
 msgid "Add a filter"
 msgstr "Adicionar filtro"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:256
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "Parâmetros"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:276
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:280
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
 msgid "Add a text box"
 msgstr "Adicionar uma caixa de texto"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:320
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:314
 msgid "Move dashboard"
 msgstr "Mover painel"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:303
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
 msgid "Edit dashboard"
 msgstr "Editar painel"
 
@@ -2970,11 +2981,11 @@ msgstr "Editar painel"
 msgid "Edit Dashboard Layout"
 msgstr "Editar layout do Painel"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:371
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:365
 msgid "You are editing a dashboard"
 msgstr "Você está editando um painel"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:376
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:370
 msgid "Select the field that should be filtered for each card"
 msgstr "Selecione o campo que deve ser filtrado para cada cartão"
 
@@ -3062,7 +3073,7 @@ msgstr "Este cartão ainda não tem campos ou parâmetros que podem ser mapeados
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Os valores nesse campo não sobrepõe os valores de outros campos que você escolheu."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:162
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "Não há campos válidos"
@@ -3130,7 +3141,7 @@ msgstr "recebeu os dados mais recentes de"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:329
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
 msgid "Unknown"
 msgstr "Desconhecido"
 
@@ -3257,6 +3268,7 @@ msgstr "{0} itens selecionados"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 msgid "Unarchive"
 msgstr "Desarquivar"
 
@@ -3349,7 +3361,7 @@ msgid "Longitude"
 msgstr "Longitude"
 
 #: frontend/src/metabase/lib/core.js:43
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:45
 msgid "Number"
 msgstr "Número"
@@ -3406,7 +3418,7 @@ msgid "User"
 msgstr "Usuário"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:211
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
 msgid "Source"
 msgstr "Fonte"
 
@@ -3448,16 +3460,17 @@ msgid "Score"
 msgstr "Pontuação"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Título"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
 msgid "Comment"
 msgstr "Comentário"
 
@@ -3509,9 +3522,9 @@ msgstr "Não incluir"
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
 msgstr "O Metabase nunca recuperará este campo. Use-o para informações confidenciais ou irrelevante"
 
-#: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:300
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/query/description.js:77
+#: frontend/src/metabase/lib/query/description.js:262
+#: frontend/src/metabase/lib/schema_metadata.js:476
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
@@ -3526,8 +3539,7 @@ msgstr "Contagem"
 msgid "CumulativeCount"
 msgstr "Contagem cumulativa"
 
-#: frontend/src/metabase/lib/expressions/config.js:9
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:485
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3537,7 +3549,6 @@ msgstr "Soma"
 msgid "CumulativeSum"
 msgstr "Soma cumulativa"
 
-#: frontend/src/metabase/lib/expressions/config.js:11
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Distinct"
 msgstr "Diferente"
@@ -3546,25 +3557,22 @@ msgstr "Diferente"
 msgid "StandardDeviation"
 msgstr "Desvio padrão"
 
-#: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:494
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Média"
 
-#: frontend/src/metabase/lib/expressions/config.js:14
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:539
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Mínimo"
 
-#: frontend/src/metabase/lib/expressions/config.js:15
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:548
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:503
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:492
 msgid "Max"
 msgstr "Máximo"
 
@@ -3618,54 +3626,66 @@ msgstr "Que tem em mente?"
 msgid "What do you want to find out?"
 msgstr "O que você quer saber?"
 
-#: frontend/src/metabase/lib/query.js:298
-#: frontend/src/metabase/lib/schema_metadata.js:466
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:250
+#: frontend/src/metabase/lib/query/description.js:75
+#: frontend/src/metabase/lib/query/description.js:260
+#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Dados brutos"
 
-#: frontend/src/metabase/lib/query.js:302
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/query/description.js:79
+#: frontend/src/metabase/lib/query/description.js:264
+#: frontend/src/metabase/lib/schema_metadata.js:521
 msgid "Cumulative count"
 msgstr "Contagem cumulativa"
 
-#: frontend/src/metabase/lib/query.js:305
+#: frontend/src/metabase/lib/query/description.js:82
+#: frontend/src/metabase/lib/query/description.js:266
 msgid "Average of "
 msgstr "Média de "
 
-#: frontend/src/metabase/lib/query.js:310
+#: frontend/src/metabase/lib/query/description.js:87
+#: frontend/src/metabase/lib/query/description.js:268
 msgid "Distinct values of "
 msgstr "Valores que não sejam "
 
-#: frontend/src/metabase/lib/query.js:315
+#: frontend/src/metabase/lib/query/description.js:92
+#: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
 msgstr "Desvio padrão de "
 
-#: frontend/src/metabase/lib/query.js:320
+#: frontend/src/metabase/lib/query/description.js:97
+#: frontend/src/metabase/lib/query/description.js:272
 msgid "Sum of "
 msgstr "Soma de "
 
-#: frontend/src/metabase/lib/query.js:325
+#: frontend/src/metabase/lib/query/description.js:102
+#: frontend/src/metabase/lib/query/description.js:274
 msgid "Cumulative sum of "
 msgstr "Soma cumulativa de "
 
-#: frontend/src/metabase/lib/query.js:330
+#: frontend/src/metabase/lib/query/description.js:107
+#: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
 msgstr "Máximo de "
 
-#: frontend/src/metabase/lib/query.js:335
+#: frontend/src/metabase/lib/query/description.js:112
+#: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
 msgstr "Mínimo de "
 
-#: frontend/src/metabase/lib/query.js:349
+#: frontend/src/metabase/lib/query/description.js:126
+#: frontend/src/metabase/lib/query/description.js:286
 msgid "Grouped by "
 msgstr "Agrupado por "
 
-#: frontend/src/metabase/lib/query.js:363
+#: frontend/src/metabase/lib/query/description.js:140
+#: frontend/src/metabase/lib/query/description.js:295
 msgid "Filtered by "
 msgstr "Filtrado por "
 
-#: frontend/src/metabase/lib/query.js:392
+#: frontend/src/metabase/lib/query/description.js:169
+#: frontend/src/metabase/lib/query/description.js:320
 msgid "Sorted by "
 msgstr "Ordenado por "
 
@@ -3677,55 +3697,45 @@ msgstr "Verdadeiro"
 msgid "False"
 msgstr "Falso"
 
-#: frontend/src/metabase/lib/schema_metadata.js:321
+#: frontend/src/metabase/lib/schema_metadata.js:322
 msgid "Select longitude field"
 msgstr "Selecione o campo longitude"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:323
 msgid "Enter upper latitude"
 msgstr "Latitude Superior"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:324
 msgid "Enter left longitude"
 msgstr "Longitude Esquerdo"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:325
 msgid "Enter lower latitude"
 msgstr "Latitude Inferior"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:326
 msgid "Enter right longitude"
 msgstr "Longitude certo"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:539
 #: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:397
-#: frontend/src/metabase/lib/schema_metadata.js:405
-#: frontend/src/metabase/lib/schema_metadata.js:411
-#: frontend/src/metabase/lib/schema_metadata.js:416
-msgid "Is"
-msgstr "É"
-
 #: frontend/src/metabase/lib/schema_metadata.js:362
 #: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:398
 #: frontend/src/metabase/lib/schema_metadata.js:406
 #: frontend/src/metabase/lib/schema_metadata.js:412
-msgid "Is not"
-msgstr "Não é"
+#: frontend/src/metabase/lib/schema_metadata.js:417
+msgid "Is"
+msgstr "É"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:417
-msgid "Is empty"
-msgstr "Vazio"
+#: frontend/src/metabase/lib/schema_metadata.js:413
+msgid "Is not"
+msgstr "Não é"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:378
@@ -3734,111 +3744,121 @@ msgstr "Vazio"
 #: frontend/src/metabase/lib/schema_metadata.js:402
 #: frontend/src/metabase/lib/schema_metadata.js:408
 #: frontend/src/metabase/lib/schema_metadata.js:418
+msgid "Is empty"
+msgstr "Vazio"
+
+#: frontend/src/metabase/lib/schema_metadata.js:365
+#: frontend/src/metabase/lib/schema_metadata.js:379
+#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:395
+#: frontend/src/metabase/lib/schema_metadata.js:403
+#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:419
 msgid "Not empty"
 msgstr "Não vazio"
 
-#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:371
 msgid "Equal to"
 msgstr "Igual à"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:372
 msgid "Not equal to"
 msgstr "Diferente"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Greater than"
 msgstr "Maior do que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Less than"
 msgstr "Menos que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Entre"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:376
 msgid "Greater than or equal to"
 msgstr "Maior que ou igual a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Less than or equal to"
 msgstr "Menor ou igual a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
+#: frontend/src/metabase/lib/schema_metadata.js:384
 msgid "Contains"
 msgstr "Contém"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:385
 msgid "Does not contain"
 msgstr "Não contém"
 
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:388
 msgid "Starts with"
 msgstr "Comece com"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:389
 msgid "Ends with"
 msgstr "Termina em"
 
-#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:399
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Antes"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:400
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Depois"
 
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:414
 msgid "Inside"
 msgstr "Dentro"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Apenas uma tabela com as linhas na resposta, sem operações adicionais."
 
-#: frontend/src/metabase/lib/schema_metadata.js:474
+#: frontend/src/metabase/lib/schema_metadata.js:475
 msgid "Count of rows"
 msgstr "Número de linhas"
 
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:477
 msgid "Total number of rows in the answer."
 msgstr "Número total de linhas na resposta."
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Sum of ..."
 msgstr "Soma de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:486
 msgid "Sum of all the values of a column."
 msgstr "Soma de todos os valores de uma coluna."
 
 #. Acho que a agregação de "Medium of.... " está ficando errada, pois traduz em 
 #. "Média de... de" mas vou deixar a tradução assim por enquanto
-#: frontend/src/metabase/lib/schema_metadata.js:492
+#: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Average of ..."
 msgstr "Média de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:495
 msgid "Average of all the values of a column"
 msgstr "Média de todos os valores em uma coluna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:501
+#: frontend/src/metabase/lib/schema_metadata.js:502
 msgid "Number of distinct values of ..."
 msgstr "Número de valores diferentes de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:504
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Número de valores exclusivos de uma coluna entre todas as linhas na resposta"
 
-#: frontend/src/metabase/lib/schema_metadata.js:510
+#: frontend/src/metabase/lib/schema_metadata.js:511
 msgid "Cumulative sum of ..."
 msgstr "Soma acumulada de ..."
 
@@ -3847,7 +3867,7 @@ msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over t
 msgstr "Soma aditiva de todos os valores em uma coluna. \n"
 " por exemplo, receita total ao longo do tempo"
 
-#: frontend/src/metabase/lib/schema_metadata.js:519
+#: frontend/src/metabase/lib/schema_metadata.js:520
 msgid "Cumulative count of rows"
 msgstr "Contagem cumulativa de linhas"
 
@@ -3856,27 +3876,27 @@ msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over
 msgstr "Contagem aditiva do número de linhas. \n"
 " por exemplo, número total de vendas ao longo do tempo"
 
-#: frontend/src/metabase/lib/schema_metadata.js:528
+#: frontend/src/metabase/lib/schema_metadata.js:529
 msgid "Standard deviation of ..."
 msgstr "Desvio padrão de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:531
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Número que expressa o quanto os valores de uma coluna variam entre todos os linhas na resposta."
 
-#: frontend/src/metabase/lib/schema_metadata.js:537
+#: frontend/src/metabase/lib/schema_metadata.js:538
 msgid "Minimum of ..."
 msgstr "Mínimo de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Minimum value of a column"
 msgstr "Valor Mínimo de uma Coluna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:546
+#: frontend/src/metabase/lib/schema_metadata.js:547
 msgid "Maximum of ..."
 msgstr "Máximo de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:549
 msgid "Maximum value of a column"
 msgstr "Valor máximo de uma coluna"
 
@@ -4052,7 +4072,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Categoria, Tipo, Modelo, Classificação, etc."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:43
-#: frontend/src/metabase/user/components/UserSettings.jsx:55
+#: frontend/src/metabase/user/components/UserSettings.jsx:56
 msgid "Account settings"
 msgstr "Configuração da conta"
 
@@ -4064,7 +4084,7 @@ msgstr "Sair do admin"
 msgid "Logs"
 msgstr "Logs"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:103
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:104
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:22
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:65
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:100
@@ -4104,9 +4124,9 @@ msgid "Metabase Admin"
 msgstr "Administrador do Metabase"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:36
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:36
 msgid "Ask a question"
 msgstr "Fazer uma pergunta"
 
@@ -4127,7 +4147,7 @@ msgstr "Referência"
 msgid "Which metric?"
 msgstr "Qual métrica?"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "Definir métricas comuns para sua equipe facilita ainda mais fazer perguntas"
 
@@ -4139,7 +4159,7 @@ msgstr "Como criar métricas"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Verifique os dados ao longo do tempo, como um mapa, ou gire-os para ajudar você a entender tendências ou mudanças."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:149
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
 msgid "Custom"
 msgstr "Personalizado"
 
@@ -4152,13 +4172,13 @@ msgstr "Nova pergunta"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Use o gerador de perguntas para ver tendências, listas de coisas ou para criar suas próprias métricas."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:107
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:110
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Consulta nativa"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:108
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:111
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Para perguntas mais complicadas, você pode escrever sua própria consulta SQL ou nativo"
 
@@ -4263,6 +4283,7 @@ msgid "Enter a default value..."
 msgstr "Digite um valor padrão..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
+#: frontend/src/metabase/containers/Form.jsx:307
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Ocorreu um erro"
@@ -4511,7 +4532,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "Recomendamos manter as notificações pequenas e simples para mantê-las fáceis e úteis para toda a equipe."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:161
-#: frontend/src/metabase/query_builder/components/view/View.jsx:131
+#: frontend/src/metabase/query_builder/components/view/View.jsx:133
 msgid "Pick your data"
 msgstr "Escolha seus dados"
 
@@ -4527,47 +4548,47 @@ msgstr "E-mails"
 msgid "Slack messages"
 msgstr "Mensagens Slack"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:216
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Enviado"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:217
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} será enviado para"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:219
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Mensagens"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:235
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "Enviar e-mail agora"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:236
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Envie para {0} agora"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:238
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Enviando..."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "Envio falhou"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "Não foi enviado porque a notificação não tem resultados."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Notificação enviada"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:282
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} deve ser configurado por um administrador."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:295
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:299
 msgid "Slack"
 msgstr "Slack"
 
@@ -4720,7 +4741,7 @@ msgstr "Média"
 msgid "Distincts"
 msgstr "Distintos"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:55
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "Veja este {0}"
@@ -4732,11 +4753,12 @@ msgstr[1] "Veja estes {0}"
 msgid "Zoom in"
 msgstr "Aumentar Zoom"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Expressão personalizada"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Common Metrics"
 msgstr "Métricas Comuns"
 
@@ -4933,34 +4955,34 @@ msgstr "geralmente"
 msgid "Pick a segment or table"
 msgstr "Escolha um segmento ou tabela"
 
-#: frontend/src/metabase/entities/databases/forms.js:191
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
+#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Selecione um banco de dados"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:94
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:85
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:31
 msgid "Select..."
 msgstr "Selecione..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:134
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
 msgid "Select a table"
 msgstr "Selecione uma tabela"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:819
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:926
 msgid "No tables found in this database."
 msgstr "Nenhuma tabela foi encontrada neste banco de dados."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:856
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:901
 msgid "Is a question missing?"
 msgstr "Uma pergunta está faltando?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:863
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:909
 msgid "Learn more about nested queries"
 msgstr "Saiba mais sobre consultas aninhadas"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:898
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:951
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:40
 msgid "Fields"
 msgstr "Campos"
 
@@ -4994,11 +5016,11 @@ msgstr "Ordenar"
 msgid "Row limit"
 msgstr "Limite de linha"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
 msgid "Unknown Field"
 msgstr "Campo Desconhecido"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:75
 msgid "field"
 msgstr "campo"
 
@@ -5006,19 +5028,20 @@ msgstr "campo"
 msgid "Matches"
 msgstr "Combinações"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:148
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:156
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:135
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Adicione filtros para limitar sua resposta"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:293
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
 msgstr "Adicione um grupo"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:37
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:313
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
-#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:66
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:67
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:89
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:131
@@ -5034,16 +5057,16 @@ msgstr "Adicione um grupo"
 msgid "Data"
 msgstr "Dados"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:340
 msgid "Filtered by"
 msgstr "Filtrado por"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:376
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:357
 msgid "View"
 msgstr "Ver"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:393
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:374
 msgid "Grouped By"
 msgstr "Agrupado por"
 
@@ -5051,7 +5074,7 @@ msgstr "Agrupado por"
 msgid "None"
 msgstr "Nenhum"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:471
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
 msgid "This question is written in {0}."
 msgstr "Esta questão está escrita em {0}."
 
@@ -5063,7 +5086,7 @@ msgstr "Ocultar editor"
 msgid "Hide Query"
 msgstr "Esconder consulta"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:481
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
 msgid "Open Editor"
 msgstr "Abrir editor"
 
@@ -5304,7 +5327,7 @@ msgstr "Todos os valores diferentes de {0}"
 msgid "Number of {0} grouped by {1}"
 msgstr "Número de {0} agrupados por {1}"
 
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:77
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5363,32 +5386,33 @@ msgstr "Veja os dados brutos de {0}"
 msgid "More"
 msgstr "Mais"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:194
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:216
 msgid "Invalid expression"
 msgstr "Expressão inválida"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:269
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:282
 msgid "unknown error"
 msgstr "erro desconhecido"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:47
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:53
 msgid "Field formula"
 msgstr "Campo fórmula"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:60
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:64
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Pense nisso como algo como escrever uma fórmula em um programa de planilhas: você pode usar números, campos nesta tabela, símbolos matemáticos como +, e algumas funções. Então você poderia escrever algo como Subtotal &minus; Custo."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:69
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:208
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
 msgid "Learn more"
 msgstr "Saiba mais"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:77
 msgid "Give it a name"
 msgstr "Dê um nome a ele"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:79
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
 msgid "Something nice and descriptive"
 msgstr "Algo legal e descritivo"
 
@@ -5468,11 +5492,11 @@ msgid "Enter desired number"
 msgstr "Digite o número desejado"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:154
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:161
 msgid "Empty"
 msgstr "Vazio"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:119
 msgid "Find a value"
 msgstr "Encontre um valor"
 
@@ -5540,35 +5564,35 @@ msgstr "Leia a documentação completa"
 msgid "Filter label"
 msgstr "Filtro de Etiqueta"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:135
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:134
 msgid "Variable type"
 msgstr "Tipo de Variável"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:143
 msgid "Text"
 msgstr "Texto"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
 msgid "Date"
 msgstr "Data"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:147
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
 msgid "Field Filter"
 msgstr "Filtro de campo"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Field to map to"
 msgstr "Campo para mapear para"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:180
 msgid "Filter widget type"
 msgstr "Tipo de filtro"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:230
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
 msgid "Required?"
 msgstr "Obrigatório?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:240
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
 msgid "Default filter widget value"
 msgstr "Valor padrão do filtro"
 
@@ -5580,7 +5604,7 @@ msgstr "Arquivar esta pergunta?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Esta questão será removida de qualquer painel ou notificação que a utilize."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:158
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
 msgid "Question"
 msgstr "Pergunta"
 
@@ -5750,7 +5774,7 @@ msgid "Details"
 msgstr "Detalhes"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
-#: frontend/src/metabase/reference/databases/TableList.jsx:116
+#: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
 msgstr "Tabelas em {0}"
 
@@ -5831,24 +5855,24 @@ msgstr "Por que esta tabela é interessante"
 msgid "Things to be aware of about this table"
 msgstr "Coisas para manter em mente sobre esta tabela"
 
-#: frontend/src/metabase/reference/databases/TableList.jsx:30
+#: frontend/src/metabase/reference/databases/TableList.jsx:29
 msgid "Tables in this database will appear here as they're added"
 msgstr "As tabelas neste banco de dados aparecerão aqui quando forem adicionadas"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:34
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:33
 msgid "Questions about this table will appear here as they're added"
 msgstr "Perguntas sobre esta tabela aparecerão aqui quando forem adicionadas"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:73
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:77
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:76
 msgid "Questions about {0}"
 msgstr "Perguntas sobre {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
 msgid "Created {0} by {1}"
 msgstr "Criado {0} por {1}"
 
@@ -6037,19 +6061,19 @@ msgstr "Outros campos pelos quais você pode agrupar essa métrica"
 msgid "Fields you can group this metric by"
 msgstr "Campos pelos quais você pode agrupar essa métrica"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "As métricas são os números oficiais com os quais sua equipe se preocupa"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Metrics will appear here once your admins have created some"
 msgstr "As métricas aparecerão aqui quando seus administradores tiverem criado alguns"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:28
 msgid "Learn how to create metrics"
 msgstr "Aprenda como criar métricas"
 
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:34
 msgid "Questions about this metric will appear here as they're added"
 msgstr "Perguntas sobre essa métrica aparecerão aqui quando forem adicionadas"
 
@@ -6075,23 +6099,23 @@ msgstr "Por que esse segmento é interessante"
 msgid "Things to be aware of about this Segment"
 msgstr "Coisas a ter em mente sobre este segmento"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
 msgid "Segments are interesting subsets of tables"
 msgstr "Segmentos são subconjuntos interessantes de tabelas"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "Definir segmentos comuns para sua equipe facilita ainda mais fazer perguntas"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Segments will appear here once your admins have created some"
 msgstr "Os segmentos aparecerão aqui quando os administradores tiverem criado alguns"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
 msgid "Learn how to create segments"
 msgstr "Aprenda a criar segmentos"
 
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:35
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:34
 msgid "Questions about this segment will appear here as they're added"
 msgstr "Perguntas sobre este segmento aparecerão aqui quando forem adicionadas"
 
@@ -6111,22 +6135,22 @@ msgstr "Perguntas sobre este segmento"
 msgid "X-ray this segment"
 msgstr "Aplique raios-X a este segmento"
 
-#: frontend/src/metabase/routes.jsx:178 frontend/src/metabase/routes.jsx:179
+#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
 msgid "Login"
 msgstr "Iniciar sessão"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:303
 #: frontend/src/metabase/containers/ItemPicker.jsx:115
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:204
+#: frontend/src/metabase/routes.jsx:195
 msgid "Search"
 msgstr "Pesquisar"
 
-#: frontend/src/metabase/routes.jsx:223
+#: frontend/src/metabase/routes.jsx:214
 msgid "Dashboard"
 msgstr "Painel"
 
-#: frontend/src/metabase/routes.jsx:236
+#: frontend/src/metabase/routes.jsx:227
 msgid "New Question"
 msgstr "Nova pergunta"
 
@@ -6170,63 +6194,63 @@ msgstr "Obrigado por nos ajudar a melhorar"
 msgid "We won't collect any usage events"
 msgstr "Nós não coletaremos nenhum evento de uso"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:88
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Para nos ajudar a melhorar o Metabase, gostaríamos de coletar certas informações sobre o uso através do Google Analytics."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:90
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Here's a full list of everything we track and why."
 msgstr "Aqui está uma lista completa de tudo que acompanhamos e por quê."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Permitir que o Metabase colete eventos de uso anonimamente"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:113
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0} coleta informações sobre seus dados ou resultados de perguntas."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:114
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
 msgid "never"
 msgstr "nunca"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:119
 msgid "All collection is completely anonymous."
 msgstr "Toda a informação obtida é completamente anônima."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "A coleção pode ser desativada a qualquer momento na seção de configuração"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:44
+#: frontend/src/metabase/setup/components/Setup.jsx:59
 msgid "If you feel stuck"
 msgstr "Se você se sentir sobrecarregado"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:49
+#: frontend/src/metabase/setup/components/Setup.jsx:64
 msgid "our getting started guide"
 msgstr "nosso guia inicial"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:50
+#: frontend/src/metabase/setup/components/Setup.jsx:65
 msgid "is just a click away."
 msgstr "É um único clique."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:92
+#: frontend/src/metabase/setup/components/Setup.jsx:111
 msgid "Welcome to Metabase"
 msgstr "Bem vindo ao Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:93
+#: frontend/src/metabase/setup/components/Setup.jsx:112
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Parece que tudo está funcionando. Agora vamos conhecê-lo, conecte-se com o seu dados e comece a encontrar algumas respostas!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:97
+#: frontend/src/metabase/setup/components/Setup.jsx:116
 msgid "Let's get started"
 msgstr "Vamos começar"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:142
+#: frontend/src/metabase/setup/components/Setup.jsx:166
 msgid "You're all set up!"
 msgstr "Estás pronto!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:153
+#: frontend/src/metabase/setup/components/Setup.jsx:177
 msgid "Take me to Metabase"
 msgstr "Leve-me para o Metabase"
 
@@ -6238,13 +6262,13 @@ msgstr "Como devemos ligar para você?"
 msgid "Hi, {0}. nice to meet you!"
 msgstr "Olá, {0}. Prazer em conhecê-lo!"
 
-#: frontend/src/metabase/entities/users/forms.js:33
+#: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
 msgstr "Crie uma senha"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:44
-#: frontend/src/metabase/entities/users/forms.js:35
-#: frontend/src/metabase/entities/users/forms.js:82
+#: frontend/src/metabase/entities/users/forms.js:50
+#: frontend/src/metabase/entities/users/forms.js:97
 msgid "Shhh..."
 msgstr "Shhh..."
 
@@ -6252,11 +6276,11 @@ msgstr "Shhh..."
 msgid "Confirm password"
 msgstr "Confirme a senha"
 
-#: frontend/src/metabase/entities/users/forms.js:42
+#: frontend/src/metabase/entities/users/forms.js:57
 msgid "Shhh... but one more time so we get it right"
 msgstr "Shhh... novamente, para ter certeza de que fazemos certo"
 
-#: frontend/src/metabase/entities/users/forms.js:70
+#: frontend/src/metabase/entities/users/forms.js:85
 msgid "Your company or team name"
 msgstr "O nome da sua empresa ou equipe"
 
@@ -6426,7 +6450,7 @@ msgstr "Senha atualizada corretamente!"
 msgid "Account updated successfully!"
 msgstr "Conta atualizada com sucesso!"
 
-#: frontend/src/metabase/entities/users/forms.js:81
+#: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
 msgstr "Senha atual"
 
@@ -6438,7 +6462,7 @@ msgstr "Faça login com o endereço de e-mail do Google"
 msgid "User Details"
 msgstr "Detalhes do usuário"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:327
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:344
 msgid "Reset to defaults"
 msgstr "Redefinir para o padrão"
 
@@ -6463,15 +6487,15 @@ msgstr "Quais campos você deseja usar para os eixos X e Y?"
 msgid "Choose fields"
 msgstr "Escolha campos"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:217
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:234
 msgid "Save as default view"
 msgstr "Salvar como visualização padrão"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Draw box to filter"
 msgstr "Desenhar caixa para filtrar"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Cancel filter"
 msgstr "Cancelar filtro"
 
@@ -6499,19 +6523,19 @@ msgstr "A visualização não pôde ser encontrada"
 msgid "Could not display this chart with this data."
 msgstr "Não foi possível mostrar este gráfico com essas informações."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:526
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
 msgid "No results!"
 msgstr "Nenhum resultado!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:547
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
 msgid "Still Waiting..."
 msgstr "Ainda esperando..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:550
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
 msgid "This usually takes an average of {0}."
 msgstr "Isso geralmente leva cerca de {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:556
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Isso é um pouco demorado para um painel)"
 
@@ -6671,19 +6695,19 @@ msgstr "Adicionar regra"
 msgid "Update rule"
 msgstr "Atualizar regra"
 
-#: frontend/src/metabase/visualizations/index.js:32
+#: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
 msgstr "Visualização nula"
 
-#: frontend/src/metabase/visualizations/index.js:37
+#: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
 msgstr "A visualização deve definir uma variável 'identificadora' estática: "
 
-#: frontend/src/metabase/visualizations/index.js:43
+#: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
 msgstr "A visualização com este identificador já está registrada: "
 
-#: frontend/src/metabase/visualizations/index.js:71
+#: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
 msgstr "Nenhuma exibição para {0}"
 
@@ -6709,23 +6733,23 @@ msgid "Doh! The data from your query doesn't fit the chosen display choice. This
 msgstr "Epa! Os dados em sua consulta não correspondem à opção de exibição escolhida. Esta visualização requer pelo menos {0} {1} de dados."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:9
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:117
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:120
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:161
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:169
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:249
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:267
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "coluna"
@@ -6836,83 +6860,83 @@ msgstr "Nada"
 msgid "Linear Interpolated"
 msgstr "Linha interpolada"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
 msgstr "Escala do Eixo X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
 msgstr "Séries cronológica"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:454
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
 msgid "Linear"
 msgstr "Linear"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
 msgid "Power"
 msgstr "Expoente"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:428
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:445
 msgid "Log"
 msgstr "Logarítmico"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:441
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:430
 msgid "Histogram"
 msgstr "Histograma"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
 msgstr "Ordinal"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
 msgstr "Escala do Eixo Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:462
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
 msgstr "Mostrar marcas de linha e eixo X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:360
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:468
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:349
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
 msgid "Compact"
 msgstr "Compacto"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:469
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
 msgid "Rotate 45°"
 msgstr "Rodar 45°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:459
 msgid "Rotate 90°"
 msgstr "Rodar 90°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
 msgid "Show y-axis line and marks"
 msgstr "Mostrar linha e marcas do eixo Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:489
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Auto y-axis range"
 msgstr "Eixo Y automático"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:533
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:522
 msgid "Use a split y-axis when necessary"
 msgstr "Use um eixo Y dividido quando necessário"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:540
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:529
 msgid "Show label on x-axis"
 msgstr "Mostrar rótulo no eixo X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:546
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:535
 msgid "X-axis label"
 msgstr "Etiqueta do eixo X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:555
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:544
 msgid "Show label on y-axis"
 msgstr "Mostrar rótulo no eixo Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:561
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:550
 msgid "Y-axis label"
 msgstr "Etiqueta do eixo Y"
 
@@ -7038,23 +7062,23 @@ msgstr "Opacidade mínima"
 msgid "Max Zoom"
 msgstr "Zoom máximo"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:231
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:234
 msgid "No relationships found."
 msgstr "Nenhum relacionamento foi encontrado."
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:269
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:272
 msgid "via {0}"
 msgstr "via {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:347
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
 msgid "This {0} is connected to:"
 msgstr "Este {0} está conectado a:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "Object Detail"
 msgstr "Detalhe do Objeto"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:93
 msgid "object"
 msgstr "objeto"
 
@@ -7446,7 +7470,7 @@ msgstr "Você tem muitas perguntas salvas em {0}? Crie coleções para ajudar G
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:149 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -8967,19 +8991,19 @@ msgstr "Pode editar essa coleção e seu conteúdo"
 msgid "Can view items in this collection"
 msgstr "Pode ver os itens dessa coleção"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:767
+#: frontend/src/metabase/admin/permissions/selectors.js:765
 msgid "Collection Access"
 msgstr "Acesso à coleção"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:841
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Este grupo tem permissão para ver ao menos uma sub-coleção desta coleção."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:848
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Este grupo tem permissão para editar ao menos uma sub-coleção desta coleção."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:861
+#: frontend/src/metabase/admin/permissions/selectors.js:859
 msgid "View sub-collections"
 msgstr "Ver sub-coleções"
 
@@ -8987,7 +9011,7 @@ msgstr "Ver sub-coleções"
 msgid "Remember Me"
 msgstr "Lembre me"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:63
+#: frontend/src/metabase/components/BrowseApp.jsx:73
 msgid "X-ray this schema"
 msgstr "Raio-X desse esquema"
 
@@ -9048,15 +9072,15 @@ msgstr "Metabase não pode localizar nenhum resultado da sua pesquisa."
 msgid "No metrics"
 msgstr "Sem métricas"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:31
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:41
 msgid "Aggregations"
 msgstr "Agregações"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:32
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:42
 msgid "Operators"
 msgstr "Operadores"
 
-#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:30
+#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:35
 msgid "Custom fields"
 msgstr "Campos personalizados"
 
@@ -9222,7 +9246,7 @@ msgstr "nome-meu-cluster.abcd1234.us-east-1.redshift.amazonaws.com"
 msgid "toucan_sightings"
 msgstr "toucan_sightings"
 
-#: src/metabase/driver/sparksql.clj
+#: src/metabase/models/collection.clj
 msgid "default"
 msgstr "padrão"
 
@@ -9250,10 +9274,10 @@ msgstr "N/D"
 msgid "Windows domain"
 msgstr "Domínio Windows"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:539
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:545
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:554
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:560
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:528
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:534
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:543
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
 msgstr "Rótulos"
 
@@ -9288,9 +9312,9 @@ msgstr "Compartilhamento"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:286
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:294
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:302
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:319
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:324
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
@@ -9305,19 +9329,18 @@ msgstr "Compartilhamento"
 msgid "Display"
 msgstr "Exibição"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:461
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:476
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:502
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:532
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:402
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:465
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:483
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:521
 msgid "Axes"
 msgstr "Eixos"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:212
-#: frontend/src/metabase/admin/settings/selectors.js:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:219
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:62
 msgid "Formatting"
@@ -9353,7 +9376,7 @@ msgstr "Raio-X"
 msgid "Compare to the rest"
 msgstr "Comparar ao restante"
 
-#: frontend/src/metabase/entities/databases/forms.js:16
+#: frontend/src/metabase/entities/databases/forms.js:18
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Usar o fuso horário da Maquina Virtual Java (JVM)"
 
@@ -9382,24 +9405,24 @@ msgstr "Use o fuso horário da JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Nós estamos atualmente analisando as tabelas e campos para ajudar-lhe a explorar seus dados."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
 msgid "Tip: "
 msgstr "Dica: "
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:237
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
 msgstr "Selecione um tipo de moeda"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:300
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
 msgid "Field Type"
 msgstr "Tipo de Campo"
 
-#: frontend/src/metabase/admin/routes.jsx:113
+#: frontend/src/metabase/admin/routes.jsx:118
 #: frontend/src/metabase/nav/containers/Navbar.jsx:267
 msgid "Troubleshooting"
 msgstr "Solução de Problemas"
 
-#: frontend/src/metabase/admin/settings/selectors.js:103
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Enable X-ray features"
 msgstr "Habilitar funções Raio-X"
 
@@ -9444,7 +9467,7 @@ msgstr "Duração (ms)"
 msgid "Currency"
 msgstr "Moeda"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
 msgstr "Selecione um usuário ou canal..."
 
@@ -9592,7 +9615,7 @@ msgstr "Estilo de linha"
 msgid "Show dots on lines"
 msgstr "Mostrar pontos nas linhas"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:348
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
@@ -9606,7 +9629,7 @@ msgstr "Qual eixo?"
 msgid "Line + Bar"
 msgstr "Linha + Coluna"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
 msgid "line and bar chart"
 msgstr "gráfico de linha e coluna"
 
@@ -11054,7 +11077,7 @@ msgstr "Como essa métrica é distribuída através de diferentes números"
 msgid "Sessions by page where the session began"
 msgstr "Sessões por página onde essa sessão começou"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:503
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -11423,7 +11446,7 @@ msgstr "Duplicar este item"
 msgid "Archive this item"
 msgstr "Arquivar este item"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:331
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:325
 msgid "Duplicate dashboard"
 msgstr "Duplicar painel"
 
@@ -11528,7 +11551,7 @@ msgid_plural "Quarters of year"
 msgstr[0] "Trimestre do ano"
 msgstr[1] "Trimestres do ano"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
@@ -11544,8 +11567,8 @@ msgstr "[T]T"
 msgid "This"
 msgstr "Isto"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:97
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:137
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:136
 msgid "Invalid"
 msgstr "Inválido"
 
@@ -12308,6 +12331,7 @@ msgstr "Aqui estão seus {0} cartões mais recentes"
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
 msgstr "Você poderia ser um pouco mais especifico, ou usar o ID? Eu localizei esses cartões onde os nomes combinam:"
 
+#: src/metabase/driver/common/parameters/values.clj
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
 msgstr "Cartão {0} não localizado"
@@ -12416,11 +12440,11 @@ msgstr "Falha de instrução"
 msgid "Archive this?"
 msgstr "Arquivar?"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:243
+#: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
 msgstr "Aprenda sobre seus dados"
 
-#: frontend/src/metabase/entities/databases/forms.js:20
+#: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
 msgstr "Use DNS SRV quando conectado"
 
@@ -12430,7 +12454,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "Utilizar essa opção requer que o host seja um FQDN. Caso esteja conectando-se a um cluster Atlas, você talvez precise habilitar essa opção. Se não souber o que isso significa, deixe-a desativada."
 
-#: frontend/src/metabase/entities/databases/forms.js:204
+#: frontend/src/metabase/entities/databases/forms.js:273
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Execute queries automaticamente ao filtrar ou sumarizar"
 
@@ -12455,11 +12479,11 @@ msgstr "Todos resultados"
 msgid "Our Analytics"
 msgstr "Nossas análises"
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:513
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
 msgstr "Soma acumulada de todos valores da coluna.\\ne.x. faturamento total no tempo."
 
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
 msgstr "Contagem acumulada de linhas.\\ne.x. quantidade total de vendas no tempo."
 
@@ -12469,7 +12493,7 @@ msgstr "Contagem acumulada de linhas.\\ne.x. quantidade total de vendas no tempo
 msgid "Filter"
 msgstr "Filtrar"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:50
 msgid "record"
 msgid_plural "records"
 msgstr[0] "registro"
@@ -12483,27 +12507,27 @@ msgstr "Navegue pelos dados"
 msgid "Write SQL"
 msgstr "Escrever em SQL"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:83
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
 msgstr "Pergunta simples"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:84
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:87
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
 msgstr "Escolha alguns dados, explore-os e facilmente filtre, sumarize e visualize-os"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:95
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:98
 msgid "Custom question"
 msgstr "Pergunta customizada"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:96
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:99
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Use o editor de texto avançado para juntar dados, criar colunas customizadas, efetuar cálculos e muito mais."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Basic Metrics"
 msgstr "Métricas Básicas"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:322
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
 msgid "Custom…"
 msgstr "Customizado..."
 
@@ -12572,15 +12596,15 @@ msgstr "Selecione uma coluna para agrupar"
 msgid "Pick your starting data"
 msgstr "Selecione seu dado inicial"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select None"
 msgstr "Selecionar Nenhum"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select All"
 msgstr "Selecionar Todos"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:151
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:152
 msgid "Pick a table..."
 msgstr "Escolha uma tabela"
 
@@ -12703,15 +12727,15 @@ msgstr "Adicione uma métrica"
 #: frontend/src/metabase/lib/core.js:137 frontend/src/metabase/lib/core.js:142
 #: frontend/src/metabase/lib/core.js:147 frontend/src/metabase/lib/core.js:152
 #: frontend/src/metabase/lib/core.js:157 frontend/src/metabase/lib/core.js:162
-#: frontend/src/metabase/user/components/UserSettings.jsx:63
+#: frontend/src/metabase/user/components/UserSettings.jsx:64
 msgid "Profile"
 msgstr "Perfil"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:560
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "Isso normalmente é bem rápido mas parece estar demorando um pouco agora"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
 msgid "Combo"
 msgstr "Combo"
 
@@ -12727,11 +12751,11 @@ msgstr "Tendência"
 msgid "Boolean"
 msgstr "Booleano"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:62
 msgid "Unknown Segment"
 msgstr "Segmento desconhecido"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:73
 msgid "Unknown Filter"
 msgstr "Filtro desconhecido"
 
@@ -12861,6 +12885,7 @@ msgstr "Usando o classloader NEWLY CREATED como classloader de contexto comparti
 msgid "Failed to copy file"
 msgstr "Falha ao copiar arquivo"
 
+#. check that the URL is valid
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
 msgstr "URL do site inválido: {0}"
@@ -13135,7 +13160,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Selecione as colunas que quer incluir"
 
-#: frontend/src/metabase/entities/databases/forms.js:205
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Quando ativado, essa opção faz com que o Metabase realize consultas quando usuários fazem explorações de dados simples com os botões de Resumir e Filtrar. Você pode desabilitar se as consultas ao banco estão lentas. Isso não afeta as consultas SQL ou drill-throughs."
 
@@ -13173,7 +13198,7 @@ msgstr "Erro ao determinar colunas esperadas da consulta"
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "Exceção não tratada, esperávamos que o middleware 'catch-exceptions` ia processá-la."
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:125
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
 msgid "Diagnostic Info"
 msgstr "Informações do Diagnóstico"
 
@@ -13197,11 +13222,11 @@ msgstr "Ocorreu um erro ao logar com a conta Google. Por favor, contate um admin
 msgid "Sign in with email"
 msgstr "Login com e-mail"
 
-#: frontend/src/metabase/entities/databases/forms.js:21
+#: frontend/src/metabase/entities/databases/forms.js:23
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "Esta opção existe que o host informado seja um FQDN (Fully Qualified Domain Name). Se estiver se conectando a um cluster no Atlas, você pode precisar habilitar esta opção. Caso não saiba o que isso significa, deixe esta opção desabilitada."
 
-#: frontend/src/metabase/entities/databases/forms.js:213
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Por padrão, o Metabase faz uma leve sincronização de hora em hora e uma varredura intensa diariamente dos valores dos campos. Se você possui um grande banco de dados, nos recomendamos que ative isso e analise quando e quão frequente a varredura do valor do campo acontece."
 
@@ -13269,11 +13294,11 @@ msgstr "Não incluir"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "Este campo não estará visível ou selecionável em perguntas criadas à partir da interface de usuário. Ele ainda estará acessível em SQL/queries nativas."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:512
 msgid "Cumulative sum"
 msgstr "Soma acumulada"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Standard deviation"
 msgstr "Desvio padrão"
 
@@ -13285,23 +13310,23 @@ msgstr "deve ter pelo menos {0} caracteres"
 msgid "Must be at least {0} characters long"
 msgstr "Deve ter pelo menos {0} caracteres"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:389
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:82
 msgid "Name (required)"
 msgstr "Nome (obrigatório)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:556
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
 msgid "Run selected text"
 msgstr "Executar texto selecionado"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:557
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
 msgid "Run query"
 msgstr "Executar consulta"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(⌘ + enter)"
 msgstr "(⌘ + enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + enter)"
 
@@ -13313,7 +13338,7 @@ msgstr "Aqui é onde seus resultadores irão aparecer"
 msgid "You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question."
 msgstr "Você não irá fazer nenhuma alteração permanente em uma questão salva até que clique em Salvar e escolher substituir a questão original."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:199
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:200
 msgid "There aren't any filter widgets for this type of field yet."
 msgstr "Não há nenhum widget de filtro para este tipo de campo ainda."
 
@@ -13349,19 +13374,19 @@ msgstr "Linha de meta"
 msgid "Trend line"
 msgstr "Linha de tendência"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:320
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:317
 msgid "Show values on data points"
 msgstr "Mostre valores nos pontos de dados"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:334
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:325
 msgid "Values to show"
 msgstr "Valores a serem exibidos"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:342
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:332
 msgid "As many as can fit nicely"
 msgstr "Quantas forem possíveis enquadrar agradavelmente"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:343
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
 msgid "All"
 msgstr "Todos"
 
@@ -13654,31 +13679,31 @@ msgstr "Números"
 msgid "No mappable groups"
 msgstr "Nenhum grupo mapeável"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:107
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
 msgstr "Documentação do Metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
 msgstr "Inclui um guia de solução de problemas"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:112
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
 msgid "Post on the Metabase support forum"
 msgstr "Poste no fórum de suporte do Metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:114
 msgid "A community forum for all things Metabase"
 msgstr "Um fórum da comunidade para todas as questões do Metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:117
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
 msgid "File a bug report"
 msgstr "Arquivar um relatório de erro "
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:119
 msgid "Create a GitHub issue (includes the diagnostic info below)"
 msgstr "Crie uma discussão no GitHub (inclua informações sobre o diagnóstico abaixo)"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:127
 msgid "Please include these details in support requests. Thank you!"
 msgstr "Por favor inclua estes detalhes na requisição de suporte. Obrigado!"
 
@@ -13706,38 +13731,40 @@ msgstr "Nenhum resultado correspondente"
 msgid "Submit"
 msgstr "Enviar"
 
-#: frontend/src/metabase/entities/databases/forms.js:13
+#: frontend/src/metabase/entities/databases/forms.js:15
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host. This option also provides an extra layer of security when a VPN is not available. Enabling this is usually slower than a direct connection."
 msgstr "Algumas instalações de banco de dados só podem ser acessadas conectando-se através de serviço SSH. Essa opção também fornece uma camada extra de segurança quando uma VPN não está disponível. Habilitar isso geralmente é mais lento do que uma conexão direta."
 
-#: frontend/src/metabase/entities/databases/forms.js:17
+#: frontend/src/metabase/entities/databases/forms.js:19
 msgid "We suggest you leave this off unless you're doing manual timezone casting in many or most of your queries with this data."
 msgstr "Sugerimos que você o deixe desligado, a menos que esteja fazendo o lançamento manual do fuso horário em muitas ou na maioria das suas consultas com esses dados."
 
-#: frontend/src/metabase/entities/databases/forms.js:93
+#: frontend/src/metabase/entities/databases/forms.js:128
 msgid "{0} to get an auth code."
 msgstr "{0} para obter um código de autenticação."
 
-#: frontend/src/metabase/entities/databases/forms.js:101
+#: frontend/src/metabase/entities/databases/forms.js:136
+#: src/metabase/models/collection.clj
 msgid "or"
 msgstr "ou"
 
-#: frontend/src/metabase/entities/databases/forms.js:159
-#: frontend/src/metabase/entities/databases/forms.js:197
-#: frontend/src/metabase/entities/users/forms.js:44
+#: frontend/src/metabase/entities/databases/forms.js:39
+#: frontend/src/metabase/entities/databases/forms.js:226
+#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "requerido"
 
-#: frontend/src/metabase/entities/databases/forms.js:188
+#: frontend/src/metabase/entities/databases/forms.js:257
 msgid "Database type"
 msgstr "Tipo base de dados"
 
-#: frontend/src/metabase/entities/databases/forms.js:222
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Esse é um processo ligeiro que verifica se há atualizações no esquema desse banco de dados. Na maioria dos casos, você deve deixar esse conjunto  de dados sincronizando a cada hora."
 
-#: frontend/src/metabase/entities/databases/forms.js:230
+#: frontend/src/metabase/entities/databases/forms.js:299
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase pode varrer os valores presentes em cada campo deste banco de dados para ativar filtros de caixas de seleção em painéis e perguntas. Esse pode ser um processo que consome muitos recursos, principalmente se você tiver um banco de dados muito grande."
 
@@ -13745,15 +13772,15 @@ msgstr "Metabase pode varrer os valores presentes em cada campo deste banco de d
 msgid "Collection"
 msgstr "Coleção"
 
-#: frontend/src/metabase/entities/users/forms.js:40
+#: frontend/src/metabase/entities/users/forms.js:55
 msgid "Confirm your password"
 msgstr "Confirme sua senha"
 
-#: frontend/src/metabase/entities/users/forms.js:45
+#: frontend/src/metabase/entities/users/forms.js:60
 msgid "passwords do not match"
 msgstr "Senhas não conferem"
 
-#: frontend/src/metabase/entities/users/forms.js:71
+#: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
 msgstr "Departamento de Incríveis"
 
@@ -13793,328 +13820,324 @@ msgid "Returns the average of the values in the column."
 msgstr "Retorna a média dos valores na coluna."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:18
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
 msgid "The column whose values to average."
 msgstr "A coluna cujos valores são médios"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "start"
 msgstr "início"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "end"
 msgstr "fim"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
 msgid "Checks a date or numeric column's values to see if they're within the specified range."
 msgstr "Verifica se os valores de uma data ou coluna numérica estão dentro do intervalo especificado."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
 msgstr "Classificando"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:24
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:98
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
 msgid "condition"
 msgstr "condição"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
 msgid "output"
 msgstr "saída"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Testa uma lista de casos e retorna o valor correspondente ao primeiro caso verdadeiro, com um valor padrão opcional se nada for encontrado."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
 msgid "Weight"
 msgstr "Peso"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
 msgid "Large"
 msgstr "Grande"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
 msgid "Medium"
 msgstr "Médio"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
 msgid "Small"
 msgstr "Pequeno"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
 msgid "Something that should evaluate to true or false."
 msgstr "Algo que deve ser avaliado como verdadeiro ou falso."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:54
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "O valor que será retornado se a condição anterior for verdadeira."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:62
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "value1"
 msgstr "valor1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:74
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
 msgid "value2"
 msgstr "valor2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Examina os valores em cada argumento em ordem e retorna o primeiro valor não nulo para cada linha."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:56
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
 msgid "Comments"
 msgstr "Comentários"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
 msgid "Notes"
 msgstr "Notas"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
 msgid "No comments"
 msgstr "Sem comentários"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
 msgid "A column or value."
 msgstr "Uma coluna ou valor"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:65
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:77
 msgid "If value1 is empty, value2 gets returned if it's not empty, and so on."
 msgstr "Se valor1 é vazio, valor2 irá retornar se não for vazio, e assim por diante."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 msgid "Combines two or more strings of text together."
 msgstr "Combina duas ou mais strings de texto juntas."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
 msgid "Last Name"
 msgstr "Sobrenome"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 msgid "First Name"
 msgstr "Primeiro Nome"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
 msgstr "valor2 será adicionado no final disso."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
 msgstr "Isso será adicionado ao final do valor1."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
 msgid "string1"
 msgstr "string1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
 msgid "string2"
 msgstr "string2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:80
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Verifica se string1 contém string2 em seu interior."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:284
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
 msgid "Status"
 msgstr "Status"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 msgid "Pass"
 msgstr "Senha"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
 msgstr "O conteúdo dessa string será checado"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
 msgid "The string of text to look for."
 msgstr "A string de texto para pesquisar"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:90
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:116
 msgid "Returns the count of rows in the source data."
 msgstr "Retorna a contagem de linhas da fonte de dados"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Only counts rows where the condition is true."
 msgstr "Somente conta as linhas quando a condição for verdadeira"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:97
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:261
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
 msgid "Subtotal"
 msgstr "Subtotal"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
 msgid "The additive total of rows across a breakout."
 msgstr "O somatório de linhas através de uma quebra"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:110
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
 msgid "The rolling sum of a column across a breakout."
 msgstr "A soma parcial de uma coluna através de uma quebra"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:113
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:268
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
 msgstr "A coluna para somar"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
 msgid "The number of distinct values in this column."
 msgstr "O número de valores distintos nessa coluna"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "The column whose distinct values to count."
 msgstr "A coluna para contar os distintos valores"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:128
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:145
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:153
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:201
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:274
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
 msgid "text"
 msgstr "texto"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:130
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:223
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
 msgid "comparison"
 msgstr "comparação"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Retorna verdadeiro se o final do texto corresponde ao texto de comparação"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "Appetite"
 msgstr "Apetite"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "hungry"
 msgstr "faminto"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 msgid "A column or string of text to check."
 msgstr "Uma coluna ou string de texto para checar"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
 msgid "The string of text that the original text should end with."
 msgstr "A sequência de texto com a qual o texto original deve terminar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 msgid "regular_expression"
 msgstr "expressão_regular"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:136
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Extrai substrings correspondentes de acordo com uma expressão regular."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:137
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
 msgid "Address"
 msgstr "Endereço"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 msgid "The column or string of text to search though."
 msgstr "A coluna ou sequência de texto a ser pesquisada."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
 msgid "The regular expression to match."
 msgstr "A expressão regular a combinar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the string of text in all lowercase."
 msgstr "Retorna a sequência de texto em minúsculas."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:149
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to lowercase."
 msgstr "A coluna com valores a serem convertidos em minúsculas."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:154
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 msgid "Removes leading whitespace from a string of text."
 msgstr "Remove o espaço em branco à esquerda de uma sequência de texto."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:157
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column with values you want to trim."
 msgstr "A coluna com os valores que você deseja cortar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "Returns the largest value found in the column."
 msgstr "Retorna o maior valor encontrado na coluna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
 msgid "Age"
 msgstr "Idade"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:165
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
 msgid "The numeric column whose maximum you want to find."
 msgstr "A coluna numérica cujo valor máximo você deseja encontrar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:170
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "Returns the smallest value found in the column."
 msgstr "Retorna o menor valor encontrado na coluna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
 msgid "Salary"
 msgstr "Salário"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:173
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
 msgid "The numeric column whose minimum you want to find."
 msgstr "A coluna numérica cujo mínimo você deseja encontrar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:181
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:242
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
 msgid "position"
 msgstr "posição"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:194
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
 msgid "length"
 msgstr "comprimento"
 
@@ -14123,7 +14146,7 @@ msgstr "comprimento"
 msgid "new_text"
 msgstr "novo_texto"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:187
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
 msgid "Replaces a part of the input text with new text."
 msgstr "Substitui uma parte do texto de entrada por um novo texto."
 
@@ -14135,7 +14158,7 @@ msgstr "ID do pedido"
 msgid "Updated Part of ID"
 msgstr "Parte do ID atualizada"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
 msgid "The text that will be modified."
 msgstr "O texto que será modificado."
 
@@ -14151,87 +14174,87 @@ msgstr "O número de caracteres para substituir."
 msgid "The text to use in the replacement."
 msgstr "O texto a ser usado na substituição."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Remove o espaço em branco à direita de uma sequência de texto."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:210
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Retorna a porcentagem de linhas nos dados que correspondem à condição, como um decimal."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:218
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Retorna verdadeiro se o início do texto corresponder ao texto de comparação."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Course Name"
 msgstr "Nome do curso"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Computer Science"
 msgstr "Ciência da Computação"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
 msgid "The string of text that the original text should start with."
 msgstr "A sequência de texto com a qual o texto original deve começar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:229
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
 msgid "Calculates the standard deviation of the column."
 msgstr "Calcula o desvio padrão da coluna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:230
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
 msgid "Population"
 msgstr "População"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
 msgid "A numeric column."
 msgstr "Uma coluna numérica"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
 msgid "Returns a portion of the supplied text."
 msgstr "Retorna uma parte do texto fornecido."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:241
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:313
 msgid "The text to return a portion of."
 msgstr "O texto para o qual retornar uma parte."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
 msgid "The position to start copying characters."
 msgstr "A posição para começar a copiar caracteres."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:245
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
 msgid "The number of characters to return."
 msgstr "Um número de caracteres para retorno."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
 msgid "Adds up all the values of the column."
 msgstr "Adiciona todos os valores da coluna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:253
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
 msgid "The numeric column to sum."
 msgstr "A coluna numérica para somar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Soma os valores em uma coluna onde as linhas correspondem à condição."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
 msgid "Order Status"
 msgstr "Status do pedido"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
 msgid "Valid"
 msgstr "Válido"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Remove os espaços em branco iniciais e finais de uma sequência de texto."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
 msgid "Returns the string of text in all upper case."
 msgstr "Retorna a sequência de texto em maiúsculas."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
 msgid "The column with values to convert to upper case."
 msgstr "A coluna com valores para converter em maiúsculas."
 
@@ -14293,39 +14316,39 @@ msgstr "Obrigado por usar Metabase"
 msgid "Powered by {0}"
 msgstr "Desenvolvido por {0}"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:191
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
 msgid "To:"
 msgstr "Para:"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:40
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
 msgstr "Esta pergunta não pode ser usada porque é baseada em um banco de dados diferente."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:44
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:43
 msgid "Couldn't find a saved question with that ID number."
 msgstr "Não foi possível encontrar uma pergunta salva com esse número de ID."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:55
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:54
 msgid "Pick a saved question"
 msgstr "Escolha uma pergunta salva"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:57
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:56
 msgid "Pick a different question"
 msgstr "Escolha uma questão diferente"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:62
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:61
 msgid "Loading…"
 msgstr "Carregando…"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:79
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:78
 msgid "Question #…"
 msgstr "Pergunta #…"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:81
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
 msgstr "Pergunta nº {0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:115
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
 msgstr "Última edição {0}"
 
@@ -14337,11 +14360,11 @@ msgstr "{0} cria uma variável neste modelo de consulta chamada \"variável_nome
 msgid "Giving a variable the \"Field Filter\" type allows you to link questions to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "Fornecer a uma variável o tipo \"Filtro de campo\" permite vincular perguntas a widgets de filtro do painel ou usar mais tipos de widgets de filtro na sua pergunta SQL. Uma variável de Filtro de Campo insere SQL semelhante ao gerado pelo construtor de consultas da GUI ao incluir filtros em colunas existentes."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:131
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
 msgstr "Nome da variável"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:217
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:218
 msgid "Filter widget label"
 msgstr "Rótulo do widget de filtro"
 
@@ -14373,11 +14396,11 @@ msgstr "No cabeçalho da coluna"
 msgid "In every table cell"
 msgstr "Em cada célula da tabela"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:351
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:341
 msgid "Value formatting"
 msgstr "Formatação valor"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:361
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
 msgid "Full"
 msgstr "Cheio"
 
@@ -14705,4 +14728,484 @@ msgstr "Erro ao gerar informações para a coluna:"
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandonment email!"
 msgstr "Enviando email de abandono!"
+
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
+msgstr "Você pode criar métricas salvas para adicionar uma opção de métrica nomeada. As métricas salvas incluem: o tipo de agregação, o campo agregado e, opcionalmente, qualquer filtro que você adicionar. Como exemplo, você pode usar isso para criar algo como a maneira padrão de calcular o \"Preço médio\" para uma tabela de pedidos."
+
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:105
+msgid "Select and add filters to create your new segment."
+msgstr "Selecione e adicione filtros para criar seu novo segmento."
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+msgid "Alphabetical"
+msgstr "Alfabetico"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+msgid "Smart"
+msgstr "Inteligente"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+msgid "Column order: {0}"
+msgstr "Ordem da coluna: {0}"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
+msgid "Unhide all"
+msgstr "Mostrar tudo"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:204
+msgid "Hide all"
+msgstr "Esconder tudo"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:206
+msgid "Unhide"
+msgstr "Mostrar"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:22
+msgid "New metric"
+msgstr "Nova metrica"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:45
+msgid "Create metrics to add them to the Summarize dropdown in the query builder"
+msgstr "Crie métricas para adicioná-las à lista suspensa Resumir no construtor de consultas"
+
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:22
+msgid "New segment"
+msgstr "Novo segmento"
+
+#: frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx:71
+msgid "Filter by table"
+msgstr "Filtrar por tabela"
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:64
+msgid "Checking HTTPS..."
+msgstr "Verificando HTTPS..."
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:66
+msgid "It looks like HTTPS is not properly configured"
+msgstr "Parece que o HTTPS não esta configurado corretamente"
+
+#: frontend/src/metabase/admin/settings/selectors.js:57
+msgid "Redirect to HTTPS"
+msgstr "Redirecionando para HTTPS"
+
+#: frontend/src/metabase/admin/settings/selectors.js:219
+msgid "Localization"
+msgstr "Idioma"
+
+#: frontend/src/metabase/admin/settings/selectors.js:222
+msgid "Instance language"
+msgstr "Idioma da instância"
+
+#: frontend/src/metabase/admin/settings/selectors.js:237
+msgid "Localization options"
+msgstr "Opções de idioma"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:51
+msgid "This database doesn't have any tables."
+msgstr "Este banco de dados não tem tabelas."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
+msgid "This field only accepts a single value because it's used in a SQL query."
+msgstr "Este campo somente aceita um único valor por que é usado no SQL."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:17
+msgid "Service Accounts"
+msgstr "Contas de Serviço"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:26
+msgid "Metabase connects to Big Query via {0}."
+msgstr "O Metabase se conecta ao Big Query por {0}."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:29
+msgid "Continue using an OAuth application to connect"
+msgstr "Continue usando um aplicativo OAuth para conectar-se"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:43
+msgid "We recommend switching to use {0} instead of an OAuth application to connect to BigQuery"
+msgstr "Recomendamos alternar para usar {0} em vez de um aplicativo OAuth para conectar-se ao BigQuery"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:48
+msgid "Connect to a Service Account instead"
+msgstr "Em vez disso, conecte-se a uma conta de serviço"
+
+#: frontend/src/metabase/entities/databases/forms.js:44
+msgid "invalid JSON"
+msgstr "JSON inválido"
+
+#: frontend/src/metabase/entities/databases/forms.js:50
+msgid "SSH private key"
+msgstr "Chave privada SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:51
+msgid "Paste the contents of your ssh private key here"
+msgstr "Cole o conteúdo da sua chave privada ssh aqui"
+
+#: frontend/src/metabase/entities/databases/forms.js:55
+msgid "Passphrase for the SSH private key"
+msgstr "Senha da chave privada SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:58
+msgid "SSH Authentication"
+msgstr "Autenticação SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:60
+msgid "SSH Key"
+msgstr "Chave SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:65
+msgid "Server SSL certificate chain"
+msgstr "Cadeia de certificados SSL do servidor"
+
+#: frontend/src/metabase/entities/databases/forms.js:66
+msgid "Paste the contents of the server's SSL certificate chain here"
+msgstr "Cole o conteúdo da cadeia de certificados SSL do servidor aqui"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:11
+msgid "Paste a connection string"
+msgstr "Cole uma string de conexão"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:12
+msgid "Fill out individual fields"
+msgstr "Preencha os campos individuais"
+
+#: frontend/src/metabase/entities/snippets.js:14
+msgid "Enter some SQL here so you can reuse it later"
+msgstr "Digite um trecho SQL aqui para poder reutilizá-lo mais tarde"
+
+#: frontend/src/metabase/entities/snippets.js:24
+msgid "Give your snippet a name"
+msgstr "Dê um nome ao seu trecho"
+
+#: frontend/src/metabase/entities/snippets.js:25
+msgid "Current Customers"
+msgstr "Clientes atuais"
+
+#: frontend/src/metabase/entities/snippets.js:30
+msgid "Add a description"
+msgstr "Adicione uma descrição"
+
+#: frontend/src/metabase/entities/users/forms.js:37
+msgid "Use site default"
+msgstr "Use site padrão"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+msgid "find"
+msgstr "encontrar"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+msgid "replace"
+msgstr "substitua"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+msgid "The text to find."
+msgstr "O texto para encontrar."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "The text to use as the replacement."
+msgstr "O texto a ser usado como substituto."
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+msgid "Editing {0}"
+msgstr "Editando {0}"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+msgid "Create your new snippet"
+msgstr "Crie seu novo trecho"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+msgid "Archived snippets"
+msgstr "Trechos arquivados"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+msgid "Snippets are reusable bits of SQL"
+msgstr "Trechos são pedaços reutilizáveis de SQL"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+msgid "Create a snippet"
+msgstr "Crie um trecho"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+msgid "Snippets"
+msgstr "Trechos"
+
+#: frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx:15
+msgid "SQL Snippets"
+msgstr "Trechos de SQL"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:38
+msgid "Your language is set to {0}"
+msgstr "Seu idioma está em {0}"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:50
+msgid "What's your preferred language?"
+msgstr "Qual é o seu idioma preferido?"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:54
+msgid "This language will be used throughout Metabase and will be the default for new users."
+msgstr "Esse idioma será usado em toda o Metabase e será o padrão para novos usuários."
+
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:159
+msgid "We filtered out {0} row(s) containing null values."
+msgstr "Nós filtramos {0} linha(s) contendo valores nulos."
+
+#: frontend/src/metabase/visualizations/lib/settings/series.js:133
+msgid "Show values for this series"
+msgstr "Mostre valores para esta série"
+
+#: src/metabase/api/card.clj
+msgid "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
+msgstr "A duração média de execução da pergunta é {0}; usando TTL '' mágico '' de {1}"
+
+#: src/metabase/api/native_query_snippet.clj
+msgid "A snippet with that name already exists. Please pick a different name."
+msgstr "Um trecho com esse nome já existe. Por favor, escolha um nome diferente"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Metric]"
+msgstr "[Métrica Desconhecida]"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Segment]"
+msgstr "[Segmento Desconhecido]"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error writing error to output stream"
+msgstr "Erro ao salvar erro no fluxo de saída"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Caught unexpected Exception in streaming response body"
+msgstr "Capturado uma exceção inesperada no corpo de resposta da streaming"
+
+#: src/metabase/async/streaming_response.clj
+msgid "bound-fn caught unexpected Exception"
+msgstr "bound-fn capturou uma Exceção inesperada"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error determining whether HTTP request was canceled"
+msgstr "Erro ao determinar se a requisição HTTP foi cancelada"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Check cancelation status timed out after {0}"
+msgstr "O status de cancelamento da verificação expirou após {0}"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Unexpected exception in do-f-async"
+msgstr "Exceção inesperada no do-f-async"
+
+#: src/metabase/async/streaming_response.clj src/metabase/server.clj
+msgid "Unexpected exception writing error response"
+msgstr "Resposta de erro de gravação de exceção inesperada"
+
+#: src/metabase/driver/common.clj
+msgid "Server certificate not trusted - did you specify the correct SSL certificate chain?"
+msgstr "Certificado do servidor não é confiável - você especificou a cadeia de certificados SSL correta?"
+
+#: src/metabase/driver/common.clj
+msgid "Server appears to require SSL - please enable SSL above"
+msgstr "O servidor parece exigir SSL - ative o SSL acima"
+
+#: src/metabase/driver/common.clj
+msgid "Username"
+msgstr "Usuário"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Don''t know how to parse parameter of type {0}"
+msgstr "Não sabe como analisar o parâmetro do tipo {0}"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Invalid :card parameter: missing `:card-id`"
+msgstr "O parâmetro :card inválido: esta faltando `: card-id`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Unable to resolve Snippet: missing `:snippet-id`"
+msgstr "Não foi possível resolver o Trecho: falta `: snippet-id`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Snippet {0} {1} not found."
+msgstr "Trecho {0} {1} não encontrado."
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error determining value for parameter"
+msgstr "Erro ao determinar o valor do parâmetro"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error building query parameter map"
+msgstr "Erro ao construir o mapa de paramêtros da busca"
+
+#: src/metabase/middleware/log.clj
+msgid "ASYNC"
+msgstr "ASYNC"
+
+#: src/metabase/middleware/log.clj
+msgid "{0} ({1} DB calls)"
+msgstr "{0} ({1} chamadas ao banco de dados)"
+
+#: src/metabase/middleware/log.clj
+msgid "App DB connections: {0}/{1}"
+msgstr "Conexões de banco de dados do aplicativo: {0} / {1}"
+
+#: src/metabase/middleware/log.clj
+msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
+msgstr "Threads do Jetty: {0} / {1} ({2} ocioso, {3} na fila)"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} total active threads)"
+msgstr "({0} total de threads ativas)"
+
+#: src/metabase/middleware/log.clj
+msgid "Queries in flight: {0}"
+msgstr "Consultas ativas: {0}"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} queued)"
+msgstr "({0} na fila)"
+
+#: src/metabase/models/collection.clj
+msgid "Collection must be in the same namespace as its parent"
+msgstr "A coleção deve estar no mesmo espaço de nome da coleção-mãe"
+
+#. Namespace?
+#: src/metabase/models/collection.clj
+msgid "Personal Collections must be in the default namespace"
+msgstr "Coleções Pessoais devem estar no espaço de nomes padrão"
+
+#: src/metabase/models/collection.clj
+msgid "You cannot move a Collection to a different namespace once it has been created."
+msgstr "Você não pode mover uma coleção para um espaço de nomes diferente, depois de criada"
+
+#: src/metabase/models/collection.clj src/metabase/models/permissions.clj
+msgid "Collection does not exist."
+msgstr "A coleção não existe."
+
+#: src/metabase/models/collection.clj
+msgid "A {0} can only go in Collections in the {1} namespace."
+msgstr "Um {0} pode ir apenas em Coleções para o namespace {1}."
+
+#: src/metabase/models/database.clj
+msgid "Error sending database deletion notification"
+msgstr "Erro ao enviar notificação de exclusão do banco de dados"
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "You cannot update the creator_id of a NativeQuerySnippet."
+msgstr "Você não pode atualizar o creator_id de um NativeQuerySnippet."
+
+#: src/metabase/models/setting.clj
+msgid "Error fetching value of Setting"
+msgstr "Erro ao buscar o valor de Configuração"
+
+#: src/metabase/public_settings.clj
+msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
+msgstr "O idioma à ser usado na Interface do Metabase, sistema, emails, pulsos e alertas."
+
+#: src/metabase/public_settings.clj
+msgid "This is also the default language for all users, which they can change from their own account settings."
+msgstr "Esse é o idioma padrão para todos os usuários, mas eles podem modificar isso em suas próprias configurações de conta."
+
+#: src/metabase/public_settings.clj
+msgid "Invalid locale {0}"
+msgstr "Idioma inválido {0}"
+
+#: src/metabase/public_settings.clj
+msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
+msgstr "Se a URL do site é HTTPS, force todo o tráfego para usar HTTPS por redirecionamento,"
+
+#: src/metabase/public_settings.clj
+msgid "Cannot redirect requests to HTTPS unless `site-url` is HTTPS."
+msgstr "Não é possível redirecionar requisições HTTPS, a não ser que `site-url` seja HTTPS também."
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error registering fonts: Metabase will not be able to send Pulses."
+msgstr "Erro ao registrar fontes: o Metabase não poderá enviar pulsos."
+
+#: src/metabase/pulse/render/png.clj
+msgid "This is a known issue with certain JVMs. See {0} and for more details."
+msgstr "Esse é um problema conhecido em algumas JVMs. Veja {0} para mais detalhes."
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error rendering Pulse"
+msgstr "Erro ao processar o Pulse"
+
+#: src/metabase/query_processor/context/default.clj
+msgid "Query timed out after {0}, raising timeout exception."
+msgstr "Tempo da Query esgotou depois de {0}, com erro de timeout"
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "No fields found for table {0}."
+msgstr "Campos não foram encontrados para a tabela {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Case"
+msgstr "Caso"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Variance of {0}"
+msgstr "Variância de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Median of {0}"
+msgstr "Mediana de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "{0}th percentile of {1}"
+msgstr "{0} percentil de {1}"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Not caching results: results are larger than {0} KB"
+msgstr "Não está armazenando em cache os resultados: os resultados são maiores que {0} KB"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Cannot cache results: expected byte array, got {0}"
+msgstr "Não é possível armazenar em cache os resultados: a matriz de bytes esperada obteve {0}"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Request is closed; no one to return cached results to"
+msgstr "Requisição fechada; ninguém para retornar os resultados em cache"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Error attempting to fetch cached results for query with hash {0}"
+msgstr "Erro ao buscar dados em cache para a query de hash {0}"
+
+#: src/metabase/query_processor/middleware/cache_backend/db.clj
+msgid "Error preparing statement to fetch cached query results"
+msgstr "Erro ao preparar a instrução para buscar resultados da consulta em cache"
+
+#: src/metabase/query_processor/middleware/catch_exceptions.clj
+msgid "Error processing query: {0}"
+msgstr "Erro ao processar a query: {0}"
+
+#: src/metabase/server.clj
+msgid "Unexpected exception in endpoint"
+msgstr "Exceção inesperada no endpoint"
+
+#: src/metabase/server.clj
+msgid "Unexpected Exception in API request handler"
+msgstr "Exceção inesperada no manipulador de solicitações da API"
+
+#: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+msgid "Error reducing {0}"
+msgstr "Erro ao reduzir {0}"
+
+#: src/metabase/sync/analyze/fingerprint/insights.clj
+msgid "Error generating timeseries insight keyed by: {0}"
+msgstr "Erro ao gerar insight de séries temporais digitado por: {0}"
+
+#: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
+msgstr "A posição do banco de dados {0} foi alterada de ''{1}'' para ''{2}''."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Unscheduling task for Database {0}: trigger: {1}"
+msgstr "Tarefa de cancelamento de agendamento para o Banco de Dados {0}: gatilho: {1}"
+
+#: src/metabase/util/schema.clj
+msgid "value must be a keyword or string."
+msgstr "valor precisa ser uma palavra-chave ou texto."
+
+#: src/metabase/util/schema.clj
+msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
+msgstr "A sequência deve ser um idioma ISO válido de duas letras ou um código de idioma do país, por exemplo. 'pt' ou 'pt_BR'."
 

--- a/locales/ru.po
+++ b/locales/ru.po
@@ -29,13 +29,14 @@ msgid "Select a database type"
 msgstr "Выберите тип базы данных"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:411
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:154
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -46,9 +47,9 @@ msgstr "Сохранить"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:122
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
-msgstr "Мы должны просканировать вашу базу данных. Мы так же будем переодически повторять это действие для актуальности данных. Ниже вы можете контролировать периодичность."
+msgstr "Мы должны просканировать вашу базу данных. Мы так же будем периодически повторять это действие для поддержки актуальности данных. Ниже вы можете управлять периодичностью."
 
-#: frontend/src/metabase/entities/databases/forms.js:221
+#: frontend/src/metabase/entities/databases/forms.js:290
 msgid "Database syncing"
 msgstr "База данных синхронизируется"
 
@@ -56,14 +57,14 @@ msgstr "База данных синхронизируется"
 msgid "This is a lightweight process that checks for\n"
 "updates to this database’s schema. In most cases, you should be fine leaving this\n"
 "set to sync hourly."
-msgstr "Это лёгкий процесс проверяющий обновления структуры этой базы данных. В большинстве случаев Вам будет достаточно оставить ежечасное обновление"
+msgstr "Это лёгкий процесс проверяющий структуру базы данных на изменения. В большинстве случаев вам будет достаточно оставить обновление 1 раз в час."
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:42
 #: frontend/src/metabase/admin/databases/components/widgets/MetadataSyncScheduleWidget.jsx:22
 msgid "Scan"
 msgstr "Сканирование"
 
-#: frontend/src/metabase/entities/databases/forms.js:228
+#: frontend/src/metabase/entities/databases/forms.js:297
 msgid "Scanning for Filter Values"
 msgstr "Сканирование для значения фильтров"
 
@@ -74,7 +75,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase может просканировать значения каждого поля базы данных и сделать доступными checkbox-фильтры на панелях индикаторов и в вопросах. Процесс достаточно ресурсозатратный, особенно, если речь идет об очень большой базе данных."
 
-#: frontend/src/metabase/entities/databases/forms.js:232
+#: frontend/src/metabase/entities/databases/forms.js:301
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Когда Metabase должен автоматически сканировать и кэшировать значения?"
 
@@ -93,9 +94,10 @@ msgstr "Когда пользователь добавляет новый фил
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:62
 msgid "Never, I'll do this manually if I need to"
-msgstr "Нет, я сделаю это когда нужно"
+msgstr "Нет, я сделаю это сам когда будет нужно"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 msgid "Saving..."
@@ -132,9 +134,9 @@ msgid "in this box:"
 msgstr "в этом поле:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:75
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
@@ -151,18 +153,18 @@ msgstr "в этом поле:"
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:301
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:39
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:90
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:99
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:311
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:328
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "Отмена"
@@ -179,7 +181,7 @@ msgstr "Удалить"
 #: frontend/src/metabase/admin/permissions/selectors.js:323
 #: frontend/src/metabase/admin/permissions/selectors.js:330
 #: frontend/src/metabase/admin/permissions/selectors.js:441
-#: frontend/src/metabase/admin/routes.jsx:57
+#: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
@@ -199,9 +201,10 @@ msgid "Scheduling"
 msgstr "Расписание"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:71
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
@@ -209,8 +212,8 @@ msgid "Save changes"
 msgstr "Сохранить изменения"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:203
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:35
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
 msgstr "Действия"
 
@@ -222,8 +225,8 @@ msgstr "Произвести синхронизацию схемы"
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:90
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:98
 msgid "Starting…"
 msgstr "Начинаю..."
 
@@ -241,13 +244,13 @@ msgstr "Пересканировать значения полей"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
 msgstr "Невозможно начать сканирование"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:92
 msgid "Scan triggered!"
 msgstr "Сканирование запланировано!"
 
@@ -270,15 +273,15 @@ msgid "Add database"
 msgstr "Добавить базу данных"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:28
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:28
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
 #: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:195
+#: frontend/src/metabase/entities/databases/forms.js:264
 #: frontend/src/metabase/entities/questions.js:86
 #: frontend/src/metabase/entities/questions.js:102
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
@@ -318,6 +321,7 @@ msgstr "Сохранено!"
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Изменить"
@@ -360,44 +364,43 @@ msgstr "Завершено с ошибкой"
 msgid "Success"
 msgstr "Успешно завершено"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:185
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Предварительный просмотр"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:93
 msgid "No column description yet"
 msgstr "Еще нет описания стоблца"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:127
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:126
 msgid "Select a field visibility"
 msgstr "Выберите видимость поля"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:187
 msgid "No special type"
 msgstr "Без специального типа"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
 #: frontend/src/metabase/lib/core.js:275
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:44
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:37
 msgid "Other"
 msgstr "Другое"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:221
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Выбрать специальный тип"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:255
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:262
 #: frontend/src/metabase/reference/components/Field.jsx:99
 msgid "Select a target"
 msgstr "Выбрать цель"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
@@ -405,18 +408,18 @@ msgstr "Выбрать цель"
 msgid "Columns"
 msgstr "Столбцы"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Столбец"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:144
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:288
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
 msgid "Visibility"
 msgstr "Видимость"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
 msgid "Type"
 msgstr "Тип"
 
@@ -424,7 +427,7 @@ msgstr "Тип"
 msgid "Current database:"
 msgstr "Текущая база данных:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
 msgid "Show original schema"
 msgstr "Показать оригинальную схему"
 
@@ -448,27 +451,27 @@ msgstr[1] "{0} схем"
 msgstr[2] "{0} схем"
 msgstr[3] "{0} схемы"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:99
 msgid "Why Hide?"
 msgstr "Зачем скрывать?"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:100
 msgid "Technical Data"
 msgstr "Технические данные"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
 msgstr "Не важно/Хлам"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 msgid "Queryable"
 msgstr "Доступно в запросах"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:108
 msgid "Hidden"
 msgstr "Скрыто"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136
 msgid "No table description yet"
 msgstr "Еще нет описания таблицы"
 
@@ -476,7 +479,7 @@ msgstr "Еще нет описания таблицы"
 msgid "Metadata Strength"
 msgstr "Сложность метаданных"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0} доступных для запроса таблиц"
@@ -484,7 +487,7 @@ msgstr[1] "{0} доступных для запроса таблиц"
 msgstr[2] "{0} доступных для запроса таблиц"
 msgstr[3] "{0} доступных для запроса таблиц"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:91
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} скрытая таблица"
@@ -492,20 +495,21 @@ msgstr[1] "{0} скрытых таблиц"
 msgstr[2] "{0} скрытых таблиц"
 msgstr[3] "{0} скрытые таблицы"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:115
 msgid "Find a table"
 msgstr "Найти таблицу"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:128
 msgid "Schemas"
 msgstr "Схемы"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:838
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:21
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:43
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:62
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 msgid "Metrics"
 msgstr "Метрики"
@@ -514,8 +518,8 @@ msgstr "Метрики"
 msgid "Add a Metric"
 msgstr "Добавить Метрику"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "Определение"
@@ -524,12 +528,12 @@ msgstr "Определение"
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "Создать метрики для добавления в мастер запросов"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:21
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
 #: frontend/src/metabase/home/containers/SearchApp.jsx:72
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:961
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:61
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Сегменты"
@@ -538,35 +542,35 @@ msgstr "Сегменты"
 msgid "Add a Segment"
 msgstr "Добавить Сегмент"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:51
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:45
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "Создать сегменты для добавления в фильтры мастера запросов"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:21
 msgid "created"
 msgstr "создано"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "reverted to a previous version"
 msgstr "возвращена предыдущая версия"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:30
 msgid "edited the title"
 msgstr "изменен заголовок"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:32
 msgid "edited the description"
 msgstr "изменено описание"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:34
 msgid "edited the "
 msgstr "изменено "
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:40
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "made some changes"
 msgstr "сделаны некоторые изменения"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
 #: frontend/src/metabase/home/components/Activity.jsx:83
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
@@ -576,84 +580,84 @@ msgstr "Вы"
 msgid "Datamodel"
 msgstr "Модель данных"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:41
 msgid " History"
 msgstr " История"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
 msgstr "История изменений за"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:228
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
 msgid "{0} – Field Settings"
 msgstr "{0} – установки поля"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:289
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
 msgid "Where this field will appear throughout Metabase"
 msgstr "Где это поле будет отображено в системе"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:311
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
 msgid "Filtering on this field"
 msgstr "Фильтрация этого поля"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:312
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Если это поле используется как фильтр, какой вид информации должны использовать пользователи для фильтрации?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:437
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
 msgid "No description for this field yet"
 msgstr "Для этого поля пока нет описания"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
 msgid "Original value"
 msgstr "Оригинальное значение"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:390
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
 msgid "Mapped value"
 msgstr "Связанное значение"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
 msgid "Enter value"
 msgstr "Введите значение"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use original value"
 msgstr "Использовать исходное значение"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Use foreign key"
 msgstr "Использовать внешний ключ"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 msgid "Custom mapping"
 msgstr "Своя связь"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
 msgid "Unrecognized mapping type"
 msgstr "Неопознанный вид связи"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Данное поле не является внешним ключем либо метаданные другой таблицы, содержащей внешний ключ, отсутствуют"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
 msgid "The selected field isn't a foreign key"
 msgstr "Выбранное поле не является внешнем ключём"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:327
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
 msgid "Display values"
 msgstr "Показать значения"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:328
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Выберите, что отобразить в поле: исходное значение из базы данных, ассоциированную или иную настраиваемую информацию."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:278
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
 msgid "Choose a field"
 msgstr "Выберите поле"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:299
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
 msgid "Please select a column to use for display."
 msgstr "Пожалуйста, выберете столбец для отображения."
 
@@ -661,16 +665,16 @@ msgstr "Пожалуйста, выберете столбец для отобр�
 msgid "Tip:"
 msgstr "Подсказка:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:443
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Возможно, вы захотите обновить наименование поля, чтобы убедиться, что оно соответствует выбранному варианту переназначения связи."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:344
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Кэшированные значения полей"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:345
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase может сканировать значения данного поля и включить возможность использования checkbox-фильтров на панели индикаторов и в вопросах."
 
@@ -679,53 +683,53 @@ msgid "Re-scan this field"
 msgstr "Пересканировать это поле"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
 msgstr "Сбросить кэшированные значения полей"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
 msgstr "Не удалось сбросить значения"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 msgid "Discard triggered!"
 msgstr "Сброс значений начался!"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Выбрать базу данных что бы увидеть её схему или изменить мета данные."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:36
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "Имя обязательно"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:39
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "Описание обязательно"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:43
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Описание внесенных изменений обязательно"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
 msgid "Aggregation is required"
 msgstr "Агрегация обязательна"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Edit Your Metric"
 msgstr "Изменить Вашу Метрику"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Create Your Metric"
 msgstr "Создать Вашу Метрику"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Внесите изменения в метрику и оставьте к ним пояснение."
 
@@ -733,62 +737,62 @@ msgstr "Внесите изменения в метрику и оставьте 
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Вы можете создать сохраненные метрики, чтобы использовать их в данной таблице. Сохраненные метрики включают тип агрегации, агрегированное поле и, при необходимости, любой фильтр. Например, вы можете использовать их, чтобы создать что-то вроде единственного официального способа вычисления \"Средней цены\" для таблицы \"Заказы\"."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:180
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
 msgid "Result: "
 msgstr "Результаты: "
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
 msgid "Name Your Metric"
 msgstr "Имя вашей Метрики"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:190
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Give your metric a name to help others find it."
 msgstr "Задайте имя для вашей метрики, чтобы другие пользователи смогли ее найти."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:194
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:152
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Что-нибудь описательное, но не слишком длинное"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:198
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
 msgid "Describe Your Metric"
 msgstr "Опишите вашу Метрику"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:199
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Укажите описание вашей метрики, чтобы помочь другим понять о чем она."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:203
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Это идеальное место, чтобы быть более конкретным в отношении менее очевидных правил вычисления метрики"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:207
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:165
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Причина изменений"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:209
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Оставьте описание внесенных вами изменений и почему они были необходимы."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:213
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Данное сообщение появится в истории изменений метрики и поможет всем восстановить ход событий"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
 msgstr "Необходим как минимум один фильтр"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
 msgstr "Изменить ваш Сегмент"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
 msgstr "Создать ваш Сегмент"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Внесите изменения в ваш сегмент и оставьте к ним пояснение."
 
@@ -796,33 +800,33 @@ msgstr "Внесите изменения в ваш сегмент и остав
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "Выберите и добавьте фильтры для создания вашего нового сегмента к таблице {0}"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
 msgstr "Задайте имя для вашего Сегмента"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:148
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
 msgstr "Задайте имя для вашего сегмента, чтобы другие смогли его найти."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:156
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
 msgstr "Опишите ваш Сегмент"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Укажите описание вашей метрики, чтобы помочь другим понять о чем она. "
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "Это идеальное место, чтобы быть более конкретным в отношении менее очевидных правил определения сегмента"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "Данное сообщение появится в истории изменений сегмента и поможет всем восстановить ход событий"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
-#: frontend/src/metabase/admin/routes.jsx:132
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:215
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
+#: frontend/src/metabase/admin/routes.jsx:137
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
@@ -830,11 +834,11 @@ msgstr "Данное сообщение появится в истории из�
 msgid "Settings"
 msgstr "Настройки"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase может сканировать значения в этом таблицы для того, чтобы построить выпадающие списки для фильтров дашбордов и запросов."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
 msgstr "Пересканировать эту таблицу"
 
@@ -848,11 +852,11 @@ msgstr "Добавить"
 msgid "Not a valid formatted email address"
 msgstr "Email указан неверно"
 
-#: frontend/src/metabase/entities/users/forms.js:12
+#: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
 msgstr "Имя"
 
-#: frontend/src/metabase/entities/users/forms.js:18
+#: frontend/src/metabase/entities/users/forms.js:20
 msgid "Last name"
 msgstr "Фамилия"
 
@@ -894,10 +898,10 @@ msgstr "Участники"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
-#: frontend/src/metabase/admin/settings/selectors.js:120
-#: frontend/src/metabase/entities/users/forms.js:24
+#: frontend/src/metabase/admin/settings/selectors.js:121
+#: frontend/src/metabase/entities/users/forms.js:26
 #: frontend/src/metabase/lib/core.js:146
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:294
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:298
 msgid "Email"
 msgstr "Email"
 
@@ -907,14 +911,14 @@ msgid "A group is only as good as its members."
 msgstr "Группа также хороша, как и ее члены."
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
-#: frontend/src/metabase/admin/routes.jsx:52
+#: frontend/src/metabase/admin/routes.jsx:55
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Admin"
 msgstr "Администрирование"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:241
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:299
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:288
 msgid "and"
 msgstr "и"
 
@@ -968,12 +972,12 @@ msgstr "Удалить группу"
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:42
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:294
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:397
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:317
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:334
 msgid "Done"
 msgstr "Готово"
 
@@ -984,8 +988,9 @@ msgstr "Имя группы"
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
-#: frontend/src/metabase/admin/routes.jsx:92
+#: frontend/src/metabase/admin/routes.jsx:97
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Группы"
 
@@ -1015,7 +1020,7 @@ msgstr "Деактивировать"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:21
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
-#: frontend/src/metabase/admin/routes.jsx:88
+#: frontend/src/metabase/admin/routes.jsx:93
 #: frontend/src/metabase/nav/containers/Navbar.jsx:235
 msgid "People"
 msgstr "Люди"
@@ -1331,25 +1336,25 @@ msgstr "Посмотреть коллекцию"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:542
+#: frontend/src/metabase/admin/permissions/selectors.js:558
 msgid "Data Access"
 msgstr "Доступ к данным"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:667
-#: frontend/src/metabase/admin/permissions/selectors.js:672
+#: frontend/src/metabase/admin/permissions/selectors.js:665
+#: frontend/src/metabase/admin/permissions/selectors.js:670
 msgid "View tables"
 msgstr "Посмотреть таблицы"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:608
+#: frontend/src/metabase/admin/permissions/selectors.js:606
 msgid "SQL Queries"
 msgstr "SQL запросы"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:678
+#: frontend/src/metabase/admin/permissions/selectors.js:676
 msgid "View schemas"
 msgstr "Посмотреть схемы"
 
-#: frontend/src/metabase/admin/routes.jsx:63
+#: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
 msgstr "Модель данных"
@@ -1379,20 +1384,24 @@ msgid "Allows users within your LDAP directory to log in to Metabase with their 
 msgstr "Позволяет пользователям в каталоге LDAP входить в Metabase с учетными данными LDAP, а также автоматически связывает группы LDAP с группами Metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:19
-#: frontend/src/metabase/admin/settings/selectors.js:167
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
+#: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
 msgstr "Это не валидный email адрес"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
 msgstr "Это не валидное целое число"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
 msgstr "Изменения сохранены"
 
-#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:178
+#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
 msgid "Looks like we ran into some problems"
 msgstr "Похоже, мы столкнулись с кое-какими проблемами"
 
@@ -1414,7 +1423,7 @@ msgstr "Очистить"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:195
+#: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Аутентификация"
 
@@ -1466,15 +1475,15 @@ msgstr "Ваш Google client ID"
 msgid "Allow users to sign up on their own if their Google account email address is from:"
 msgstr "Разрешить пользователям регистрироваться с их Google аккаунтом по email отсюда:"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:242
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:249
 msgid "Answers sent right to your Slack #channels"
 msgstr "Ответы будут отправляться в ваши Slack #каналы"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:251
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:258
 msgid "Create a Slack Bot User for MetaBot"
 msgstr "Создать Slack Bot пользователя для MetaBot"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:261
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:268
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "Пока вы здесь, дайте имя и нажмите {0}. Затем скопируйте и вставьте Bot API токен в поле ниже. После этого, создайте канал \"metabase_files\" в Slack. Это требуется Metabase для загрузки графиков."
 
@@ -1487,8 +1496,8 @@ msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Metabase {0} доступна. Вы используете {1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:41
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 msgid "Update"
 msgstr "Обновить"
 
@@ -1515,16 +1524,16 @@ msgstr "Удалить текущую карту"
 #: frontend/src/metabase/containers/Overworld.jsx:293
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:115
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Удалить"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:165
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:141
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
 msgstr "Выбрать..."
 
@@ -1707,48 +1716,46 @@ msgid "Generate Key"
 msgstr "Сгенерировать ключ"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:87
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:18
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enabled"
 msgstr "Включено"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:92
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:19
+#: frontend/src/metabase/admin/settings/selectors.js:93
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Отключено"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:112
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:113
 msgid "Unknown setting {0}"
 msgstr "Неизвестная настройка {0}"
 
-#: frontend/src/metabase/admin/settings/selectors.js:34
+#: frontend/src/metabase/admin/settings/selectors.js:37
 msgid "Setup"
 msgstr "Настроить"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:207
-#: frontend/src/metabase/admin/settings/selectors.js:39
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:214
+#: frontend/src/metabase/admin/settings/selectors.js:42
 msgid "General"
 msgstr "Общее"
 
-#: frontend/src/metabase/admin/settings/selectors.js:43
+#: frontend/src/metabase/admin/settings/selectors.js:46
 msgid "Site Name"
 msgstr "Имя сайта"
 
-#: frontend/src/metabase/admin/settings/selectors.js:48
+#: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Site URL"
 msgstr "Ссылка на сайт"
 
-#: frontend/src/metabase/admin/settings/selectors.js:53
+#: frontend/src/metabase/admin/settings/selectors.js:64
 msgid "Email Address for Help Requests"
 msgstr "Email адрес для запроса помощи"
 
-#: frontend/src/metabase/admin/settings/selectors.js:58
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
 msgstr "Часовой пояс отчетов"
 
-#: frontend/src/metabase/admin/settings/selectors.js:61
+#: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
 msgstr "По-умолчанию для базы данных"
 
@@ -1756,11 +1763,11 @@ msgstr "По-умолчанию для базы данных"
 msgid "Select a timezone"
 msgstr "Выбрать часовой пояс"
 
-#: frontend/src/metabase/admin/settings/selectors.js:64
+#: frontend/src/metabase/admin/settings/selectors.js:75
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "Не все базы данных поддерживают часовые пояса, поэтому данная настройка может не сработать."
 
-#: frontend/src/metabase/admin/settings/selectors.js:69
+#: frontend/src/metabase/entities/users/forms.js:34
 msgid "Language"
 msgstr "Язык"
 
@@ -1768,64 +1775,64 @@ msgstr "Язык"
 msgid "Select a language"
 msgstr "Выбрать язык"
 
-#: frontend/src/metabase/admin/settings/selectors.js:79
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
 msgstr "Анонимное отслеживание"
 
-#: frontend/src/metabase/admin/settings/selectors.js:84
+#: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
 msgstr "Понятные имена таблиц и полей"
 
-#: frontend/src/metabase/admin/settings/selectors.js:90
+#: frontend/src/metabase/admin/settings/selectors.js:91
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Только замените знаки нижнего подчеркивания и точки пробелами"
 
-#: frontend/src/metabase/admin/settings/selectors.js:98
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Enable Nested Queries"
 msgstr "Включить вложенные запросы"
 
-#: frontend/src/metabase/admin/settings/selectors.js:109
+#: frontend/src/metabase/admin/settings/selectors.js:110
 msgid "Updates"
 msgstr "Обновления"
 
-#: frontend/src/metabase/admin/settings/selectors.js:114
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
 msgstr "Проверить обновления"
 
-#: frontend/src/metabase/admin/settings/selectors.js:125
+#: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
 msgstr "SMTP хост"
 
-#: frontend/src/metabase/admin/settings/selectors.js:133
+#: frontend/src/metabase/admin/settings/selectors.js:134
 msgid "SMTP Port"
 msgstr "SMTP порт"
 
-#: frontend/src/metabase/admin/settings/selectors.js:137
+#: frontend/src/metabase/admin/settings/selectors.js:138
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:47
 msgid "That's not a valid port number"
 msgstr "Некорректный номер порта"
 
-#: frontend/src/metabase/admin/settings/selectors.js:141
+#: frontend/src/metabase/admin/settings/selectors.js:142
 msgid "SMTP Security"
 msgstr "Безопасность SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:150
 msgid "SMTP Username"
 msgstr "SMTP пользователь"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "SMTP Password"
 msgstr "SMTP пароль"
 
-#: frontend/src/metabase/admin/settings/selectors.js:163
+#: frontend/src/metabase/admin/settings/selectors.js:164
 msgid "From Address"
 msgstr "От кого"
 
-#: frontend/src/metabase/admin/settings/selectors.js:176
+#: frontend/src/metabase/admin/settings/selectors.js:178
 msgid "Slack API Token"
 msgstr "Slack API Token"
 
-#: frontend/src/metabase/admin/settings/selectors.js:178
+#: frontend/src/metabase/admin/settings/selectors.js:180
 msgid "Enter the token you received from Slack"
 msgstr "Введите токен полученный от Slack"
 
@@ -1854,8 +1861,10 @@ msgid "Username or DN"
 msgstr "Пользователь или DN"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:43
+#: frontend/src/metabase/entities/databases/forms.js:61
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:64
-#: frontend/src/metabase/user/components/UserSettings.jsx:65
+#: frontend/src/metabase/user/components/UserSettings.jsx:66
+#: src/metabase/driver/common.clj
 msgid "Password"
 msgstr "Пароль"
 
@@ -1891,79 +1900,79 @@ msgstr "Синхронизировать членство в группе"
 msgid "Group search base"
 msgstr "База для поиска группы"
 
-#: frontend/src/metabase/admin/settings/selectors.js:199
+#: frontend/src/metabase/admin/settings/selectors.js:201
 msgid "Maps"
 msgstr "Карты"
 
-#: frontend/src/metabase/admin/settings/selectors.js:203
+#: frontend/src/metabase/admin/settings/selectors.js:205
 msgid "Map tile server URL"
 msgstr "URL сервера загрузки плиток карты"
 
-#: frontend/src/metabase/admin/settings/selectors.js:204
+#: frontend/src/metabase/admin/settings/selectors.js:206
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "По умолчанию, Metabase использует OpenStreetMaps."
 
-#: frontend/src/metabase/admin/settings/selectors.js:209
+#: frontend/src/metabase/admin/settings/selectors.js:211
 msgid "Custom Maps"
 msgstr "Пользовательская карта"
 
-#: frontend/src/metabase/admin/settings/selectors.js:210
+#: frontend/src/metabase/admin/settings/selectors.js:212
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Добавьте собственные GeoJSON файлы для возможности визуализации различных регионов на картах"
 
-#: frontend/src/metabase/admin/settings/selectors.js:228
+#: frontend/src/metabase/admin/settings/selectors.js:245
 msgid "Public Sharing"
 msgstr "Общий доступ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:232
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "Enable Public Sharing"
 msgstr "Включить общий доступ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:254
 msgid "Shared Dashboards"
 msgstr "Публичные дашборды"
 
-#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Shared Questions"
 msgstr "Публичные запросы"
 
-#: frontend/src/metabase/admin/settings/selectors.js:250
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Embedding in other Applications"
 msgstr "Встраивание в других Приложениях"
 
-#: frontend/src/metabase/admin/settings/selectors.js:276
+#: frontend/src/metabase/admin/settings/selectors.js:293
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Включить встраивание Metabase в других Приложениях"
 
-#: frontend/src/metabase/admin/settings/selectors.js:286
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Embedding secret key"
 msgstr "Секретный ключ для встраивания"
 
-#: frontend/src/metabase/admin/settings/selectors.js:292
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Embedded Dashboards"
 msgstr "Встраиваемые дашборды"
 
-#: frontend/src/metabase/admin/settings/selectors.js:298
+#: frontend/src/metabase/admin/settings/selectors.js:315
 msgid "Embedded Questions"
 msgstr "Встраиваемые запросы"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:322
 msgid "Caching"
 msgstr "Кэширование"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:326
 msgid "Enable Caching"
 msgstr "Включить кэширование"
 
-#: frontend/src/metabase/admin/settings/selectors.js:314
+#: frontend/src/metabase/admin/settings/selectors.js:331
 msgid "Minimum Query Duration"
 msgstr "Минимальное время запроса"
 
-#: frontend/src/metabase/admin/settings/selectors.js:321
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Множитель Cache Time-To-Live (TTL)"
 
-#: frontend/src/metabase/admin/settings/selectors.js:328
+#: frontend/src/metabase/admin/settings/selectors.js:345
 msgid "Max Cache Entry Size"
 msgstr "Максимальный объем записи в кеш"
 
@@ -2131,7 +2140,8 @@ msgstr "Дашборды, коллекции и пульсы в этой кол�
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/routes.jsx:205
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
+#: frontend/src/metabase/routes.jsx:196
 msgid "Archive"
 msgstr "Архив"
 
@@ -2147,21 +2157,21 @@ msgstr "Посмотреть архив"
 msgid "Unarchive this {0}"
 msgstr "Востоновить этот {0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:39
-#: frontend/src/metabase/components/BrowseApp.jsx:102
-#: frontend/src/metabase/components/BrowseApp.jsx:194
+#: frontend/src/metabase/components/BrowseApp.jsx:46
+#: frontend/src/metabase/components/BrowseApp.jsx:112
+#: frontend/src/metabase/components/BrowseApp.jsx:204
 #: frontend/src/metabase/containers/Overworld.jsx:270
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
 msgstr "Наши данные"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:146
+#: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
 msgid "X-ray this table"
 msgstr "Просканировать эту таблицу"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:161
+#: frontend/src/metabase/components/BrowseApp.jsx:171
 msgid "Learn about this table"
 msgstr "Узнать больше об этой таблице"
 
@@ -2256,7 +2266,7 @@ msgstr "Прикрепленные"
 msgid "Drag something here to pin it to the top"
 msgstr "Переместите что-то для того чтобы закрепить наверху"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:755
+#: frontend/src/metabase/admin/permissions/selectors.js:753
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2312,7 +2322,7 @@ msgstr "Новая коллекция"
 msgid "Copied!"
 msgstr "Скопировано!"
 
-#: frontend/src/metabase/entities/databases/forms.js:12
+#: frontend/src/metabase/entities/databases/forms.js:14
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Использать SSH-туннель для связи с базой данных"
 
@@ -2324,7 +2334,7 @@ msgstr "Некоторые инсталляции баз данных могут
 "Эта опция так же предоставляет дополнительный уровень безопасности, когда недоступен VPN. \n"
 "Использование может снизить скорость в сравнении с прямым соединением."
 
-#: frontend/src/metabase/entities/databases/forms.js:212
+#: frontend/src/metabase/entities/databases/forms.js:281
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Это большая база данных, так что дайте я выберу когда Мэтабэйз синхронизирует и сканирует"
 
@@ -2334,17 +2344,17 @@ msgid "By default, Metabase does a lightweight hourly sync and an intensive dail
 msgstr "По-умолчанию, Metabase выполняет поверхностное сканирование каждый час и полное сканирование значений полей каждые сутки.\n"
 "Если у вас большая база данных, мы рекомендуем настроить подходящее расписание для сканирования значений полей."
 
-#: frontend/src/metabase/entities/databases/forms.js:78
+#: frontend/src/metabase/entities/databases/forms.js:113
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0} для генерации Client ID и Client Secret для вашего проекта."
 
-#: frontend/src/metabase/entities/databases/forms.js:80
-#: frontend/src/metabase/entities/databases/forms.js:95
-#: frontend/src/metabase/entities/databases/forms.js:131
+#: frontend/src/metabase/entities/databases/forms.js:115
+#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:166
 msgid "Click here"
 msgstr "Нажмите здесь"
 
-#: frontend/src/metabase/entities/databases/forms.js:83
+#: frontend/src/metabase/entities/databases/forms.js:118
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Выберите \"Прочее\" как тип приложения. Назовите его на ваш вкус."
 
@@ -2352,19 +2362,19 @@ msgstr "Выберите \"Прочее\" как тип приложения. Н
 msgid "{0} to get an auth code"
 msgstr "{0} для получения кода аутентификации"
 
-#: frontend/src/metabase/entities/databases/forms.js:107
+#: frontend/src/metabase/entities/databases/forms.js:142
 msgid "with Google Drive permissions"
 msgstr "с разрешениями Google Drive"
 
-#: frontend/src/metabase/entities/databases/forms.js:129
+#: frontend/src/metabase/entities/databases/forms.js:164
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "Вам необходимо разрешить доступ по API в Google Developers Console, чтобы использовать эти данные в Metabase."
 
-#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:165
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} перейдите в консоль, если вы этого еще не сделали"
 
-#: frontend/src/metabase/entities/databases/forms.js:196
+#: frontend/src/metabase/entities/databases/forms.js:265
 msgid "How would you like to refer to this database?"
 msgstr "Как бы вы хотели обращаться к этой базе данных?"
 
@@ -2373,7 +2383,8 @@ msgstr "Как бы вы хотели обращаться к этой базе 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:143
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:70
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:123
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:96
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:126
 #: frontend/src/metabase/setup/components/UserStep.jsx:93
 msgid "Next"
 msgstr "Дальше"
@@ -2556,7 +2567,7 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Возвращен к более ранней редакции и {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:290
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "История ревизий"
@@ -2602,7 +2613,7 @@ msgid "Questions"
 msgstr "Запросы"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:320
+#: frontend/src/metabase/routes.jsx:311
 msgid "Pulses"
 msgstr "Пульсы"
 
@@ -2647,15 +2658,16 @@ msgstr "Мы немного заблудились…"
 msgid "Temporary Password"
 msgstr "Временный пароль"
 
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:207
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:481
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
 msgid "Hide"
 msgstr "Скрыть"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:467
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:482
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:471
 msgid "Show"
 msgstr "Показать"
 
@@ -2765,7 +2777,7 @@ msgstr "Извините, у вас отсутствуют разрешения 
 msgid "Unknown error encountered"
 msgstr "Возникла неизвестная ошибка"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/nav/containers/Navbar.jsx:373
 msgid "Create"
 msgstr "Создать"
@@ -2778,7 +2790,7 @@ msgstr "Создать дашборд"
 msgid "Table"
 msgstr "Таблица"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
 msgid "Database"
 msgstr "База данных"
 
@@ -2798,7 +2810,7 @@ msgstr "Попробуйте установить фильтр для того �
 msgid "View by"
 msgstr "Просмотрено"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:122
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:121
 msgid "of"
 msgstr "из"
 
@@ -2825,33 +2837,33 @@ msgstr "Наша статистика"
 msgid "Browse all items"
 msgstr "Просмотреть все элементы"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:118
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:117
 msgid "Replace or save as new?"
 msgstr "Заменить или сохранить как новый?"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:168
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace original question, \"{0}\""
 msgstr "Заменить исходный запрос, \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:172
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:171
 msgid "Save as new question"
 msgstr "Сохранить как новый запрос"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:92
 msgid "First, save your question"
 msgstr "Для начала, сохраните ваш запрос"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:94
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
 msgid "Save question"
 msgstr "Сохранить запрос"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:133
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
 msgid "What is the name of your card?"
 msgstr "Как называется ваша карточка?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
 #: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/entities/questions.js:89
@@ -2867,15 +2879,16 @@ msgstr "Как называется ваша карточка?"
 msgid "Description"
 msgstr "Описание"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
 #: frontend/src/metabase/entities/dashboards.js:150
 #: frontend/src/metabase/entities/questions.js:91
 #: frontend/src/metabase/entities/questions.js:107
+#: frontend/src/metabase/entities/snippets.js:31
 msgid "It's optional but oh, so helpful"
 msgstr "Это не обязательно, но может быть полезным"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:148
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "В какую коллекцию следует это включить?"
@@ -2892,19 +2905,19 @@ msgstr "элемент"
 msgid "Undo"
 msgstr "Отмена"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:266
 msgid "Applying Question"
 msgstr "Применить запрос"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:286
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "That question isn't compatible"
 msgstr "Этот запрос несовместим"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:322
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:309
 msgid "Search for a question"
 msgstr "Найти запрос"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:351
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:343
 msgid "We're not sure if this question is compatible"
 msgstr "Мы не уверены, сочетается ли данный запрос"
 
@@ -2953,25 +2966,23 @@ msgstr "Добавить запрос"
 msgid "Add a question to this dashboard"
 msgstr "Добавить запрос на этот дашборд"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
 msgid "Add a filter"
 msgstr "Добавить фильтр"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:256
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "Параметры"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:276
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:280
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
 msgid "Add a text box"
 msgstr "Добавить текстовое поле"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:320
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:314
 msgid "Move dashboard"
 msgstr "Переместить дашборд"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:303
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
 msgid "Edit dashboard"
 msgstr "Изменить дашборд"
 
@@ -2979,11 +2990,11 @@ msgstr "Изменить дашборд"
 msgid "Edit Dashboard Layout"
 msgstr "Изменить внешний вид дашборда"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:371
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:365
 msgid "You are editing a dashboard"
 msgstr "Вы редактируете дашборд"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:376
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:370
 msgid "Select the field that should be filtered for each card"
 msgstr "Выберите поле, которое должно быть фильтром в каждой из карт"
 
@@ -3071,7 +3082,7 @@ msgstr "Карточка не содержит полей или парамет�
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Значение этого поля не покрывают значения никаких полей, которые вы выбрали."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:162
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "Нет корректных полей"
@@ -3139,7 +3150,7 @@ msgstr "последние данные получены"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:329
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
 msgid "Unknown"
 msgstr "Неизвестно"
 
@@ -3266,6 +3277,7 @@ msgstr "{0} элементов выбрано"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 msgid "Unarchive"
 msgstr "Разархивировать"
 
@@ -3358,7 +3370,7 @@ msgid "Longitude"
 msgstr "Долгота"
 
 #: frontend/src/metabase/lib/core.js:43
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:45
 msgid "Number"
 msgstr "Число"
@@ -3416,7 +3428,7 @@ msgid "User"
 msgstr "Пользователь"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:211
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
 msgid "Source"
 msgstr "Источник"
 
@@ -3457,16 +3469,17 @@ msgid "Score"
 msgstr "Результат"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Заголовок"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
 msgid "Comment"
 msgstr "Комментарий"
 
@@ -3518,9 +3531,9 @@ msgstr "Не включать"
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
 msgstr "Metabase никогда не получит это поле. Используйте для чувствительной нерелевантной информации."
 
-#: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:300
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/query/description.js:77
+#: frontend/src/metabase/lib/query/description.js:262
+#: frontend/src/metabase/lib/schema_metadata.js:476
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
@@ -3535,8 +3548,7 @@ msgstr "Количество"
 msgid "CumulativeCount"
 msgstr "Накопительное количество"
 
-#: frontend/src/metabase/lib/expressions/config.js:9
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:485
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3547,7 +3559,6 @@ msgid "CumulativeSum"
 msgstr "Накопительная сумма"
 
 #. Во множественном числе исходя из применяемости в Metabase.
-#: frontend/src/metabase/lib/expressions/config.js:11
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Distinct"
 msgstr "Уникальные"
@@ -3556,25 +3567,22 @@ msgstr "Уникальные"
 msgid "StandardDeviation"
 msgstr "Стандартное отклонение"
 
-#: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:494
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Среднее"
 
-#: frontend/src/metabase/lib/expressions/config.js:14
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:539
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Минимальное"
 
-#: frontend/src/metabase/lib/expressions/config.js:15
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:548
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:503
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:492
 msgid "Max"
 msgstr "Максимальное"
 
@@ -3631,54 +3639,66 @@ msgstr "О чем вы думаете?"
 msgid "What do you want to find out?"
 msgstr "Что вас интересует?"
 
-#: frontend/src/metabase/lib/query.js:298
-#: frontend/src/metabase/lib/schema_metadata.js:466
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:250
+#: frontend/src/metabase/lib/query/description.js:75
+#: frontend/src/metabase/lib/query/description.js:260
+#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Исходные данные"
 
-#: frontend/src/metabase/lib/query.js:302
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/query/description.js:79
+#: frontend/src/metabase/lib/query/description.js:264
+#: frontend/src/metabase/lib/schema_metadata.js:521
 msgid "Cumulative count"
 msgstr "Накопительное количество"
 
-#: frontend/src/metabase/lib/query.js:305
+#: frontend/src/metabase/lib/query/description.js:82
+#: frontend/src/metabase/lib/query/description.js:266
 msgid "Average of "
 msgstr "Среднее "
 
-#: frontend/src/metabase/lib/query.js:310
+#: frontend/src/metabase/lib/query/description.js:87
+#: frontend/src/metabase/lib/query/description.js:268
 msgid "Distinct values of "
 msgstr "Уникальные значения "
 
-#: frontend/src/metabase/lib/query.js:315
+#: frontend/src/metabase/lib/query/description.js:92
+#: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
 msgstr "Стандартное отклонение "
 
-#: frontend/src/metabase/lib/query.js:320
+#: frontend/src/metabase/lib/query/description.js:97
+#: frontend/src/metabase/lib/query/description.js:272
 msgid "Sum of "
 msgstr "Сумма "
 
-#: frontend/src/metabase/lib/query.js:325
+#: frontend/src/metabase/lib/query/description.js:102
+#: frontend/src/metabase/lib/query/description.js:274
 msgid "Cumulative sum of "
 msgstr "Накопительная сумма "
 
-#: frontend/src/metabase/lib/query.js:330
+#: frontend/src/metabase/lib/query/description.js:107
+#: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
 msgstr "Максимум "
 
-#: frontend/src/metabase/lib/query.js:335
+#: frontend/src/metabase/lib/query/description.js:112
+#: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
 msgstr "Минимум "
 
-#: frontend/src/metabase/lib/query.js:349
+#: frontend/src/metabase/lib/query/description.js:126
+#: frontend/src/metabase/lib/query/description.js:286
 msgid "Grouped by "
 msgstr "Сгруппировано по "
 
-#: frontend/src/metabase/lib/query.js:363
+#: frontend/src/metabase/lib/query/description.js:140
+#: frontend/src/metabase/lib/query/description.js:295
 msgid "Filtered by "
 msgstr "Отфильтровано по "
 
-#: frontend/src/metabase/lib/query.js:392
+#: frontend/src/metabase/lib/query/description.js:169
+#: frontend/src/metabase/lib/query/description.js:320
 msgid "Sorted by "
 msgstr "Сортировано по "
 
@@ -3690,55 +3710,45 @@ msgstr "Истина"
 msgid "False"
 msgstr "Ложь"
 
-#: frontend/src/metabase/lib/schema_metadata.js:321
+#: frontend/src/metabase/lib/schema_metadata.js:322
 msgid "Select longitude field"
 msgstr "Выберите поле с долготой"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:323
 msgid "Enter upper latitude"
 msgstr "Введите верхнюю широту"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:324
 msgid "Enter left longitude"
 msgstr "Введите левую долготу"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:325
 msgid "Enter lower latitude"
 msgstr "Введите нижнюю широту"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:326
 msgid "Enter right longitude"
 msgstr "Введите правую долготу"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:539
 #: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:397
-#: frontend/src/metabase/lib/schema_metadata.js:405
-#: frontend/src/metabase/lib/schema_metadata.js:411
-#: frontend/src/metabase/lib/schema_metadata.js:416
-msgid "Is"
-msgstr "-"
-
 #: frontend/src/metabase/lib/schema_metadata.js:362
 #: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:398
 #: frontend/src/metabase/lib/schema_metadata.js:406
 #: frontend/src/metabase/lib/schema_metadata.js:412
-msgid "Is not"
-msgstr "Не"
+#: frontend/src/metabase/lib/schema_metadata.js:417
+msgid "Is"
+msgstr "-"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:417
-msgid "Is empty"
-msgstr "Пусто"
+#: frontend/src/metabase/lib/schema_metadata.js:413
+msgid "Is not"
+msgstr "Не"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:378
@@ -3747,109 +3757,119 @@ msgstr "Пусто"
 #: frontend/src/metabase/lib/schema_metadata.js:402
 #: frontend/src/metabase/lib/schema_metadata.js:408
 #: frontend/src/metabase/lib/schema_metadata.js:418
+msgid "Is empty"
+msgstr "Пусто"
+
+#: frontend/src/metabase/lib/schema_metadata.js:365
+#: frontend/src/metabase/lib/schema_metadata.js:379
+#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:395
+#: frontend/src/metabase/lib/schema_metadata.js:403
+#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:419
 msgid "Not empty"
 msgstr "Не пусто"
 
-#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:371
 msgid "Equal to"
 msgstr "Равно"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:372
 msgid "Not equal to"
 msgstr "Не равно"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Greater than"
 msgstr "Больше чем"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Less than"
 msgstr "Меньше чем"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Между"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:376
 msgid "Greater than or equal to"
 msgstr "Больше или равно"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Less than or equal to"
 msgstr "Меньше или равно"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
+#: frontend/src/metabase/lib/schema_metadata.js:384
 msgid "Contains"
 msgstr "Содержит"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:385
 msgid "Does not contain"
 msgstr "Не содержит"
 
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:388
 msgid "Starts with"
 msgstr "Начинается с"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:389
 msgid "Ends with"
 msgstr "Заканчивается"
 
-#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:399
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "До"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:400
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "После"
 
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:414
 msgid "Inside"
 msgstr "Внутри"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Просто таблица со строками результатов, без дополнительных операций."
 
-#: frontend/src/metabase/lib/schema_metadata.js:474
+#: frontend/src/metabase/lib/schema_metadata.js:475
 msgid "Count of rows"
 msgstr "Количество записей"
 
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:477
 msgid "Total number of rows in the answer."
 msgstr "Общее количество записей в ответе"
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Sum of ..."
 msgstr "Количество ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:486
 msgid "Sum of all the values of a column."
 msgstr "Количество всех значений колонки."
 
-#: frontend/src/metabase/lib/schema_metadata.js:492
+#: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Average of ..."
 msgstr "Среднее ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:495
 msgid "Average of all the values of a column"
 msgstr "Среднее всех значений колонки."
 
-#: frontend/src/metabase/lib/schema_metadata.js:501
+#: frontend/src/metabase/lib/schema_metadata.js:502
 msgid "Number of distinct values of ..."
 msgstr "Уникальные значения..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:504
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Количество уникальных значений столбца среди всех записей в ответе."
 
-#: frontend/src/metabase/lib/schema_metadata.js:510
+#: frontend/src/metabase/lib/schema_metadata.js:511
 msgid "Cumulative sum of ..."
 msgstr "Сумма нарастащим итогом…"
 
@@ -3858,7 +3878,7 @@ msgstr "Сумма нарастащим итогом…"
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Совокупное сумма всех значений столбца.\\\\ne.x. всего доход за временной интервал."
 
-#: frontend/src/metabase/lib/schema_metadata.js:519
+#: frontend/src/metabase/lib/schema_metadata.js:520
 msgid "Cumulative count of rows"
 msgstr "Нарастающий итог"
 
@@ -3866,28 +3886,28 @@ msgstr "Нарастающий итог"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Совокупное количество записей.\\\\ne.x. всего продаж за временной интервал."
 
-#: frontend/src/metabase/lib/schema_metadata.js:528
+#: frontend/src/metabase/lib/schema_metadata.js:529
 msgid "Standard deviation of ..."
 msgstr "Стандартное отклонение…"
 
 #. Кривая формулировка получилась, нужно уточнение.
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:531
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Число, отражающее насколько значения столбца отклоняются от всех записей ответа."
 
-#: frontend/src/metabase/lib/schema_metadata.js:537
+#: frontend/src/metabase/lib/schema_metadata.js:538
 msgid "Minimum of ..."
 msgstr "Минимум ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Minimum value of a column"
 msgstr "Минимальное значение столбца"
 
-#: frontend/src/metabase/lib/schema_metadata.js:546
+#: frontend/src/metabase/lib/schema_metadata.js:547
 msgid "Maximum of ..."
 msgstr "Максимум ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:549
 msgid "Maximum value of a column"
 msgstr "Максимальное значение колонки"
 
@@ -4063,7 +4083,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Категория, Тип, Модель, Рейтинг, прочее."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:43
-#: frontend/src/metabase/user/components/UserSettings.jsx:55
+#: frontend/src/metabase/user/components/UserSettings.jsx:56
 msgid "Account settings"
 msgstr "Настройки учетной записи"
 
@@ -4075,7 +4095,7 @@ msgstr "Выйти из администрирования"
 msgid "Logs"
 msgstr "Логи"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:103
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:104
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:22
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:65
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:100
@@ -4115,9 +4135,9 @@ msgid "Metabase Admin"
 msgstr "Управление Metabase"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:36
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:36
 msgid "Ask a question"
 msgstr "Создать запрос"
 
@@ -4138,7 +4158,7 @@ msgstr "Справочник"
 msgid "Which metric?"
 msgstr "Какая метрика?"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "Определение произвольных метрик для вашей команды позволит упростить поиск ответов на запросы."
 
@@ -4150,7 +4170,7 @@ msgstr "Как создать метрики"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Смотрите данные по времени, как карту, сводную таблицу для того чтобы понять тренды или изменения."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:149
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
 msgid "Custom"
 msgstr "Произвольный"
 
@@ -4163,13 +4183,13 @@ msgstr "Новый запрос"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Используйте простой построитель запросов для просмотра трендов, списка вещей, или создания собственных метрик."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:107
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:110
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Прямой запрос"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:108
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:111
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Для более сложных запросов, вы можете написать собственный SQL или прямой запрос."
 
@@ -4280,6 +4300,7 @@ msgid "Enter a default value..."
 msgstr "Введите значение по-умолчания..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
+#: frontend/src/metabase/containers/Form.jsx:307
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Возникла ошибка"
@@ -4530,7 +4551,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "Мы рекомендуем держать пульсы небольшими и целенаправленными, что бы приносить пользу всей команде."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:161
-#: frontend/src/metabase/query_builder/components/view/View.jsx:131
+#: frontend/src/metabase/query_builder/components/view/View.jsx:133
 msgid "Pick your data"
 msgstr "Выберите данные"
 
@@ -4546,47 +4567,47 @@ msgstr "Электронные адреса"
 msgid "Slack messages"
 msgstr "Сообщения Slack"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:216
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Отправлено"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:217
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} будет отправлено на"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:219
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Сообщения"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:235
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "Отправить Email прямо сейчас"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:236
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Отправить {0} прямо сейчас"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:238
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Отправка..."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "Отправка не удалась"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "Не отправлено, потому что пульс не содержит результатов."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Пульс отправлен"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:282
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} должно быть настроено администратором."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:295
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:299
 msgid "Slack"
 msgstr "Slack"
 
@@ -4739,7 +4760,7 @@ msgstr "Среднее"
 msgid "Distincts"
 msgstr "Уникальные"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:55
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "Показать {0}"
@@ -4752,11 +4773,12 @@ msgstr[3] "Показать {0}"
 msgid "Zoom in"
 msgstr "Приблизить"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Произвольное выражение"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Common Metrics"
 msgstr "Общие Метрики"
 
@@ -4953,34 +4975,34 @@ msgstr "обычно"
 msgid "Pick a segment or table"
 msgstr "Прикрепите сегмент или таблицу"
 
-#: frontend/src/metabase/entities/databases/forms.js:191
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
+#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Выберите базу данных"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:94
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:85
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:31
 msgid "Select..."
 msgstr "Выбрать..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:134
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
 msgid "Select a table"
 msgstr "Выберите таблицу"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:819
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:926
 msgid "No tables found in this database."
 msgstr "В этой базе данных не найдено ни одной таблицы."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:856
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:901
 msgid "Is a question missing?"
 msgstr "Запрос пропущен?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:863
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:909
 msgid "Learn more about nested queries"
 msgstr "Узнать больше о вложенных запросах"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:898
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:951
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:40
 msgid "Fields"
 msgstr "Поля"
 
@@ -5014,11 +5036,11 @@ msgstr "Сортировка"
 msgid "Row limit"
 msgstr "Количество строк"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
 msgid "Unknown Field"
 msgstr "Неизвестное поле"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:75
 msgid "field"
 msgstr "поле"
 
@@ -5026,19 +5048,20 @@ msgstr "поле"
 msgid "Matches"
 msgstr "Совпадения"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:148
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:156
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:135
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Добавьте фильтры чтобы сократить результаты запроса"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:293
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
 msgstr "Добавить группировку"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:37
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:313
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
-#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:66
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:67
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:89
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:131
@@ -5054,16 +5077,16 @@ msgstr "Добавить группировку"
 msgid "Data"
 msgstr "Данные"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:340
 msgid "Filtered by"
 msgstr "Отфильтровано по"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:376
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:357
 msgid "View"
 msgstr "Просмотр"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:393
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:374
 msgid "Grouped By"
 msgstr "Сгруппировано по"
 
@@ -5071,7 +5094,7 @@ msgstr "Сгруппировано по"
 msgid "None"
 msgstr "Ничего"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:471
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
 msgid "This question is written in {0}."
 msgstr "Этот запрос написан в {0}."
 
@@ -5083,7 +5106,7 @@ msgstr "Скрыть Редактор"
 msgid "Hide Query"
 msgstr "Скрыть Запрос"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:481
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
 msgid "Open Editor"
 msgstr "Открыть Редактор"
 
@@ -5327,7 +5350,7 @@ msgstr "Уникальные значения {0}"
 msgid "Number of {0} grouped by {1}"
 msgstr "Число {0} сгруппированных по {1}"
 
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:77
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5386,32 +5409,33 @@ msgstr "Посмотреть исходные данные для {0}"
 msgid "More"
 msgstr "Больше"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:194
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:216
 msgid "Invalid expression"
 msgstr "Некорректное выражение"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:269
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:282
 msgid "unknown error"
 msgstr "неизвестная ошибка"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:47
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:53
 msgid "Field formula"
 msgstr "Формула поля"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:60
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:64
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Подумайте об этом как о том, как написать формулу в программе для работы с электронными таблицами: вы можете использовать числа, поля таблицы, математические символы, такие как +, и некоторые функции. Таким образом, вы можете ввести что-то вроде Итого - Стоимость."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:69
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:208
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
 msgid "Learn more"
 msgstr "Узнать больше"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:77
 msgid "Give it a name"
 msgstr "Дать имя"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:79
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
 msgid "Something nice and descriptive"
 msgstr "Что-нибудь замечательное и понятное"
 
@@ -5491,11 +5515,11 @@ msgid "Enter desired number"
 msgstr "Введите желаемый номер"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:154
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:161
 msgid "Empty"
 msgstr "Пусто"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:119
 msgid "Find a value"
 msgstr "Найти значение"
 
@@ -5563,35 +5587,35 @@ msgstr "Ознакомиться с полной документацией"
 msgid "Filter label"
 msgstr "Заголовок фильтра"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:135
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:134
 msgid "Variable type"
 msgstr "Тип переменной"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:143
 msgid "Text"
 msgstr "Текст"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
 msgid "Date"
 msgstr "Дата"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:147
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
 msgid "Field Filter"
 msgstr "Фильтр поля"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Field to map to"
 msgstr "Связующие поля"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:180
 msgid "Filter widget type"
 msgstr "Тип фильтра виджета"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:230
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
 msgid "Required?"
 msgstr "Обязательно?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:240
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
 msgid "Default filter widget value"
 msgstr "Значение по-умолчанию для фильтра виджета"
 
@@ -5603,7 +5627,7 @@ msgstr "Переместить этот запрос в архив?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Этот запрос будет удален со всех дашбордов или пульсов, где он был добавлен."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:158
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
 msgid "Question"
 msgstr "Запрос"
 
@@ -5775,7 +5799,7 @@ msgid "Details"
 msgstr "Детали"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
-#: frontend/src/metabase/reference/databases/TableList.jsx:116
+#: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
 msgstr "Таблицы в {0}"
 
@@ -5856,24 +5880,24 @@ msgstr "Почему эта таблица может быть интересн�
 msgid "Things to be aware of about this table"
 msgstr "Что нужно знать об этой таблице"
 
-#: frontend/src/metabase/reference/databases/TableList.jsx:30
+#: frontend/src/metabase/reference/databases/TableList.jsx:29
 msgid "Tables in this database will appear here as they're added"
 msgstr "Таблицы в этой базе данных появятся после добавления"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:34
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:33
 msgid "Questions about this table will appear here as they're added"
 msgstr "Запросы об этой таблице появятся после добавления"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:73
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:77
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:76
 msgid "Questions about {0}"
 msgstr "Запросы о {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
 msgid "Created {0} by {1}"
 msgstr "Создано {0} пользователем {1}"
 
@@ -6062,19 +6086,19 @@ msgstr "Другие поля, по которым вы можете групп�
 msgid "Fields you can group this metric by"
 msgstr "Метрика может быть сгруппирована по следующим полям"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "Метрики это официальные цифры, о которых заботится ваша команда"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Metrics will appear here once your admins have created some"
 msgstr "Метрики будут появляться здесь как только ваши админы их сделают"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:28
 msgid "Learn how to create metrics"
 msgstr "Узнайте как создать метрики"
 
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:34
 msgid "Questions about this metric will appear here as they're added"
 msgstr "Запросы об этой метрике появятся после их добавления"
 
@@ -6100,23 +6124,23 @@ msgstr "Почему этот сегмент интересен"
 msgid "Things to be aware of about this Segment"
 msgstr "Что нужно знать об этом сегменте"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
 msgid "Segments are interesting subsets of tables"
 msgstr "Сегменты это интересные срезы по таблицам"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "Определение общих сегментов для вашей команды упрощает создание запросов"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Segments will appear here once your admins have created some"
 msgstr "Сегменты появятся здесь после того как администраторы их создадут"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
 msgid "Learn how to create segments"
 msgstr "Узнайте как создавать сегменты"
 
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:35
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:34
 msgid "Questions about this segment will appear here as they're added"
 msgstr "Запросы об этом сегменте появятся здесь после их добавления"
 
@@ -6136,22 +6160,22 @@ msgstr "Запросы с этим сегментом"
 msgid "X-ray this segment"
 msgstr "Просканировать этот сегмент"
 
-#: frontend/src/metabase/routes.jsx:178 frontend/src/metabase/routes.jsx:179
+#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
 msgid "Login"
 msgstr "Логин"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:303
 #: frontend/src/metabase/containers/ItemPicker.jsx:115
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:204
+#: frontend/src/metabase/routes.jsx:195
 msgid "Search"
 msgstr "Поиск"
 
-#: frontend/src/metabase/routes.jsx:223
+#: frontend/src/metabase/routes.jsx:214
 msgid "Dashboard"
 msgstr "Дашборд"
 
-#: frontend/src/metabase/routes.jsx:236
+#: frontend/src/metabase/routes.jsx:227
 msgid "New Question"
 msgstr "Новый запрос"
 
@@ -6195,63 +6219,63 @@ msgstr "Спасибо за помощь в улучшении"
 msgid "We won't collect any usage events"
 msgstr "Мы не хотим собирать никакие события использования"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:88
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Для улучшения Metabase, мы бы хотели собирать некоторые данные по использованию через Google Analytics."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:90
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Here's a full list of everything we track and why."
 msgstr "Вот полный список всего что мы отслеживаем и почему."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Разрешить Metabase собирать анонимные данные о использовании"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:113
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0} собирает что либо о ваших данных или результатах вопросов."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:114
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
 msgid "never"
 msgstr "никогда"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:119
 msgid "All collection is completely anonymous."
 msgstr "Все коллекции полностью анонимны."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Коллекция может быть отключена в любой момент в настройках администратора."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:44
+#: frontend/src/metabase/setup/components/Setup.jsx:59
 msgid "If you feel stuck"
 msgstr "Если вы застряли"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:49
+#: frontend/src/metabase/setup/components/Setup.jsx:64
 msgid "our getting started guide"
 msgstr "наше руководство по началу работы"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:50
+#: frontend/src/metabase/setup/components/Setup.jsx:65
 msgid "is just a click away."
 msgstr "всего в одном клике от вас."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:92
+#: frontend/src/metabase/setup/components/Setup.jsx:111
 msgid "Welcome to Metabase"
 msgstr "Добро пожаловать в Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:93
+#: frontend/src/metabase/setup/components/Setup.jsx:112
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Похоже, все работает. Теперь давайте познакомимся поближе: настройте подключение к данным и пойдем искать ответы!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:97
+#: frontend/src/metabase/setup/components/Setup.jsx:116
 msgid "Let's get started"
 msgstr "Начнем"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:142
+#: frontend/src/metabase/setup/components/Setup.jsx:166
 msgid "You're all set up!"
 msgstr "Все настроено!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:153
+#: frontend/src/metabase/setup/components/Setup.jsx:177
 msgid "Take me to Metabase"
 msgstr "Покажите мне Metabase"
 
@@ -6263,13 +6287,13 @@ msgstr "Как мы можем вас называть?"
 msgid "Hi, {0}. nice to meet you!"
 msgstr "Привет, {0}. рады вас видеть!"
 
-#: frontend/src/metabase/entities/users/forms.js:33
+#: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
 msgstr "Создайте пароль"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:44
-#: frontend/src/metabase/entities/users/forms.js:35
-#: frontend/src/metabase/entities/users/forms.js:82
+#: frontend/src/metabase/entities/users/forms.js:50
+#: frontend/src/metabase/entities/users/forms.js:97
 msgid "Shhh..."
 msgstr "Тссс..."
 
@@ -6277,11 +6301,11 @@ msgstr "Тссс..."
 msgid "Confirm password"
 msgstr "Подтверждение пароля"
 
-#: frontend/src/metabase/entities/users/forms.js:42
+#: frontend/src/metabase/entities/users/forms.js:57
 msgid "Shhh... but one more time so we get it right"
 msgstr "Тсс… но еще раз, чтобы наверняка"
 
-#: frontend/src/metabase/entities/users/forms.js:70
+#: frontend/src/metabase/entities/users/forms.js:85
 msgid "Your company or team name"
 msgstr "Название вашей компании или команды"
 
@@ -6450,7 +6474,7 @@ msgstr "Пароль успешно изменен!"
 msgid "Account updated successfully!"
 msgstr "Учетная запись успешно изменена!"
 
-#: frontend/src/metabase/entities/users/forms.js:81
+#: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
 msgstr "Текущий пароль"
 
@@ -6462,7 +6486,7 @@ msgstr "Войти с помощью аккаунта Google"
 msgid "User Details"
 msgstr "Детали пользователя"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:327
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:344
 msgid "Reset to defaults"
 msgstr "Сбросить по-умолчанию"
 
@@ -6487,15 +6511,15 @@ msgstr "Какие поля вы хотите использовать для о
 msgid "Choose fields"
 msgstr "Выберите поля"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:217
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:234
 msgid "Save as default view"
 msgstr "Сохранить как вид по-умолчанию"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Draw box to filter"
 msgstr "Нарисуйте \"коробку\" для фильтрации"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Cancel filter"
 msgstr "Отменить фильтр"
 
@@ -6523,19 +6547,19 @@ msgstr "Невозможно найти визуализацию"
 msgid "Could not display this chart with this data."
 msgstr "Невозможно отобразить график с текущими данным."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:526
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
 msgid "No results!"
 msgstr "Нет результатов!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:547
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
 msgid "Still Waiting..."
 msgstr "Ожидание..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:550
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
 msgid "This usually takes an average of {0}."
 msgstr "Это в среднем занимает {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:556
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Это несколько длинновато для дашборда)"
 
@@ -6694,19 +6718,19 @@ msgstr "Добавить правило"
 msgid "Update rule"
 msgstr "Обновить правило"
 
-#: frontend/src/metabase/visualizations/index.js:32
+#: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
 msgstr "Визуализация не задана"
 
-#: frontend/src/metabase/visualizations/index.js:37
+#: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
 msgstr "Визуализация должна определять статичную переменную 'identifier': "
 
-#: frontend/src/metabase/visualizations/index.js:43
+#: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
 msgstr "Визуализация с этим идентификатором уже зарегистрирована: "
 
-#: frontend/src/metabase/visualizations/index.js:71
+#: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
 msgstr "Нет визуализации для {0}"
 
@@ -6733,23 +6757,23 @@ msgstr "Ой! Данные из запроса не подходят к выбр
 " {1} данных"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:9
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:117
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:120
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:161
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:169
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:249
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:267
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "столбец"
@@ -6862,83 +6886,83 @@ msgstr "Ничего"
 msgid "Linear Interpolated"
 msgstr "Линейная интерполяция"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
 msgstr "Шкала оси абсцисс"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
 msgstr "Временная шкала"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:454
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
 msgid "Linear"
 msgstr "Линейный"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
 msgid "Power"
 msgstr "В степени"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:428
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:445
 msgid "Log"
 msgstr "Лог"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:441
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:430
 msgid "Histogram"
 msgstr "Гистограмма"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
 msgstr "Порядковый"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
 msgstr "Масштаб Y оси"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:462
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
 msgstr "Показать строку и метки по оси x"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:360
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:468
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:349
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
 msgid "Compact"
 msgstr "Компактно"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:469
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
 msgid "Rotate 45°"
 msgstr "Перевернуть на 45°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:459
 msgid "Rotate 90°"
 msgstr "Перевернуть на 90°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
 msgid "Show y-axis line and marks"
 msgstr "Показать строку и метки по оси y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:489
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Auto y-axis range"
 msgstr "Авто диапазон оси ординат"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:533
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:522
 msgid "Use a split y-axis when necessary"
 msgstr "Использовать разрывы школы ординат когда это необходимо"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:540
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:529
 msgid "Show label on x-axis"
 msgstr "Показать метку на X оси"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:546
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:535
 msgid "X-axis label"
 msgstr "Метка X оси"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:555
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:544
 msgid "Show label on y-axis"
 msgstr "Показать метку на Y оси"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:561
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:550
 msgid "Y-axis label"
 msgstr "Метка Y оси"
 
@@ -7064,23 +7088,23 @@ msgstr "Минимальная прозрачность"
 msgid "Max Zoom"
 msgstr "Максимальное приближение"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:231
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:234
 msgid "No relationships found."
 msgstr "Связи не найдены."
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:269
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:272
 msgid "via {0}"
 msgstr "через {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:347
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
 msgid "This {0} is connected to:"
 msgstr "{0} связано с:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "Object Detail"
 msgstr "Детали объекта"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:93
 msgid "object"
 msgstr "объект"
 
@@ -7471,7 +7495,7 @@ msgstr "У вас множество сохраненных запросов в 
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:149 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -9005,19 +9029,19 @@ msgstr "Может редактировать коллекцию и содерж
 msgid "Can view items in this collection"
 msgstr "Может смотреть содержимое этой коллекции"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:767
+#: frontend/src/metabase/admin/permissions/selectors.js:765
 msgid "Collection Access"
 msgstr "Доступ к коллекции"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:841
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "У этой группы есть разрешение на просмотре как минимум одного подмножества этой коллекции."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:848
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "У этой группы есть разрешение на редактирование как минимум одного подмножества этой коллекции."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:861
+#: frontend/src/metabase/admin/permissions/selectors.js:859
 msgid "View sub-collections"
 msgstr "Просмотр под-коллекций"
 
@@ -9025,7 +9049,7 @@ msgstr "Просмотр под-коллекций"
 msgid "Remember Me"
 msgstr "Запомнить меня"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:63
+#: frontend/src/metabase/components/BrowseApp.jsx:73
 msgid "X-ray this schema"
 msgstr "Просканировать эту схему"
 
@@ -9086,15 +9110,15 @@ msgstr "Metabase не смог ничего найти по этому запр�
 msgid "No metrics"
 msgstr "Нет метрик"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:31
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:41
 msgid "Aggregations"
 msgstr "Агрегации"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:32
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:42
 msgid "Operators"
 msgstr "Операторы"
 
-#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:30
+#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:35
 msgid "Custom fields"
 msgstr "Произвольные поля"
 
@@ -9260,7 +9284,7 @@ msgstr "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
 msgid "toucan_sightings"
 msgstr "toucan_sightings"
 
-#: src/metabase/driver/sparksql.clj
+#: src/metabase/models/collection.clj
 msgid "default"
 msgstr "по-умолчанию"
 
@@ -9288,10 +9312,10 @@ msgstr "Н/Д"
 msgid "Windows domain"
 msgstr "Домен Windows"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:539
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:545
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:554
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:560
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:528
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:534
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:543
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
 msgstr "Заголовки"
 
@@ -9326,9 +9350,9 @@ msgstr "Поделиться"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:286
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:294
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:302
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:319
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:324
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
@@ -9343,19 +9367,18 @@ msgstr "Поделиться"
 msgid "Display"
 msgstr "Отображение"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:461
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:476
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:502
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:532
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:402
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:465
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:483
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:521
 msgid "Axes"
 msgstr "Оси"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:212
-#: frontend/src/metabase/admin/settings/selectors.js:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:219
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:62
 msgid "Formatting"
@@ -9389,7 +9412,7 @@ msgstr "X-ray"
 msgid "Compare to the rest"
 msgstr "Cравнить с остальным"
 
-#: frontend/src/metabase/entities/databases/forms.js:16
+#: frontend/src/metabase/entities/databases/forms.js:18
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Использовать часовой пояс виртуальной Java машины (JVM)"
 
@@ -9418,24 +9441,24 @@ msgstr "Использовать часовой пояс JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Сейчас мы анализируем таблицы и поля чтобы помочь вам изучать свои данные"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
 msgid "Tip: "
 msgstr "Подсказка: "
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:237
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
 msgstr "Выберите тип валюты"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:300
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
 msgid "Field Type"
 msgstr "Тип поля"
 
-#: frontend/src/metabase/admin/routes.jsx:113
+#: frontend/src/metabase/admin/routes.jsx:118
 #: frontend/src/metabase/nav/containers/Navbar.jsx:267
 msgid "Troubleshooting"
 msgstr "Разрешение проблем"
 
-#: frontend/src/metabase/admin/settings/selectors.js:103
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Enable X-ray features"
 msgstr "Включить функции \"X-ray\""
 
@@ -9480,7 +9503,7 @@ msgstr "Продолжительность (мс)"
 msgid "Currency"
 msgstr "Валюта"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
 msgstr "Выберите пользователя или канал..."
 
@@ -9628,7 +9651,7 @@ msgstr "Стиль линии"
 msgid "Show dots on lines"
 msgstr "Показать точки на линии"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:348
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
@@ -9642,7 +9665,7 @@ msgstr "Какая ось?"
 msgid "Line + Bar"
 msgstr "Линия + Столбец"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
 msgid "line and bar chart"
 msgstr "линейные и Столбчатые диаграммы"
 
@@ -11089,7 +11112,7 @@ msgstr "Как эта метрика распределяется по разн�
 msgid "Sessions by page where the session began"
 msgstr "Сессии за страницей, где сессия началась"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:503
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -11458,7 +11481,7 @@ msgstr "Дублировать этот элемент"
 msgid "Archive this item"
 msgstr "Архивировать этот элемент"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:331
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:325
 msgid "Duplicate dashboard"
 msgstr "Дублировать Панель Управления"
 
@@ -11581,7 +11604,7 @@ msgstr[1] "Кварталы года"
 msgstr[2] "Кварталы года"
 msgstr[3] "Кварталы года"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
@@ -11599,8 +11622,8 @@ msgstr "[?]?"
 msgid "This"
 msgstr "Этот"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:97
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:137
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:136
 msgid "Invalid"
 msgstr "Некорректный"
 
@@ -12364,6 +12387,7 @@ msgstr "Вот ваши {0} самые последних карточек:"
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
 msgstr "Не могли бы вы быть более конкретным или использовать ID? Я нашел  карточки с именами, которые совпадают с:"
 
+#: src/metabase/driver/common/parameters/values.clj
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
 msgstr "Карточка {0} не найдена."
@@ -12472,11 +12496,11 @@ msgstr "Пропустить инструкцию"
 msgid "Archive this?"
 msgstr "Архивировать это?"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:243
+#: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
 msgstr "Узнайте о ваших данных"
 
-#: frontend/src/metabase/entities/databases/forms.js:20
+#: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
 msgstr "Использовать DNS SRV для подключения"
 
@@ -12486,7 +12510,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "Использование этой опции требует предоставить FQDN хост. При подключении к Atlas cluster, вам потребуется разрешить эту опцию. Если вы не знаете что это значит - оставьте отключенным."
 
-#: frontend/src/metabase/entities/databases/forms.js:204
+#: frontend/src/metabase/entities/databases/forms.js:273
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Автоматически запускать запросы при простой фильтрации и суммировании"
 
@@ -12510,11 +12534,11 @@ msgstr "Все результаты"
 msgid "Our Analytics"
 msgstr "Наша аналитика"
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:513
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
 msgstr "Добавочная сумма всех значений колонки.\\nнапример, общая выручка по времени."
 
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
 msgstr "Добавочное количество строк.\\nнапример, количество продаж по времени."
 
@@ -12524,7 +12548,7 @@ msgstr "Добавочное количество строк.\\nнапример
 msgid "Filter"
 msgstr "Фильтр"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:50
 msgid "record"
 msgid_plural "records"
 msgstr[0] "запись"
@@ -12540,27 +12564,27 @@ msgstr "Просмотр данных"
 msgid "Write SQL"
 msgstr "Написать SQL"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:83
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
 msgstr "Простой запрос"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:84
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:87
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
 msgstr "Выберите данные, просмотрите, отфильтруйте, суммируйте и визуализируйте их."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:95
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:98
 msgid "Custom question"
 msgstr "Пользовательский запрос"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:96
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:99
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Используйте расширенный редактор записной книжки, чтобы объединять данные, создавать пользовательские столбцы, выполнять математические операции и многое другое."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Basic Metrics"
 msgstr "Базовые метрики"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:322
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
 msgid "Custom…"
 msgstr "Произвольный..."
 
@@ -12629,15 +12653,15 @@ msgstr "Выберите колонки для группировки"
 msgid "Pick your starting data"
 msgstr "Выберите начальные данные"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select None"
 msgstr "Отменить выбор"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select All"
 msgstr "Выбрать все"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:151
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:152
 msgid "Pick a table..."
 msgstr "Выберите таблицу..."
 
@@ -12764,15 +12788,15 @@ msgstr "Добавить метрику"
 #: frontend/src/metabase/lib/core.js:137 frontend/src/metabase/lib/core.js:142
 #: frontend/src/metabase/lib/core.js:147 frontend/src/metabase/lib/core.js:152
 #: frontend/src/metabase/lib/core.js:157 frontend/src/metabase/lib/core.js:162
-#: frontend/src/metabase/user/components/UserSettings.jsx:63
+#: frontend/src/metabase/user/components/UserSettings.jsx:64
 msgid "Profile"
 msgstr "Профиль"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:560
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "Это обычно довольно быстро, но, похоже, сейчас потребует чуть больше времени."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
 msgid "Combo"
 msgstr "Комбо"
 
@@ -12788,11 +12812,11 @@ msgstr "Тренд"
 msgid "Boolean"
 msgstr "Логическое"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:62
 msgid "Unknown Segment"
 msgstr "Неизвестный сегмент"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:73
 msgid "Unknown Filter"
 msgstr "Неизвестный фильтр"
 
@@ -12922,6 +12946,7 @@ msgstr "Использование НОВОГО СОЗДАННОГО загру�
 msgid "Failed to copy file"
 msgstr "Невозможно скопировать файл"
 
+#. check that the URL is valid
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
 msgstr "Некорректный URL сайта: {0}"
@@ -13196,7 +13221,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Выберите столбцы которые хотите включить"
 
-#: frontend/src/metabase/entities/databases/forms.js:205
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Когда это включено, Metabase будет автоматически запускать запросы, когда пользователи выполняют простые исследования с помощью кнопок Итоги и Фильтр при просмотре таблицы или диаграммы. Вы можете отключить это, если запросы к этой базе данных выполняются медленно. Этот параметр не влияет на детализацию или запросы SQL."
 
@@ -13234,7 +13259,7 @@ msgstr "Ошибка определения ожидаемых столбцов 
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "Необрабатываемое исключение, ожидаем прослойку  `catch-exceptions` для обработки."
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:125
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
 msgid "Diagnostic Info"
 msgstr "Диагностическая информация"
 
@@ -13258,11 +13283,11 @@ msgstr "При входе в Google произошла ошибка. Пожал�
 msgid "Sign in with email"
 msgstr "Войти с помощью Email"
 
-#: frontend/src/metabase/entities/databases/forms.js:21
+#: frontend/src/metabase/entities/databases/forms.js:23
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "Для использования этого параметра необходимо, чтобы указанный хост являлся полным доменным именем. При подключении к кластеру Atlas может потребоваться включить эту опцию. Если вы не знаете, что это значит, оставьте это отключенным."
 
-#: frontend/src/metabase/entities/databases/forms.js:213
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "По умолчанию Metabase выполняет легкую часовую синхронизацию и интенсивное ежедневное сканирование значений полей. Если у вас большая база данных, мы рекомендуем включить ее и проверить, когда и как часто происходит сканирование значений поля."
 
@@ -13330,11 +13355,11 @@ msgstr "Не включать"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "Это поле не будет отображаться или выбираться в вопросах, созданных с помощью интерфейсов GUI. Он все еще будет доступен в SQL / нативных запросах."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:512
 msgid "Cumulative sum"
 msgstr "Накопленная сумма"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Standard deviation"
 msgstr "Стандартное отклонение"
 
@@ -13346,23 +13371,23 @@ msgstr "должно быть длиной не менее {0} символов"
 msgid "Must be at least {0} characters long"
 msgstr "Должно быть длиной не менее {0} символов"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:389
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:82
 msgid "Name (required)"
 msgstr "Имя (обязательно)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:556
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
 msgid "Run selected text"
 msgstr "Запустить выделенный текст"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:557
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
 msgid "Run query"
 msgstr "Выполнить запрос"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(⌘ + enter)"
 msgstr "(⌘ + enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + enter)"
 
@@ -13374,7 +13399,7 @@ msgstr "Здесь появятся ваши результаты"
 msgid "You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question."
 msgstr "Изменения не будут учтены в сохраненный запрос, если не нажмете «Сохранить» и не решите заменить исходный запрос."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:199
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:200
 msgid "There aren't any filter widgets for this type of field yet."
 msgstr "Для этого типа поля еще нет виджетов фильтра."
 
@@ -13410,19 +13435,19 @@ msgstr "Линия достижения"
 msgid "Trend line"
 msgstr "Линия тренда"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:320
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:317
 msgid "Show values on data points"
 msgstr "Показать значения на точках данных"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:334
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:325
 msgid "Values to show"
 msgstr "Значения, чтобы показать"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:342
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:332
 msgid "As many as can fit nicely"
 msgstr "Столько, сколько может поместиться"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:343
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
 msgid "All"
 msgstr "Все"
 
@@ -13714,31 +13739,31 @@ msgstr "Числа"
 msgid "No mappable groups"
 msgstr "Нет связанных групп"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:107
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
 msgstr "Документация Metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
 msgstr "Включает руководство по устранению неполадок"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:112
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
 msgid "Post on the Metabase support forum"
 msgstr "Сообщение на форуме поддержки Metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:114
 msgid "A community forum for all things Metabase"
 msgstr "Форум сообщества для всех аспектов Metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:117
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
 msgid "File a bug report"
 msgstr "Отправить отчет об ошибке"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:119
 msgid "Create a GitHub issue (includes the diagnostic info below)"
 msgstr "Создать проблему на GitHub (включая диагностическую информацию ниже)"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:127
 msgid "Please include these details in support requests. Thank you!"
 msgstr "Пожалуйста, включите эти детали в запросы поддержки. Спасибо!"
 
@@ -13766,38 +13791,40 @@ msgstr "Совпадений не найдено"
 msgid "Submit"
 msgstr "Разместить"
 
-#: frontend/src/metabase/entities/databases/forms.js:13
+#: frontend/src/metabase/entities/databases/forms.js:15
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host. This option also provides an extra layer of security when a VPN is not available. Enabling this is usually slower than a direct connection."
 msgstr "Доступ к некоторым базам данных возможен только при подключении через промежуточный хост SSH. Эта опция также обеспечивает дополнительный уровень безопасности, когда VPN недоступна. Использование этого режима обычно медленнее, чем прямое соединение с базой."
 
-#: frontend/src/metabase/entities/databases/forms.js:17
+#: frontend/src/metabase/entities/databases/forms.js:19
 msgid "We suggest you leave this off unless you're doing manual timezone casting in many or most of your queries with this data."
 msgstr "Мы рекомендуем вам не включать эту опцию, если вы не выполняете ручное приведение часового пояса во многих или большинстве ваших запросов с этими данными."
 
-#: frontend/src/metabase/entities/databases/forms.js:93
+#: frontend/src/metabase/entities/databases/forms.js:128
 msgid "{0} to get an auth code."
 msgstr "{0} чтобы получить код авторизации."
 
-#: frontend/src/metabase/entities/databases/forms.js:101
+#: frontend/src/metabase/entities/databases/forms.js:136
+#: src/metabase/models/collection.clj
 msgid "or"
 msgstr "или"
 
-#: frontend/src/metabase/entities/databases/forms.js:159
-#: frontend/src/metabase/entities/databases/forms.js:197
-#: frontend/src/metabase/entities/users/forms.js:44
+#: frontend/src/metabase/entities/databases/forms.js:39
+#: frontend/src/metabase/entities/databases/forms.js:226
+#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "required"
 
-#: frontend/src/metabase/entities/databases/forms.js:188
+#: frontend/src/metabase/entities/databases/forms.js:257
 msgid "Database type"
 msgstr "Тип базы данных"
 
-#: frontend/src/metabase/entities/databases/forms.js:222
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Это легкий процесс, который проверяет наличие обновлений схемы этой базы данных. В большинстве случаев вполне можно использовать этот режим для синхронизации каждый час."
 
-#: frontend/src/metabase/entities/databases/forms.js:230
+#: frontend/src/metabase/entities/databases/forms.js:299
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Метабаза может сканировать значения, присутствующие в каждом поле в этой базе данных, чтобы включить фильтры флажков на сводных панелях и в вопросах. Это может быть несколько ресурсоемким процессом, особенно если у вас ОЧЕНЬ большая база данных."
 
@@ -13805,15 +13832,15 @@ msgstr "Метабаза может сканировать значения, п�
 msgid "Collection"
 msgstr "Коллекция"
 
-#: frontend/src/metabase/entities/users/forms.js:40
+#: frontend/src/metabase/entities/users/forms.js:55
 msgid "Confirm your password"
 msgstr "Подтвердите ваш пароль"
 
-#: frontend/src/metabase/entities/users/forms.js:45
+#: frontend/src/metabase/entities/users/forms.js:60
 msgid "passwords do not match"
 msgstr "пароли не совпадают"
 
-#: frontend/src/metabase/entities/users/forms.js:71
+#: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
 msgstr "Удивительный отдел"
 
@@ -13853,328 +13880,324 @@ msgid "Returns the average of the values in the column."
 msgstr "Возвращает среднее значение в столбце."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:18
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
 msgid "The column whose values to average."
 msgstr "Столбец, значения которого для усреднения."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "start"
 msgstr "начало"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "end"
 msgstr "конец"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
 msgid "Checks a date or numeric column's values to see if they're within the specified range."
 msgstr "Проверяет дату или числовые значения столбца, чтобы увидеть, находятся ли они в указанном диапазоне."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
 msgstr "Рейтинг"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:24
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:98
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
 msgid "condition"
 msgstr "условие"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
 msgid "output"
 msgstr "вывод"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Проверяет список случаев и возвращает соответствующее значение первого истинного случая с необязательным значением по умолчанию, если больше ничего не встречается."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
 msgid "Weight"
 msgstr "Вес"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
 msgid "Large"
 msgstr "Большой"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
 msgid "Medium"
 msgstr "Средний"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
 msgid "Small"
 msgstr "Малый"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
 msgid "Something that should evaluate to true or false."
 msgstr "Что-то, что следует оценивать как истинное или ложное."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:54
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "Значение, которое будет возвращено, если предыдущее условие истинно."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:62
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "value1"
 msgstr "значение1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:74
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
 msgid "value2"
 msgstr "значение2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Просматривает значения в каждом аргументе по порядку и возвращает первое ненулевое значение для каждой строки."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:56
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
 msgid "Comments"
 msgstr "Комментарии"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
 msgid "Notes"
 msgstr "Заметки"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
 msgid "No comments"
 msgstr "Нет комментариев"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
 msgid "A column or value."
 msgstr "Столбец или значение."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:65
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:77
 msgid "If value1 is empty, value2 gets returned if it's not empty, and so on."
 msgstr "Если значение1 пусто, значение2 возвращается, если оно не пустое и т.д."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 msgid "Combines two or more strings of text together."
 msgstr "Объединяет две или более строки текста вместе."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
 msgid "Last Name"
 msgstr "Фамилия"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 msgid "First Name"
 msgstr "Имя"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
 msgstr "Значение2 будет добавлено в конце этого."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
 msgstr "Это будет добавлено в конец значения1."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
 msgid "string1"
 msgstr "строка1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
 msgid "string2"
 msgstr "строка2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:80
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Проверяет, содержит ли string1 строку string2."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:284
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
 msgid "Status"
 msgstr "Статус"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 msgid "Pass"
 msgstr "Pass"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
 msgstr "Содержимое этой строки будет проверено."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
 msgid "The string of text to look for."
 msgstr "Строка текста для поиска."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:90
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:116
 msgid "Returns the count of rows in the source data."
 msgstr "Возвращает количество строк в исходных данных."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Only counts rows where the condition is true."
 msgstr "Подсчитывает только те строки, в которых выполняется условие."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:97
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:261
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
 msgid "Subtotal"
 msgstr "Подытог"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
 msgid "The additive total of rows across a breakout."
 msgstr "The additive total of rows across a breakout."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:110
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
 msgid "The rolling sum of a column across a breakout."
 msgstr "The rolling sum of a column across a breakout."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:113
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:268
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
 msgstr "Столбец для суммирования."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
 msgid "The number of distinct values in this column."
 msgstr "Количество различных значений в этом столбце."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "The column whose distinct values to count."
 msgstr "Столбец, чьи отдельные значения считать."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:128
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:145
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:153
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:201
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:274
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
 msgid "text"
 msgstr "текст"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:130
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:223
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
 msgid "comparison"
 msgstr "сравнение"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Возвращает true, если конец текста совпадает с текстом сравнения."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "Appetite"
 msgstr "Аппетит"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "hungry"
 msgstr "голоден"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 msgid "A column or string of text to check."
 msgstr "Столбец или строка текста для проверки."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
 msgid "The string of text that the original text should end with."
 msgstr "Строка текста, которой должен заканчиваться исходный текст."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 msgid "regular_expression"
 msgstr "регулярное_выражение"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:136
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Извлекает соответствующие подстроки согласно регулярному выражению."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:137
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
 msgid "Address"
 msgstr "Адрес"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 msgid "The column or string of text to search though."
 msgstr "Столбец или строка текста для поиска."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
 msgid "The regular expression to match."
 msgstr "Регулярное выражение для соответствия."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the string of text in all lowercase."
 msgstr "Возвращает строку текста в нижнем регистре."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:149
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to lowercase."
 msgstr "Столбец со значениями для преобразования в нижний регистр."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:154
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 msgid "Removes leading whitespace from a string of text."
 msgstr "Удаляет начальные пробелы из строки текста."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:157
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column with values you want to trim."
 msgstr "Столбец со значениями, которые вы хотите обрезать."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "Returns the largest value found in the column."
 msgstr "Возвращает наибольшее значение, найденное в столбце."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
 msgid "Age"
 msgstr "Период"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:165
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
 msgid "The numeric column whose maximum you want to find."
 msgstr "Числовой столбец, максимум которого вы хотите найти."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:170
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "Returns the smallest value found in the column."
 msgstr "Возвращает наименьшее значение, найденное в столбце."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
 msgid "Salary"
 msgstr "Оплата"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:173
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
 msgid "The numeric column whose minimum you want to find."
 msgstr "Числовой столбец, минимум которого вы хотите найти."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:181
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:242
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
 msgid "position"
 msgstr "position"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:194
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
 msgid "length"
 msgstr "длина"
 
@@ -14183,7 +14206,7 @@ msgstr "длина"
 msgid "new_text"
 msgstr "новый_текст"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:187
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
 msgid "Replaces a part of the input text with new text."
 msgstr "Заменяет часть входного текста новым текстом."
 
@@ -14195,7 +14218,7 @@ msgstr "ID заказа"
 msgid "Updated Part of ID"
 msgstr "Обновленная часть c ID"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
 msgid "The text that will be modified."
 msgstr "Текст, который будет изменен."
 
@@ -14211,87 +14234,87 @@ msgstr "Количество символов для замены."
 msgid "The text to use in the replacement."
 msgstr "Текст для использования в замене."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Удаляет завершающие пробелы из строки текста."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:210
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Возвращает процент строк в данных, соответствующих условию, в виде десятичной дроби."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:218
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Возвращает true, если начало текста совпадает с текстом сравнения."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Course Name"
 msgstr "Название курса"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Computer Science"
 msgstr "Компьютерная наука"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
 msgid "The string of text that the original text should start with."
 msgstr "Строка текста, с которой должен начинаться исходный текст."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:229
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
 msgid "Calculates the standard deviation of the column."
 msgstr "Вычисляет стандартное отклонение в столбце."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:230
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
 msgid "Population"
 msgstr "Population"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
 msgid "A numeric column."
 msgstr "Числовой столбец."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
 msgid "Returns a portion of the supplied text."
 msgstr "Возвращает часть предоставленного текста."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:241
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:313
 msgid "The text to return a portion of."
 msgstr "Текст для возврата части."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
 msgid "The position to start copying characters."
 msgstr "Позиция для начала копирования символов."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:245
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
 msgid "The number of characters to return."
 msgstr "Количество возвращаемых символов."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
 msgid "Adds up all the values of the column."
 msgstr "Суммирует все значения столбца."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:253
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
 msgid "The numeric column to sum."
 msgstr "Числовой столбец для суммирования."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Суммирует значения в столбце, где строки соответствуют условию."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
 msgid "Order Status"
 msgstr "Статус заказа"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
 msgid "Valid"
 msgstr "Действительный"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Удаляет начальные и конечные пробелы из строки текста."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
 msgid "Returns the string of text in all upper case."
 msgstr "Возвращает строку текста в верхнем регистре."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
 msgid "The column with values to convert to upper case."
 msgstr "Столбец со значениями для преобразования в верхний регистр."
 
@@ -14363,39 +14386,39 @@ msgstr "Спасибо за использование Metabase"
 msgid "Powered by {0}"
 msgstr "Работает на {0}"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:191
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
 msgid "To:"
 msgstr "Кому:"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:40
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
 msgstr "Этот запрос нельзя использовать, потому что он основан на другой базе данных."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:44
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:43
 msgid "Couldn't find a saved question with that ID number."
 msgstr "Не удалось найти сохраненный запрос с этим идентификационным номером."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:55
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:54
 msgid "Pick a saved question"
 msgstr "Выберите сохраненный запрос"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:57
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:56
 msgid "Pick a different question"
 msgstr "Выберите другой запрос"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:62
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:61
 msgid "Loading…"
 msgstr "Загрузка..."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:79
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:78
 msgid "Question #…"
 msgstr "Запрос #… "
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:81
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
 msgstr "Запрос #{0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:115
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
 msgstr "Последний раз редактировалось {0}"
 
@@ -14407,11 +14430,11 @@ msgstr "{0} создает переменную в этом шаблоне за�
 msgid "Giving a variable the \"Field Filter\" type allows you to link questions to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "Задавая переменную типа «Фильтр поля», вы можете связать запросы с виджетами фильтра приборной панели или использовать больше типов виджетов фильтра в своем запросе SQL. Переменная Field Filter вставляет SQL, аналогичный сгенерированному построителем запросов GUI, при добавлении фильтров в существующие столбцы."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:131
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
 msgstr "Имя переменной"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:217
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:218
 msgid "Filter widget label"
 msgstr "Фильтр метки виджета"
 
@@ -14443,11 +14466,11 @@ msgstr "В заголовке столбца"
 msgid "In every table cell"
 msgstr " In every table cell "
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:351
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:341
 msgid "Value formatting"
 msgstr "Форматирование значения"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:361
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
 msgid "Full"
 msgstr "Полностью"
 
@@ -14775,4 +14798,483 @@ msgstr "Ошибка при создании информации для сто�
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandonment email!"
 msgstr "Отправка письма об отказе!"
+
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
+msgstr "Вы можете создать сохраненные метрики, чтобы добавить именованный параметр метрики. Сохраненные метрики включают тип агрегации, агрегированное поле и, при необходимости, любой фильтр, который вы добавляете. Например, вы можете использовать это, чтобы создать что-то вроде официального способа расчета «средней цены» для таблицы «Заказы»."
+
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:105
+msgid "Select and add filters to create your new segment."
+msgstr "Выберите и добавьте фильтры для создания нового сегмента."
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+msgid "Alphabetical"
+msgstr "По алфавиту"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+msgid "Smart"
+msgstr "Умная"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+msgid "Column order: {0}"
+msgstr "Порядок столбцов: {0}"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
+msgid "Unhide all"
+msgstr "Отобразить все"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:204
+msgid "Hide all"
+msgstr "Скрыть все"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:206
+msgid "Unhide"
+msgstr "Скрыть"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:22
+msgid "New metric"
+msgstr "Новая метрика"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:45
+msgid "Create metrics to add them to the Summarize dropdown in the query builder"
+msgstr "Создайте метрики, чтобы добавить их в раскрывающийся список «Суммирование» в построителе запросов."
+
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:22
+msgid "New segment"
+msgstr "Новый сегмент"
+
+#: frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx:71
+msgid "Filter by table"
+msgstr "Фильтр по таблице"
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:64
+msgid "Checking HTTPS..."
+msgstr "Проверка HTTPS..."
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:66
+msgid "It looks like HTTPS is not properly configured"
+msgstr "Фильтр по таблице"
+
+#: frontend/src/metabase/admin/settings/selectors.js:57
+msgid "Redirect to HTTPS"
+msgstr "Редирект на HTTPS"
+
+#: frontend/src/metabase/admin/settings/selectors.js:219
+msgid "Localization"
+msgstr "Локализация"
+
+#: frontend/src/metabase/admin/settings/selectors.js:222
+msgid "Instance language"
+msgstr "Язык экземпляра"
+
+#: frontend/src/metabase/admin/settings/selectors.js:237
+msgid "Localization options"
+msgstr "Варианты локализации"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:51
+msgid "This database doesn't have any tables."
+msgstr "В этой базе данных нет таблиц."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
+msgid "This field only accepts a single value because it's used in a SQL query."
+msgstr "Это поле принимает только одно значение, поскольку оно используется в запросе SQL."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:17
+msgid "Service Accounts"
+msgstr "Сервисные аккаунты"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:26
+msgid "Metabase connects to Big Query via {0}."
+msgstr "Metabase подключается к BigQuery через {0}."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:29
+msgid "Continue using an OAuth application to connect"
+msgstr "Продолжайте использовать приложение OAuth для подключения"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:43
+msgid "We recommend switching to use {0} instead of an OAuth application to connect to BigQuery"
+msgstr "Мы рекомендуем переключиться на использование {0} вместо приложения OAuth для подключения к BigQuery"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:48
+msgid "Connect to a Service Account instead"
+msgstr "Вместо этого подключитесь к сервисной учетной записи"
+
+#: frontend/src/metabase/entities/databases/forms.js:44
+msgid "invalid JSON"
+msgstr " Не валидный JSON "
+
+#: frontend/src/metabase/entities/databases/forms.js:50
+msgid "SSH private key"
+msgstr "Закрытый ключ SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:51
+msgid "Paste the contents of your ssh private key here"
+msgstr "Вставьте содержимое вашего закрытого ключа ssh сюда"
+
+#: frontend/src/metabase/entities/databases/forms.js:55
+msgid "Passphrase for the SSH private key"
+msgstr "Пароль для закрытого ключа SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:58
+msgid "SSH Authentication"
+msgstr "SSH аутентификация"
+
+#: frontend/src/metabase/entities/databases/forms.js:60
+msgid "SSH Key"
+msgstr " SSH ключ"
+
+#: frontend/src/metabase/entities/databases/forms.js:65
+msgid "Server SSL certificate chain"
+msgstr "Цепочка сертификатов SSL сервера"
+
+#: frontend/src/metabase/entities/databases/forms.js:66
+msgid "Paste the contents of the server's SSL certificate chain here"
+msgstr "Вставьте содержимое цепочки SSL-сертификатов сервера сюда"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:11
+msgid "Paste a connection string"
+msgstr "Вставить строку подключения"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:12
+msgid "Fill out individual fields"
+msgstr "Заполните отдельные поля"
+
+#: frontend/src/metabase/entities/snippets.js:14
+msgid "Enter some SQL here so you can reuse it later"
+msgstr "Введите здесь какой-нибудь SQL, чтобы вы могли использовать его позже"
+
+#: frontend/src/metabase/entities/snippets.js:24
+msgid "Give your snippet a name"
+msgstr "Дайте вашему фрагменту имя"
+
+#: frontend/src/metabase/entities/snippets.js:25
+msgid "Current Customers"
+msgstr "Текущие пользователи"
+
+#: frontend/src/metabase/entities/snippets.js:30
+msgid "Add a description"
+msgstr "Добавить описание"
+
+#: frontend/src/metabase/entities/users/forms.js:37
+msgid "Use site default"
+msgstr "Использовать сайт по умолчанию"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+msgid "find"
+msgstr "найти"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+msgid "replace"
+msgstr "заменить"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+msgid "The text to find."
+msgstr "Текст для поиска"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "The text to use as the replacement."
+msgstr "Текст для замены"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+msgid "Editing {0}"
+msgstr "Редактирование {0}"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+msgid "Create your new snippet"
+msgstr "Создайте свой новый фрагмент"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+msgid "Archived snippets"
+msgstr "Архивные фрагменты"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+msgid "Snippets are reusable bits of SQL"
+msgstr "Фрагменты для многократного использования в SQL"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+msgid "Create a snippet"
+msgstr "Создать фрагмент"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+msgid "Snippets"
+msgstr "Фрагменты"
+
+#: frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx:15
+msgid "SQL Snippets"
+msgstr "SQL фрагменты"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:38
+msgid "Your language is set to {0}"
+msgstr "Ваш язык установлен на {0}"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:50
+msgid "What's your preferred language?"
+msgstr "Какой ваш предпочтительный язык?"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:54
+msgid "This language will be used throughout Metabase and will be the default for new users."
+msgstr "Этот язык будет использоваться во всей Metabase и будет использоваться по умолчанию для новых пользователей."
+
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:159
+msgid "We filtered out {0} row(s) containing null values."
+msgstr "Мы отфильтровали {0} строк, содержащих нулевые значения."
+
+#: frontend/src/metabase/visualizations/lib/settings/series.js:133
+msgid "Show values for this series"
+msgstr "Показать значения для этой серии"
+
+#: src/metabase/api/card.clj
+msgid "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
+msgstr "Средняя продолжительность выполнения вопроса: {0}; используя '' magic '' TTL из {1}"
+
+#: src/metabase/api/native_query_snippet.clj
+msgid "A snippet with that name already exists. Please pick a different name."
+msgstr "Фрагмент с таким именем уже существует. Пожалуйста, выберите другое имя."
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Metric]"
+msgstr "[Неизвестная метрика]"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Segment]"
+msgstr "[Неизвестный сегмент]"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error writing error to output stream"
+msgstr "Ошибка записи ошибки в выходной поток"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Caught unexpected Exception in streaming response body"
+msgstr "Появилось неожиданное исключение в теле ответа"
+
+#: src/metabase/async/streaming_response.clj
+msgid "bound-fn caught unexpected Exception"
+msgstr "bound-fn поймал неожиданное исключение"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error determining whether HTTP request was canceled"
+msgstr "Ошибка определения отмены HTTP-запроса"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Check cancelation status timed out after {0}"
+msgstr "Время отмены статуса проверки истекло после {0}"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Unexpected exception in do-f-async"
+msgstr "Неожиданное исключение в do-f-async"
+
+#: src/metabase/async/streaming_response.clj src/metabase/server.clj
+msgid "Unexpected exception writing error response"
+msgstr "Неожиданная ошибка записи исключения"
+
+#: src/metabase/driver/common.clj
+msgid "Server certificate not trusted - did you specify the correct SSL certificate chain?"
+msgstr "Сертификат сервера не является доверенным - вы указали правильную цепочку сертификатов SSL?"
+
+#: src/metabase/driver/common.clj
+msgid "Server appears to require SSL - please enable SSL above"
+msgstr "Сервер, кажется, требует SSL - пожалуйста, включите SSL выше"
+
+#: src/metabase/driver/common.clj
+msgid "Username"
+msgstr "Имя пользователя"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Don''t know how to parse parameter of type {0}"
+msgstr "Не знаю, как разобрать параметр типа {0}"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Invalid :card parameter: missing `:card-id`"
+msgstr "Неверный: параметр карты: потерян`: идентификатор карты`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Unable to resolve Snippet: missing `:snippet-id`"
+msgstr "Невозможно разрешить фрагмент: отсутствует `: идентификатор фрагмента`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Snippet {0} {1} not found."
+msgstr "Фрагмент {0} {1} не найден."
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error determining value for parameter"
+msgstr "Ошибка определения значения для параметра"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error building query parameter map"
+msgstr "Ошибка построения карты параметров запроса"
+
+#: src/metabase/middleware/log.clj
+msgid "ASYNC"
+msgstr "АСИНХРОННЫЙ"
+
+#: src/metabase/middleware/log.clj
+msgid "{0} ({1} DB calls)"
+msgstr "{0} ({1} вызовы БД)"
+
+#: src/metabase/middleware/log.clj
+msgid "App DB connections: {0}/{1}"
+msgstr "Соединения с БД приложения: {0} / {1}"
+
+#: src/metabase/middleware/log.clj
+msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
+msgstr "Потоки Jetty: {0} / {1} ({2} бездействует, {3} в очереди)"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} total active threads)"
+msgstr "({0} всего активных тем)"
+
+#: src/metabase/middleware/log.clj
+msgid "Queries in flight: {0}"
+msgstr "Запросы в полете: {0}"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} queued)"
+msgstr "({0} в очереди)"
+
+#: src/metabase/models/collection.clj
+msgid "Collection must be in the same namespace as its parent"
+msgstr "Коллекция должна находиться в том же пространстве имен, что и ее родитель"
+
+#: src/metabase/models/collection.clj
+msgid "Personal Collections must be in the default namespace"
+msgstr "Личные коллекции должны находиться в пространстве имен по умолчанию"
+
+#: src/metabase/models/collection.clj
+msgid "You cannot move a Collection to a different namespace once it has been created."
+msgstr "Вы не можете переместить коллекцию в другое пространство имен после ее создания."
+
+#: src/metabase/models/collection.clj src/metabase/models/permissions.clj
+msgid "Collection does not exist."
+msgstr "Коллекция не существует."
+
+#: src/metabase/models/collection.clj
+msgid "A {0} can only go in Collections in the {1} namespace."
+msgstr "{0} может входить только в коллекции в пространстве имен {1}."
+
+#: src/metabase/models/database.clj
+msgid "Error sending database deletion notification"
+msgstr "Ошибка отправки уведомления об удалении базы данных"
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "You cannot update the creator_id of a NativeQuerySnippet."
+msgstr "Вы не можете обновить creator_id для NativeQuerySnippet."
+
+#: src/metabase/models/setting.clj
+msgid "Error fetching value of Setting"
+msgstr "Ошибка при получении значения настройки"
+
+#: src/metabase/public_settings.clj
+msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
+msgstr "Язык, который следует использовать для пользовательского интерфейса Metabase, системных писем, пульсов и оповещений."
+
+#: src/metabase/public_settings.clj
+msgid "This is also the default language for all users, which they can change from their own account settings."
+msgstr "Это также язык по умолчанию для всех пользователей, который они могут изменить в настройках своей учетной записи."
+
+#: src/metabase/public_settings.clj
+msgid "Invalid locale {0}"
+msgstr "Неверная локаль {0}"
+
+#: src/metabase/public_settings.clj
+msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
+msgstr "Принудительно весь трафик использовать HTTPS через перенаправление, если URL сайта является HTTPS"
+
+#: src/metabase/public_settings.clj
+msgid "Cannot redirect requests to HTTPS unless `site-url` is HTTPS."
+msgstr "Невозможно перенаправить запросы к HTTPS, если `site-url` не является HTTPS."
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error registering fonts: Metabase will not be able to send Pulses."
+msgstr "Ошибка регистрации шрифтов: metabase не сможет отправлять пульсы."
+
+#: src/metabase/pulse/render/png.clj
+msgid "This is a known issue with certain JVMs. See {0} and for more details."
+msgstr "Это известная проблема с некоторыми JVM. Смотрите {0} и для более подробной информации."
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error rendering Pulse"
+msgstr "Ошибка рендеринга пульса"
+
+#: src/metabase/query_processor/context/default.clj
+msgid "Query timed out after {0}, raising timeout exception."
+msgstr "Тайм-аут запроса после {0}, исключение тайм-аута."
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "No fields found for table {0}."
+msgstr "Поля для таблицы {0} не найдены."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Case"
+msgstr "случай"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Variance of {0}"
+msgstr "Дисперсия {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Median of {0}"
+msgstr "Медиана {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "{0}th percentile of {1}"
+msgstr "{0} й процентиль {1}"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Not caching results: results are larger than {0} KB"
+msgstr "Не кэшировать результаты: результаты больше {0} КБ"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Cannot cache results: expected byte array, got {0}"
+msgstr "Невозможно кэшировать результаты: ожидаемый байтовый массив, получено {0}"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Request is closed; no one to return cached results to"
+msgstr "Запрос закрыт; никто не вернет кэшированные результаты"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Error attempting to fetch cached results for query with hash {0}"
+msgstr "Ошибка при попытке получить кэшированные результаты для запроса с хэшем {0}"
+
+#: src/metabase/query_processor/middleware/cache_backend/db.clj
+msgid "Error preparing statement to fetch cached query results"
+msgstr "Ошибка при подготовке оператора для получения результатов кэшированного запроса"
+
+#: src/metabase/query_processor/middleware/catch_exceptions.clj
+msgid "Error processing query: {0}"
+msgstr "Ошибка обработки запроса: {0}"
+
+#: src/metabase/server.clj
+msgid "Unexpected exception in endpoint"
+msgstr "Неожиданное исключение в конечной точке"
+
+#: src/metabase/server.clj
+msgid "Unexpected Exception in API request handler"
+msgstr "Неожиданное исключение в обработчике запросов API"
+
+#: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+msgid "Error reducing {0}"
+msgstr "Ошибка уменьшения {0}"
+
+#: src/metabase/sync/analyze/fingerprint/insights.clj
+msgid "Error generating timeseries insight keyed by: {0}"
+msgstr "Ошибка генерации информации о временных сериях с ключом: {0}"
+
+#: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
+msgstr "Позиция базы данных {0} изменена с '' {1} '' на '' {2} ''."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Unscheduling task for Database {0}: trigger: {1}"
+msgstr "Отмена планирования для базы данных {0}: триггер: {1}"
+
+#: src/metabase/util/schema.clj
+msgid "value must be a keyword or string."
+msgstr "значение должно быть ключевым словом или строкой."
+
+#: src/metabase/util/schema.clj
+msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
+msgstr "Строка должна быть действительным двухбуквенным языком ISO или кодом страны-страны, например, 'en' или 'en_US'."
 

--- a/locales/sk.po
+++ b/locales/sk.po
@@ -29,13 +29,14 @@ msgid "Select a database type"
 msgstr "Vyberte typ databázy"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:411
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:154
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -48,7 +49,7 @@ msgstr "Uložiť"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "Ak chcete urobiť niečo zo svojej analýzy, Metabase potrebuje prehľadať vašu databázu. Pravidelne ju znova preskúmavame, aby boli metadáta aktuálne. Nižšie môžete určiť, kedy sa budú skenovania opakovať."
 
-#: frontend/src/metabase/entities/databases/forms.js:221
+#: frontend/src/metabase/entities/databases/forms.js:290
 msgid "Database syncing"
 msgstr "Databáza sa synchronizuje"
 
@@ -63,7 +64,7 @@ msgstr "Toto je proces, ktorý kontroluje aktualizácie schémy tejto databázy.
 msgid "Scan"
 msgstr "Skenovať"
 
-#: frontend/src/metabase/entities/databases/forms.js:228
+#: frontend/src/metabase/entities/databases/forms.js:297
 msgid "Scanning for Filter Values"
 msgstr "Vyhľadávanie hodnôt filtra"
 
@@ -74,7 +75,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase môže skenovať hodnoty vo všetkých poliach v tejto databáze. Povoľte to zaškrtnutím checkboxov v dashboardoch a otázkach. Tento proces može byť náročný hlavne na zdroje, hlavne ak mate viac databáz."
 
-#: frontend/src/metabase/entities/databases/forms.js:232
+#: frontend/src/metabase/entities/databases/forms.js:301
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Kedy má Metabase automaticky skenovať a ukladať polia do vyrovnávacej pamäte?"
 
@@ -97,6 +98,7 @@ msgid "Never, I'll do this manually if I need to"
 msgstr "Nikdy, urobím to ručne keď budem potrebovať"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 msgid "Saving..."
@@ -133,9 +135,9 @@ msgid "in this box:"
 msgstr "do tohto poľa:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:75
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
@@ -152,18 +154,18 @@ msgstr "do tohto poľa:"
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:301
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:39
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:90
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:99
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:311
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:328
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "Zrušiť"
@@ -180,7 +182,7 @@ msgstr "Zmazať"
 #: frontend/src/metabase/admin/permissions/selectors.js:323
 #: frontend/src/metabase/admin/permissions/selectors.js:330
 #: frontend/src/metabase/admin/permissions/selectors.js:441
-#: frontend/src/metabase/admin/routes.jsx:57
+#: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
@@ -200,9 +202,10 @@ msgid "Scheduling"
 msgstr "Plánovanie"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:71
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
@@ -210,8 +213,8 @@ msgid "Save changes"
 msgstr "Uložiť zmeny"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:203
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:35
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
 msgstr "Akcie"
 
@@ -223,8 +226,8 @@ msgstr "Synchronizujte schému databázy teraz"
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:90
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:98
 msgid "Starting…"
 msgstr "Začínam..."
 
@@ -242,13 +245,13 @@ msgstr "Znova preskenujte hodnoty polí"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
 msgstr "Spustenie skenovania zlyhalo"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:92
 msgid "Scan triggered!"
 msgstr "Skenovanie bolo spustené!"
 
@@ -271,15 +274,15 @@ msgid "Add database"
 msgstr "Pridať databázu"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:28
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:28
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
 #: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:195
+#: frontend/src/metabase/entities/databases/forms.js:264
 #: frontend/src/metabase/entities/questions.js:86
 #: frontend/src/metabase/entities/questions.js:102
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
@@ -319,6 +322,7 @@ msgstr "Úspešne uložené!"
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Upraviť"
@@ -361,44 +365,43 @@ msgstr "Neúspešne"
 msgid "Success"
 msgstr "Úspešne"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:185
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Náhľad"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:93
 msgid "No column description yet"
 msgstr "Žiadny popis stĺpca"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:127
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:126
 msgid "Select a field visibility"
 msgstr "Vyberte viditeľnosť poľa"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:187
 msgid "No special type"
 msgstr "Žiaden špeciálny typ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
 #: frontend/src/metabase/lib/core.js:275
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:44
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:37
 msgid "Other"
 msgstr "Iné"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:221
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Vyberte špeciálny typ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:255
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:262
 #: frontend/src/metabase/reference/components/Field.jsx:99
 msgid "Select a target"
 msgstr "Vyberte cieľ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
@@ -406,18 +409,18 @@ msgstr "Vyberte cieľ"
 msgid "Columns"
 msgstr "Stĺpce"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Stĺpec"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:144
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:288
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
 msgid "Visibility"
 msgstr "Viditeľnosť"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
 msgid "Type"
 msgstr "Typ"
 
@@ -425,7 +428,7 @@ msgstr "Typ"
 msgid "Current database:"
 msgstr "Aktuálna databáza:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
 msgid "Show original schema"
 msgstr "Zobraziť originálnu schému"
 
@@ -449,27 +452,27 @@ msgstr[1] "{0} schémy"
 msgstr[2] "{0} schém"
 msgstr[3] "{0} schém"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:99
 msgid "Why Hide?"
 msgstr "Prečo schovať."
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:100
 msgid "Technical Data"
 msgstr "Technické data"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
 msgstr "Nerelevantné"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 msgid "Queryable"
 msgstr "Dotazovateľné"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:108
 msgid "Hidden"
 msgstr "Schované"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136
 msgid "No table description yet"
 msgstr "Žiaden popis tabuľky"
 
@@ -477,7 +480,7 @@ msgstr "Žiaden popis tabuľky"
 msgid "Metadata Strength"
 msgstr "Sila metadát"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0} dotazovateľná tabuľka"
@@ -485,7 +488,7 @@ msgstr[1] "{0} dotazovateľné tabuľky"
 msgstr[2] "{0} dotazovateľných tabuliek"
 msgstr[3] "{0} dotazovateľných tabuliek"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:91
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} skrytá tabuľka"
@@ -493,20 +496,21 @@ msgstr[1] "{0} skryté tabuľky"
 msgstr[2] "{0} skrytých tabuliek"
 msgstr[3] "{0} skrytch tabuliek"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:115
 msgid "Find a table"
 msgstr "Nájdi tabuľku"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:128
 msgid "Schemas"
 msgstr "Schéma"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:838
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:21
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:43
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:62
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 msgid "Metrics"
 msgstr "Metrika"
@@ -515,8 +519,8 @@ msgstr "Metrika"
 msgid "Add a Metric"
 msgstr "Pridaj metriku"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "Definícia"
@@ -525,12 +529,12 @@ msgstr "Definícia"
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "Vytvorte metriku a pridajte ju do rozbaľovacieho menu v náhľade v nástroji na dotazy"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:21
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
 #: frontend/src/metabase/home/containers/SearchApp.jsx:72
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:961
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:61
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Segmenty"
@@ -539,35 +543,35 @@ msgstr "Segmenty"
 msgid "Add a Segment"
 msgstr "Pridaj segment"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:51
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:45
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "Vytvorte segmenty a pridajte ich do rozbaľovacieho menu vo filtry v nástroji na dotazy"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:21
 msgid "created"
 msgstr "vytvorené"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "reverted to a previous version"
 msgstr "Vrátiť na predchádzajúcu verziu"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:30
 msgid "edited the title"
 msgstr "upravený nadpis"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:32
 msgid "edited the description"
 msgstr "popis bol upravený"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:34
 msgid "edited the "
 msgstr "bolo upravené "
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:40
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "made some changes"
 msgstr "urobte nejakú zmenu"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
 #: frontend/src/metabase/home/components/Activity.jsx:83
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
@@ -577,84 +581,84 @@ msgstr "Vy"
 msgid "Datamodel"
 msgstr "Datamodel"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:41
 msgid " History"
 msgstr " História"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
 msgstr "História revízií pre"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:228
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
 msgid "{0} – Field Settings"
 msgstr "{0} – Nastavenia poľa"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:289
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
 msgid "Where this field will appear throughout Metabase"
 msgstr "Kde sa toto pole objaví v Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:311
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
 msgid "Filtering on this field"
 msgstr "Filtrovanie v tomto poli"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:312
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Keď sa toto pole použije vo filtri, aký typ hodnoty by ľudia mali používať, ak chcú v tomto poli filtrovať?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:437
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
 msgid "No description for this field yet"
 msgstr "Žiaden popis tohto poľa"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
 msgid "Original value"
 msgstr "Originálna hodnota"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:390
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
 msgid "Mapped value"
 msgstr "Namapovaná hodnota"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
 msgid "Enter value"
 msgstr "Zadajte hodnotu"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use original value"
 msgstr "Použite originálnu hodnotu"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Use foreign key"
 msgstr "Použite cudzí kľuč"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 msgid "Custom mapping"
 msgstr "Vlastné mapovanie"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
 msgid "Unrecognized mapping type"
 msgstr "Nerozpoznaný typ mapovania"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Aktuálne pole nie je cudzí kľúč alebo chýbajú metadáta cieľovej tabuľky s cudzím kľúčom"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
 msgid "The selected field isn't a foreign key"
 msgstr "Vybraté pole nie je cudzí kľúč"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:327
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
 msgid "Display values"
 msgstr "Zobraziť hodnoty"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:328
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Vyberte, či chcete zobraziť pôvodnú hodnotu z databázy, alebo nechať toto pole zobraziť priradenú alebo vlastnú informáciu."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:278
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
 msgid "Choose a field"
 msgstr "Vyberte pole"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:299
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
 msgid "Please select a column to use for display."
 msgstr "Vyberte stĺpec, ktorý chcete použiť na zobrazenie."
 
@@ -662,16 +666,16 @@ msgstr "Vyberte stĺpec, ktorý chcete použiť na zobrazenie."
 msgid "Tip:"
 msgstr "Tip:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:443
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Možno budete chcieť aktualizovať názov poľa, aby sa ubezpečil, že má stále zmysel na základe vašich možností premapovania."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:344
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Hodnoty poľa vo vyrovnávacej pamäti"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:345
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase môže skontrolovať hodnoty tohto poľa a povoliť filtre checkboxov políčok na dashboardoch a otázkach."
 
@@ -680,53 +684,53 @@ msgid "Re-scan this field"
 msgstr "Znovu naskenujte toto pole"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
 msgstr "Vyčistiť hodnoty polí vo vyrovnávacej pamäti"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
 msgstr "Nepodarilo sa vyčistiť hodnoty"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 msgid "Discard triggered!"
 msgstr "Čistenie spustené!"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Vyberte ľubovoľnú tabuľku, aby sa zobrazila jej schéma a pridajte alebo upravte metadáta."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:36
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "Meno je povinné"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:39
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "Popis je povinný"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:43
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Správa pri revízií je povinná"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
 msgid "Aggregation is required"
 msgstr "Agregácia je povinná"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Edit Your Metric"
 msgstr "Upraviť vaše metriky"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Create Your Metric"
 msgstr "Vytvorte svoje metriky"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Vykonajte zmeny v metrike a pridajte vysvetľujúcu poznámku."
 
@@ -734,62 +738,62 @@ msgstr "Vykonajte zmeny v metrike a pridajte vysvetľujúcu poznámku."
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Môžete vytvoriť uložené metriky a pridať do tejto tabuľky voľbu pomenovanej metriky. Medzi uložené metriky patrí typ agregácie, agregované pole a prípadne akýkoľvek filter, ktorý pridáte. Ako príklad môžete použiť na vytvorenie niečoho ako oficiálny spôsob výpočtu „priemernej ceny“ pre tabuľku Objednávky."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:180
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
 msgid "Result: "
 msgstr "Výsledok:"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
 msgid "Name Your Metric"
 msgstr "Meno vašej metriky"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:190
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Give your metric a name to help others find it."
 msgstr "Pridajte meno pre vašu metriku "
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:194
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:152
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Niečo popisné, ale nie príliš dlhé"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:198
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
 msgid "Describe Your Metric"
 msgstr "Popíšte svoju metriku"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:199
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Zadajte popis svojej metriky, aby ste ostatným pomohli pochopiť, o čo ide."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:203
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Toto je dobré miesto na presnejšie vymedzenie menej zrejmých metrických pravidiel"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:207
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:165
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Dôvod zmeny"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:209
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Pridajte poznámku a vysvetlite, aké zmeny ste vykonali a prečo boli potrebné."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:213
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Toto sa zobrazí v histórii revízií pre túto metriku, aby všetci vedeli prečo sa veci zmenili"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
 msgstr "Aspoň jeden filter je povinný"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
 msgstr "Upravte svoj segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
 msgstr "Vytvorte svoj segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Vykonajte zmeny vo svojom segmente a pridajte vysvetľujúcu poznámku."
 
@@ -797,33 +801,33 @@ msgstr "Vykonajte zmeny vo svojom segmente a pridajte vysvetľujúcu poznámku."
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "Vyberte a pridajte filtre a vytvorte nový segment pre tabuľku {0}"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
 msgstr "Pomenujte svoj segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:148
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
 msgstr "Pomenujte svoj segment a pomôžte ostatným ho nájsť."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:156
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
 msgstr "Popíšte svoj segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Zadajte popis svojho segmentu, aby ste ostatným pomohli pochopiť, o čo ide."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "Toto je miesto na presnejšie vymedzenie pravidiel segmentu"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "Toto sa objaví v histórii revízií pre tento segment, aby všetci vedeli prečo sa veci zmenili"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
-#: frontend/src/metabase/admin/routes.jsx:132
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:215
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
+#: frontend/src/metabase/admin/routes.jsx:137
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
@@ -831,11 +835,11 @@ msgstr "Toto sa objaví v histórii revízií pre tento segment, aby všetci ved
 msgid "Settings"
 msgstr "Nastavenia"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase môže naskenovať hodnoty v tejto tabuľke a povoliť filtre v checkboxoch na dashboardoch a otázkach."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
 msgstr "Znovu naskenujte túto tabuľku"
 
@@ -849,11 +853,11 @@ msgstr "Pridať"
 msgid "Not a valid formatted email address"
 msgstr "Emailová adresa má zlý tvar"
 
-#: frontend/src/metabase/entities/users/forms.js:12
+#: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
 msgstr "Krstné meno"
 
-#: frontend/src/metabase/entities/users/forms.js:18
+#: frontend/src/metabase/entities/users/forms.js:20
 msgid "Last name"
 msgstr "Priezvisko"
 
@@ -893,10 +897,10 @@ msgstr "Členovia"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
-#: frontend/src/metabase/admin/settings/selectors.js:120
-#: frontend/src/metabase/entities/users/forms.js:24
+#: frontend/src/metabase/admin/settings/selectors.js:121
+#: frontend/src/metabase/entities/users/forms.js:26
 #: frontend/src/metabase/lib/core.js:146
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:294
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:298
 msgid "Email"
 msgstr "Email"
 
@@ -905,14 +909,14 @@ msgid "A group is only as good as its members."
 msgstr "Skupina je taká dobrá ako jej členovia."
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
-#: frontend/src/metabase/admin/routes.jsx:52
+#: frontend/src/metabase/admin/routes.jsx:55
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Admin"
 msgstr "Admin"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:241
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:299
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:288
 msgid "and"
 msgstr "a"
 
@@ -967,12 +971,12 @@ msgstr "Odstrániť skupinu"
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:42
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:294
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:397
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:317
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:334
 msgid "Done"
 msgstr "Hotovo"
 
@@ -983,8 +987,9 @@ msgstr "Názov skupiny"
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
-#: frontend/src/metabase/admin/routes.jsx:92
+#: frontend/src/metabase/admin/routes.jsx:97
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Skupiny"
 
@@ -1014,7 +1019,7 @@ msgstr "Deactivovať"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:21
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
-#: frontend/src/metabase/admin/routes.jsx:88
+#: frontend/src/metabase/admin/routes.jsx:93
 #: frontend/src/metabase/nav/containers/Navbar.jsx:235
 msgid "People"
 msgstr "Ľudia"
@@ -1330,25 +1335,25 @@ msgstr "Zobraziť kolekciu"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:542
+#: frontend/src/metabase/admin/permissions/selectors.js:558
 msgid "Data Access"
 msgstr "Prístup k údajom"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:667
-#: frontend/src/metabase/admin/permissions/selectors.js:672
+#: frontend/src/metabase/admin/permissions/selectors.js:665
+#: frontend/src/metabase/admin/permissions/selectors.js:670
 msgid "View tables"
 msgstr "Zobraziť tabuľky"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:608
+#: frontend/src/metabase/admin/permissions/selectors.js:606
 msgid "SQL Queries"
 msgstr "SQL dotaz"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:678
+#: frontend/src/metabase/admin/permissions/selectors.js:676
 msgid "View schemas"
 msgstr "Zobraziť schému"
 
-#: frontend/src/metabase/admin/routes.jsx:63
+#: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
 msgstr "Dátový model"
@@ -1378,20 +1383,24 @@ msgid "Allows users within your LDAP directory to log in to Metabase with their 
 msgstr "Umožňuje používateľom vo vašom adresári LDAP prihlásiť sa do Metabase pomocou svojich LDAP prístupov a umožňuje automatické mapovanie skupín LDAP na skupiny Metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:19
-#: frontend/src/metabase/admin/settings/selectors.js:167
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
+#: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
 msgstr "Toto nie je platná e-mailová adresa"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
 msgstr "To nie je platné celé číslo"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
 msgstr "Zmeny boli uložené!"
 
-#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:178
+#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
 msgid "Looks like we ran into some problems"
 msgstr "Vyzerá to, že sme narazili na nejaké problémy"
 
@@ -1413,7 +1422,7 @@ msgstr "Čisté"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:195
+#: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Overenie"
 
@@ -1465,15 +1474,15 @@ msgstr "Google client ID"
 msgid "Allow users to sign up on their own if their Google account email address is from:"
 msgstr "Povoliť používateľom prihlásiť sa samostatne, ak ich e-mailová adresa účtu Google pochádza z:"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:242
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:249
 msgid "Answers sent right to your Slack #channels"
 msgstr "Odpovede odoslané priamo na vaše Slack #kanály"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:251
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:258
 msgid "Create a Slack Bot User for MetaBot"
 msgstr "Vytvorte Slack Bot používateľa pre MetaBot"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:261
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:268
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "Keď už ste tam, pomenujte ho a kliknite na {0}. Potom skopírujte a vložte Bot API Token do poľa nižšie. Po dokončení vytvorte v Slack kanáli „metabase_files“. Metabase to potrebuje na posielanie grafov."
 
@@ -1486,8 +1495,8 @@ msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Metabase {0} je k dispozícii. Používate {1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:41
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 msgid "Update"
 msgstr "Aktualizovať"
 
@@ -1514,16 +1523,16 @@ msgstr "Odstránte vlastnú mapu"
 #: frontend/src/metabase/containers/Overworld.jsx:293
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:115
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Odstrániť"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:165
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:141
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
 msgstr "Vybrať..."
 
@@ -1708,48 +1717,46 @@ msgid "Generate Key"
 msgstr "Vygenerujte kľúč"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:87
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:18
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enabled"
 msgstr "Zapnuté"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:92
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:19
+#: frontend/src/metabase/admin/settings/selectors.js:93
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Vypnuté"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:112
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:113
 msgid "Unknown setting {0}"
 msgstr "Neznáme nastavenie {0}"
 
-#: frontend/src/metabase/admin/settings/selectors.js:34
+#: frontend/src/metabase/admin/settings/selectors.js:37
 msgid "Setup"
 msgstr "Nastaviť"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:207
-#: frontend/src/metabase/admin/settings/selectors.js:39
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:214
+#: frontend/src/metabase/admin/settings/selectors.js:42
 msgid "General"
 msgstr "Všeobecné"
 
-#: frontend/src/metabase/admin/settings/selectors.js:43
+#: frontend/src/metabase/admin/settings/selectors.js:46
 msgid "Site Name"
 msgstr "Názov stránky"
 
-#: frontend/src/metabase/admin/settings/selectors.js:48
+#: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Site URL"
 msgstr "URL stránky"
 
-#: frontend/src/metabase/admin/settings/selectors.js:53
+#: frontend/src/metabase/admin/settings/selectors.js:64
 msgid "Email Address for Help Requests"
 msgstr "Emailová adresa kde môžte nápisať email ak máte problém."
 
-#: frontend/src/metabase/admin/settings/selectors.js:58
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
 msgstr "Nahlásiť časové pásmo"
 
-#: frontend/src/metabase/admin/settings/selectors.js:61
+#: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
 msgstr "Predvolená databáza"
 
@@ -1757,11 +1764,11 @@ msgstr "Predvolená databáza"
 msgid "Select a timezone"
 msgstr "Vyberte časové pásmo"
 
-#: frontend/src/metabase/admin/settings/selectors.js:64
+#: frontend/src/metabase/admin/settings/selectors.js:75
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "Nie všetky databázy podporujú časové pásma. V takom prípade sa toto nastavenie neprejaví."
 
-#: frontend/src/metabase/admin/settings/selectors.js:69
+#: frontend/src/metabase/entities/users/forms.js:34
 msgid "Language"
 msgstr "Jazyk"
 
@@ -1769,64 +1776,64 @@ msgstr "Jazyk"
 msgid "Select a language"
 msgstr "Vyberte jazyk"
 
-#: frontend/src/metabase/admin/settings/selectors.js:79
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
 msgstr "Anonymné sledovanie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:84
+#: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
 msgstr "Spriatelené tabuľky a názvy polí"
 
-#: frontend/src/metabase/admin/settings/selectors.js:90
+#: frontend/src/metabase/admin/settings/selectors.js:91
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Podčiarknutia a pomlčky nahrádzajte iba medzerami"
 
-#: frontend/src/metabase/admin/settings/selectors.js:98
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Enable Nested Queries"
 msgstr "Povoliť vnorené dopyty"
 
-#: frontend/src/metabase/admin/settings/selectors.js:109
+#: frontend/src/metabase/admin/settings/selectors.js:110
 msgid "Updates"
 msgstr "Aktualizácie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:114
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
 msgstr "Skontroluj aktualizácie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:125
+#: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
 msgstr "SMTP Host"
 
-#: frontend/src/metabase/admin/settings/selectors.js:133
+#: frontend/src/metabase/admin/settings/selectors.js:134
 msgid "SMTP Port"
 msgstr "SMTP Port"
 
-#: frontend/src/metabase/admin/settings/selectors.js:137
+#: frontend/src/metabase/admin/settings/selectors.js:138
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:47
 msgid "That's not a valid port number"
 msgstr "Toto nie je valídne číslo portu"
 
-#: frontend/src/metabase/admin/settings/selectors.js:141
+#: frontend/src/metabase/admin/settings/selectors.js:142
 msgid "SMTP Security"
 msgstr "SMTP bezpečnosť"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:150
 msgid "SMTP Username"
 msgstr "SMTP používateľske meno"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "SMTP Password"
 msgstr "SMTP heslo"
 
-#: frontend/src/metabase/admin/settings/selectors.js:163
+#: frontend/src/metabase/admin/settings/selectors.js:164
 msgid "From Address"
 msgstr "Z adresy"
 
-#: frontend/src/metabase/admin/settings/selectors.js:176
+#: frontend/src/metabase/admin/settings/selectors.js:178
 msgid "Slack API Token"
 msgstr "Slack API token"
 
-#: frontend/src/metabase/admin/settings/selectors.js:178
+#: frontend/src/metabase/admin/settings/selectors.js:180
 msgid "Enter the token you received from Slack"
 msgstr "Vložiť token na reaktiváciu Slacku"
 
@@ -1855,8 +1862,10 @@ msgid "Username or DN"
 msgstr "Prihlasovacie meno"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:43
+#: frontend/src/metabase/entities/databases/forms.js:61
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:64
-#: frontend/src/metabase/user/components/UserSettings.jsx:65
+#: frontend/src/metabase/user/components/UserSettings.jsx:66
+#: src/metabase/driver/common.clj
 msgid "Password"
 msgstr "Heslo"
 
@@ -1892,79 +1901,79 @@ msgstr "Synchronizujte členstvo v skupinách"
 msgid "Group search base"
 msgstr "Základňa vyhľadávania v skupinach"
 
-#: frontend/src/metabase/admin/settings/selectors.js:199
+#: frontend/src/metabase/admin/settings/selectors.js:201
 msgid "Maps"
 msgstr "Mapy"
 
-#: frontend/src/metabase/admin/settings/selectors.js:203
+#: frontend/src/metabase/admin/settings/selectors.js:205
 msgid "Map tile server URL"
 msgstr "Namapujte polia z URL servra"
 
-#: frontend/src/metabase/admin/settings/selectors.js:204
+#: frontend/src/metabase/admin/settings/selectors.js:206
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Metabase používa OpenStreetMaps ako predvolené."
 
-#: frontend/src/metabase/admin/settings/selectors.js:209
+#: frontend/src/metabase/admin/settings/selectors.js:211
 msgid "Custom Maps"
 msgstr "Voliteľné mapy"
 
-#: frontend/src/metabase/admin/settings/selectors.js:210
+#: frontend/src/metabase/admin/settings/selectors.js:212
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Pridajte vlastné súbory GeoJSON, aby ste povolili rôzne vizualizácie máp regiónov"
 
-#: frontend/src/metabase/admin/settings/selectors.js:228
+#: frontend/src/metabase/admin/settings/selectors.js:245
 msgid "Public Sharing"
 msgstr "Verejné zdieľanie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:232
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "Enable Public Sharing"
 msgstr "Zapnúť verejné zdieľanie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:254
 msgid "Shared Dashboards"
 msgstr "Zdieľaný dashboard"
 
-#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Shared Questions"
 msgstr "Zdieľané otázky"
 
-#: frontend/src/metabase/admin/settings/selectors.js:250
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Embedding in other Applications"
 msgstr "Vložiť do inej aplikácie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:276
+#: frontend/src/metabase/admin/settings/selectors.js:293
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Povoľte vkladanie Metabase do iných aplikácií"
 
-#: frontend/src/metabase/admin/settings/selectors.js:286
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Embedding secret key"
 msgstr "Kľúč pre zdieľanie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:292
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Embedded Dashboards"
 msgstr "Vložený dashboardy"
 
-#: frontend/src/metabase/admin/settings/selectors.js:298
+#: frontend/src/metabase/admin/settings/selectors.js:315
 msgid "Embedded Questions"
 msgstr "Vložené otázky"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:322
 msgid "Caching"
 msgstr "Uloženie do dočasnej pamäte"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:326
 msgid "Enable Caching"
 msgstr "Zapnúť ukladanie do dočasnej pamäte"
 
-#: frontend/src/metabase/admin/settings/selectors.js:314
+#: frontend/src/metabase/admin/settings/selectors.js:331
 msgid "Minimum Query Duration"
 msgstr "Minimálne trvanie dopytu"
 
-#: frontend/src/metabase/admin/settings/selectors.js:321
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Násobiteľ času dočasnej pamäte (TTL)"
 
-#: frontend/src/metabase/admin/settings/selectors.js:328
+#: frontend/src/metabase/admin/settings/selectors.js:345
 msgid "Max Cache Entry Size"
 msgstr "Maximálna veľkosť vstupu do dočasnej pamäte"
 
@@ -2131,7 +2140,8 @@ msgstr "Dashboardy, kolekcie a impulzy v tejto kolekcii sa tiež archivujú."
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/routes.jsx:205
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
+#: frontend/src/metabase/routes.jsx:196
 msgid "Archive"
 msgstr "Archivovať"
 
@@ -2147,21 +2157,21 @@ msgstr "Zobraziť archív"
 msgid "Unarchive this {0}"
 msgstr "Vrátiť z archivu {0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:39
-#: frontend/src/metabase/components/BrowseApp.jsx:102
-#: frontend/src/metabase/components/BrowseApp.jsx:194
+#: frontend/src/metabase/components/BrowseApp.jsx:46
+#: frontend/src/metabase/components/BrowseApp.jsx:112
+#: frontend/src/metabase/components/BrowseApp.jsx:204
 #: frontend/src/metabase/containers/Overworld.jsx:270
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
 msgstr "Vaše data"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:146
+#: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
 msgid "X-ray this table"
 msgstr "Preskúmať túto tabuľku"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:161
+#: frontend/src/metabase/components/BrowseApp.jsx:171
 msgid "Learn about this table"
 msgstr "Naučiť sa niečo o tejto tabuľke"
 
@@ -2256,7 +2266,7 @@ msgstr "Pripnúť"
 msgid "Drag something here to pin it to the top"
 msgstr "Potiahnite niečo sem a pripnite to hore"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:755
+#: frontend/src/metabase/admin/permissions/selectors.js:753
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2312,7 +2322,7 @@ msgstr "Nová kolekcia"
 msgid "Copied!"
 msgstr "Kopírovaný!"
 
-#: frontend/src/metabase/entities/databases/forms.js:12
+#: frontend/src/metabase/entities/databases/forms.js:14
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Na pripojenie k databáze použite tunel SSH"
 
@@ -2323,7 +2333,7 @@ msgid "Some database installations can only be accessed by connecting through an
 msgstr "Prístup k niektorým inštaláciám databázy je možný iba pripojením cez SSH tunel.\n"
 "Táto voľba tiež poskytuje ďalšiu úroveň zabezpečenia, keď nie je k dispozícii sieť VPN. Povolenie je zvyčajne pomalšie ako priame pripojenie."
 
-#: frontend/src/metabase/entities/databases/forms.js:212
+#: frontend/src/metabase/entities/databases/forms.js:281
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Táto databáza je  veľká, takže nastavte kedy má Metabase spustiť synchronizáciu a skenovanie"
 
@@ -2332,17 +2342,17 @@ msgid "By default, Metabase does a lightweight hourly sync and an intensive dail
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Metabase predvolene vykonáva hodinovú synchronizáciu a denné skenovanie hodnôt polí. Ak máte rozsiahlu databázu, odporúčame vám skontrolovať, kedy a ako často sa uskutoční kontrola hodnôt poľa."
 
-#: frontend/src/metabase/entities/databases/forms.js:78
+#: frontend/src/metabase/entities/databases/forms.js:113
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0} vygenerujte ID klienta a kľúč klienta pre svoj projekt."
 
-#: frontend/src/metabase/entities/databases/forms.js:80
-#: frontend/src/metabase/entities/databases/forms.js:95
-#: frontend/src/metabase/entities/databases/forms.js:131
+#: frontend/src/metabase/entities/databases/forms.js:115
+#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:166
 msgid "Click here"
 msgstr "Tu kliknite"
 
-#: frontend/src/metabase/entities/databases/forms.js:83
+#: frontend/src/metabase/entities/databases/forms.js:118
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Ako typ aplikácie vyberte možnosť \"Iné“. Pomenujte ho ako chcete."
 
@@ -2350,19 +2360,19 @@ msgstr "Ako typ aplikácie vyberte možnosť \"Iné“. Pomenujte ho ako chcete.
 msgid "{0} to get an auth code"
 msgstr "{0} získate autorizačný kód"
 
-#: frontend/src/metabase/entities/databases/forms.js:107
+#: frontend/src/metabase/entities/databases/forms.js:142
 msgid "with Google Drive permissions"
 msgstr "s povoleniami Google Drive"
 
-#: frontend/src/metabase/entities/databases/forms.js:129
+#: frontend/src/metabase/entities/databases/forms.js:164
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "Ak chcete používať Metabase s týmito údajmi, musíte povoliť prístup k rozhraniu API v konzole pre vývojárov Google."
 
-#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:165
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} prejdite na konzolu, ak ste tak ešte neurobili."
 
-#: frontend/src/metabase/entities/databases/forms.js:196
+#: frontend/src/metabase/entities/databases/forms.js:265
 msgid "How would you like to refer to this database?"
 msgstr "Ako by ste chceli odkazovať na túto databázu?"
 
@@ -2371,7 +2381,8 @@ msgstr "Ako by ste chceli odkazovať na túto databázu?"
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:143
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:70
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:123
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:96
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:126
 #: frontend/src/metabase/setup/components/UserStep.jsx:93
 msgid "Next"
 msgstr "Ďalej"
@@ -2554,7 +2565,7 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Vrátiť na skoršiu revíziu a {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:290
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "História revízií"
@@ -2600,7 +2611,7 @@ msgid "Questions"
 msgstr "Otázky"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:320
+#: frontend/src/metabase/routes.jsx:311
 msgid "Pulses"
 msgstr "Impulzy"
 
@@ -2645,15 +2656,16 @@ msgstr "Sme trochu stratení ..."
 msgid "Temporary Password"
 msgstr "Dočasné heslo"
 
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:207
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:481
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
 msgid "Hide"
 msgstr "Skryť"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:467
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:482
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:471
 msgid "Show"
 msgstr "Zobraziť"
 
@@ -2763,7 +2775,7 @@ msgstr "Prepáčte, ale nemáte dostatočné oprávnenie na zobrazenie."
 msgid "Unknown error encountered"
 msgstr "Vyskytla sa neznáma chyba"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/nav/containers/Navbar.jsx:373
 msgid "Create"
 msgstr "Vytvoriť"
@@ -2776,7 +2788,7 @@ msgstr "Vytvoriť dashboard"
 msgid "Table"
 msgstr "Tabuľka"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
 msgid "Database"
 msgstr "Databáza"
 
@@ -2796,7 +2808,7 @@ msgstr "Skúste upraviť filter, aby ste našli, čo hľadáte."
 msgid "View by"
 msgstr "Zobraziť podľa"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:122
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:121
 msgid "of"
 msgstr "z"
 
@@ -2823,33 +2835,33 @@ msgstr "Naša analytika"
 msgid "Browse all items"
 msgstr "Prehliadajte všetky položky"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:118
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:117
 msgid "Replace or save as new?"
 msgstr "Prepísať alebo uložiť ako novú?"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:168
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace original question, \"{0}\""
 msgstr "Prepísať originálnu otázku, \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:172
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:171
 msgid "Save as new question"
 msgstr "Uložiť ako novú otázku"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:92
 msgid "First, save your question"
 msgstr "Najskôr uložte vašu otázku"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:94
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
 msgid "Save question"
 msgstr "Uložte otázku"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:133
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
 msgid "What is the name of your card?"
 msgstr "Aký je názov vašej karty?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
 #: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/entities/questions.js:89
@@ -2865,15 +2877,16 @@ msgstr "Aký je názov vašej karty?"
 msgid "Description"
 msgstr "Popis"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
 #: frontend/src/metabase/entities/dashboards.js:150
 #: frontend/src/metabase/entities/questions.js:91
 #: frontend/src/metabase/entities/questions.js:107
+#: frontend/src/metabase/entities/snippets.js:31
 msgid "It's optional but oh, so helpful"
 msgstr "Nie je to povinné, ale pomáha to pri rozlišovaný"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:148
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "Do ktoréj kolekcie to chcete zaradiť?"
@@ -2890,19 +2903,19 @@ msgstr "položka"
 msgid "Undo"
 msgstr "Späť"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:266
 msgid "Applying Question"
 msgstr "Použiť otázku"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:286
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "That question isn't compatible"
 msgstr "Táto otázka nie je kompatibilná"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:322
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:309
 msgid "Search for a question"
 msgstr "Vyhľadajte otázku"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:351
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:343
 msgid "We're not sure if this question is compatible"
 msgstr "Nie sme si istý že táto otázka je kompatibilná"
 
@@ -2951,25 +2964,23 @@ msgstr "Pridať otázku"
 msgid "Add a question to this dashboard"
 msgstr "Pridať otázku do tohto dashboardu"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
 msgid "Add a filter"
 msgstr "Pridať filter"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:256
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "Parametre"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:276
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:280
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
 msgid "Add a text box"
 msgstr "Pridať textové pole"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:320
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:314
 msgid "Move dashboard"
 msgstr "Presunúť dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:303
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
 msgid "Edit dashboard"
 msgstr "Upraviť dashboard"
 
@@ -2977,11 +2988,11 @@ msgstr "Upraviť dashboard"
 msgid "Edit Dashboard Layout"
 msgstr "Upraviť rozloženie dashboardu"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:371
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:365
 msgid "You are editing a dashboard"
 msgstr "Upravujete dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:376
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:370
 msgid "Select the field that should be filtered for each card"
 msgstr "Vyberte pole, ktoré sa môže fitrovať v každej karte"
 
@@ -3069,7 +3080,7 @@ msgstr "Táto karta neobsahuje polia ani parametre, ktoré je možné mapovať n
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Hodnoty v tomto poli sa nezhodujú s hodnotami iných polí, ktoré ste vybrali."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:162
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "Žiadne platné polia"
@@ -3137,7 +3148,7 @@ msgstr "boli pridané dáta z"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:329
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
 msgid "Unknown"
 msgstr "Neznáme"
 
@@ -3264,6 +3275,7 @@ msgstr "{0} vybraných položiek"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 msgid "Unarchive"
 msgstr "Zrušiť archiváciu"
 
@@ -3356,7 +3368,7 @@ msgid "Longitude"
 msgstr "Zemepisná dĺžka"
 
 #: frontend/src/metabase/lib/core.js:43
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:45
 msgid "Number"
 msgstr "Číslo"
@@ -3413,7 +3425,7 @@ msgid "User"
 msgstr "Používateľ"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:211
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
 msgid "Source"
 msgstr "Zdroj"
 
@@ -3454,16 +3466,17 @@ msgid "Score"
 msgstr "Skóre"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Nadpis"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
 msgid "Comment"
 msgstr "Komentár"
 
@@ -3515,9 +3528,9 @@ msgstr "Nevložené"
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
 msgstr "Metabase toto pole nikdy nezíska. Použite na citlivé alebo irelevantné informácie."
 
-#: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:300
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/query/description.js:77
+#: frontend/src/metabase/lib/query/description.js:262
+#: frontend/src/metabase/lib/schema_metadata.js:476
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
@@ -3532,8 +3545,7 @@ msgstr "Počet"
 msgid "CumulativeCount"
 msgstr "Kumulovaný počet"
 
-#: frontend/src/metabase/lib/expressions/config.js:9
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:485
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3543,7 +3555,6 @@ msgstr "Suma"
 msgid "CumulativeSum"
 msgstr "Kumulovaná suma"
 
-#: frontend/src/metabase/lib/expressions/config.js:11
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Distinct"
 msgstr "Jednoznačný"
@@ -3552,25 +3563,22 @@ msgstr "Jednoznačný"
 msgid "StandardDeviation"
 msgstr "Štandardná odchýlka"
 
-#: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:494
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Priemer"
 
-#: frontend/src/metabase/lib/expressions/config.js:14
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:539
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Min"
 
-#: frontend/src/metabase/lib/expressions/config.js:15
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:548
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:503
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:492
 msgid "Max"
 msgstr "Max"
 
@@ -3627,54 +3635,66 @@ msgstr "Na čo myslíte?"
 msgid "What do you want to find out?"
 msgstr "Čo chcete zistiť?"
 
-#: frontend/src/metabase/lib/query.js:298
-#: frontend/src/metabase/lib/schema_metadata.js:466
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:250
+#: frontend/src/metabase/lib/query/description.js:75
+#: frontend/src/metabase/lib/query/description.js:260
+#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Čisté data"
 
-#: frontend/src/metabase/lib/query.js:302
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/query/description.js:79
+#: frontend/src/metabase/lib/query/description.js:264
+#: frontend/src/metabase/lib/schema_metadata.js:521
 msgid "Cumulative count"
 msgstr "Kumulatívny počet"
 
-#: frontend/src/metabase/lib/query.js:305
+#: frontend/src/metabase/lib/query/description.js:82
+#: frontend/src/metabase/lib/query/description.js:266
 msgid "Average of "
 msgstr "Priemer "
 
-#: frontend/src/metabase/lib/query.js:310
+#: frontend/src/metabase/lib/query/description.js:87
+#: frontend/src/metabase/lib/query/description.js:268
 msgid "Distinct values of "
 msgstr "Samostatné hodnoty z "
 
-#: frontend/src/metabase/lib/query.js:315
+#: frontend/src/metabase/lib/query/description.js:92
+#: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
 msgstr "Štandardná odchýlka "
 
-#: frontend/src/metabase/lib/query.js:320
+#: frontend/src/metabase/lib/query/description.js:97
+#: frontend/src/metabase/lib/query/description.js:272
 msgid "Sum of "
 msgstr "Súčet "
 
-#: frontend/src/metabase/lib/query.js:325
+#: frontend/src/metabase/lib/query/description.js:102
+#: frontend/src/metabase/lib/query/description.js:274
 msgid "Cumulative sum of "
 msgstr "Kumulatívna suma "
 
-#: frontend/src/metabase/lib/query.js:330
+#: frontend/src/metabase/lib/query/description.js:107
+#: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
 msgstr "Maximum "
 
-#: frontend/src/metabase/lib/query.js:335
+#: frontend/src/metabase/lib/query/description.js:112
+#: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
 msgstr "Minimum "
 
-#: frontend/src/metabase/lib/query.js:349
+#: frontend/src/metabase/lib/query/description.js:126
+#: frontend/src/metabase/lib/query/description.js:286
 msgid "Grouped by "
 msgstr "Zoskupené podľa"
 
-#: frontend/src/metabase/lib/query.js:363
+#: frontend/src/metabase/lib/query/description.js:140
+#: frontend/src/metabase/lib/query/description.js:295
 msgid "Filtered by "
 msgstr "Filtrované podľa"
 
-#: frontend/src/metabase/lib/query.js:392
+#: frontend/src/metabase/lib/query/description.js:169
+#: frontend/src/metabase/lib/query/description.js:320
 msgid "Sorted by "
 msgstr "Zoradené podľa"
 
@@ -3686,55 +3706,45 @@ msgstr "Pravdivý"
 msgid "False"
 msgstr "Nepravdivý"
 
-#: frontend/src/metabase/lib/schema_metadata.js:321
+#: frontend/src/metabase/lib/schema_metadata.js:322
 msgid "Select longitude field"
 msgstr "Vyberte pole zemepisnej dĺžky"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:323
 msgid "Enter upper latitude"
 msgstr "Zadajte hornú zemepisnú šírku"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:324
 msgid "Enter left longitude"
 msgstr "Zadajte ľavú zemepisnú dĺžku"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:325
 msgid "Enter lower latitude"
 msgstr "Zadajte dolnú zemepisnú šírku"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:326
 msgid "Enter right longitude"
 msgstr "Zadajte pravú zemepisnú dĺžku"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:539
 #: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:397
-#: frontend/src/metabase/lib/schema_metadata.js:405
-#: frontend/src/metabase/lib/schema_metadata.js:411
-#: frontend/src/metabase/lib/schema_metadata.js:416
-msgid "Is"
-msgstr "Je"
-
 #: frontend/src/metabase/lib/schema_metadata.js:362
 #: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:398
 #: frontend/src/metabase/lib/schema_metadata.js:406
 #: frontend/src/metabase/lib/schema_metadata.js:412
-msgid "Is not"
-msgstr "Nie je"
+#: frontend/src/metabase/lib/schema_metadata.js:417
+msgid "Is"
+msgstr "Je"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:417
-msgid "Is empty"
-msgstr "Je prázdne"
+#: frontend/src/metabase/lib/schema_metadata.js:413
+msgid "Is not"
+msgstr "Nie je"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:378
@@ -3743,109 +3753,119 @@ msgstr "Je prázdne"
 #: frontend/src/metabase/lib/schema_metadata.js:402
 #: frontend/src/metabase/lib/schema_metadata.js:408
 #: frontend/src/metabase/lib/schema_metadata.js:418
+msgid "Is empty"
+msgstr "Je prázdne"
+
+#: frontend/src/metabase/lib/schema_metadata.js:365
+#: frontend/src/metabase/lib/schema_metadata.js:379
+#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:395
+#: frontend/src/metabase/lib/schema_metadata.js:403
+#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:419
 msgid "Not empty"
 msgstr "Nie je prázdne"
 
-#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:371
 msgid "Equal to"
 msgstr "Rovná sa"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:372
 msgid "Not equal to"
 msgstr "Nerovná sa"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Greater than"
 msgstr "Väčšie ako"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Less than"
 msgstr "Menšie ako"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Medzi"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:376
 msgid "Greater than or equal to"
 msgstr "Väčšie alebo rovné ako"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Less than or equal to"
 msgstr "Menšie alebo rovné ako"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
+#: frontend/src/metabase/lib/schema_metadata.js:384
 msgid "Contains"
 msgstr "Obsahuje"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:385
 msgid "Does not contain"
 msgstr "Neobsahuje"
 
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:388
 msgid "Starts with"
 msgstr "Začína s"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:389
 msgid "Ends with"
 msgstr "Končí s"
 
-#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:399
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Pred"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:400
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Za"
 
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:414
 msgid "Inside"
 msgstr "Vnútri"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Iba tabuľka s riadkami v odpovedi, žiadne ďalšie operácie."
 
-#: frontend/src/metabase/lib/schema_metadata.js:474
+#: frontend/src/metabase/lib/schema_metadata.js:475
 msgid "Count of rows"
 msgstr "Počet riadkov"
 
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:477
 msgid "Total number of rows in the answer."
 msgstr "Celkový počet riadkov v odpovedi."
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Sum of ..."
 msgstr "Súčet ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:486
 msgid "Sum of all the values of a column."
 msgstr "Súčet všetkých hodnôt v stĺpci."
 
-#: frontend/src/metabase/lib/schema_metadata.js:492
+#: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Average of ..."
 msgstr "Priemerná hodnota ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:495
 msgid "Average of all the values of a column"
 msgstr "Priemerná hodnota všetkých hodôt v stĺpci"
 
-#: frontend/src/metabase/lib/schema_metadata.js:501
+#: frontend/src/metabase/lib/schema_metadata.js:502
 msgid "Number of distinct values of ..."
 msgstr "Počet rôznych hodnôt ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:504
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Počet jedinečných hodnôt v stĺpci medzi všetkými riadkami v odpovedi."
 
-#: frontend/src/metabase/lib/schema_metadata.js:510
+#: frontend/src/metabase/lib/schema_metadata.js:511
 msgid "Cumulative sum of ..."
 msgstr "Kumulatívna suma ..."
 
@@ -3853,7 +3873,7 @@ msgstr "Kumulatívna suma ..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Aditívny súčet všetkých hodnôt v stĺpci."
 
-#: frontend/src/metabase/lib/schema_metadata.js:519
+#: frontend/src/metabase/lib/schema_metadata.js:520
 msgid "Cumulative count of rows"
 msgstr "Kumulatívny počet riadkov"
 
@@ -3861,27 +3881,27 @@ msgstr "Kumulatívny počet riadkov"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Aditívny počet riadkov."
 
-#: frontend/src/metabase/lib/schema_metadata.js:528
+#: frontend/src/metabase/lib/schema_metadata.js:529
 msgid "Standard deviation of ..."
 msgstr "Štandardná odchýlka ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:531
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Číslo, ktoré vyjadruje, do akej miery sa hodnoty stĺpca líšia medzi všetkými riadkami v odpovedi."
 
-#: frontend/src/metabase/lib/schema_metadata.js:537
+#: frontend/src/metabase/lib/schema_metadata.js:538
 msgid "Minimum of ..."
 msgstr "Minimálna hodnota ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Minimum value of a column"
 msgstr "Minimálna hodnota stĺpca"
 
-#: frontend/src/metabase/lib/schema_metadata.js:546
+#: frontend/src/metabase/lib/schema_metadata.js:547
 msgid "Maximum of ..."
 msgstr "Maximálna hodnota ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:549
 msgid "Maximum value of a column"
 msgstr "Maximálna hodnota stĺpca"
 
@@ -4057,7 +4077,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Kategória, Typ, Model, Hodnotenie, atď."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:43
-#: frontend/src/metabase/user/components/UserSettings.jsx:55
+#: frontend/src/metabase/user/components/UserSettings.jsx:56
 msgid "Account settings"
 msgstr "Nastavenia účtu"
 
@@ -4069,7 +4089,7 @@ msgstr "Opustiť admin"
 msgid "Logs"
 msgstr "Logy"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:103
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:104
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:22
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:65
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:100
@@ -4109,9 +4129,9 @@ msgid "Metabase Admin"
 msgstr "Metabase admin"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:36
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:36
 msgid "Ask a question"
 msgstr "Pridajte otázku"
 
@@ -4132,7 +4152,7 @@ msgstr "Referencia"
 msgid "Which metric?"
 msgstr "Vyberte metriku"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "Definovanie spoločných metrík pre váš tím uľahčuje vytváranie otázok"
 
@@ -4144,7 +4164,7 @@ msgstr "Ako vytvoriť metriku"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Zobrazte údaje v priebehu času, aby vám pomohli pochopiť trendy alebo zmeny."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:149
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
 msgid "Custom"
 msgstr "Voliteľný"
 
@@ -4157,13 +4177,13 @@ msgstr "Nová otázka"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Pomocou jednoduchého nástroja na tvorbu otázok môžete zobraziť trendy, zoznamy vecí alebo vytvoriť svoje vlastné metriky."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:107
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:110
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Natívny dotaz"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:108
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:111
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Pre zložitejšie otázky môžete napísať svoj vlastný SQL alebo natívny dotaz."
 
@@ -4274,6 +4294,7 @@ msgid "Enter a default value..."
 msgstr "Zadajte prednastavenú hodnotu..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
+#: frontend/src/metabase/containers/Form.jsx:307
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Nastala chyba"
@@ -4524,7 +4545,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "Odporúčame vám udržiavať malé impulzy, aby boli rýchle a užitočné pre celý tím."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:161
-#: frontend/src/metabase/query_builder/components/view/View.jsx:131
+#: frontend/src/metabase/query_builder/components/view/View.jsx:133
 msgid "Pick your data"
 msgstr "Vyberte svoje údaje"
 
@@ -4540,47 +4561,47 @@ msgstr "Emaily"
 msgid "Slack messages"
 msgstr "Spravy pre Slack"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:216
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Odoslať"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:217
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} bude odoslaný na"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:219
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Správy"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:235
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "Teraz odošlite email"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:236
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Teraz odošlite {0}"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:238
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Odosielanie ..."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "Odoslanie zlyhalo"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "Neodoslali sme pretože impulz nemá žiadne výsledky."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Impulz bol odoslaný"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:282
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} musí byť nastavený správcom."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:295
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:299
 msgid "Slack"
 msgstr "Slack"
 
@@ -4733,7 +4754,7 @@ msgstr "Priemer"
 msgid "Distincts"
 msgstr "Odlišné"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:55
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "Zobraziť {0}"
@@ -4746,11 +4767,12 @@ msgstr[3] "Zobraziť {0}"
 msgid "Zoom in"
 msgstr "Priblížiť"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Vlastná hodnota"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Common Metrics"
 msgstr "Základne metriky"
 
@@ -4947,34 +4969,34 @@ msgstr "zvyčajne"
 msgid "Pick a segment or table"
 msgstr "Vyberte segment alebo tabuľku"
 
-#: frontend/src/metabase/entities/databases/forms.js:191
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
+#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Vyberte databázu"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:94
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:85
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:31
 msgid "Select..."
 msgstr "Vyberte..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:134
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
 msgid "Select a table"
 msgstr "Vyberte tabuľku"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:819
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:926
 msgid "No tables found in this database."
 msgstr "Nenašla sa žiadna tabuľka v tejto databáze."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:856
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:901
 msgid "Is a question missing?"
 msgstr "Chýba otázka?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:863
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:909
 msgid "Learn more about nested queries"
 msgstr "Viac informácií o vnorených dotazoch"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:898
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:951
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:40
 msgid "Fields"
 msgstr "Polia"
 
@@ -5008,11 +5030,11 @@ msgstr "Zoradiť"
 msgid "Row limit"
 msgstr "Limit riadkov"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
 msgid "Unknown Field"
 msgstr "Neznáme pole"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:75
 msgid "field"
 msgstr "pole"
 
@@ -5020,19 +5042,20 @@ msgstr "pole"
 msgid "Matches"
 msgstr "Zhody"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:148
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:156
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:135
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Pridajte filtre, aby ste zúžili výber"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:293
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
 msgstr "Pridajte skupinu"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:37
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:313
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
-#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:66
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:67
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:89
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:131
@@ -5048,16 +5071,16 @@ msgstr "Pridajte skupinu"
 msgid "Data"
 msgstr "Data"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:340
 msgid "Filtered by"
 msgstr "Filtrovať podľa"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:376
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:357
 msgid "View"
 msgstr "Zobraziť"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:393
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:374
 msgid "Grouped By"
 msgstr "Zoskupiť podľa"
 
@@ -5065,7 +5088,7 @@ msgstr "Zoskupiť podľa"
 msgid "None"
 msgstr "Žiadne"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:471
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
 msgid "This question is written in {0}."
 msgstr "Táto otázka je napísaná v {0}."
 
@@ -5077,7 +5100,7 @@ msgstr "Skryť editor"
 msgid "Hide Query"
 msgstr "Skryť dotaz"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:481
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
 msgid "Open Editor"
 msgstr "Otvoriť editor"
 
@@ -5320,7 +5343,7 @@ msgstr "Všetky odlišné hodnoty z {0}"
 msgid "Number of {0} grouped by {1}"
 msgstr "Počet {0} zoskupených podľa {1}"
 
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:77
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5379,32 +5402,33 @@ msgstr "Zobraziť nespracované údaje {0}"
 msgid "More"
 msgstr "Viac"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:194
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:216
 msgid "Invalid expression"
 msgstr "Nesprávny výraz"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:269
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:282
 msgid "unknown error"
 msgstr "neznáma chyyba"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:47
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:53
 msgid "Field formula"
 msgstr "Vzorec poľa"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:60
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:64
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Myslite na to, akoby to bolo ako písanie vzorca v tabuľkovom programe: môžete použiť čísla, polia v tejto tabuľke, matematické symboly ako + a niektoré funkcie. Môžete teda zadať niečo ako medzisúčet - náklady."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:69
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:208
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
 msgid "Learn more"
 msgstr "Dozvedieť sa viac"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:77
 msgid "Give it a name"
 msgstr "Pridajte názov"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:79
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
 msgid "Something nice and descriptive"
 msgstr "Niečo opisné a praktické"
 
@@ -5484,11 +5508,11 @@ msgid "Enter desired number"
 msgstr "Zadajte požadované číslo"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:154
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:161
 msgid "Empty"
 msgstr "Prázdny"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:119
 msgid "Find a value"
 msgstr "Nájsť hodnotu"
 
@@ -5556,35 +5580,35 @@ msgstr "Prečítajte si celú dokumentáciu"
 msgid "Filter label"
 msgstr "Popis filtra"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:135
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:134
 msgid "Variable type"
 msgstr "Typ premennej"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:143
 msgid "Text"
 msgstr "Text"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
 msgid "Date"
 msgstr "Dátum"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:147
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
 msgid "Field Filter"
 msgstr "Pole filtra"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Field to map to"
 msgstr "Pole na priradenie do"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:180
 msgid "Filter widget type"
 msgstr "Typ filtra"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:230
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
 msgid "Required?"
 msgstr "Povinné?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:240
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
 msgid "Default filter widget value"
 msgstr "Predvolená hodnota widget filtra"
 
@@ -5596,7 +5620,7 @@ msgstr "Archivovať  túto otázku?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Táto otázka bude odstránená zo všetkých dashboardov alebo impulzov, ktoré ju používajú."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:158
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
 msgid "Question"
 msgstr "Otázka"
 
@@ -5766,7 +5790,7 @@ msgid "Details"
 msgstr "Podrobnosti"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
-#: frontend/src/metabase/reference/databases/TableList.jsx:116
+#: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
 msgstr "Tabuľky v {0}"
 
@@ -5847,24 +5871,24 @@ msgstr "Prečo je táto tabuľka zaujímavá"
 msgid "Things to be aware of about this table"
 msgstr "Čo je potrebné vedieť o tejto tabuľke"
 
-#: frontend/src/metabase/reference/databases/TableList.jsx:30
+#: frontend/src/metabase/reference/databases/TableList.jsx:29
 msgid "Tables in this database will appear here as they're added"
 msgstr "Tabuľky v tejto databáze sa zobrazia po pridaní"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:34
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:33
 msgid "Questions about this table will appear here as they're added"
 msgstr "Otázky týkajúce sa tejto tabuľky sa zobrazia pri pridaní"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:73
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:77
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:76
 msgid "Questions about {0}"
 msgstr "Otázky týkajúce sa {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
 msgid "Created {0} by {1}"
 msgstr "Vytvorené {0} používateľom {1}"
 
@@ -6053,19 +6077,19 @@ msgstr "Ostatné polia, do ktorých môžete túto metriku zoskupiť"
 msgid "Fields you can group this metric by"
 msgstr "Polia, do ktorých môžete túto metriku zoskupiť"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "Metriky sú oficiálne čísla, o ktoré sa váš tím stará"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Metrics will appear here once your admins have created some"
 msgstr "Metriky sa zobrazia tu, po ich vytvorení"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:28
 msgid "Learn how to create metrics"
 msgstr "Naučte sa, ako vytvárať metriky"
 
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:34
 msgid "Questions about this metric will appear here as they're added"
 msgstr "Po pridaní sa tu zobrazia otázky týkajúce sa tejto metriky"
 
@@ -6091,23 +6115,23 @@ msgstr "Prečo je tento segment zaujímavý?"
 msgid "Things to be aware of about this Segment"
 msgstr "Čo by ste mali vedieť o tomto segmente"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
 msgid "Segments are interesting subsets of tables"
 msgstr "Segmenty sú zaujímavé podmnožiny tabuliek"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "Definovanie spoločných segmentov pre váš tím uľahčuje klásť otázky"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Segments will appear here once your admins have created some"
 msgstr "Segmenty sa zobrazia tu, po tom čo budú vytvoreé"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
 msgid "Learn how to create segments"
 msgstr "Naučte sa, ako vytvárať segmenty"
 
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:35
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:34
 msgid "Questions about this segment will appear here as they're added"
 msgstr "Po pridaní sa tu zobrazia otázky týkajúce sa tohto segmentu"
 
@@ -6127,22 +6151,22 @@ msgstr "Otázky týkajúce sa tohto segmentu"
 msgid "X-ray this segment"
 msgstr "Preskúmať tento segment"
 
-#: frontend/src/metabase/routes.jsx:178 frontend/src/metabase/routes.jsx:179
+#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
 msgid "Login"
 msgstr "Prihlásiť sa"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:303
 #: frontend/src/metabase/containers/ItemPicker.jsx:115
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:204
+#: frontend/src/metabase/routes.jsx:195
 msgid "Search"
 msgstr "Vyhľadávanie"
 
-#: frontend/src/metabase/routes.jsx:223
+#: frontend/src/metabase/routes.jsx:214
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#: frontend/src/metabase/routes.jsx:236
+#: frontend/src/metabase/routes.jsx:227
 msgid "New Question"
 msgstr "Nová otázka"
 
@@ -6186,63 +6210,63 @@ msgstr "Ďakujeme, že ste nám pomohli vylepšiť"
 msgid "We won't collect any usage events"
 msgstr "Nebudeme zhromažďovať žiadne udalosti použitia"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:88
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Aby ste nám pomohli vylepšiť Metabase, chceme zhromažďovať určité údaje o používaní prostredníctvom služby Google Analytics."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:90
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Here's a full list of everything we track and why."
 msgstr "Tu je úplný zoznam všetkého, čo sledujeme a prečo."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Povoliť metabáze anonymne zbierať udalosti použitia"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:113
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0} zhromažďuje čokoľvek o vašich údajoch alebo výsledkoch otázok."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:114
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
 msgid "never"
 msgstr "nikdy"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:119
 msgid "All collection is completely anonymous."
 msgstr "Celá zbierka je úplne anonymná."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Zbieranie môžete kedykoľvek vypnúť v nastaveniach správcu."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:44
+#: frontend/src/metabase/setup/components/Setup.jsx:59
 msgid "If you feel stuck"
 msgstr "Ak sa cítite zaseknutý"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:49
+#: frontend/src/metabase/setup/components/Setup.jsx:64
 msgid "our getting started guide"
 msgstr "náš sprievodca Začíname"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:50
+#: frontend/src/metabase/setup/components/Setup.jsx:65
 msgid "is just a click away."
 msgstr "je vzdialený len na jedno kliknutie."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:92
+#: frontend/src/metabase/setup/components/Setup.jsx:111
 msgid "Welcome to Metabase"
 msgstr "Vitajte v Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:93
+#: frontend/src/metabase/setup/components/Setup.jsx:112
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Vyzerá to, že všetko funguje. Teraz sa s vami zoznámime, pripojíme sa k vašim údajom a začneme prehľadávať dáta."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:97
+#: frontend/src/metabase/setup/components/Setup.jsx:116
 msgid "Let's get started"
 msgstr "Začnime"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:142
+#: frontend/src/metabase/setup/components/Setup.jsx:166
 msgid "You're all set up!"
 msgstr "Všetci ste pripravení!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:153
+#: frontend/src/metabase/setup/components/Setup.jsx:177
 msgid "Take me to Metabase"
 msgstr "Ukážte mi Metabase"
 
@@ -6254,13 +6278,13 @@ msgstr "Čo by sme vám mali spustiť?"
 msgid "Hi, {0}. nice to meet you!"
 msgstr "Ahoj, {0}. rád ťa spoznávam!"
 
-#: frontend/src/metabase/entities/users/forms.js:33
+#: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
 msgstr "Vytvoriť heslo"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:44
-#: frontend/src/metabase/entities/users/forms.js:35
-#: frontend/src/metabase/entities/users/forms.js:82
+#: frontend/src/metabase/entities/users/forms.js:50
+#: frontend/src/metabase/entities/users/forms.js:97
 msgid "Shhh..."
 msgstr "Ticho..."
 
@@ -6268,11 +6292,11 @@ msgstr "Ticho..."
 msgid "Confirm password"
 msgstr "Potvrďte heslo"
 
-#: frontend/src/metabase/entities/users/forms.js:42
+#: frontend/src/metabase/entities/users/forms.js:57
 msgid "Shhh... but one more time so we get it right"
 msgstr "Ticho ... takže ešte raz, takže to máme v poriadku"
 
-#: frontend/src/metabase/entities/users/forms.js:70
+#: frontend/src/metabase/entities/users/forms.js:85
 msgid "Your company or team name"
 msgstr "Názov vašej spoločnosti alebo tímu"
 
@@ -6442,7 +6466,7 @@ msgstr "Heslo bolo úspešne aktualizované!"
 msgid "Account updated successfully!"
 msgstr "Účet bol úspešne aktualizovaný!"
 
-#: frontend/src/metabase/entities/users/forms.js:81
+#: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
 msgstr "Aktuálne heslo"
 
@@ -6454,7 +6478,7 @@ msgstr "Prihláste sa pomocou e-mailovej adresy Google"
 msgid "User Details"
 msgstr "Detaily používateľa"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:327
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:344
 msgid "Reset to defaults"
 msgstr "Obnoviť predvolené hodnoty"
 
@@ -6479,15 +6503,15 @@ msgstr "Ktoré polia chcete použiť pre osi X a Y?"
 msgid "Choose fields"
 msgstr "Vyberte polia"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:217
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:234
 msgid "Save as default view"
 msgstr "Uložiť ako predvolené zobrazenie"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Draw box to filter"
 msgstr "Pridať rámček na filtrovanie"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Cancel filter"
 msgstr "Zrušiť filter"
 
@@ -6515,19 +6539,19 @@ msgstr "Nepodarilo sa nájsť vizualizáciu"
 msgid "Could not display this chart with this data."
 msgstr "Tento graf sa nedal zobraziť s týmito údajmi."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:526
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
 msgid "No results!"
 msgstr "Žiadne výsledky!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:547
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
 msgid "Still Waiting..."
 msgstr "Stále čakám..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:550
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
 msgid "This usually takes an average of {0}."
 msgstr "Zvyčajne to trvá v priemere {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:556
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Je to trochu dlhá doba pre dashboard)"
 
@@ -6687,19 +6711,19 @@ msgstr "Pridajte pravidlo"
 msgid "Update rule"
 msgstr "Aktualizovať pravidlo"
 
-#: frontend/src/metabase/visualizations/index.js:32
+#: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
 msgstr "Vizualizácia je nulová"
 
-#: frontend/src/metabase/visualizations/index.js:37
+#: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
 msgstr "Vizualizácia musí definovať statickú premennú 'identifikátor':"
 
-#: frontend/src/metabase/visualizations/index.js:43
+#: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
 msgstr "Vizualizácia s týmto identifikátorom je už zaregistrovaná:"
 
-#: frontend/src/metabase/visualizations/index.js:71
+#: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
 msgstr "Žiadna vizualizácia pre {0}"
 
@@ -6725,23 +6749,23 @@ msgid "Doh! The data from your query doesn't fit the chosen display choice. This
 msgstr "Údaje z vášho dotazu sa nezhodujú s vybranou voľbou zobrazenia. Táto vizualizácia vyžaduje najmenej {0} {1} údajov."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:9
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:117
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:120
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:161
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:169
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:249
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:267
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "stĺpec"
@@ -6854,83 +6878,83 @@ msgstr "Nič"
 msgid "Linear Interpolated"
 msgstr "Lineárne interpolované"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
 msgstr "Mierka osi X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
 msgstr "Časová séria"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:454
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
 msgid "Linear"
 msgstr "Lineárne"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
 msgid "Power"
 msgstr "Sila"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:428
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:445
 msgid "Log"
 msgstr "Log"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:441
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:430
 msgid "Histogram"
 msgstr "Stĺpcový diagram"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
 msgstr "Rádový"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
 msgstr "Mierka osi Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:462
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
 msgstr "Zobraziť čiaru a značky na osi x"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:360
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:468
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:349
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
 msgid "Compact"
 msgstr "Kompaktné"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:469
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
 msgid "Rotate 45°"
 msgstr "Otočiť o 45 °"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:459
 msgid "Rotate 90°"
 msgstr "Otočiť o 90 °"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
 msgid "Show y-axis line and marks"
 msgstr "Zobraziť čiaru a značky na osi y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:489
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Auto y-axis range"
 msgstr "Automatický rozsah osi y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:533
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:522
 msgid "Use a split y-axis when necessary"
 msgstr "V prípade potreby použite rozdelenú os y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:540
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:529
 msgid "Show label on x-axis"
 msgstr "Zobraziť popis na osi x"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:546
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:535
 msgid "X-axis label"
 msgstr "Popis na osi X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:555
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:544
 msgid "Show label on y-axis"
 msgstr "Zobraziť popis na osi Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:561
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:550
 msgid "Y-axis label"
 msgstr "Popis na osi Y"
 
@@ -7056,23 +7080,23 @@ msgstr "Min. krytie"
 msgid "Max Zoom"
 msgstr "Max. priblíženie"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:231
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:234
 msgid "No relationships found."
 msgstr "Nenašli sa žiadne vzťahy."
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:269
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:272
 msgid "via {0}"
 msgstr "prostredníctvom {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:347
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
 msgid "This {0} is connected to:"
 msgstr "Toto {0} je spojené s:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "Object Detail"
 msgstr "Detail objektu"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:93
 msgid "object"
 msgstr "objekt"
 
@@ -7463,7 +7487,7 @@ msgstr "Máte veľa uložených otázok v {0}? Vytvorte kolekcie, ktoré im pom�
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:149 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -8992,19 +9016,19 @@ msgstr "Môže upravovať túto kolekciu a jej obsah"
 msgid "Can view items in this collection"
 msgstr "Môže zobraziť položky v tejto kolekcii"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:767
+#: frontend/src/metabase/admin/permissions/selectors.js:765
 msgid "Collection Access"
 msgstr "Prístup k inkasu"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:841
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Táto skupina má povolenie na zobrazenie aspoň jednej podskupiny tejto kolekcii."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:848
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Táto skupina má povolenie na úpravu aspoň jednej podskupiny tejto kolekcie."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:861
+#: frontend/src/metabase/admin/permissions/selectors.js:859
 msgid "View sub-collections"
 msgstr "Zobraziť podskupiny"
 
@@ -9012,7 +9036,7 @@ msgstr "Zobraziť podskupiny"
 msgid "Remember Me"
 msgstr "Pamätáš si ma"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:63
+#: frontend/src/metabase/components/BrowseApp.jsx:73
 msgid "X-ray this schema"
 msgstr "Preskúmať schému"
 
@@ -9073,15 +9097,15 @@ msgstr "Metabase nenašla žiadne výsledky pre vaše hľadanie."
 msgid "No metrics"
 msgstr "Žiadne metriky"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:31
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:41
 msgid "Aggregations"
 msgstr "Agregácie"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:32
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:42
 msgid "Operators"
 msgstr "Operátori"
 
-#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:30
+#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:35
 msgid "Custom fields"
 msgstr "Vlastné polia"
 
@@ -9247,7 +9271,7 @@ msgstr "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
 msgid "toucan_sightings"
 msgstr "toucan_sightings"
 
-#: src/metabase/driver/sparksql.clj
+#: src/metabase/models/collection.clj
 msgid "default"
 msgstr "predvolené"
 
@@ -9275,10 +9299,10 @@ msgstr "N/A"
 msgid "Windows domain"
 msgstr "Doména Windows"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:539
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:545
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:554
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:560
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:528
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:534
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:543
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
 msgstr "Popisy"
 
@@ -9313,9 +9337,9 @@ msgstr "Zdieľanie"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:286
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:294
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:302
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:319
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:324
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
@@ -9330,19 +9354,18 @@ msgstr "Zdieľanie"
 msgid "Display"
 msgstr "Zobraziť"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:461
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:476
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:502
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:532
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:402
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:465
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:483
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:521
 msgid "Axes"
 msgstr "Osi"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:212
-#: frontend/src/metabase/admin/settings/selectors.js:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:219
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:62
 msgid "Formatting"
@@ -9376,7 +9399,7 @@ msgstr "Prehľadávať"
 msgid "Compare to the rest"
 msgstr "V porovnaní so zvyškom"
 
-#: frontend/src/metabase/entities/databases/forms.js:16
+#: frontend/src/metabase/entities/databases/forms.js:18
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Použite časové pásmo Java Virtual Machine (JVM)"
 
@@ -9405,24 +9428,24 @@ msgstr "Použite časové pásmo JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Momentálne analyzujeme tabuľky a polia, ktoré vám pomôžu preskúmať vaše údaje."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
 msgid "Tip: "
 msgstr "Tip: "
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:237
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
 msgstr "Vyberte typ meny"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:300
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
 msgid "Field Type"
 msgstr "Typ poľa"
 
-#: frontend/src/metabase/admin/routes.jsx:113
+#: frontend/src/metabase/admin/routes.jsx:118
 #: frontend/src/metabase/nav/containers/Navbar.jsx:267
 msgid "Troubleshooting"
 msgstr "Riešenie problémov"
 
-#: frontend/src/metabase/admin/settings/selectors.js:103
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Enable X-ray features"
 msgstr "Povoľte funkcie automatického prehľadávania"
 
@@ -9467,7 +9490,7 @@ msgstr "Trvanie (ms)"
 msgid "Currency"
 msgstr "Mena"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
 msgstr "Vyberte používateľa alebo kanál ..."
 
@@ -9615,7 +9638,7 @@ msgstr "Štýl čiary"
 msgid "Show dots on lines"
 msgstr "Zobraziť bodky na čiarach"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:348
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
@@ -9629,7 +9652,7 @@ msgstr "Ktorá os?"
 msgid "Line + Bar"
 msgstr "Riadok + stĺpec"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
 msgid "line and bar chart"
 msgstr "čiarový a stĺpcový graf"
 
@@ -11076,7 +11099,7 @@ msgstr "Ako je táto metrika rozdelená medzi rôzne čísla"
 msgid "Sessions by page where the session began"
 msgstr "Relácie podľa stránky, kde sa relácia začala"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:503
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -11445,7 +11468,7 @@ msgstr "Duplikujte túto položku"
 msgid "Archive this item"
 msgstr "Archivovať túto položku"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:331
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:325
 msgid "Duplicate dashboard"
 msgstr "Duplikátny dashboard"
 
@@ -11568,7 +11591,7 @@ msgstr[1] "Kvartály z roku"
 msgstr[2] "Kvartálov z roku"
 msgstr[3] "Kvartálov z roku"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
@@ -11586,8 +11609,8 @@ msgstr "[Q]Q"
 msgid "This"
 msgstr "Toto"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:97
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:137
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:136
 msgid "Invalid"
 msgstr "Neplatný"
 
@@ -12350,6 +12373,7 @@ msgstr "Tu sú vaše {0} posledné karty:"
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
 msgstr "Mohli by ste byť trochu konkrétnejší alebo použiť ID? Našiel som tieto karty s menami, ktoré sa zhodujú:"
 
+#: src/metabase/driver/common/parameters/values.clj
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
 msgstr "Karta {0} sa nenašla."
@@ -12458,11 +12482,11 @@ msgstr "Pokyny k vynechaniu pri štarte"
 msgid "Archive this?"
 msgstr "Archivovať to?"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:243
+#: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
 msgstr "Získajte ďalšie informácie o dátach"
 
-#: frontend/src/metabase/entities/databases/forms.js:20
+#: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
 msgstr "Pri pripájaní použite DNS SRV"
 
@@ -12472,7 +12496,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "Použitie tejto voľby vyžaduje, aby poskytnutý host bol úplný názov domény. Ak sa pripájate k Atlas cluster bude pravdepodobne potrebné túto možnosť povoliť. Ak neviete, čo to znamená,nechajte túto možnosť vypnutú."
 
-#: frontend/src/metabase/entities/databases/forms.js:204
+#: frontend/src/metabase/entities/databases/forms.js:273
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Automaticky spúšťať dotazy pri jednoduchom filtrovaní a sumarizácii"
 
@@ -12496,11 +12520,11 @@ msgstr "Všetky výsledky"
 msgid "Our Analytics"
 msgstr "Naša analýza"
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:513
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
 msgstr "Prídavný súčet všetkých hodnôt stĺpca. \\ne.x. celkový príjem v čase."
 
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
 msgstr "Prídavný počet riadkov. \\ne.x. celkový počet predajov v čase."
 
@@ -12510,7 +12534,7 @@ msgstr "Prídavný počet riadkov. \\ne.x. celkový počet predajov v čase."
 msgid "Filter"
 msgstr "Filter"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:50
 msgid "record"
 msgid_plural "records"
 msgstr[0] "záznam"
@@ -12526,27 +12550,27 @@ msgstr "Prehliadať údaje"
 msgid "Write SQL"
 msgstr "Napíšte SQL"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:83
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
 msgstr "Jednoduchá otázka"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:84
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:87
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
 msgstr "Vyberte niektoré údaje, zobrazte ich a ľahko ich filtrujte, sumarizujte a vizualizujte."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:95
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:98
 msgid "Custom question"
 msgstr "Vlastná otázka"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:96
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:99
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Použite pokročilý editor poznámok na pripojenie údajov, vytváranie vlastných stĺpcov, výpočty a ďalšie."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Basic Metrics"
 msgstr "Základné metriky"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:322
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
 msgid "Custom…"
 msgstr "Vlastné ..."
 
@@ -12615,15 +12639,15 @@ msgstr "Vyberte stĺpec na zoskupenie podľa"
 msgid "Pick your starting data"
 msgstr "Vyberte počiatočné údaje"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select None"
 msgstr "Nevybrať nič"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select All"
 msgstr "Vybrať všetko"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:151
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:152
 msgid "Pick a table..."
 msgstr "Vyberte tabuľku"
 
@@ -12750,15 +12774,15 @@ msgstr "Pridajte metriku"
 #: frontend/src/metabase/lib/core.js:137 frontend/src/metabase/lib/core.js:142
 #: frontend/src/metabase/lib/core.js:147 frontend/src/metabase/lib/core.js:152
 #: frontend/src/metabase/lib/core.js:157 frontend/src/metabase/lib/core.js:162
-#: frontend/src/metabase/user/components/UserSettings.jsx:63
+#: frontend/src/metabase/user/components/UserSettings.jsx:64
 msgid "Profile"
 msgstr "Profil"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:560
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "To je zvyčajne dosť rýchle, ale zdá sa, že to chvíľu trvá."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
 msgid "Combo"
 msgstr "Kombinácia"
 
@@ -12774,11 +12798,11 @@ msgstr "Trend"
 msgid "Boolean"
 msgstr "Boolovská hodnota"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:62
 msgid "Unknown Segment"
 msgstr "Neznámy segment"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:73
 msgid "Unknown Filter"
 msgstr "Neznámy filter"
 
@@ -12908,6 +12932,7 @@ msgstr "Použitie novo vytvoreného classloaderu ako zdieľaného kontextu, clas
 msgid "Failed to copy file"
 msgstr "Nepodarilo sa skopírovať súbor"
 
+#. check that the URL is valid
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
 msgstr "Neplatná adresa URL stránky: {0}"
@@ -13182,7 +13207,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Vyberte stĺpce, ktoré chcete zahrnúť"
 
-#: frontend/src/metabase/entities/databases/forms.js:205
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Keď je toto zapnuté, Metabase automaticky spúšťa dotazy, keď používatelia robia jednoduché prieskumy pomocou tlačidiel Sumarizovať a Filtrovať pri prezeraní tabuľky alebo grafu. Túto možnosť môžete vypnúť, ak je vyhľadávanie v tejto databáze pomalé. Toto nastavenie nemá vplyv na dotazy SQL."
 
@@ -13220,7 +13245,7 @@ msgstr "Chyba pri určovaní očakávaných stĺpcov pre dopyt"
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "Neošetřená výnimka, očakávaný middleware `catch-exceptions`, ktorý to zvládne."
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:125
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
 msgid "Diagnostic Info"
 msgstr "Diagnostické informácie"
 
@@ -13244,11 +13269,11 @@ msgstr "Pri prihlasovaní pomocou Google sa vyskytol problém. Prosím kontaktuj
 msgid "Sign in with email"
 msgstr "Prihlásiť sa pomocou emailu"
 
-#: frontend/src/metabase/entities/databases/forms.js:21
+#: frontend/src/metabase/entities/databases/forms.js:23
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "Použitie tejto voľby vyžaduje, aby poskytnutý hostiteľ bol úplný názov domény. Ak sa pripájate ku Atlas klastru, možno bude potrebné túto možnosť povoliť. Ak neviete, čo to znamená, nechajte to vypnuté."
 
-#: frontend/src/metabase/entities/databases/forms.js:213
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Metabase predvolene vykonáva rýchlu hodinovú synchronizáciu a intenzívne denné skenovanie hodnôt polí. Ak máte rozsiahlu databázu, odporúčame vám zapnúť skenovanie a skontrolovať kedy a ako často sa uskutoční kontrola hodnôt polí."
 
@@ -13316,11 +13341,11 @@ msgstr "Nezahŕňa"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "Toto pole nebude viditeľné ani voliteľné pri otázkach vytvorených pomocou grafických rozhraní. Bude stále prístupná v SQL / natívnych dotazoch."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:512
 msgid "Cumulative sum"
 msgstr "Kumulatívna suma"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Standard deviation"
 msgstr "Štandardná odchýlka"
 
@@ -13332,23 +13357,23 @@ msgstr "musí mať aspoň {0} znakov"
 msgid "Must be at least {0} characters long"
 msgstr "Musí mať aspoň {0} znakov"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:389
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:82
 msgid "Name (required)"
 msgstr "Meno (povinné)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:556
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
 msgid "Run selected text"
 msgstr "Spustiť vybraný text"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:557
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
 msgid "Run query"
 msgstr "Spustiť dotaz"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(⌘ + enter)"
 msgstr "(⌘ + enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + enter)"
 
@@ -13360,7 +13385,7 @@ msgstr "Tu sa zobrazia vaše výsledky"
 msgid "You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question."
 msgstr "Na uloženej otázke nebudete môcť robiť žiadne trvalé zmeny, pokiaľ nekliknete na tlačidlo Uložiť a nevyberiete pôvodnú otázku."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:199
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:200
 msgid "There aren't any filter widgets for this type of field yet."
 msgstr "Pre tento typ poľa zatiaľ neexistujú žiadne miniaplikácie filtra."
 
@@ -13396,19 +13421,19 @@ msgstr "Cielľová čiara"
 msgid "Trend line"
 msgstr "Línia trendu"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:320
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:317
 msgid "Show values on data points"
 msgstr "Zobraziť hodnoty v dátových bodoch"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:334
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:325
 msgid "Values to show"
 msgstr "Hodnoty na zobrazenie"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:342
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:332
 msgid "As many as can fit nicely"
 msgstr "Toľko, koľko je možné"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:343
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
 msgid "All"
 msgstr "Všetky"
 
@@ -13700,31 +13725,31 @@ msgstr "Čísla"
 msgid "No mappable groups"
 msgstr "Žiadna primovateľná skupina"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:107
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
 msgstr "Metabase dokumentácia"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
 msgstr "Zahŕňa sprievodcu riešením problémov"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:112
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
 msgid "Post on the Metabase support forum"
 msgstr "Príspevok na fóre podpory Metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:114
 msgid "A community forum for all things Metabase"
 msgstr "Komunitné fórum pre Metabase"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:117
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
 msgid "File a bug report"
 msgstr "Odošlite hlásenie o chybe"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:119
 msgid "Create a GitHub issue (includes the diagnostic info below)"
 msgstr "Vytvorte GitHub issue (obsahuje diagnostické informácie nižšie)"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:127
 msgid "Please include these details in support requests. Thank you!"
 msgstr "Tieto podrobnosti zahrňte do žiadostí o podporu. Ďakujem!"
 
@@ -13752,38 +13777,40 @@ msgstr "Žiadny zodpovedajúci výsledok"
 msgid "Submit"
 msgstr "Odoslať"
 
-#: frontend/src/metabase/entities/databases/forms.js:13
+#: frontend/src/metabase/entities/databases/forms.js:15
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host. This option also provides an extra layer of security when a VPN is not available. Enabling this is usually slower than a direct connection."
 msgstr "Prístup k niektorým inštaláciám databázy je možný iba pripojením cez hostiteľa pomocou SSH. Táto voľba tiež poskytuje ďalšiu úroveň zabezpečenia, keď nie je k dispozícii sieť VPN. Pripojenie je zvyčajne pomalšie ako priame pripojenie."
 
-#: frontend/src/metabase/entities/databases/forms.js:17
+#: frontend/src/metabase/entities/databases/forms.js:19
 msgid "We suggest you leave this off unless you're doing manual timezone casting in many or most of your queries with this data."
 msgstr "Odporúčame vám to nechať vypnuté, pokiaľ v týchto údajoch nerobíte manuálne odovzdávanie časových pásiem do mnohých alebo väčšiny otázok."
 
-#: frontend/src/metabase/entities/databases/forms.js:93
+#: frontend/src/metabase/entities/databases/forms.js:128
 msgid "{0} to get an auth code."
 msgstr "{0} získate autorizačný kód."
 
-#: frontend/src/metabase/entities/databases/forms.js:101
+#: frontend/src/metabase/entities/databases/forms.js:136
+#: src/metabase/models/collection.clj
 msgid "or"
 msgstr "alebo"
 
-#: frontend/src/metabase/entities/databases/forms.js:159
-#: frontend/src/metabase/entities/databases/forms.js:197
-#: frontend/src/metabase/entities/users/forms.js:44
+#: frontend/src/metabase/entities/databases/forms.js:39
+#: frontend/src/metabase/entities/databases/forms.js:226
+#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "povinné"
 
-#: frontend/src/metabase/entities/databases/forms.js:188
+#: frontend/src/metabase/entities/databases/forms.js:257
 msgid "Database type"
 msgstr "Typ databázy"
 
-#: frontend/src/metabase/entities/databases/forms.js:222
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Toto je ľahký proces, ktorý zisťuje aktualizácie schémy tejto databázy. Vo väčšine prípadov by to malo byť v poriadku, ak necháte tento proces synchronizovať každú hodinu."
 
-#: frontend/src/metabase/entities/databases/forms.js:230
+#: frontend/src/metabase/entities/databases/forms.js:299
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase môže skenovať hodnoty prítomné v každom poli v tejto databáze. Môže to byť proces, ktorý je trochu náročný na prostriedky, najmä ak máte veľmi veľkú databázu."
 
@@ -13791,15 +13818,15 @@ msgstr "Metabase môže skenovať hodnoty prítomné v každom poli v tejto data
 msgid "Collection"
 msgstr "Zbierka"
 
-#: frontend/src/metabase/entities/users/forms.js:40
+#: frontend/src/metabase/entities/users/forms.js:55
 msgid "Confirm your password"
 msgstr "Potvrďte svoje heslo"
 
-#: frontend/src/metabase/entities/users/forms.js:45
+#: frontend/src/metabase/entities/users/forms.js:60
 msgid "passwords do not match"
 msgstr "heslá sa nezhodujú"
 
-#: frontend/src/metabase/entities/users/forms.js:71
+#: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
 msgstr "Pracovisko úžasných"
 
@@ -13839,328 +13866,324 @@ msgid "Returns the average of the values in the column."
 msgstr "Vráti priemer hodnôt v stĺpci."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:18
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
 msgid "The column whose values to average."
 msgstr "Stĺpec, ktorého hodnoty sa majú spriemerovať."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "start"
 msgstr "štart"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "end"
 msgstr "koniec"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
 msgid "Checks a date or numeric column's values to see if they're within the specified range."
 msgstr "Kontroluje hodnoty dátumu alebo číselného stĺpca a zisťuje, či sa nachádzajú v zadanom rozsahu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
 msgstr "Hodnotenie"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:24
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:98
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
 msgid "condition"
 msgstr "podmienka"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
 msgid "output"
 msgstr "výstup"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Testuje zoznam prípadov a vracia zodpovedajúcu hodnotu prvého skutočného prípadu s voliteľnou predvolenou hodnotou, ak nie je splnené nič iné."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
 msgid "Weight"
 msgstr "Váha"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
 msgid "Large"
 msgstr "Veľkosť"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
 msgid "Medium"
 msgstr "Stredná"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
 msgid "Small"
 msgstr "Malá"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
 msgid "Something that should evaluate to true or false."
 msgstr "Niečo, čo by sa malo vyhodnocovať ako pravda alebo nepravda."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:54
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "Hodnota, ktorá sa vráti, ak je predchádzajúca podmienka splnená."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:62
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "value1"
 msgstr "hodnota1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:74
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
 msgid "value2"
 msgstr "hodnota2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Pozrie hodnoty v každom argumente v poradí a vráti prvú nenulovú hodnotu pre každý riadok."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:56
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
 msgid "Comments"
 msgstr "Komentáre"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
 msgid "Notes"
 msgstr "Poznámky"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
 msgid "No comments"
 msgstr "Žiadne komentáre"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
 msgid "A column or value."
 msgstr "Stĺpec alebo hodnota."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:65
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:77
 msgid "If value1 is empty, value2 gets returned if it's not empty, and so on."
 msgstr "Ak je hodnota1 prázdna, hodnota2 sa vráti, ak nie je prázdna, atď."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 msgid "Combines two or more strings of text together."
 msgstr "Kombinuje dva alebo viac reťazcov textu dohromady."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
 msgid "Last Name"
 msgstr "Priezvisko"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 msgid "First Name"
 msgstr "Meno"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
 msgstr "value2 sa pridá na koniec."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
 msgstr "Toto sa pripočíta na koniec hodnoty1."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
 msgid "string1"
 msgstr "reťazec1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
 msgid "string2"
 msgstr "reťazec2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:80
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Skontroluje, či reťazec1 obsahuje v sebe reťazec2."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:284
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
 msgid "Status"
 msgstr "Status"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 msgid "Pass"
 msgstr "Skončiť sa"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
 msgstr "Obsah tohto reťazca sa skontroluje."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
 msgid "The string of text to look for."
 msgstr "Reťazec textu, ktorý treba hľadať."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:90
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:116
 msgid "Returns the count of rows in the source data."
 msgstr "Vráti počet riadkov v zdrojových dátach."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Only counts rows where the condition is true."
 msgstr "Počíta sa iba riadok, v ktorom je podmienka splnená."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:97
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:261
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
 msgid "Subtotal"
 msgstr "Medzisúčet"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
 msgid "The additive total of rows across a breakout."
 msgstr "Doplnkový celkový počet riadkov naprieč dokončením."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:110
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
 msgid "The rolling sum of a column across a breakout."
 msgstr "Kumulatívny súčet naprieč stĺpcom."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:113
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:268
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
 msgstr "Stĺpec na súčet."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
 msgid "The number of distinct values in this column."
 msgstr "Počet rôznych hodnôt v tomto stĺpci."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "The column whose distinct values to count."
 msgstr "Stĺpec, ktorého hodnoty sa majú počítať."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:128
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:145
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:153
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:201
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:274
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
 msgid "text"
 msgstr "text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:130
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:223
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
 msgid "comparison"
 msgstr "porovnanie"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Vráti pravdivú hodnotu, ak sa koniec textu zhoduje s textom porovnania."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "Appetite"
 msgstr "Chuť"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "hungry"
 msgstr "hladný"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 msgid "A column or string of text to check."
 msgstr "Stĺpec alebo reťazec textu na kontrolu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
 msgid "The string of text that the original text should end with."
 msgstr "Reťazec textu, ktorým by mal pôvodný text končiť."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 msgid "regular_expression"
 msgstr "regulárny_výraz"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:136
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Extrahuje zodpovedajúce podreťazce podľa regulárneho výrazu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:137
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
 msgid "Address"
 msgstr "Adresa"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 msgid "The column or string of text to search though."
 msgstr "Stĺpec alebo reťazec textu, ktorý sa má prehľadávať."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
 msgid "The regular expression to match."
 msgstr "Regulárny výraz, ktorý sa má zhodovať."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the string of text in all lowercase."
 msgstr "Vráti reťazec textu v malých písmenách."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:149
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to lowercase."
 msgstr "Stĺpec s hodnotami na prevod na malé písmená."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:154
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 msgid "Removes leading whitespace from a string of text."
 msgstr "Odstráni úvodné medzery z reťazca textu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:157
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column with values you want to trim."
 msgstr "Stĺpec s hodnotami, ktoré chcete orezať."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "Returns the largest value found in the column."
 msgstr "Vráti najväčšiu hodnotu nachádzajúcu sa v stĺpci."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
 msgid "Age"
 msgstr "Vek"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:165
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
 msgid "The numeric column whose maximum you want to find."
 msgstr "Číselný stĺpec, ktorého maximum chcete nájsť."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:170
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "Returns the smallest value found in the column."
 msgstr "Vráti najmenšiu hodnotu nachádzajúcu sa v stĺpci."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
 msgid "Salary"
 msgstr "Plat"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:173
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
 msgid "The numeric column whose minimum you want to find."
 msgstr "Číselný stĺpec, ktorého minimum chcete nájsť."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:181
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:242
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
 msgid "position"
 msgstr "pozícia"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:194
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
 msgid "length"
 msgstr "dĺžka"
 
@@ -14169,7 +14192,7 @@ msgstr "dĺžka"
 msgid "new_text"
 msgstr "nový_text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:187
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
 msgid "Replaces a part of the input text with new text."
 msgstr "Nahradí časť vstupného textu novým textom."
 
@@ -14181,7 +14204,7 @@ msgstr "Číslo objednávky"
 msgid "Updated Part of ID"
 msgstr "Aktualizovaná časť ID"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
 msgid "The text that will be modified."
 msgstr "Text, ktorý bude upravený."
 
@@ -14197,87 +14220,87 @@ msgstr "Počet znakov, ktoré sa majú nahradiť."
 msgid "The text to use in the replacement."
 msgstr "Text, ktorý sa má použiť ako náhrada."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Odstráni koncové medzery z textového reťazca."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:210
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Vráti percento riadkov v údajoch, ktoré zodpovedajú podmienke, ako číslo."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:218
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Vráti hodnotu pravda, ak sa začiatok textu zhoduje s textom porovnania."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Course Name"
 msgstr "Názov kurzu"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Computer Science"
 msgstr "Počítačová veda"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
 msgid "The string of text that the original text should start with."
 msgstr "Reťazec textu, s ktorým by mal pôvodný text začínať."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:229
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
 msgid "Calculates the standard deviation of the column."
 msgstr "Vypočíta smerodajnú odchýlku stĺpca."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:230
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
 msgid "Population"
 msgstr "Populácia"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
 msgid "A numeric column."
 msgstr "Číselný stĺpec."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
 msgid "Returns a portion of the supplied text."
 msgstr "Vráti časť dodaného textu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:241
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:313
 msgid "The text to return a portion of."
 msgstr "Text na vrátenie časti."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
 msgid "The position to start copying characters."
 msgstr "Pozícia na začatie kopírovania znakov."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:245
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
 msgid "The number of characters to return."
 msgstr "Počet znakov, ktoré sa majú vrátiť."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
 msgid "Adds up all the values of the column."
 msgstr "Sčíta všetky hodnoty stĺpca."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:253
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
 msgid "The numeric column to sum."
 msgstr "Číselný stĺpec, ktorý sa má sčítať."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Sčítava hodnoty v stĺpci, kde riadky zodpovedajú podmienkam."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
 msgid "Order Status"
 msgstr "Stav objednávky"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
 msgid "Valid"
 msgstr "Platná"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Odstráni úvodné a koncové medzery z reťazca textu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
 msgid "Returns the string of text in all upper case."
 msgstr "Vráti reťazec textu vo veľkých písmenách."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
 msgid "The column with values to convert to upper case."
 msgstr "Stĺpec s hodnotami pre prevod na veľké písmená."
 
@@ -14349,39 +14372,39 @@ msgstr "Ďakujeme, že používate Metabase!"
 msgid "Powered by {0}"
 msgstr "Beží na {0}"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:191
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
 msgid "To:"
 msgstr "Pre:"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:40
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
 msgstr "Túto otázku nemožno použiť, pretože je postavená pre inú databázu."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:44
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:43
 msgid "Couldn't find a saved question with that ID number."
 msgstr "Uloženú otázku s týmto ID číslom sa nepodarilo nájsť."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:55
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:54
 msgid "Pick a saved question"
 msgstr "Vyberte uloženú otázku"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:57
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:56
 msgid "Pick a different question"
 msgstr "Vyberte inú otázku"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:62
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:61
 msgid "Loading…"
 msgstr "Načítava…"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:79
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:78
 msgid "Question #…"
 msgstr "Otázka č.…"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:81
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
 msgstr "Otázka č.{0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:115
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
 msgstr "Naposledy upravené {0}"
 
@@ -14393,11 +14416,11 @@ msgstr "{0} vytvorí premennú v tejto šablóne dotazu nazvanú \"názov_ preme
 msgid "Giving a variable the \"Field Filter\" type allows you to link questions to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "Poskytnutím premennej typu „Filter Poľa“ môžete prepojiť otázky s miniaplikáciami filtra na dashboarde alebo použiť viac typov miniaplikácií filtra na svoju otázku SQL. Pri pridávaní filtrov do existujúcich stĺpcov vloží premenná Filter Poľa premennú SQL podobnú tej, ktorú vytvoril tvorca dotazov GUI."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:131
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
 msgstr "Názov premennej"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:217
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:218
 msgid "Filter widget label"
 msgstr "Filtrovať popis miniaplikácie"
 
@@ -14429,11 +14452,11 @@ msgstr "V záhlaví stĺpca"
 msgid "In every table cell"
 msgstr "V každej bunke tabuľky"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:351
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:341
 msgid "Value formatting"
 msgstr "Formátovanie hodnoty"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:361
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
 msgid "Full"
 msgstr "Plný"
 
@@ -14761,3 +14784,482 @@ msgstr "Chyba pri generovaní štatistík pre stĺpec:"
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandonment email!"
 msgstr "Odosielame e-mail o opustení účtu!"
+
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
+msgstr "Ak chcete pridať pomenovanú možnosť metriky, môžete vytvoriť uložené metriky. Medzi uložené metriky patrí typ agregácie, agregované pole a prípadne akýkoľvek filter, ktorý pridáte. Ako príklad môžete použiť na vytvorenie niečoho ako oficiálny spôsob výpočtu „priemernej ceny“ pre tabuľku Objednávky."
+
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:105
+msgid "Select and add filters to create your new segment."
+msgstr "Vyberte a pridajte filtre na vytvorenie nového segmentu."
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+msgid "Alphabetical"
+msgstr "abecedne"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+msgid "Smart"
+msgstr "šikovný"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+msgid "Column order: {0}"
+msgstr "Poradie stĺpcov: {0}"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
+msgid "Unhide all"
+msgstr "Odkryť všetko"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:204
+msgid "Hide all"
+msgstr "Skryť všetko"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:206
+msgid "Unhide"
+msgstr "odkryť"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:22
+msgid "New metric"
+msgstr "Nová metrika"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:45
+msgid "Create metrics to add them to the Summarize dropdown in the query builder"
+msgstr "Vytvorte metriky a pridajte ich do rozbaľovacej ponuky Sumarizácia v nástroji na tvorbu dotazov"
+
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:22
+msgid "New segment"
+msgstr "Nový segment"
+
+#: frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx:71
+msgid "Filter by table"
+msgstr "Filtrovať podľa tabuľky"
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:64
+msgid "Checking HTTPS..."
+msgstr "Prebieha kontrola protokolu HTTPS ..."
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:66
+msgid "It looks like HTTPS is not properly configured"
+msgstr "Vyzerá to, že protokol HTTPS nie je správne nakonfigurovaný"
+
+#: frontend/src/metabase/admin/settings/selectors.js:57
+msgid "Redirect to HTTPS"
+msgstr "Presmerovanie na HTTPS"
+
+#: frontend/src/metabase/admin/settings/selectors.js:219
+msgid "Localization"
+msgstr "lokalizácia"
+
+#: frontend/src/metabase/admin/settings/selectors.js:222
+msgid "Instance language"
+msgstr "Jazyk inštancie"
+
+#: frontend/src/metabase/admin/settings/selectors.js:237
+msgid "Localization options"
+msgstr "Možnosti lokalizácie"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:51
+msgid "This database doesn't have any tables."
+msgstr "Táto databáza nemá žiadne tabuľky."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
+msgid "This field only accepts a single value because it's used in a SQL query."
+msgstr "Toto pole akceptuje iba jednu hodnotu, pretože sa používa v dotaze SQL."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:17
+msgid "Service Accounts"
+msgstr "Účty služieb"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:26
+msgid "Metabase connects to Big Query via {0}."
+msgstr "Metabáza sa pripája k Big Query cez {0}."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:29
+msgid "Continue using an OAuth application to connect"
+msgstr "Na pripojenie sa naďalej používajte aplikáciu OAuth"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:43
+msgid "We recommend switching to use {0} instead of an OAuth application to connect to BigQuery"
+msgstr "Na pripojenie k aplikácii BigQuery odporúčame namiesto aplikácie OAuth prepnúť používanie {0}"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:48
+msgid "Connect to a Service Account instead"
+msgstr "Namiesto toho sa pripojte k účtu služby"
+
+#: frontend/src/metabase/entities/databases/forms.js:44
+msgid "invalid JSON"
+msgstr "neplatný JSON"
+
+#: frontend/src/metabase/entities/databases/forms.js:50
+msgid "SSH private key"
+msgstr "Súkromný kľúč SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:51
+msgid "Paste the contents of your ssh private key here"
+msgstr "Sem vložte obsah súkromného kľúča ssh"
+
+#: frontend/src/metabase/entities/databases/forms.js:55
+msgid "Passphrase for the SSH private key"
+msgstr "Prístupová fráza pre súkromný kľúč SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:58
+msgid "SSH Authentication"
+msgstr "Autentifikácia SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:60
+msgid "SSH Key"
+msgstr "Kľúč SSH"
+
+#: frontend/src/metabase/entities/databases/forms.js:65
+msgid "Server SSL certificate chain"
+msgstr "Reťaz certifikátov SSL servera"
+
+#: frontend/src/metabase/entities/databases/forms.js:66
+msgid "Paste the contents of the server's SSL certificate chain here"
+msgstr "Sem prilepte obsah reťazca certifikátov SSL servera"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:11
+msgid "Paste a connection string"
+msgstr "Prilepte pripojovací reťazec"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:12
+msgid "Fill out individual fields"
+msgstr "Vyplňte jednotlivé polia"
+
+#: frontend/src/metabase/entities/snippets.js:14
+msgid "Enter some SQL here so you can reuse it later"
+msgstr "Sem zadajte nejaký SQL, aby ste ho mohli znova použiť neskôr"
+
+#: frontend/src/metabase/entities/snippets.js:24
+msgid "Give your snippet a name"
+msgstr "Zadajte svoj úryvok"
+
+#: frontend/src/metabase/entities/snippets.js:25
+msgid "Current Customers"
+msgstr "Súčasní zákazníci"
+
+#: frontend/src/metabase/entities/snippets.js:30
+msgid "Add a description"
+msgstr "pridaj popis"
+
+#: frontend/src/metabase/entities/users/forms.js:37
+msgid "Use site default"
+msgstr "Použiť predvolené nastavenie lokality"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+msgid "find"
+msgstr "Nájsť"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+msgid "replace"
+msgstr "vymeniť"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+msgid "The text to find."
+msgstr "Text, ktorý treba nájsť."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "The text to use as the replacement."
+msgstr "Text, ktorý sa má použiť ako náhrada."
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+msgid "Editing {0}"
+msgstr "Úpravy {0}"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+msgid "Create your new snippet"
+msgstr "Vytvorte si nový útržok"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+msgid "Archived snippets"
+msgstr "Archivované úryvky"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+msgid "Snippets are reusable bits of SQL"
+msgstr "Útržky sú opakovane použiteľné bity SQL"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+msgid "Create a snippet"
+msgstr "Vytvorte úryvok"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+msgid "Snippets"
+msgstr "úryvky"
+
+#: frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx:15
+msgid "SQL Snippets"
+msgstr "Úryvky SQL"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:38
+msgid "Your language is set to {0}"
+msgstr "Váš jazyk je nastavený na {0}"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:50
+msgid "What's your preferred language?"
+msgstr "Aký je váš preferovaný jazyk?"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:54
+msgid "This language will be used throughout Metabase and will be the default for new users."
+msgstr "Tento jazyk sa bude používať v metabáze a bude predvolený pre nových používateľov."
+
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:159
+msgid "We filtered out {0} row(s) containing null values."
+msgstr "Vyfiltrovali sme {0} riadkov obsahujúcich nulové hodnoty."
+
+#: frontend/src/metabase/visualizations/lib/settings/series.js:133
+msgid "Show values for this series"
+msgstr "Zobraziť hodnoty pre túto sériu"
+
+#: src/metabase/api/card.clj
+msgid "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
+msgstr "Priemerná doba vykonávania otázky je {0}; pomocou magického TTL z {1}"
+
+#: src/metabase/api/native_query_snippet.clj
+msgid "A snippet with that name already exists. Please pick a different name."
+msgstr "Útržok s týmto menom už existuje. Vyberte iný názov."
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Metric]"
+msgstr "[Neznáme metriky]"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Segment]"
+msgstr "[Neznámy segment]"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error writing error to output stream"
+msgstr "Chyba pri zápise chyby do výstupného toku"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Caught unexpected Exception in streaming response body"
+msgstr "Zachytená neočakávaná výnimka v tele odpovede na streamovanie"
+
+#: src/metabase/async/streaming_response.clj
+msgid "bound-fn caught unexpected Exception"
+msgstr "bound-fn chytil nečakanú výnimku"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error determining whether HTTP request was canceled"
+msgstr "Chyba pri určovaní, či bola žiadosť HTTP zrušená"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Check cancelation status timed out after {0}"
+msgstr "Časový limit kontroly zrušenia vyprší po {0}"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Unexpected exception in do-f-async"
+msgstr "Neočakávaná výnimka v do-f-async"
+
+#: src/metabase/async/streaming_response.clj src/metabase/server.clj
+msgid "Unexpected exception writing error response"
+msgstr "Neočakávaná odpoveď na chybu pri neočakávanej výnimke"
+
+#: src/metabase/driver/common.clj
+msgid "Server certificate not trusted - did you specify the correct SSL certificate chain?"
+msgstr "Serverový certifikát nie je dôveryhodný - zadali ste správny reťaz certifikátov SSL?"
+
+#: src/metabase/driver/common.clj
+msgid "Server appears to require SSL - please enable SSL above"
+msgstr "Zdá sa, že server vyžaduje SSL - povoľte vyššie uvedený protokol SSL"
+
+#: src/metabase/driver/common.clj
+msgid "Username"
+msgstr "užívateľské meno"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Don''t know how to parse parameter of type {0}"
+msgstr "Neviem, ako analyzovať parameter typu {0}"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Invalid :card parameter: missing `:card-id`"
+msgstr "Neplatný: parameter karty: chýba `: id-karty`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Unable to resolve Snippet: missing `:snippet-id`"
+msgstr "Úryvok nie je možné vyriešiť: chýba `: snippet-id`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Snippet {0} {1} not found."
+msgstr "Úryvok {0} {1} sa nenašiel."
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error determining value for parameter"
+msgstr "Chyba pri určovaní hodnoty parametra"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error building query parameter map"
+msgstr "Chyba pri vytváraní mapy parametrov dotazu"
+
+#: src/metabase/middleware/log.clj
+msgid "ASYNC"
+msgstr "ASYNC"
+
+#: src/metabase/middleware/log.clj
+msgid "{0} ({1} DB calls)"
+msgstr "{0} ({1} hovory DB)"
+
+#: src/metabase/middleware/log.clj
+msgid "App DB connections: {0}/{1}"
+msgstr "Pripojenia DB aplikácií: {0} / {1}"
+
+#: src/metabase/middleware/log.clj
+msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
+msgstr "Mólové vlákna: {0} / {1} ({2} nečinné, {3} v poradí)"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} total active threads)"
+msgstr "({0} celkom aktívnych vlákien)"
+
+#: src/metabase/middleware/log.clj
+msgid "Queries in flight: {0}"
+msgstr "Otázky za letu: {0}"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} queued)"
+msgstr "({0} v poradí)"
+
+#: src/metabase/models/collection.clj
+msgid "Collection must be in the same namespace as its parent"
+msgstr "Zbierka musí byť v rovnakom priestore mien ako jej rodič"
+
+#: src/metabase/models/collection.clj
+msgid "Personal Collections must be in the default namespace"
+msgstr "Osobné zbierky musia byť v predvolenom priestore mien"
+
+#: src/metabase/models/collection.clj
+msgid "You cannot move a Collection to a different namespace once it has been created."
+msgstr "Po vytvorení kolekcie nemôžete presunúť do iného priestoru názvov."
+
+#: src/metabase/models/collection.clj src/metabase/models/permissions.clj
+msgid "Collection does not exist."
+msgstr "Zbierka neexistuje."
+
+#: src/metabase/models/collection.clj
+msgid "A {0} can only go in Collections in the {1} namespace."
+msgstr "{0} môže ísť iba do zbierky v priestore názvov {1}."
+
+#: src/metabase/models/database.clj
+msgid "Error sending database deletion notification"
+msgstr "Chyba pri odosielaní oznámenia o odstránení databázy"
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "You cannot update the creator_id of a NativeQuerySnippet."
+msgstr "Nemôžete aktualizovať creator_id z NativeQuerySnippet."
+
+#: src/metabase/models/setting.clj
+msgid "Error fetching value of Setting"
+msgstr "Chyba pri načítaní hodnoty nastavenia"
+
+#: src/metabase/public_settings.clj
+msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
+msgstr "Jazyk, ktorý by sa mal používať pre používateľské rozhranie Metabase, systémové e-maily, impulzy a výstrahy."
+
+#: src/metabase/public_settings.clj
+msgid "This is also the default language for all users, which they can change from their own account settings."
+msgstr "Toto je tiež predvolený jazyk pre všetkých používateľov, ktorý môžu zmeniť z nastavení svojho vlastného účtu."
+
+#: src/metabase/public_settings.clj
+msgid "Invalid locale {0}"
+msgstr "Neplatné miestne nastavenie {0}"
+
+#: src/metabase/public_settings.clj
+msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
+msgstr "Vynútiť všetku komunikáciu pri používaní protokolu HTTPS prostredníctvom presmerovania, ak je webová adresa stránky HTTPS"
+
+#: src/metabase/public_settings.clj
+msgid "Cannot redirect requests to HTTPS unless `site-url` is HTTPS."
+msgstr "Nemožno presmerovať žiadosti na HTTPS, pokiaľ `site-url` nie je HTTPS."
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error registering fonts: Metabase will not be able to send Pulses."
+msgstr "Chyba pri registrácii písem: Metabase nebude môcť odosielať impulzy."
+
+#: src/metabase/pulse/render/png.clj
+msgid "This is a known issue with certain JVMs. See {0} and for more details."
+msgstr "Toto je známy problém s niektorými JVM. Viac informácií nájdete v {0}."
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error rendering Pulse"
+msgstr "Chyba pri vykresľovaní pulzu"
+
+#: src/metabase/query_processor/context/default.clj
+msgid "Query timed out after {0}, raising timeout exception."
+msgstr "Časový limit dopytu vypršal po {0}, čím sa zvýšila výnimka časového limitu."
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "No fields found for table {0}."
+msgstr "Pre tabuľku {0} sa nenašli žiadne polia."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Case"
+msgstr "púzdro"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Variance of {0}"
+msgstr "Varianta {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Median of {0}"
+msgstr "Medián {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "{0}th percentile of {1}"
+msgstr "{0} percentil z {1}"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Not caching results: results are larger than {0} KB"
+msgstr "Výsledky neukladané do vyrovnávacej pamäte: výsledky sú väčšie ako {0} kB"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Cannot cache results: expected byte array, got {0}"
+msgstr "Výsledky sa nedajú vyrovnávať: očakávané pole bajtov, {0}"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Request is closed; no one to return cached results to"
+msgstr "Žiadosť je uzavretá; nikto vrátiť výsledky z vyrovnávacej pamäte"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Error attempting to fetch cached results for query with hash {0}"
+msgstr "Chyba pri pokuse o získanie výsledkov z vyrovnávacej pamäte pre dopyt s hash {0}"
+
+#: src/metabase/query_processor/middleware/cache_backend/db.clj
+msgid "Error preparing statement to fetch cached query results"
+msgstr "Chyba pri príprave výpisu na získanie výsledkov dotazov v pamäti"
+
+#: src/metabase/query_processor/middleware/catch_exceptions.clj
+msgid "Error processing query: {0}"
+msgstr "Chyba pri spracovaní dotazu: {0}"
+
+#: src/metabase/server.clj
+msgid "Unexpected exception in endpoint"
+msgstr "Neočakávaná výnimka v koncovom bode"
+
+#: src/metabase/server.clj
+msgid "Unexpected Exception in API request handler"
+msgstr "Neočakávaná výnimka v obsluhe žiadosti API"
+
+#: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+msgid "Error reducing {0}"
+msgstr "Chyba pri znižovaní {0}"
+
+#: src/metabase/sync/analyze/fingerprint/insights.clj
+msgid "Error generating timeseries insight keyed by: {0}"
+msgstr "Pri generovaní prehľadu o časoch došlo k chybe s kľúčom: {0}"
+
+#: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
+msgstr "Pozícia databázy {0} sa zmenila z '' {1} '' na '' {2} ''."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Unscheduling task for Database {0}: trigger: {1}"
+msgstr "Neplánovaná úloha pre databázu {0}: trigger: {1}"
+
+#: src/metabase/util/schema.clj
+msgid "value must be a keyword or string."
+msgstr "hodnota musí byť kľúčové slovo alebo reťazec."
+
+#: src/metabase/util/schema.clj
+msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
+msgstr "Reťazec musí byť platným dvojpísmenovým jazykom ISO alebo jazykovým kódom krajiny, napr. 'en' alebo 'en_US'."

--- a/locales/sv.po
+++ b/locales/sv.po
@@ -5,28 +5,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 "Project-Id-Version: Metabase\n"
-"Language: es\n"
+"Language: sv\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:24
 msgid "Your database has been added!"
-msgstr "¡Tu base de datos ha sido añadida!"
+msgstr "Din databas har lagts till!"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:28
 msgid "We took a look at your data, and we have some automated explorations that we can show you!"
-msgstr "Echamos un vistazo a tus datos y ¡tenemos algunas exploraciones automatizadas que podemos mostrarte!"
+msgstr "Vi tog en titt på din data och vi har några automatiska utforskningar vi kan visa dig!"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:35
 msgid "I'm good thanks"
-msgstr "Está bien, gracias"
+msgstr "Det är bra så, tack"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:42
 msgid "Explore this data"
-msgstr "Explora estos datos"
+msgstr "Utforska denna data"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:42
 msgid "Select a database type"
-msgstr "Selecciona un tipo de base de datos"
+msgstr "Välj en databastyp"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
@@ -43,100 +43,95 @@ msgstr "Selecciona un tipo de base de datos"
 #: frontend/src/metabase/reference/components/EditHeader.jsx:69
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:30
 msgid "Save"
-msgstr "Guardar"
+msgstr "Spara"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:122
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
-msgstr "Para hacer algo de magia, Metabase necesita escanear la base de datos. Lo volveremos a hacer periódicamente para mantener actualizados los metadatos. Puedes controlar cuando se realizan los repasos periódicos a continuación."
+msgstr "För att göra sin magi behöver Metabase skanna din databas. Vi kommer göra detta regelbundet för att hålla data uppdaterat. Ni kan kontrollera intervallen nedan."
 
 #: frontend/src/metabase/entities/databases/forms.js:290
 msgid "Database syncing"
-msgstr "Sincronizando base de datos"
+msgstr "Databas synkar"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:128
 msgid "This is a lightweight process that checks for\n"
 "updates to this database’s schema. In most cases, you should be fine leaving this\n"
 "set to sync hourly."
-msgstr "Este es un proceso rápido que busca \n"
-"actualizaciones al esquema de esta base de datos. En la mayoría de los casos, estará bien dejar esto\n"
-"configurado para sincronizar cada hora."
+msgstr "Denna process kontrollerar databasens schema, och är inte dataintensiv. I flesta fall är det bra med synkning en gång i timmen."
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:42
 #: frontend/src/metabase/admin/databases/components/widgets/MetadataSyncScheduleWidget.jsx:22
 msgid "Scan"
-msgstr "Explorar"
+msgstr "Skanna"
 
 #: frontend/src/metabase/entities/databases/forms.js:297
 msgid "Scanning for Filter Values"
-msgstr "Buscando valores de filtrado"
+msgstr "Skanna efter filtervärden"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:153
 msgid "Metabase can scan the values present in each\n"
 "field in this database to enable checkbox filters in dashboards and questions. This\n"
 "can be a somewhat resource-intensive process, particularly if you have a very large\n"
 "database."
-msgstr "Metabase puede escanear los valores presentes en cada \n"
-"campo en esta base de datos para habilitar filtros de casilla de verificación en cuadros de mando y preguntas. Esto \n"
-"puede ser un proceso que consume muchos recursos, particularmente si tienes una \n"
-"base de datos grande."
+msgstr "Metabase kan skanna värden i varje databasfält för att tillåta användning checkboxval i dashboards och frågor. Det kan vara en hyfsat dataintensiv process, speciellt om databasen är väldigt stor."
 
 #: frontend/src/metabase/entities/databases/forms.js:301
 msgid "When should Metabase automatically scan and cache field values?"
-msgstr "¿Cuándo debería Metabase escanear y almacenar automáticamente los valores de campo?"
+msgstr "När ska Metabase automatiskt skanna och cacha fältvärden?"
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:25
 msgid "Regularly, on a schedule"
-msgstr "Periódicamente, siguiendo un horario"
+msgstr "Regelbundet, enligt schema"
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:50
 msgid "Only when adding a new filter widget"
-msgstr "Solo cuando se añade un nuevo elemento de filtro"
+msgstr "Endast vid en ny filter widget"
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:54
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
-msgstr "Cuando un usuario añade un nuevo filtro o una pregunta SQL al Dashboard Metabase escaneará los campos asignados a ese filtro para mostrar la lista de valores seleccionables."
+msgstr "När en användare lägger till ett nytt filter till en dashboard eller SQL fråga, kommer Metabase att skanna fält använda i det filtret, för att visa valbara val."
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:62
 msgid "Never, I'll do this manually if I need to"
-msgstr "Nunca, lo haré manualmente si lo necesito"
+msgstr "Aldrig, jag gör det vid behov manuellt"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 msgid "Saving..."
-msgstr "Guardando..."
+msgstr "Sparar..."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
 msgid "Server error encountered"
-msgstr "Se ha encontrado un error en el servidor"
+msgstr "Serverfel inträffat"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 msgid "Delete this database?"
-msgstr "¿Eliminar esta base de datos?"
+msgstr "Ta bort denna databas?"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
-msgstr "Todas las preguntas, métricas y segmentos guardados que dependen de esta base de datosse perderán."
+msgstr "Alla sparade frågor, mätvärden, och segment som behöver database kommer tas bort."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
-msgstr "Esta acción no se puede deshacer."
+msgstr "Detta kan inte ångras."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
-msgstr "Si estás seguro, por favor teclea:"
+msgstr "Är du säker? Isåfall, skriv"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
-msgstr "ELIMINAR"
+msgstr "RADERA"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
-msgstr "en esta casilla:"
+msgstr "här i rutan:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
@@ -172,14 +167,14 @@ msgstr "en esta casilla:"
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:328
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
-msgstr "Cancelar"
+msgstr "Ångra"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
-msgstr "Eliminar"
+msgstr "Radera"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
@@ -191,19 +186,19 @@ msgstr "Eliminar"
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
-msgstr "Bases de datos"
+msgstr "Databaser"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:148
 msgid "Add Database"
-msgstr "Añadir base de datos"
+msgstr "Lägg till databas"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:73
 msgid "Connection"
-msgstr "Conexión"
+msgstr "Anslutning"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:77
 msgid "Scheduling"
-msgstr "Programación"
+msgstr "Schemaläggning"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
@@ -214,17 +209,17 @@ msgstr "Programación"
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
-msgstr "Guardar cambios"
+msgstr "Spara ändringar"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:203
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
-msgstr "Acciones"
+msgstr "Åtgärder"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 msgid "Sync database schema now"
-msgstr "Sincronizar el esquema de la base de datos ahora"
+msgstr "Synka databas schema nu"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:212
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
@@ -233,49 +228,49 @@ msgstr "Sincronizar el esquema de la base de datos ahora"
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:90
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:98
 msgid "Starting…"
-msgstr "Empezando…"
+msgstr "Startar..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:213
 msgid "Failed to sync"
-msgstr "No se ha podido sincronizar"
+msgstr "Fel vid synkning"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:214
 msgid "Sync triggered!"
-msgstr "¡Sincronización iniciada!"
+msgstr "Synkning triggad!"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:223
 msgid "Re-scan field values now"
-msgstr "Vuelva a escanear los valores de campo ahora"
+msgstr "Omskanna fältvärden nu"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
-msgstr "No se ha podido iniciar la exploración"
+msgstr "Fel vid skanning"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:92
 msgid "Scan triggered!"
-msgstr "¡Exploración iniciada!"
+msgstr "Skanning triggad!"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:233
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
-msgstr "Zona Peligrosa"
+msgstr "Farlig zon"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Discard saved field values"
-msgstr "Descartar valores de campos guardados"
+msgstr "Kassera sparade fältvärden"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:257
 msgid "Remove this database"
-msgstr "Eliminar esta base de datos"
+msgstr "Ta bort denna databas"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
-msgstr "Añadir base de datos"
+msgstr "Lägg till databas"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:28
@@ -292,37 +287,36 @@ msgstr "Añadir base de datos"
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
-msgstr "Nombre"
+msgstr "Namn"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
-msgstr "Motor"
+msgstr "Databasmotor"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
-msgstr "Eliminando..."
+msgstr "Tar bort..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
-msgstr "Cargando..."
+msgstr "Laddar ..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
-msgstr "Recuperar la base de datos de prueba"
+msgstr "Återställ exempeldata"
 
 #: frontend/src/metabase/admin/databases/database.js:167
 msgid "Couldn't connect to the database. Please check the connection details."
-msgstr "No se ha podido conectar a la base de datos. Por favor, comprueba los detalles de la conexión."
+msgstr "Kunde inte ansluta till databasen. Vänligen kontrollera anslutningsdetaljerna."
 
 #: frontend/src/metabase/admin/databases/database.js:384
 msgid "Successfully created!"
-msgstr "¡Creado con éxito!"
+msgstr "Lyckades skapa!"
 
 #: frontend/src/metabase/admin/databases/database.js:394
 msgid "Successfully saved!"
-msgstr "¡Guardado con éxito!"
+msgstr "Lyckades spara!"
 
-#. Editar
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
@@ -330,64 +324,65 @@ msgstr "¡Guardado con éxito!"
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
-msgstr "Editar"
+msgstr "Ändra"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:59
 msgid "Revision History"
-msgstr "Historial de Revisiones"
+msgstr "Revisionshistorik"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
-msgstr "¿Retirar este {0}?"
+msgstr "Arkivera denna {0}?"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
-msgstr "Las preguntas guardadas y otras cosas que dependen de este {0} continuarán funcionando pero este {1} ya no se podrá seleccionar desde el generador de consultas."
+msgstr "Sparade frågor och annat som behöver denna {0} kommer fortsätta fungera, men denna {1} kommer inte längre vara valbar i frågebyggaren."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
-msgstr "Si estás seguro de querer retirar este {0} escribe una explicación de por qué está siendo retirado:"
+msgstr "Om du är säker på att du vill arkivera denna {0}, vänligen skriv en kort förklaring om varför den arkiveras:"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
+#, fuzzy
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
-msgstr "Esto se mostrará en el resumen de actividades y en un correo electrónico que se enviará a cualquier persona de tu equipo que haya creado algo que use este {0}."
+msgstr "Detta kommer visas på din aktivitets \"feed\" och i ett e-post som kommer skickas till de personer inom ditt \"team\" som skapade något som används av detta {0}."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
-msgstr "Retirar"
+msgstr "Arkivera"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
-msgstr "Retirando…"
+msgstr "Arkiverar..."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 #: frontend/src/metabase/components/form/CustomForm.jsx:188
 msgid "Failed"
-msgstr "Ha fallado"
+msgstr "Misslyckades"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 #: frontend/src/metabase/components/form/CustomForm.jsx:189
 msgid "Success"
-msgstr "Éxito"
+msgstr "Lyckades"
 
 #: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:185
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
-msgstr "Vista preliminar"
+msgstr "Förhandsvisa"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:93
 msgid "No column description yet"
-msgstr "No hay una descripción de la columna"
+msgstr "Ingen kolumnbeskrivning ännu"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:126
 msgid "Select a field visibility"
-msgstr "Selecciona una visibilidad de campo"
+msgstr "Välj fältsynlighet"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:187
 msgid "No special type"
-msgstr "Sin tipo especial"
+msgstr "Ingen special-typ"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
 #: frontend/src/metabase/lib/core.js:275
@@ -395,16 +390,16 @@ msgstr "Sin tipo especial"
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:37
 msgid "Other"
-msgstr "Otro"
+msgstr "Annat"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
-msgstr "Seleccione un tipo especial"
+msgstr "Välj en special-typ"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:262
 #: frontend/src/metabase/reference/components/Field.jsx:99
 msgid "Select a target"
-msgstr "Seleccione un objetivo"
+msgstr "Välj mål"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
@@ -412,98 +407,96 @@ msgstr "Seleccione un objetivo"
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Columns"
-msgstr "Columnas"
+msgstr "Kolumner"
 
-#. Campo
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
-msgstr "Campo"
+msgstr "Kolumn"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
 msgid "Visibility"
-msgstr "Visibilidad"
+msgstr "Synlighet"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
 msgid "Type"
-msgstr "Tipo"
+msgstr "Typ"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
-msgstr "Base de datos actual:"
+msgstr "Vald databas:"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
 msgid "Show original schema"
-msgstr "Mostrar esquema original"
+msgstr "Visa ursprungligt schema"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
-msgstr "Tipo de dato"
+msgstr "Datatyp"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
-msgstr "Información adicional"
+msgstr "Ytterligare info"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
-msgstr "Encontrar un esquema"
+msgstr "Hitta ett schema"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
-msgstr[0] "Ver esquema"
-msgstr[1] "Ver esquemas"
+msgstr[0] "{0} scheman"
+msgstr[1] "{0} scheman"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:99
 msgid "Why Hide?"
-msgstr "¿Por qué esconderlo?"
+msgstr "Anledning till att dölja?"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:100
 msgid "Technical Data"
-msgstr "Datos Técnicos"
+msgstr "Teknisk Data"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
-msgstr "Irrelevante"
+msgstr "Irrelevant"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 msgid "Queryable"
-msgstr "Consultable"
+msgstr "Frågningsbar"
 
-#. Oculto
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:108
 msgid "Hidden"
-msgstr "Oculto"
+msgstr "Dold"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136
 msgid "No table description yet"
-msgstr "No hay una descripción de la tabla"
+msgstr "Ingen tabellbeskrivning ännu"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:124
 msgid "Metadata Strength"
-msgstr "Alcance Metadatos"
+msgstr "Metadatats styrka"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
-msgstr[0] "{0] Tabla Consultable"
-msgstr[1] "{0] Tablas consultables"
+msgstr[0] "{0} frågningsbar tabell"
+msgstr[1] "{0} frågningsbara tabeller"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:91
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
-msgstr[0] "{0] Tabla Escondida"
-msgstr[1] "{0] Tablas escondidas"
+msgstr[0] "{0} Dolda tabeller"
+msgstr[1] "{0} Dolda tabeller"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:115
 msgid "Find a table"
-msgstr "Encontrar una tabla"
+msgstr "Hitta tabell"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:128
 msgid "Schemas"
-msgstr "Esquemas"
+msgstr "Scheman"
 
 #: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
@@ -514,21 +507,21 @@ msgstr "Esquemas"
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:62
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 msgid "Metrics"
-msgstr "Métricas"
+msgstr "Mått"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:27
 msgid "Add a Metric"
-msgstr "Añadir una métrica"
+msgstr "Lägg till mått"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
-msgstr "Definición"
+msgstr "Definition"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:51
 msgid "Create metrics to add them to the View dropdown in the query builder"
-msgstr "Crea métricas para añadirlas al menú Ver en el generador de consultas"
+msgstr "Skapa mått för att lägga till dem till rullgardinsmenyn för vyer i \"frågeskaparen\""
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
@@ -538,293 +531,293 @@ msgstr "Crea métricas para añadirlas al menú Ver en el generador de consultas
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:61
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
-msgstr "Segmentos"
+msgstr "Segment"
 
 #: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:27
 msgid "Add a Segment"
-msgstr "Añadir un segmento"
+msgstr "Lägg till segment"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:45
 msgid "Create segments to add them to the Filter dropdown in the query builder"
-msgstr "Crea segmentos para añadirlos al menú Filtro en el generador de consultas"
+msgstr "Skapa segment för att lägga till dem till Filter rullgardinsmenyn i \"frågeskaparen\""
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:21
 msgid "created"
-msgstr "creado"
+msgstr "skapad"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "reverted to a previous version"
-msgstr "revertido a una versión anterior"
+msgstr "återgå till föregående version"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:30
 msgid "edited the title"
-msgstr "editado el título"
+msgstr "ändrade title"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:32
 msgid "edited the description"
-msgstr "editado la descripción"
+msgstr "ändrade beskrivning"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:34
 msgid "edited the "
-msgstr "editado el"
+msgstr "ändrade "
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "made some changes"
-msgstr "he hecho algunos cambios"
+msgstr "gjort några ändringar"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
 #: frontend/src/metabase/home/components/Activity.jsx:83
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
-msgstr "Tu"
+msgstr "Du"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
-msgstr "Modelo de datos"
+msgstr "Datamodell"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:41
 msgid " History"
-msgstr "Historia"
+msgstr "Logg"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
-msgstr "Historial de Revisiones para"
+msgstr "Versionshistorik"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
 msgid "{0} – Field Settings"
-msgstr "{0} – Configuración de campos"
+msgstr "{0} - Fältinställning"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
 msgid "Where this field will appear throughout Metabase"
-msgstr "Donde aparecerá este campo en Metabase"
+msgstr "Där detta fält kommer synas inom Metabase"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
 msgid "Filtering on this field"
-msgstr "Filtrando sobre este campo"
+msgstr "Filtrera på detta fält"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
-msgstr "Cuando este campo se usa en un filtro, ¿qué valores debería aceptar?"
+msgstr "När detta fält används i ett filter, vad skall användarna använda för värde att filtrera på?"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
 msgid "No description for this field yet"
-msgstr "No hay descripción para este campo todavía"
+msgstr "Ingen beskrivning finns för detta fält ännu"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
 msgid "Original value"
-msgstr "Valor original"
+msgstr "Ursprungligt värde"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
 msgid "Mapped value"
-msgstr "Valor asignado"
+msgstr "Mappat värde"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
 msgid "Enter value"
-msgstr "Introduce un valor"
+msgstr "Ange värde"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use original value"
-msgstr "Utiliza valor original"
+msgstr "Använd ursprungligt värde"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Use foreign key"
-msgstr "Utilizar clave foránea"
+msgstr "Använd främmande nyckel"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 msgid "Custom mapping"
-msgstr "Mapeo personalizado"
+msgstr "Anpassad mappning"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
 msgid "Unrecognized mapping type"
-msgstr "Tipo de mapeo no reconocido"
+msgstr "Okänd mappningstyp"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
-msgstr "El campo actual no es una clave foránea o faltan los metadatos de clave foránea en la tabla de destino"
+msgstr "Detta fält är inte en \"främmande nyckel\" eller FK måltabells metadata saknas"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
 msgid "The selected field isn't a foreign key"
-msgstr "El campo seleccionado no es una clave foránea"
+msgstr "Valt fält är inte en \"främmande nyckel\""
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
 msgid "Display values"
-msgstr "Valores mostrados"
+msgstr "Visa värden"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
-msgstr "Elige si quieres mostrar el valor original de la base de datos, o mostrar información asociada o personalizada."
+msgstr "Välj att visa orginal värde från databasen, eller välj att visa fältets associerade eller anpassad information."
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
 msgid "Choose a field"
-msgstr "Elige un campo"
+msgstr "Välj fält"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
 msgid "Please select a column to use for display."
-msgstr "Selecciona una columna para mostrar."
+msgstr "Välj en kolumn för visning."
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:771
 msgid "Tip:"
-msgstr "Consejo:"
+msgstr "Tips:"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
-msgstr "Es posible que quieras actualizar el nombre del campo para asegurarte de que todavía tenga sentidoen función de las opciones de asignación."
+msgstr "Du rekommenderas att uppdatera fältnamnen för att säkerställa att de fortfarande stämmer baserat på dina mappningsval"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
-msgstr "Valores de campo en caché"
+msgstr "Sparade fält värden"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
-msgstr "Metabase puede escanear los valores de este campo para habilitar los filtros de casilla de verificación en cuadros de mando y preguntas."
+msgstr "Metabase kan skanna värdena i detta fält för att aktivera kryssrute-filter i instrumentpaneler och frågor"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:14
 msgid "Re-scan this field"
-msgstr "Vuelve a escanear este campo"
+msgstr "Återskanna detta fält"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
-msgstr "Descartar valores de campo en caché"
+msgstr "Radera sparade fältvärden"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
-msgstr "Error al descartar valores"
+msgstr "Misslyckades med att radera värden"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 msgid "Discard triggered!"
-msgstr "¡Limpieza iniciada!"
+msgstr "Radering påbörjad"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
-msgstr "Selecciona cualquier tabla para ver su esquema y añadir o editar metadatos."
+msgstr "Välj en tabell för att se dess schema och lägga till eller redigera metadata."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
-msgstr "Nombre es obligatorio"
+msgstr "Namn är obligatoriskt"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
-msgstr "Descripción es obligatorio"
+msgstr "Beskrivning är obligatorisk"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
-msgstr "Mensaje de la revisión es obligatorio"
+msgstr "Revisionsmeddelande är obligatorisk"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
 msgid "Aggregation is required"
-msgstr "Agregación es obligatoria"
+msgstr "Aggregering krävs"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Edit Your Metric"
-msgstr "Edita tu Métrica"
+msgstr "Ändra ditt mått"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Create Your Metric"
-msgstr "Crea tu Métrica"
+msgstr "Skapa ditt mått"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "Make changes to your metric and leave an explanatory note."
-msgstr "Haz cambios en tu métrica y deja una nota explicativa."
+msgstr "Gör förändringar till din metrik och skriv en beskrivande anteckning."
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:145
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
-msgstr "Puedes crear métricas y guardarlas como campo calculado en esta tabla.Las métricas guardadas incluyen el tipo de agregación, el campo agregado y, opcionalmente, cualquier filtro que añadas.Por ejemplo, puedes usar esto para definir la forma oficial de calcular el \"Precio promedio\" para una tabla de Pedidos."
+msgstr "Du kan skapa sparade mått för att lägga till namngivna mått-alternativ till denna tabell. Sparade mått innehåller typ av sammanslagning, det sammanslagna fältet och ev. några filter du vill lägga till. Till exempel kan du använda detta för att skapa någon som det officiella sättet att räkna ut snittpris i en ordertabell."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
 msgid "Result: "
-msgstr "Resultado:"
+msgstr "Resultat:"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
 msgid "Name Your Metric"
-msgstr "Ponle nombre a tu Métrica"
+msgstr "Namnge ditt mått"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Give your metric a name to help others find it."
-msgstr "Dale un nombre a tu métrica para ayudar a otros a encontrarla."
+msgstr "Ge ditt mått ett namn så andra kan hitta den."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
-msgstr "Algo descriptivo pero no demasiado largo"
+msgstr "Något beskrivande, men inte för långt"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
 msgid "Describe Your Metric"
-msgstr "Describe tu Métrica"
+msgstr "Beskriv ditt mått"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Give your metric a description to help others understand what it's about."
-msgstr "Dale una descripción a tu métrica para ayudar a otros a entender de qué se trata."
+msgstr "Ge ditt mått en beskrivning så att andra användare kan förstå vad det handlar om."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
 msgid "This is a good place to be more specific about less obvious metric rules"
-msgstr "Este es un buen lugar para ser más específico sobre las reglas métricas menos obvias"
+msgstr "Detta är en bra plats att detaljerat beskriva icke självklara måttregler."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
-msgstr "Motivo de los cambios"
+msgstr "Orsak till ändring"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
-msgstr "Deja una nota para explicar qué cambios has hecho y por qué fueron necesarios."
+msgstr "Skriv ett kort meddelande som beskriver vilka ändringar du gjort och varför de var nödvändiga."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
-msgstr "Esto aparecerá en el historial de revisiones de esta métrica para ayudar a todos a recordar por qué se realizó el cambio"
+msgstr "Detta kommer visas i revisionshistoriken för detta mått för att hjälpa alla att komma ihåg varför saker ändrats"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
-msgstr "Se requiere al menos un filtro"
+msgstr "Minst ett filter krävs"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
-msgstr "Edita tu Segmento"
+msgstr "Ändra ditt segment"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
-msgstr "Crea tu Segmento"
+msgstr "Skapa ditt segment"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
-msgstr "Haz cambios en tu segmento y deja una nota explicativa."
+msgstr "Gör ändringar i ditt segment och skriv en förklarande anteckning."
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
-msgstr "Selecciona y añade filtros para crear un nuevo segmento para la tabla {0}"
+msgstr "Välj och lägg till filter för att skapa ditt nya segment för tabell {0}"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
-msgstr "Ponle nombre a tu segmento"
+msgstr "Namnge ditt segment"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
-msgstr "Dale un nombre a tu segmento para ayudar a otros a encontrarla."
+msgstr "Ge ditt segment ett namn för att hjälp andra att hitta det."
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
-msgstr "Describe tu Segmento"
+msgstr "Beskriv ditt segment"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 msgid "Give your segment a description to help others understand what it's about."
-msgstr "Dale una descripción a tu segmento para ayudar a otros a entender de qué se trata."
+msgstr "Ge ditt segment en beskrivning för att hjälp andra förstå vad det handlar om."
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
-msgstr "Este es un buen lugar para ser más específico sobre las reglas de segmentación menos obvias"
+msgstr "Detta är ett bra ställe att mera detaljerat beskriva de mindre tydliga segment-reglerna"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
-msgstr "Esto aparecerá en el historial de revisiones de este segmento para ayudar a todos a recordar por qué se realizó el cambio"
+msgstr "Detta kommer att synas i revisionshistoriken för detta segment för att hjälpa alla att komma ihåg varför saker ändrades"
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
 #: frontend/src/metabase/admin/routes.jsx:137
@@ -834,66 +827,66 @@ msgstr "Esto aparecerá en el historial de revisiones de este segmento para ayud
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
-msgstr "Configuración"
+msgstr "Inställningar"
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
-msgstr "Metabase puede leer los valores en esta tabla para habilitar filtros de casillas de verificación en cuadros de mandos y preguntas."
+msgstr "Metabase kan skanna värden i denna tabell för att aktivera kryssruteboxar i instrumentpaneler och frågor."
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
-msgstr "Re-Leer esta tabla"
+msgstr "Åter-skanna denna tabell"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 msgid "Add"
-msgstr "Añadir"
+msgstr "Lägg till"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:103
 msgid "Not a valid formatted email address"
-msgstr "Formato de Email incorrecto"
+msgstr "Inte en giltig epost-adress"
 
 #: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
-msgstr "Nombre"
+msgstr "Förnamn"
 
 #: frontend/src/metabase/entities/users/forms.js:20
 msgid "Last name"
-msgstr "Apellidos"
+msgstr "Efternamn"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
-msgstr "Dirección de Email"
+msgstr "Epost-adress"
 
 #: frontend/src/metabase/admin/people/components/EditUserForm.jsx:202
 msgid "Permission Groups"
-msgstr "Grupos de Permisos"
+msgstr "Behörighetsgrupper"
 
 #: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
 msgid "Make this user an admin"
-msgstr "Convertir a este usuario en administrador"
+msgstr "Gör denna användare till administratör"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
-msgstr "Todos los usuarios pertenecen al grupo {0} no se pueden eliminar. Establecer permisos para este grupo es una excelente manera de asegurarte qué podrán ver los nuevos usuarios de Metabase."
+msgstr "Alla användare tillhör grupp {0} och kan inte tas bort från denna. Genom att sätta behörigheter för denna grupp kan du säkerställa vad nya Metabase-användare kommer att kunna se."
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
-msgstr "Este es un grupo especial cuyos miembros pueden ver todo en la instancia de Metabase, y quienes pueden acceder y realizar cambios en la configuración en el Panel de administración, ¡incluyendo el cambio de permisos!Así que añade personas a este grupo con cuidado."
+msgstr "Detta är en special-grupp vars medlemmar kan se allt i Metabase-instansen, och som kan se och göra ändringar i inställningarna i Admin inklusive ändra rättigheter! Lägg därför till medlemmar i denna grupp med försiktighet."
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
-msgstr "Para asegurarte de no quedar sin acceso a Metabase, siempre debe haber al menos un usuario en este grupo."
+msgstr "För att säkerställa att du inte blir utelåst från Metabase måste det alltid finnas minest en användare i denna grupp."
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
-msgstr "Miembros"
+msgstr "Medlemmar"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
@@ -902,11 +895,11 @@ msgstr "Miembros"
 #: frontend/src/metabase/lib/core.js:146
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:298
 msgid "Email"
-msgstr "Email"
+msgstr "Epost"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
-msgstr "Un grupo solo vale lo que valen sus miembros."
+msgstr "En grupp är aldrig bättre än dess medlemmar."
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
 #: frontend/src/metabase/admin/routes.jsx:55
@@ -918,51 +911,50 @@ msgstr "Admin"
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:288
 msgid "and"
-msgstr "y"
+msgstr "och"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:19
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:31
 msgid "{0} other group"
 msgid_plural "{0} other groups"
-msgstr[0] "{0} grupo más"
-msgstr[1] "{0} grupos más"
+msgstr[0] "{0} annan grupp"
+msgstr[1] "{0} andra grupper"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:37
 msgid "Default"
-msgstr "Por defecto"
+msgstr "Förvald"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:39
 msgid "Something like \"Marketing\""
-msgstr "Algo como \"Marketing\""
+msgstr "Något som t.ex \"Marknad\""
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:58
 msgid "Remove this group?"
-msgstr "¿Eliminar este grupo?"
+msgstr "Ta bort denna grupp?"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:60
 msgid "Are you sure? All members of this group will lose any permissions settings they have based on this group.\n"
 "This can't be undone."
-msgstr "¿Estás seguro? Todos los miembros de este grupo perderán las configuraciones de permisos que tengan basadas en este grupo.\n"
-"Esto no puede deshacerse."
+msgstr "Är du säker? Alla medlemmar i denna grupp kommer att förlora de rättigheter de har baserat på denna grupp. Detta val kan inte ångras."
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
-msgstr "Sí"
+msgstr "Ja"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
-msgstr "No"
+msgstr "Nej"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:92
 msgid "Edit Name"
-msgstr "Editar Nombre"
+msgstr "Ändra namn"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:95
 msgid "Remove Group"
-msgstr "Borrar Grupo"
+msgstr "Radera grupp"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:46
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:138
@@ -976,11 +968,11 @@ msgstr "Borrar Grupo"
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:334
 msgid "Done"
-msgstr "Hecho"
+msgstr "Klart"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Group name"
-msgstr "Nombre Grupo"
+msgstr "Gruppnamn"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
@@ -989,383 +981,383 @@ msgstr "Nombre Grupo"
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
-msgstr "Grupos"
+msgstr "Grupper"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:364
 msgid "Create a group"
-msgstr "Crear un grupo"
+msgstr "Skapa grupp"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:370
 msgid "You can use groups to control your users' access to your data. Put users in groups and then go to the Permissions section to control each group's access. The Administrators and All Users groups are special default groups that can't be removed."
-msgstr "Puedes usar grupos para controlar el acceso de tus usuarios a los datos. Coloca a los usuarios en grupos y después, ves a la sección de Permisos para controlar el acceso de cada grupo. Los grupos Administradores y All Users son grupos predeterminados especiales que no se pueden eliminar."
+msgstr "Du kan använder grupper för att styra dina användares åtkomst till data. Lägg användare i grupper och gå sedan till Rättigheter för att styra varje grupps åtkomst. Grupperna Administratörer och Alla användare är special-grupper som inte kan tas bort."
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:79
 msgid "Edit Details"
-msgstr "Editar Detalles"
+msgstr "Ändra detaljer"
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:85
 msgid "Re-send Invite"
-msgstr "Reenviar Invitación"
+msgstr "Återsänd inbjudan"
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:90
 msgid "Reset Password"
-msgstr "Restablecer la contraseña"
+msgstr "Återställ lösenord"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:40
 msgid "Deactivate"
-msgstr "Desactivar"
+msgstr "Avaktivera"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:21
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:93
 #: frontend/src/metabase/nav/containers/Navbar.jsx:235
 msgid "People"
-msgstr "Personas"
+msgstr "Människor"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:192
 msgid "Who do you want to add?"
-msgstr "¿A quien quieres añadir?"
+msgstr "Vem vill du lägga till?"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:207
 msgid "Edit {0}'s details"
-msgstr "Edita los detalles de {0}"
+msgstr "Redigera {0}s detaljer"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:40
 msgid "{0} has been added"
-msgstr "Se ha añadido {0}"
+msgstr "{0} har lagts till"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:224
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:262
 msgid "Add another person"
-msgstr "Añade otra persona"
+msgstr "Lägg till ytterligare en person"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:231
 msgid "We couldn’t send them an email invitation,\n"
 "so make sure to tell them to log in using {0}\n"
 "and this password we’ve generated for them:"
-msgstr "No se ha podido enviarles una invitación por correo electrónico, así que asegúraste de indicarles que inicien sesión con {0} y la contraseña que les hemos generado:"
+msgstr "Vi kunde inte skicka dem en inbjudan via epost, så meddela dem att de kan logga in med {0} och detta lösenord som vi har genererat till dem:"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:73
 msgid "If you want to be able to send email invites, just go to the {0} page."
-msgstr "Si quieres poder enviar invitaciones por correo electrónico, simplemente ves a la página {0}."
+msgstr "Om du vill kunna skicka epost-inbjudningar, bara gå till {0}s sida."
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:55
 msgid "We’ve sent an invite to {0} with instructions to set their password."
-msgstr "Hemos enviado una invitación a {0} con instrucciones para configurar su contraseña."
+msgstr "Vi har skickat en inbjudan till {0} med instruktioner om hur de kan sätta sitt lösenord."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:283
 msgid "We've re-sent {0}'s invite"
-msgstr "Hemos vuelto a enviar la invitación de {0}"
+msgstr "Vi har skickat om inbjudan till {0}"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:24
 msgid "Okay"
-msgstr "Vale"
+msgstr "Okej"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:289
 msgid "Any previous email invites they have will no longer work."
-msgstr "Cualquier invitación de correo electrónico anterior que tengan ya no funcionará."
+msgstr "Eventuella tidigare epost-inbjudningar kommer inte längre att fungera."
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:31
 msgid "Deactivate {0}?"
-msgstr "¿Desactivar {0}?"
+msgstr "Inaktivera {0}?"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:34
 msgid "{0} won't be able to log in anymore."
-msgstr "{0} ya no podrá iniciar sesión."
+msgstr "{0} kommer inte längre att kunna logga in."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:320
 msgid "Reactivate {0}'s account?"
-msgstr "¿Activar la cuenta de {0}?"
+msgstr "Återaktivera {0}s konto?"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:58
 msgid "Reactivate"
-msgstr "Activar"
+msgstr "Återaktivera"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:51
 msgid "They'll be able to log in again, and they'll be placed back into the groups they were in before their account was deactivated."
-msgstr "Podrán volver a iniciar sesión y se les volverá a colocar en los grupos en los que estaban antes de que se desactivara su cuenta."
+msgstr "De kommer att kunna logga in igen och placeras i de grupper de tillhörde när de inaktiverades."
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:51
 msgid "Reset {0}'s password?"
-msgstr "¿Restablecer la contraseña de {0}?"
+msgstr "Återställa lösenord för {0}?"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:76
 msgid "Reset"
-msgstr "Reiniciar"
+msgstr "Återställ"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
 #: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
 msgid "Are you sure you want to do this?"
-msgstr "¿Seguro que quieres hacer esto?"
+msgstr "Är du säker på att du vill  göra detta?"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:41
 msgid "{0}'s password has been reset"
-msgstr "La contraseña de {0} ha sido restablecida"
+msgstr "Lösenordet för {0} har återställts."
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:45
 msgid "Here’s a temporary password they can use to log in and then change their password."
-msgstr "Aquí hay una contraseña temporal que pueden usar para iniciar sesión y luego cambiar su contraseña."
+msgstr "Här är ett tillfälligt lösenord de kan använda för att logga in och sedan ändra lösenordet."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:388
 msgid "We've sent them an email with instructions for creating a new password."
-msgstr "Les hemos enviado un correo electrónico con instrucciones para crear una nueva contraseña."
+msgstr "Vi har skickat dem epost med instruktioner om hur de kan skapa ett nytt lösenord."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 #: frontend/src/metabase/admin/settings/components/widgets/AuthenticationOption.jsx:15
 msgid "Active"
-msgstr "Activo"
+msgstr "Aktiv"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
-msgstr "Desactivado"
+msgstr "Avaktiverad"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
-msgstr "Añadir alguien"
+msgstr "Lägg till någon"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
-msgstr "Ultimo acceso"
+msgstr "Senaste inloggning"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:154
 msgid "Signed up via Google"
-msgstr "Acceso via Google"
+msgstr "Inloggad via Google"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:159
 msgid "Signed up via LDAP"
-msgstr "Acceso via LDAP"
+msgstr "Inloggad via LDAP"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:171
 msgid "Reactivate this account"
-msgstr "Activar esta cuenta"
+msgstr "Återaktivera detta konto"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:195
 msgid "Never"
-msgstr "Nunca"
+msgstr "Aldrig"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
-msgstr[0] "{0} tabla"
-msgstr[1] "{0} tablas"
+msgstr[0] "tabellen {0}"
+msgstr[1] "tabellerna {0}"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
-msgstr "será"
+msgstr "kommer att"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
-msgstr "dado el acceso a"
+msgstr "ges åtkomst till"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
-msgstr " y "
+msgstr "och"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
-msgstr "denegado el acceso a"
+msgstr "vägras åtkomst till"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
-msgstr "ya no podrá"
+msgstr "kommer inte längre att kunna"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
-msgstr "ahora será capaz de"
+msgstr "kommer nu att kunna"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
-msgstr "consultas nativas para"
+msgstr "naturliga frågor på"
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:14
 #: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Permissions"
-msgstr "Permisos"
+msgstr "Rättigheter"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:32
 msgid "Save permissions?"
-msgstr "¿Guardar permisos?"
+msgstr "Spara rättigheter?"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:38
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
 msgid "Save Changes"
-msgstr "Guardar Cambios"
+msgstr "Spara ändringar"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:44
 msgid "Discard changes?"
-msgstr "¿Descartar los cambios?"
+msgstr "Överge ändringarna?"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:46
 msgid "No changes to permissions will be made."
-msgstr "No se realizarán cambios en los permisos."
+msgstr "Inga förändingar i rättigheter kommer att göras."
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:65
 msgid "You've made changes to permissions."
-msgstr "Has realizado cambios en los permisos."
+msgstr "Du har gjort ändringar i rättigheter."
 
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
 msgid "Permissions for this collection"
-msgstr "Permisos de esta colección"
+msgstr "Rättigheter för denna samling"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:81
 msgid "You have unsaved changes"
-msgstr "Tiene cambios sin guardar"
+msgstr "Du har ändringar som ännu inte sparats"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:82
 msgid "Do you want to leave this page and discard your changes?"
-msgstr "¿Quieres abandonar esta página y descartar tus cambios?"
+msgstr "Vill du lämna denna sida och överge dina ändringar?"
 
 #: frontend/src/metabase/admin/permissions/permissions.js:129
 msgid "Sorry, an error occurred."
-msgstr "Lo siento, ocurrió un error."
+msgstr "Ursäkta, ett fel uppstod."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:71
 msgid "Administrators always have the highest level of access to everything in Metabase."
-msgstr "Los administradores siempre tienen el más alto nivel de acceso a todo en Metabase."
+msgstr "Administratörer har alltid den högsta access-nivån till allting i Metabase"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:73
 msgid "Every Metabase user belongs to the All Users group. If you want to limit or restrict a group's access to something, make sure the All Users group has an equal or lower level of access."
-msgstr "Todos los usuarios de Metabase pertenecen al grupo All Users. Si quieres limitar o restringir el acceso de un grupo a algo, asegúrate de que el grupo All Users tenga un nivel de acceso igual o inferior."
+msgstr "Varje Metabase-användare tillhör gruppen Alla användare. Om du vill begränsa en grupps rättigheter, se till att gruppen Alla användare har samma eller lägre access-nivå."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:75
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
-msgstr "MetaBot es el bot de Slack de Metabase. Puedes elegir a qué tiene acceso aquí."
+msgstr "MetaBot är Metabases Slack Bot. Du kan välja vad den har åtkomst till här."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:128
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
-msgstr "El grupo \"{0}\" puede tener acceso a un conjunto diferente de {1} que este grupo, lo que puede darle a este grupo acceso adicional a algún {2}."
+msgstr "Gruppen {0} kan ha access till en annan uppsättning av {1} än denna grupp, vilket kan ge denna grupp ytterligare till några {2}."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:131
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
-msgstr "El grupo \"{0}\" tiene un mayor nivel de acceso que este, lo que anulará esta configuración. Debes limitar o revocar el acceso del grupo \"{1}\" a este elemento."
+msgstr "Gruppen {0} har en högre accessnivå än denna, vilket kommer att ha företräde före denna inställning. Du bör begränsa eller ta bort {1}-gruppens rättigheter till denna post."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
-msgstr "¿Limitar"
+msgstr "Begränsa"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
-msgstr "¿Revocar"
+msgstr "Upphäv"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
-msgstr "el acceso a pesar de que el grupo \"{0}\" tiene mayor acceso?"
+msgstr "åtkomst trots att {0} har större rättigheter?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
-msgstr "Limitar el acceso"
+msgstr "Begränsa åtkomst"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
 msgid "Revoke access"
-msgstr "Revocar el acceso"
+msgstr "Upphäv åtkomst"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
-msgstr "¿Cambiar el acceso a esta base de datos a limitado?"
+msgstr "Ändra åtkomst för denna databas till begränsad?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
-msgstr "Cambiar"
+msgstr "Ändra"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
-msgstr "Permitir escritura de consultas directas"
+msgstr "Tillåta manuella frågor?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
-msgstr "Esto también cambiará el acceso de datos de este grupo a Sin restricciones para esta base de datos."
+msgstr "Detta kommer också att ändra denna grupps åtkomst till Obegränsad för denna databas."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
-msgstr "Permitir"
+msgstr "Tillåt"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
-msgstr "¿Revoca el acceso a todas las tablas?"
+msgstr "Upphäva åtkomst till alla tabeller?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
-msgstr "Esto también revocará el acceso de este grupo a consultas sin formato para esta base de datos."
+msgstr "Detta kommer också att upphäva denna grupps åtkomst till manuella frågor mot denna databas."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
-msgstr "Conceder acceso sin restricciones"
+msgstr "Ge obegränsad åtkomst"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
-msgstr "Acceso no restingido"
+msgstr "Obegränsad åtkomst"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
-msgstr "Acceso limitado"
+msgstr "Begränsad åtkomst"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
-msgstr "Sin acceso"
+msgstr "Ingen åtkomst"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
-msgstr "Escribir consultas directas"
+msgstr "Skriva manuella frågor"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
-msgstr "Puede escribir consultas directas"
+msgstr "Kan skriva manuella frågor"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
-msgstr "Mima la colección"
+msgstr "Utvald samling"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
-msgstr "Ver colección"
+msgstr "Visa samling"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:445
 #: frontend/src/metabase/admin/permissions/selectors.js:558
 msgid "Data Access"
-msgstr "Acceso a Datos"
+msgstr "Dataåtkomst"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:510
 #: frontend/src/metabase/admin/permissions/selectors.js:665
 #: frontend/src/metabase/admin/permissions/selectors.js:670
 msgid "View tables"
-msgstr "Ver tablas"
+msgstr "Visa tabeller"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:606
 msgid "SQL Queries"
-msgstr "Consultas SQL"
+msgstr "SQL-frågor"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:676
 msgid "View schemas"
-msgstr "Ver esquemas"
+msgstr "Visa scheman"
 
 #: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
-msgstr "Modelo de Datos"
+msgstr "Data-modell"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:118
 #: frontend/src/metabase/plugins/builtin/auth/google.js:31
 msgid "Sign in with Google"
-msgstr "Accede con Google"
+msgstr "Logga in med Google"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 #: frontend/src/metabase/plugins/builtin/auth/google.js:32
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
-msgstr "Permite a los usuarios con cuentas Metabase existentes iniciar sesión con una cuenta de Google que coincida con su dirección de correo electrónico además de su nombre de usuario y contraseña de Metabase."
+msgstr "Tillåt användare med befintliga Metabase-konton att logga in med ett Google-konto som matchar deras epost-adress utöver deras användarnamn och lösenord i Metabase"
 
 #: frontend/src/metabase/admin/settings/components/widgets/AuthenticationOption.jsx:24
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
-msgstr "Configura"
+msgstr "Konfigurera"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:20
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:15
@@ -1374,133 +1366,133 @@ msgstr "LDAP"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:16
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
-msgstr "Permite a los usuarios de tu directorio LDAP iniciar sesión en la Metabase con sus credenciales LDAP, y permite la asignación automática de grupos LDAP a grupos de metabase."
+msgstr "Tillåter LDAP-användare i din LDAP att logga in i Metabase med LDAP-uppgifter och tillåter automatisk mappning av LDAP-grupper till Metabase-grupper."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
 #: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
-msgstr "Esa no es una dirección de correo electrónico válida"
+msgstr "Det är inte en giltig epost-adress"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
-msgstr "Ese no es un entero válido"
+msgstr "Det är inte ett giltigt heltal"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
-msgstr "¡Cambios guardados!"
+msgstr "Ändringar sparade!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
 msgid "Looks like we ran into some problems"
-msgstr "Parece que nos encontramos con algunos problemas"
+msgstr "Det verkar som om något gick fel"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:19
 msgid "Send test email"
-msgstr "Enviar email de comprobación"
+msgstr "Skicka test-epost"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:20
 msgid "Sending..."
-msgstr "Enviando..."
+msgstr "Sänder..."
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:21
 msgid "Sent!"
-msgstr "¡Enviado!"
+msgstr "Skickat!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:93
 msgid "Clear"
-msgstr "Limpiar"
+msgstr "Rensa"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
-msgstr "Autenticación"
+msgstr "Autentisering"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
-msgstr "Configuración Servidor"
+msgstr "Server-inställningar"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:36
 msgid "User Schema"
-msgstr "Esquema de Usuario"
+msgstr "Användar-schema"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:40
 msgid "Attributes"
-msgstr "Atributos"
+msgstr "Egenskaper"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
-msgstr "Esquema de Grupo"
+msgstr "Grupp-schema"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetting.jsx:33
 msgid "Using "
-msgstr "Utilizando"
+msgstr "Med"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:105
 msgid "Getting set up"
-msgstr "Preparándote"
+msgstr "Sätts upp"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:106
 msgid "A few things you can do to get the most out of Metabase."
-msgstr "Algunas cosas que puedes hacer para sacar el máximo provecho de Metabase."
+msgstr "Några saker du kan göra för att få ut så mycket som möjligt av Metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:115
 msgid "Recommended next step"
-msgstr "Siguiente paso recomendado"
+msgstr "Nästa rekommenderade steg"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:114
 msgid "Google Sign-In"
-msgstr "Acceso Google"
+msgstr "Google-inloggning"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:123
 msgid "To allow users to sign in with Google you'll need to give Metabase a Google Developers console application client ID. It only takes a few steps and instructions on how to create a key can be found {0}"
-msgstr "Para permitir que los usuarios inicien sesión con Google, deberás proporcionar a Metabase un ID de cliente de aplicación de la consola de Desarrollo de Google. Solo se necesitan unos pocos pasos y se pueden encontrar instrucciones sobre cómo crear una clave {0}"
+msgstr "För att tillåta användare att logga in med Google behöver du ge Metabase \"Google Developers console application cliend ID\". Det krävs bara några steg, och instruktioner för hur du kan skapa en nyckel hittas här {0}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:140
 msgid "Your Google client ID"
-msgstr "Tu ID de cliente de Google"
+msgstr "Ditt \"Google client ID\""
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:145
 msgid "Allow users to sign up on their own if their Google account email address is from:"
-msgstr "Permite que los usuarios se registren solos si la dirección de correo electrónico de su cuenta de Google es de:"
+msgstr "Tillåt användare att själv skapa konto om deras \"Google account email address\" kommer från:"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:249
 msgid "Answers sent right to your Slack #channels"
-msgstr "Respuestas enviadas directamente a tus #canales Slack"
+msgstr "Svar skickade direkt till dina Slack #channels"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:258
 msgid "Create a Slack Bot User for MetaBot"
-msgstr "Crear un usuario de Slack Bot para MetaBot"
+msgstr "Skapa en Slack Bot-användare för MetaBot"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:268
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
-msgstr "Una vez que estés allí, asígnele un nombre y haz clic en {0}. Luego, copia y pega el API Token del Bot en el campo a continuación. En cuanto hayas terminado, crea un canal \"metabase_files\" en Slack. Metabase necesita ese para subir gráficos."
+msgstr "När du väl är där, ge den ett namn och klicka på {0}. Sedan, kopiera och klistra in \"Bot API Token\" i fältet nedan. När du väl är klar, skapa kanalen \"metabase_files\" i Slack. Metabase behöver detta för att ladda upp grafer."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:17
 msgid "You're running Metabase {0} which is the latest and greatest!"
-msgstr "¡Estás ejecutando Metabase {0} que es lo último y lo mejor!"
+msgstr "Du kör Metabase {0} vilken är den senaste och bästa!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
-msgstr "Metabase {0} está disponible.  Estás ejecutando {1}"
+msgstr "Metabase {0} finns tillgänglig. Du kör {1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:41
 #: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 msgid "Update"
-msgstr "Actualiza"
+msgstr "Uppdatera"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:46
 msgid "What's Changed:"
-msgstr "Qué ha cambiado:"
+msgstr "Vad som ändrats:"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:131
 msgid "Add a map"
-msgstr "Añade un mapa"
+msgstr "Lägg till en karta"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
 #: frontend/src/metabase/lib/core.js:267
@@ -1509,7 +1501,7 @@ msgstr "URL"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
-msgstr "Elimina mapa personalizado"
+msgstr "Ta bort anpassad karta"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
@@ -1520,7 +1512,7 @@ msgstr "Elimina mapa personalizado"
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
-msgstr "Borrar"
+msgstr "Ta bort"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
@@ -1528,330 +1520,330 @@ msgstr "Borrar"
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
-msgstr "Selecciona…"
+msgstr "Välj..."
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
-msgstr "Valores de muestra:"
+msgstr "Exempelvärden:"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
-msgstr "Añade un nuevo mapa"
+msgstr "Lägg till en ny karta"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
-msgstr "Editar mapa"
+msgstr "Redigera karta"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
-msgstr "¿Cómo quieres llamar a este mapa?"
+msgstr "Vad vill du kalla denna karta?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
-msgstr "e.g. United Kingdom, Brazil, Mars"
+msgstr "t.ex Storbritannien, Brasilien, Mars"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
-msgstr "URL para el archivo GeoJSON que quieres usar"
+msgstr "URL för GeoJSON-filen du vill använda"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
-msgstr "Como https://my-mb-server.com/maps/my-map.json"
+msgstr "som t.ex https://my-mb-server.com/maps/my-map.json"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
-msgstr "Actualizar"
+msgstr "Ladda om"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
-msgstr "Carga"
+msgstr "Ladda"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
-msgstr "¿Qué propiedad especifica el identificador de la región?"
+msgstr "Vilken egenskap anger regionens identifiering?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
-msgstr "¿Qué propiedad especifica el nombre de la región?"
+msgstr "Vilken egenskap anger regionens namn?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
-msgstr "Carga un archivo GeoJSON para ver una vista previa"
+msgstr "Ladda en GeoJSON-fil för att förhandsgranska"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
-msgstr "Guardar mapa"
+msgstr "Spara karta"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
-msgstr "Añadir mapa"
+msgstr "Lägg till karta"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:7
 msgid "Using embedding"
-msgstr "Utilizando embebido"
+msgstr "Använda inbäddad"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:9
 msgid "By enabling embedding you're agreeing to the embedding license located at"
-msgstr "Al habilitar el embebido, aceptas la licencia de incorporación ubicada en"
+msgstr "Genom att aktivera inbyggt samtycker du till inbyggnadslicensen som finns på"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
-msgstr "En lenguaje sencillo, cuando insertas tablas o cuadros de mando de Metabase en tu propia aplicación, esa aplicación no está sujeta a la Licencia AGPL que cubre el resto de Metabase, siempre que mantengas el logotipo de Metabase y el \"Powered by Metabase\" visible en esas incrustaciones. Sin embargo, debes leer el texto de licencia, ya que esa es la licencia real que aceptas al habilitar esta función."
+msgstr "På ren svenska - när du du använder inbyggda kartor eller instrumentpaneler från Metabase i din egen applikation lyder inte denna applikation under \"Affero General Public License\" som täcker resten av Metabase, under förutsättning att du behåller Metabase-logotypen och \"Powered by Metabase\" synlig i dina inbäddade objekt. Du bör emellertid läsa licenstexten i länken ovan efter det är denna du sammatycker till genom att aktivera denna funktion."
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
-msgstr "Habilitar"
+msgstr "Aktivera"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:24
 msgid "Premium embedding enabled"
-msgstr "Embebido Premium habilitado"
+msgstr "Premium-inbäddning aktiverad"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:26
 msgid "Enter the token you bought from the Metabase Store"
-msgstr "Introduce el token que compraste en la Tienda Metabase"
+msgstr "Ange värdebeviset du köpt från Metabase Store"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:53
 msgid "Premium embedding lets you disable \"Powered by Metabase\" on your embedded dashboards and questions."
-msgstr "La incrustación Premium te permite desactivar \"Powered by Metabase\" en tus cuadros de mandos y preguntas embebidas."
+msgstr "Premium-inbäddning tillåter att du inaktiverar \"Powered by Metabase\" i dina inbäddade instrumentpaneler och frågor."
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:60
 msgid "Buy a token"
-msgstr "Comprar un token"
+msgstr "Köp ett värdebevis"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:63
 msgid "Enter a token"
-msgstr "Introducir un token"
+msgstr "Använd ett värdebevis"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
 msgid "Edit Mappings"
-msgstr "Editar Asignaciones"
+msgstr "Redigera inbäddade objekt"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
 msgid "Group Mappings"
-msgstr "Asignaciones de Grupo"
+msgstr "Mappade grupper"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
 msgid "Create a mapping"
-msgstr "Crear una asignación"
+msgstr "Skapa en mappning"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
-msgstr "Las asignaciones permiten que Metabase agregue y elimine automáticamente usuarios de grupos según la información de membresía proporcionada por el servidor de directorios. La membresía al grupo de administración se puede otorgar a través de asignaciones, pero no se eliminará automáticamente como una medida a prueba de fallas."
+msgstr "Mappningar tillåter Metabase att automatiskt lägga till och ta bort användare från grupper baserat på medlemsinformation från autentiseringsservern. Tillhörighet i Admin-grupp kan aktiveras genom mappningar, men kommer som en försiktighetsåtgärd inte automatiskt att  tas bort."
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:107
 msgid "Distinguished Name"
-msgstr "Nombre Distinguido"
+msgstr "Härlett namn"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:92
 msgid "Public Link"
-msgstr "Enlace Público"
+msgstr "Publik länk"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:93
 msgid "Revoke Link"
-msgstr "Eliminar Enlace"
+msgstr "Upphäv länk"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
-msgstr "¿Deshabilitar este enlace?"
+msgstr "Inaktivera denna länk?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
-msgstr "Ya no funcionarán y no se pueden restaurar, pero puedes crear nuevos enlaces."
+msgstr "De kommer inte att fungera längre och kan inte återställas, men du kan skapa nya länkar."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 msgid "Public Dashboard Listing"
-msgstr "Listado de Cuadros de Mando Públicos"
+msgstr "Lista över publika kontrollpaneler"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
-msgstr "Aún no se ha compartido públicamente ningún cuadro de mando."
+msgstr "Inga kontrollpaneler har delats publikt ännu."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
-msgstr "Listado de tarjetas públicas"
+msgstr "Lista över publika meddelanden"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
-msgstr "Aún no se ha compartido públicamente ninguna pregunta."
+msgstr "Inga frågor har delats publikt ännu."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
-msgstr "Listado de cuadros de mando embebidos"
+msgstr "Lista över inbäddade kontrollpaneler"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
-msgstr "No se han incrustado cuadros de mando todavía."
+msgstr "Inga kontrollpaneler har bäddats in ännu."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
-msgstr "Listado de tarjetas embebidas"
+msgstr "Lista över inbäddade meddelanden"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
-msgstr "No se han incrustado preguntas todavía."
+msgstr "Inga frågor har bäddats in ännu."
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:35
 msgid "Regenerate embedding key?"
-msgstr "¿Regenerar la clave de inserción?"
+msgstr "Skapa om nyckel för inbäddning?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:36
 msgid "This will cause existing embeds to stop working until they are updated with the new key."
-msgstr "Esto hará que las inserciones existentes dejen de funcionar hasta que se actualicen con la nueva clave."
+msgstr "Detta kommer att göra att befintliga inbäddningar kommer att sluta fungera tills de har uppdaterats med den nya nyckeln."
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:39
 msgid "Regenerate key"
-msgstr "Regenerar clave"
+msgstr "Skapa om nyckel"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:47
 msgid "Generate Key"
-msgstr "Generar clave"
+msgstr "Skapa nyckel"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
 #: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enabled"
-msgstr "Habilitado"
+msgstr "Aktiverad"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
 #: frontend/src/metabase/admin/settings/selectors.js:93
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
-msgstr "Deshabilitado"
+msgstr "Inaktiverad"
 
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:113
 msgid "Unknown setting {0}"
-msgstr "La directiva de configuración {0} es desconocida"
+msgstr "{0} - okänd inställning"
 
 #: frontend/src/metabase/admin/settings/selectors.js:37
 msgid "Setup"
-msgstr "Configura"
+msgstr "Inställning"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:214
 #: frontend/src/metabase/admin/settings/selectors.js:42
 msgid "General"
-msgstr "General"
+msgstr "Generell"
 
 #: frontend/src/metabase/admin/settings/selectors.js:46
 msgid "Site Name"
-msgstr "Nombre Sitio"
+msgstr "Sajt-namn"
 
 #: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Site URL"
-msgstr "URL Sitio"
+msgstr "Sajt-URL"
 
 #: frontend/src/metabase/admin/settings/selectors.js:64
 msgid "Email Address for Help Requests"
-msgstr "Dirección de correo electrónico para solicitudes de ayuda"
+msgstr "Epost-adress för frågor"
 
 #: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
-msgstr "Zona horaria de los Informes"
+msgstr "Tidszon för rapport"
 
 #: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
-msgstr "La de la base de datos"
+msgstr "Databasförval"
 
 #: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Select a timezone"
-msgstr "Selecciona una zona horaria"
+msgstr "Välj en tidszon"
 
 #: frontend/src/metabase/admin/settings/selectors.js:75
 msgid "Not all databases support timezones, in which case this setting won't take effect."
-msgstr "No todas las bases de datos admiten zonas horarias, en cuyo caso esta configuración no tendrá efecto."
+msgstr "Alla databaser har inte stöd för tidszoner, i vilka fall denna inställning inte kommer att göra någon skillnad."
 
 #: frontend/src/metabase/entities/users/forms.js:34
 msgid "Language"
-msgstr "Idioma"
+msgstr "Språk"
 
 #: frontend/src/metabase/admin/settings/selectors.js:65
 msgid "Select a language"
-msgstr "Selecciona un idioma"
+msgstr "Välj ett språk"
 
 #: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
-msgstr "Seguimiento anónimo"
+msgstr "Anonym spårning"
 
 #: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
-msgstr "Nombres de tablas y campos amistosos"
+msgstr "Användarvänliga tabell- och fältnamn"
 
 #: frontend/src/metabase/admin/settings/selectors.js:91
 msgid "Only replace underscores and dashes with spaces"
-msgstr "Solo reemplaza los guiones bajos y guiones por espacios"
+msgstr "Ersätt bara understykningstecken och bindesstreck med blanktecken"
 
 #: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Enable Nested Queries"
-msgstr "Habilitar consultas anidadas"
+msgstr "Tillåt nästlade frågor"
 
 #: frontend/src/metabase/admin/settings/selectors.js:110
 msgid "Updates"
-msgstr "Actualizaciones"
+msgstr "Uppdatering"
 
 #: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
-msgstr "Buscar actualizaciones"
+msgstr "Leta efter uppdatering"
 
 #: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
-msgstr "Servidor SMTP"
+msgstr "SMTP-server"
 
 #: frontend/src/metabase/admin/settings/selectors.js:134
 msgid "SMTP Port"
-msgstr "Puerto SMTP"
+msgstr "SMTP-port"
 
 #: frontend/src/metabase/admin/settings/selectors.js:138
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:47
 msgid "That's not a valid port number"
-msgstr "Ese no es un número de puerto válido"
+msgstr "Det är inte ett giltigt portnummer"
 
 #: frontend/src/metabase/admin/settings/selectors.js:142
 msgid "SMTP Security"
-msgstr "Seguridad SMTP"
+msgstr "SMTP-säkerhet"
 
 #: frontend/src/metabase/admin/settings/selectors.js:150
 msgid "SMTP Username"
-msgstr "Usuario SMTP"
+msgstr "SMTP-användarnamn"
 
 #: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "SMTP Password"
-msgstr "Contraseña SMTP"
+msgstr "SMTP-lösenord"
 
 #: frontend/src/metabase/admin/settings/selectors.js:164
 msgid "From Address"
-msgstr "Email De"
+msgstr "Från adress"
 
 #: frontend/src/metabase/admin/settings/selectors.js:178
 msgid "Slack API Token"
-msgstr "Slack API Token"
+msgstr "Slack API-värdebevis"
 
 #: frontend/src/metabase/admin/settings/selectors.js:180
 msgid "Enter the token you received from Slack"
-msgstr "Introduce el token que has recibido de Slack"
+msgstr "Ange det värdebevis du mottagit från Slack"
 
 #: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
-msgstr "Inicio de sesión único"
+msgstr "Förenklad inloggning"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:30
 msgid "LDAP Authentication"
-msgstr "Autentificación LDAP"
+msgstr "LDAP-autentisering"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:36
 msgid "LDAP Host"
-msgstr "Servidor LDAP"
+msgstr "LDAP-server"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:44
 msgid "LDAP Port"
-msgstr "Puerto LDAP"
+msgstr "LDAP-port"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:51
 msgid "LDAP Security"
-msgstr "Seguridad LDAP"
+msgstr "LDAP-säkerhet"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:59
 msgid "Username or DN"
-msgstr "Nombre de Usuario o DN"
+msgstr "Användarnamn eller DN"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:43
 #: frontend/src/metabase/entities/databases/forms.js:61
@@ -1859,250 +1851,249 @@ msgstr "Nombre de Usuario o DN"
 #: frontend/src/metabase/user/components/UserSettings.jsx:66
 #: src/metabase/driver/common.clj
 msgid "Password"
-msgstr "Contraseña"
+msgstr "Lösenord"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:69
 msgid "User search base"
-msgstr "Base de búsqueda de usuario"
+msgstr "Användardatabas"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:75
 msgid "User filter"
-msgstr "Filtro de usuario"
+msgstr "Användarfilter"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:81
 msgid "Check your parentheses"
-msgstr "Verifica los paréntesis"
+msgstr "Kontrollera dina parenteser"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
-msgstr "Atributo de Email"
+msgstr "Epost-attribut"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
-msgstr "Atributo de Nombre"
+msgstr "Förnamn-attribut"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
-msgstr "Atributo de Apellidos"
+msgstr "Efternamn-attribut"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
-msgstr "Sincronizar membresías de grupo"
+msgstr "Synkronisera grupptillhörigheter"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:113
 msgid "Group search base"
-msgstr "Base de búsqueda para Grupo"
+msgstr "Gruppdatabas"
 
 #: frontend/src/metabase/admin/settings/selectors.js:201
 msgid "Maps"
-msgstr "Mapas"
+msgstr "Kartor"
 
 #: frontend/src/metabase/admin/settings/selectors.js:205
 msgid "Map tile server URL"
-msgstr "URL del servidor de capas de mapa"
+msgstr "URL för \"map tile server\""
 
 #: frontend/src/metabase/admin/settings/selectors.js:206
 msgid "Metabase uses OpenStreetMaps by default."
-msgstr "Metabase usa OpenStreetMaps por defecto."
+msgstr "Metabase använder OpenStreetMaps som förval."
 
 #: frontend/src/metabase/admin/settings/selectors.js:211
 msgid "Custom Maps"
-msgstr "Mapas Personalizados"
+msgstr "Egna kartor"
 
 #: frontend/src/metabase/admin/settings/selectors.js:212
 msgid "Add your own GeoJSON files to enable different region map visualizations"
-msgstr "Añade tus propios archivos GeoJSON para habilitar diferentes visualizaciones de mapas de región"
+msgstr "Lägg till dina egna GeoJSON-filer för att aktivera olika visningar av kartregioner"
 
 #: frontend/src/metabase/admin/settings/selectors.js:245
 msgid "Public Sharing"
-msgstr "Uso compartido público"
+msgstr "Dela publikt"
 
 #: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "Enable Public Sharing"
-msgstr "Habilitar el intercambio público"
+msgstr "Aktivera publik delning"
 
 #: frontend/src/metabase/admin/settings/selectors.js:254
 msgid "Shared Dashboards"
-msgstr "Cuadros de Mando compartidos"
+msgstr "Delade kontrollpaneler"
 
 #: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Shared Questions"
-msgstr "Preguntas compartidas"
+msgstr "Delade frågor"
 
 #: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Embedding in other Applications"
-msgstr "Incrustar en otras aplicaciones"
+msgstr "Inbäddning i andra applikationer"
 
 #: frontend/src/metabase/admin/settings/selectors.js:293
 msgid "Enable Embedding Metabase in other Applications"
-msgstr "Habilitar incrustación de Metabase en otras aplicaciones"
+msgstr "Aktivera inbäddning i andra applikationer"
 
 #: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Embedding secret key"
-msgstr "Clave secreta de incrustación"
+msgstr "Hemlig nyckel för inbäddning"
 
 #: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Embedded Dashboards"
-msgstr "Cuadros de Mando embebidos"
+msgstr "Inbäddade kontrollpaneler"
 
 #: frontend/src/metabase/admin/settings/selectors.js:315
 msgid "Embedded Questions"
-msgstr "Preguntas embebidas"
+msgstr "Inbäddade frågor"
 
 #: frontend/src/metabase/admin/settings/selectors.js:322
 msgid "Caching"
-msgstr "Almacenamiento en caché"
+msgstr "Cache"
 
 #: frontend/src/metabase/admin/settings/selectors.js:326
 msgid "Enable Caching"
-msgstr "Habilitar caché"
+msgstr "Aktivera cache"
 
 #: frontend/src/metabase/admin/settings/selectors.js:331
 msgid "Minimum Query Duration"
-msgstr "Duración mínima de la consulta"
+msgstr "Minsta tid för fråga"
 
 #: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Cache Time-To-Live (TTL) multiplier"
-msgstr "Multiplicador Time-to-Live (TTL) de caché"
+msgstr "Multiplikator för \"Cache Time-To-Live (TTL) \""
 
 #: frontend/src/metabase/admin/settings/selectors.js:345
 msgid "Max Cache Entry Size"
-msgstr "Tamaño máximo de entrada de caché"
+msgstr "Maximal cache-storlek"
 
 #: frontend/src/metabase/alert/alert.js:60
 msgid "Your alert is all set up."
-msgstr "Tu alerta está configurada."
+msgstr "Din övervakning är uppsatt."
 
 #: frontend/src/metabase/alert/alert.js:101
 msgid "Your alert was updated."
-msgstr "Tu alerta fue actualizada."
+msgstr "Din övervakning uppdaterades."
 
 #: frontend/src/metabase/alert/alert.js:149
 msgid "The alert was successfully deleted."
-msgstr "La alerta fue eliminada correctamente."
+msgstr "Övervakning har tagits bort."
 
 #: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
-msgstr "Por favor introduce una dirección de correo electrónico con formato válido."
+msgstr "Ange en giltigt formatterad epost-adress"
 
 #: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
-msgstr "Las contraseñas no coinciden"
+msgstr "Lösenorden stämmer inte överens"
 
 #: frontend/src/metabase/auth/components/BackToLogin.jsx:6
 msgid "Back to login"
-msgstr "Volver al inicio de sesión"
+msgstr "Tillbaka till inloggning"
 
 #: frontend/src/metabase/auth/components/GoogleNoAccount.jsx:15
 msgid "No Metabase account exists for this Google account."
-msgstr "No existe una cuenta de Metabase para esta cuenta de Google."
+msgstr "Inget Metabase-konto finns för ditt Google-konto"
 
 #: frontend/src/metabase/auth/components/GoogleNoAccount.jsx:17
 msgid "You'll need an administrator to create a Metabase account before you can use Google to log in."
-msgstr "Necesitará un administrador para crear una cuenta Metabase antes de poder usar Google para iniciar sesión."
+msgstr "Du behöver en administratör för att skapa ett Metabase-konto innan du kan använda Google för att logga in."
 
 #: frontend/src/metabase/auth/components/AuthProviderButton.jsx:23
 msgid "Sign in with {0}"
-msgstr "Inicia sesión con {0}"
+msgstr "Logga in med {0}"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
 msgid "Please contact an administrator to have them reset your password"
-msgstr "Por favor, ponte en contacto con un administrador para que restablezca tu contraseña"
+msgstr "Kontakta en administratör och låt dem återställa ditt lösenord"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "Forgot password"
-msgstr "Olvidé mi contraseña"
+msgstr "Glömt lösenord"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "The email you use for your Metabase account"
-msgstr "El correo electrónico que utilizas para tu cuenta Metabase"
+msgstr "Epost-adressen du använder för ditt Metabase-konto"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
 msgid "Send password reset email"
-msgstr "Enviar correo electrónico de restablecimiento de contraseña"
+msgstr "Skicka epost om återställning av lösenord"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
 msgid "Check your email for instructions on how to reset your password."
-msgstr "Consulta tu correo electrónico para obtener instrucciones sobre cómo restablecer tu contraseña."
+msgstr "Kontrollera instruktionerna i din epost för hur du återstället lösenordet."
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:44
 msgid "Sign in to Metabase"
-msgstr "Iniciar sesión en Metabase"
+msgstr "Logga in i Metabase"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:165
 msgid "OR"
-msgstr "O"
+msgstr "ELLER"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
 msgid "Username or email address"
-msgstr "Nombre de usuario o dirección de correo electrónico"
+msgstr "Användarnamn eller epost-adress"
 
 #: frontend/src/metabase/auth/components/AuthProviderButton.jsx:23
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:56
 msgid "Sign in"
-msgstr "Acceder"
+msgstr "Logga in"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:79
 msgid "I seem to have forgotten my password"
-msgstr "Parece que olvidé mi contraseña"
+msgstr "Jag verkar ha glömt lösenordet"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
 msgid "request a new reset email"
-msgstr "solicitar un nuevo correo electrónico de reinicio"
+msgstr "begär ny återställning via epost"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
 msgid "Whoops, that's an expired link"
-msgstr "Vaya, ese es un enlace caducado"
+msgstr "Hoppsan, den länken är inte längre giltig"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
-msgstr "Por razones de seguridad, los enlaces de restablecimiento de contraseña caducan después de un tiempo.\n"
-"Si aún necesita restablecer tu contraseña, puedes {0}"
+msgstr "Av säkerhetsskäl upphör länkar för återställning av lösenord efter ett tag. Om du fortfarande behöver återställa lösenord kan du {0}."
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
 msgid "New password"
-msgstr "Nueva contraseña"
+msgstr "Nytt lösenord"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
 msgid "To keep your data secure, passwords {0}"
-msgstr "Para mantener tus datos seguros, las contraseñas {0}"
+msgstr "Lösenord behöver {0} för att vara data ska vara säkra"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
-msgstr "Crear una nueva contraseña"
+msgstr "Skapa ett nytt lösenord"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:135
 msgid "Make sure its secure like the instructions above"
-msgstr "Ha de cumplir las instrucciones anteriores"
+msgstr "Se till att det är säkert enligt instruktionerna ovan"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:186
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:143
 msgid "Confirm new password"
-msgstr "Confirmar nueva contraseña"
+msgstr "Bekräfta nytt lösenord"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:193
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:152
 msgid "Make sure it matches the one you just entered"
-msgstr "Tiene que coincidir con la que acabas de poner"
+msgstr "Se till att det matchar det du nyss angav"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
 msgid "Your password has been reset."
-msgstr "Tu contraseña ha sido restablecida."
+msgstr "Ditt lösenord har återställts."
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
 msgid "Sign in with your new password"
-msgstr "Inicia sesión con tu nueva contraseña"
+msgstr "Logga in med ditt nya lösenord"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
-msgstr "Ha fallado"
+msgstr "Det gick inte att spara"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
@@ -2110,19 +2101,19 @@ msgstr "Ha fallado"
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
-msgstr "Guardado"
+msgstr "Sparat"
 
 #: frontend/src/metabase/components/Alert.jsx:12
 msgid "Ok"
-msgstr "Vale"
+msgstr "Okej"
 
 #: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
 msgid "Archive this collection?"
-msgstr "¿Archivar esta colección?"
+msgstr "Arkivera denna samling?"
 
 #: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
-msgstr "Los cuadros de mando, colecciones y pulsos guardados en esta colección también se archivarán."
+msgstr "Instrumentpaneler, samlingar och ögonblicksbilder i denna samling kommer också att arkiveras."
 
 #: frontend/src/metabase/components/ArchiveModal.jsx:38
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
@@ -2136,19 +2127,19 @@ msgstr "Los cuadros de mando, colecciones y pulsos guardados en esta colección 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
 #: frontend/src/metabase/routes.jsx:196
 msgid "Archive"
-msgstr "Archivar"
+msgstr "Arkiv"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:65
 msgid "This {0} has been archived"
-msgstr "Este {0} ha sido archivado"
+msgstr "Denna {0} har arkiverats"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:710
 msgid "View the archive"
-msgstr "Ver el archivo"
+msgstr "Visa arkivet"
 
 #: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
-msgstr "Desarchive este {0}"
+msgstr "Av-arkivera denna {0}"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:46
 #: frontend/src/metabase/components/BrowseApp.jsx:112
@@ -2157,132 +2148,132 @@ msgstr "Desarchive este {0}"
 #: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
-msgstr "Nuestros datos"
+msgstr "Våra data"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
 msgid "X-ray this table"
-msgstr "Aplica rayos-X a esta tabla"
+msgstr "Genomlys denna tabell"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:171
 msgid "Learn about this table"
-msgstr "Aprende sobre esta tabla"
+msgstr "Få information om denna tabell"
 
 #: frontend/src/metabase/components/Button.info.js:11
 #: frontend/src/metabase/components/Button.info.js:12
 #: frontend/src/metabase/components/Button.info.js:13
 msgid "Clickity click"
-msgstr "Clic"
+msgstr "Klick-klick"
 
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:9
 msgid "Saved!"
-msgstr "¡Guardado!"
+msgstr "Sparad!"
 
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:10
 msgid "Saving failed."
-msgstr "No se ha podido guardar."
+msgstr "Kunde ej spara."
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Su"
-msgstr "D"
+msgstr "Sö"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Mo"
-msgstr "L"
+msgstr "Må"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Tu"
-msgstr "M"
+msgstr "Ti"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "We"
-msgstr "X"
+msgstr "On"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Th"
-msgstr "J"
+msgstr "To"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Fr"
-msgstr "V"
+msgstr "Fr"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Sa"
-msgstr "S"
+msgstr "Lö"
 
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:41
 msgid "Your admin's email address"
-msgstr "La dirección de correo electrónico de tu administrador"
+msgstr "Din administratörs epost-adress"
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:37
 msgid "To send {0}, you'll need to set up {1} integration."
-msgstr "Para enviar {0}, tendrás que configurar la integración con {1}."
+msgstr "För att skicka {0} behöver du sätta upp integrationen med {1}."
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:38
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:41
 msgid " or "
-msgstr " o "
+msgstr "eller"
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:40
 msgid "To send {0}, an admin needs to set up {1} integration."
-msgstr "Para enviar {0}, un administrador necesita configurar la integración con {1}."
+msgstr "För att skicka {0} behöver en administratör sätta upp integration med {1}"
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:15
 msgid "This collection is empty, like a blank canvas"
-msgstr "Esta colección está vacía, como una hoja en blanco"
+msgstr "Denna samling är tom, som ett blankt papper"
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:16
 msgid "You can use collections to organize and group dashboards, questions and pulses for your team or yourself"
-msgstr "Puedes usar colecciones para organizar y agrupar cuadros de mando, preguntas y pulsos para tu equipo o para ti"
+msgstr "Du kan använda samlingar för att organisera och gruppera kontrollpaneler, frågor och ögonblicksbilder för ditt team eller dig själv"
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:28
 msgid "Create another collection"
-msgstr "Crea otra colección"
+msgstr "Skapa ytterligare en samling"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:68
 msgid "Dashboards let you collect and share data in one place."
-msgstr "Los cuadros de mando te permiten recopilar y compartir datos en un solo lugar."
+msgstr "Kontrollpaneler låter dig samla och dela data från ett ställe."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:77
 msgid "Pulses let you send out the latest data to your team on a schedule via email or slack."
-msgstr "Los pulsos te permiten enviar datos de Metabase a correo electrónico o Slack en el horario que deseas."
+msgstr "Ögonblicksbilder låter dig skicka ut senaste data till ditt team enligt tidsschema via epost eller Slack"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:86
 msgid "Questions are a saved look at your data."
-msgstr "Las preguntas son vistas guardadas de tus datos."
+msgstr "Frågor är en sparad översikt över dina data."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
-msgstr "Pins"
+msgstr "Fästnålar"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
-msgstr "Arrastra algo aquí para pegarlo arriba"
+msgstr "Dra något hit för att fästa det högst upp"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:753
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
-msgstr "Colecciones"
+msgstr "Samlingar"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:431
 #: frontend/src/metabase/components/CollectionLanding.jsx:452
 msgid "Drag here to un-pin"
-msgstr "Arrastra aquí para despegarlo"
+msgstr "Dra hit för att ta bort fästnål"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:487
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
-msgstr[0] "{0} elemento seleccionado"
-msgstr[1] "{0} elementos seleccionados"
+msgstr[0] "{0} post vald"
+msgstr[1] "{0} poster valda"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:517
 msgid "Move {0} items?"
-msgstr "¿Mover {1} elemento(s)?"
+msgstr "Flytta {0} poster?"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:518
 msgid "Move \"{0}\"?"
-msgstr "¿Mover \"{0}\"?"
+msgstr "Flytta \"{0}\"?"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:623
 #: frontend/src/metabase/components/EntityMenu.info.js:29
@@ -2290,84 +2281,81 @@ msgstr "¿Mover \"{0}\"?"
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
-msgstr "Mover"
+msgstr "Flytta"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:687
 msgid "Edit this collection"
-msgstr "Edita esta colección"
+msgstr "Redigera denna samling"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:695
 msgid "Archive this collection"
-msgstr "Archivar esta colección"
+msgstr "Arkivera denna samling"
 
 #: frontend/src/metabase/components/CollectionList.jsx:67
 #: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
-msgstr "Mi colección personal"
+msgstr "Min personliga samling"
 
 #: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
-msgstr "Nueva colección"
+msgstr "Ny samling"
 
 #: frontend/src/metabase/components/CopyButton.jsx:36
 msgid "Copied!"
-msgstr "¡Copiado!"
+msgstr "Kopierad!"
 
 #: frontend/src/metabase/entities/databases/forms.js:14
 msgid "Use an SSH-tunnel for database connections"
-msgstr "Utiliza un túnel SSH para las conexiones a la base de datos"
+msgstr "Använd en SSH-tunnel för databas-anslutningar"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
-msgstr "Algunas instalaciones de bases de datos solo se pueden acceder conectándose a través de un túnel SSH.\n"
-"Esta opción también proporciona una capa adicional de seguridad cuando no dispones de una VPN.\n"
-"Esto suele ser más lento que una conexión directa."
+msgstr "Vissa databas-installationer kan bara kommas åt via en en SSH-server. Detta alternativ ger också ett extra lager av säkerhet när VPN inte finns tillgängligt. Detta alternativ är oftast långsammare än en direktanslutning."
 
 #: frontend/src/metabase/entities/databases/forms.js:281
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
-msgstr "Esta es una base de datos grande, así que déjame elegir cuándo Metabase sincroniza y escanea"
+msgstr "Detta är en stor databas, så låt mig välja när Metabase synkar och skannar"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
-msgstr "De forma predeterminada, Metabase realiza una sincronización ligera cada hora y un análisis diario intensivo de los valores de campo.\n"
-"Si tienes una base de datos grande, te recomendamos activarla y revisar cuándo y con qué frecuencia ocurren los escaneos de valores de campo."
+msgstr "Som förval använder Metabase en resurssnål synkning varje timme och en resurskrävande daglig skanning av fältvärden. Om du har en stor databas rekommenderar vi att detta aktiveras och att du tittar igenom hur ofta skanning av fältvärden sker."
 
 #: frontend/src/metabase/entities/databases/forms.js:113
 msgid "{0} to generate a Client ID and Client Secret for your project."
-msgstr "{0} para generar un ID y clave secreta de cliente para tu proyecto."
+msgstr "{0} för att generera ett klient-ID och klient-hemlighet till ditt projekt"
 
 #: frontend/src/metabase/entities/databases/forms.js:115
 #: frontend/src/metabase/entities/databases/forms.js:130
 #: frontend/src/metabase/entities/databases/forms.js:166
 msgid "Click here"
-msgstr "Haz clic aquí"
+msgstr "Klicka här"
 
 #: frontend/src/metabase/entities/databases/forms.js:118
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
-msgstr "Elige \"Otro\" como tipo de aplicación. Llámalo como quieras"
+msgstr "Välj \"Annan\" som projekttyp. Ge det ett valfritt namn."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:357
 msgid "{0} to get an auth code"
-msgstr "{0} para obtener un código de autenticación"
+msgstr "{0} för att få en auktorisationskod"
 
 #: frontend/src/metabase/entities/databases/forms.js:142
 msgid "with Google Drive permissions"
-msgstr "con permisos de Google Drive"
+msgstr "med Google Drive-rättigheter"
 
 #: frontend/src/metabase/entities/databases/forms.js:164
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
-msgstr "Para usar Metabase con estos datos, debes habilitar el acceso a la API en Google Developers Console."
+msgstr "För att använda Metabase med detta data måste du aktivera API-åtkomst i Google Developers Console."
 
 #: frontend/src/metabase/entities/databases/forms.js:165
 msgid "{0} to go to the console if you haven't already done so."
-msgstr "{0} para ir a la consola si aún no lo has hecho."
+msgstr "{0} för att gå till kontrollpanelen om det inte redan är gjort."
 
 #: frontend/src/metabase/entities/databases/forms.js:265
 msgid "How would you like to refer to this database?"
-msgstr "¿Cómo te gustaría llamar esta base de datos?"
+msgstr "Under vilket namn vill du referera till denna databas?"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:187
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
@@ -2378,148 +2366,148 @@ msgstr "¿Cómo te gustaría llamar esta base de datos?"
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:126
 #: frontend/src/metabase/setup/components/UserStep.jsx:93
 msgid "Next"
-msgstr "Siguiente"
+msgstr "Nästa"
 
 #: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
-msgstr "Elimina este {0}"
+msgstr "Radera denna {0}"
 
 #: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
-msgstr "Fija este elemento"
+msgstr "Fäst denna post"
 
 #: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
-msgstr "Mueve este elemento"
+msgstr "Flytta denna post"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:21
 msgid "Edit this question"
-msgstr "Editar esta pregunta"
+msgstr "Redigera denna fråga"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:26
 #: frontend/src/metabase/components/EntityMenu.info.js:47
 #: frontend/src/metabase/components/EntityMenu.info.js:82
 #: frontend/src/metabase/components/EntityMenu.info.js:99
 msgid "Action type"
-msgstr "Tipo acción"
+msgstr "Åtgärdstyp"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:26
 msgid "View revision history"
-msgstr "Ver el historial de revisiones"
+msgstr "Visa revisionshistoriken"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 msgid "Move action"
-msgstr "Acción de mover"
+msgstr "Åtgärd flytta"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:33
 #: frontend/src/metabase/components/EntityMenu.info.js:89
 msgid "Archive action"
-msgstr "Acción de archivar"
+msgstr "Åtgärd arkivera"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:31
 msgid "Add to dashboard"
-msgstr "Añadir a Cuadro de Mando"
+msgstr "Lägg till kontrollpanelen"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:49
 #: frontend/src/metabase/components/EntityMenu.info.js:101
 msgid "Download results"
-msgstr "Descarga los resultados"
+msgstr "Ladda ner resultat"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:51
 #: frontend/src/metabase/components/EntityMenu.info.js:103
 #: frontend/src/metabase/dashboard/containers/DashboardEmbedWidget.jsx:53
 msgid "Sharing and embedding"
-msgstr "Compartiendo y Incrustando"
+msgstr "Dela och inbädda"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:53
 #: frontend/src/metabase/components/EntityMenu.info.js:105
 msgid "Another action type"
-msgstr "Otro tipo de acción"
+msgstr "En annan åtgärdstyp"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:65
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
 msgid "Get alerts about this"
-msgstr "Recibe alertas sobre esto"
+msgstr "Få varningar om detta"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
-msgstr "Ver el SQL"
+msgstr "Visa SQL"
 
 #: frontend/src/metabase/components/EntitySegments.jsx:18
 msgid "Segments for this"
-msgstr "Segmentos para este"
+msgstr "Segment för detta"
 
 #: frontend/src/metabase/components/ErrorDetails.jsx:20
 msgid "Show error details"
-msgstr "Mostrar detalles del error"
+msgstr "Visa detaljer om fel"
 
 #: frontend/src/metabase/components/ErrorDetails.jsx:26
 msgid "Here's the full error message"
-msgstr "Este es el mensaje de error completo"
+msgstr "Här är det fulla felmeddelandet"
 
 #: frontend/src/metabase/components/ExplorePane.jsx:19
 msgid "Hi, Metabot here."
-msgstr "Hola, soy Metabot"
+msgstr "Hej, det är jag som är Metabot"
 
 #: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
-msgstr "Basado en el esquema"
+msgstr "Baserat på schemat"
 
 #: frontend/src/metabase/components/ExplorePane.jsx:173
 msgid "A look at your"
-msgstr "Una vista a tus"
+msgstr "En titt på din"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:296
 msgid "Search the list"
-msgstr "Busca la lista"
+msgstr "Sök i listan"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:307
 msgid "Search by {0}"
-msgstr "Buscar por {0}"
+msgstr "Sök via {0}"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:309
 msgid " or enter an ID"
-msgstr "o introduce un ID"
+msgstr "eller ange ett ID"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:314
 msgid "Enter an ID"
-msgstr "Introduce un ID"
+msgstr "Ange ett ID"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:316
 msgid "Enter a number"
-msgstr "Introduce un número"
+msgstr "Ange en siffra"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:318
 msgid "Enter some text"
-msgstr "Introduce un texto"
+msgstr "Ange någon text"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:429
 msgid "No matching {0} found."
-msgstr "No se encontraron {0} coincidentes."
+msgstr "Ingen matchande {0} hittades"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:438
 msgid "Including every option in your filter probably won’t do much…"
-msgstr "Incluir cada opción en tu filtro probablemente no hará mucho…"
+msgstr "Genom att ta med varje alternativ i ditt sökfilter uppnår du inte så mycket..."
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:26
 msgid "Something's gone wrong"
-msgstr "Lo siento. Algo salió mal."
+msgstr "Något gick fel"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:27
 msgid "We've run into an error. You can try refreshing the page, or just go back."
-msgstr "Nos encontramos con un error. Puedes intentar refrescar la página, o simplemente volver atrás"
+msgstr "Vi har stött på ett fel. Du kan prova att ladda om sida eller gå tillbaka."
 
 #: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
@@ -2530,327 +2518,327 @@ msgstr "Nos encontramos con un error. Puedes intentar refrescar la página, o si
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:238
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:213
 msgid "No description yet"
-msgstr "Sin descripción todavía"
+msgstr "Ingen beskrivning ännu"
 
 #: frontend/src/metabase/components/Header.jsx:119
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
-msgstr "Nuevo {0}"
+msgstr "Ny {0}"
 
 #: frontend/src/metabase/components/Header.jsx:130
 msgid "Asked by {0}"
-msgstr "Preguntado por {0}"
+msgstr "Efterfrågad av {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
-msgstr "Hoy."
+msgstr "Idag"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
-msgstr "Ayer."
+msgstr "Igår"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
-msgstr "Primera revisión."
+msgstr "Första revisionen"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
-msgstr "Revertido a una revisión anterior y {0}"
+msgstr "Återgått till en tidigare revision av {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
-msgstr "Historial de Revisiones"
+msgstr "Revisionshistorik"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
-msgstr "Cuando"
+msgstr "När"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
-msgstr "Quien"
+msgstr "Vem"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
-msgstr "Que"
+msgstr "Vad"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
-msgstr "Revertir"
+msgstr "Återgå"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
-msgstr "Revertiendo…"
+msgstr "Återgår..."
 
 #: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
-msgstr "Falló la reversión"
+msgstr "Kunde inte återgå"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
-msgstr "Revertido"
+msgstr "Återgått"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:13
 msgid "Everything"
-msgstr "Todo"
+msgstr "Allting"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
 msgid "Dashboards"
-msgstr "Cuadros de Mando"
+msgstr "Instrumentpaneler"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
 msgid "Questions"
-msgstr "Preguntas"
+msgstr "Frågor"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
 #: frontend/src/metabase/routes.jsx:311
 msgid "Pulses"
-msgstr "Pulsos"
+msgstr "Ögonblicksbilder"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
 #: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
-msgstr "Atrás"
+msgstr "Tillbaka"
 
 #: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
-msgstr "Encontrar..."
+msgstr "Sök..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 msgid "An error occured"
-msgstr "Ha ocurrido un error"
+msgstr "Ett fel uppstod"
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:35
 msgid "Loading..."
-msgstr "Cargando..."
+msgstr "Laddar..."
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:71
 msgid "Metabase Newsletter"
-msgstr "Boletín Metabase"
+msgstr "Metabases nyhetsbrev"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:81
 msgid "Get infrequent emails about new releases and feature updates."
-msgstr "Recibe correos electrónicos infrecuentes sobre nuevos lanzamientos y actualizaciones de funciones."
+msgstr "Med längre mellanrum, få epost om nya versioner och uppdaterade funktioner"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:99
 msgid "Subscribe"
-msgstr "Suscribir"
+msgstr "Prenumerera"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:106
 msgid "You're subscribed. Thanks for using Metabase!"
-msgstr "Estás suscrito. ¡Gracias por usar Metabase!"
+msgstr "Du prenumererar nu. Tack för att du använder Metabase!"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:46
 msgid "We're a little lost..."
-msgstr "Estamos un poco perdidos..."
+msgstr "Vi är lite förvirrade..."
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:27
 msgid "Temporary Password"
-msgstr "Contraseña Temporal"
+msgstr "Tillfälligt lösenord"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:207
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:455
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:470
 msgid "Hide"
-msgstr "Esconder"
+msgstr "Dölj"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:456
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:471
 msgid "Show"
-msgstr "Mostrar"
+msgstr "Visa"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:17
 msgid "Saved! Add this to a dashboard?"
-msgstr "¡Guardado! ¿Añadir esto a un cuadro de mando?"
+msgstr "Sparat! Lägga till denna till din instrumentpanel?"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:25
 msgid "Yes please!"
-msgstr "¡Sí, por favor!"
+msgstr "Ja tack!"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:29
 msgid "Not now"
-msgstr "Ahora no"
+msgstr "Inte nu"
 
 #: frontend/src/metabase/components/SaveStatus.jsx:53
 msgid "Error:"
-msgstr "Error:"
+msgstr "Fel:"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:23
 msgid "Sunday"
-msgstr "Domingo"
+msgstr "Söndag"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:24
 msgid "Monday"
-msgstr "Lunes"
+msgstr "Måndag"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:25
 msgid "Tuesday"
-msgstr "Martes"
+msgstr "Tisdag"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:26
 msgid "Wednesday"
-msgstr "Miércoles"
+msgstr "Onsdag"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:27
 msgid "Thursday"
-msgstr "Jueves"
+msgstr "Torsdag"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:28
 msgid "Friday"
-msgstr "Viernes"
+msgstr "Fredag"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:29
 msgid "Saturday"
-msgstr "Sábado"
+msgstr "Lördag"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:33
 msgid "First"
-msgstr "Primero"
+msgstr "Första"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:34
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
 msgid "Last"
-msgstr "Ultimo"
+msgstr "Sista"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:35
 msgid "15th (Midpoint)"
-msgstr "15to (punto medio)"
+msgstr "15:e (halvtid)"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:125
 msgid "Calendar Day"
-msgstr "Día Calendario"
+msgstr "Dag i månaden"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:205
 msgid "your Metabase timezone"
-msgstr "tu zona horaria en Metabase"
+msgstr "Tidszonen i din Metabase"
 
 #: frontend/src/metabase/components/SearchHeader.jsx:21
 msgid "Filter this list..."
-msgstr "Filtra esta lista..."
+msgstr "Filtrera denna lista..."
 
 #: frontend/src/metabase/components/Select.info.js:8
 msgid "Blue"
-msgstr "Azul"
+msgstr "Blå"
 
 #: frontend/src/metabase/components/Select.info.js:9
 msgid "Green"
-msgstr "Verde"
+msgstr "Grön"
 
 #: frontend/src/metabase/components/Select.info.js:10
 msgid "Red"
-msgstr "Rojo"
+msgstr "Röd"
 
 #: frontend/src/metabase/components/Select.info.js:11
 msgid "Yellow"
-msgstr "Amarillo"
+msgstr "Gul"
 
 #: frontend/src/metabase/components/Select.info.js:7
 msgid "A component used to make a selection"
-msgstr "Un componente utilizado para hacer una selección"
+msgstr "En komponent som används för att göra ett val"
 
 #: frontend/src/metabase/components/Select.info.js:20
 #: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
-msgstr "Seleccionado"
+msgstr "Vald"
 
 #: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
-msgstr "Nada para seleccionar"
+msgstr "Inget att välja"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:56
 msgid "Sorry, you don’t have permission to see that."
-msgstr "Lo siento, no tienes permiso para ver eso."
+msgstr "Ursäkta, men du har inte rättighet att se detta."
 
 #: frontend/src/metabase/components/form/FormMessage.jsx:5
 msgid "Unknown error encountered"
-msgstr "Error desconocido encontrado"
+msgstr "Okänt fel uppstod"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/nav/containers/Navbar.jsx:373
 msgid "Create"
-msgstr "Crea"
+msgstr "Skapa"
 
 #: frontend/src/metabase/containers/DashboardForm.jsx:9
 msgid "Create dashboard"
-msgstr "Crea un Cuadro de Mando"
+msgstr "Skapa instrumentpanel"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
 msgid "Table"
-msgstr "Tabla"
+msgstr "Tabell"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
 msgid "Database"
-msgstr "Base de Datos"
+msgstr "Databas"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:49
 msgid "Creator"
-msgstr "Creador"
+msgstr "Skapare"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
-msgstr "No se han encontrado resultados"
+msgstr "Inga resultat hittades"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
-msgstr "Intenta ajustar tu filtro para encontrar lo que estás buscando."
+msgstr "Försök att justera ditt filter för att hitta det du letar efter."
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
-msgstr "Ver por"
+msgstr "Visa enligt"
 
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:121
 msgid "of"
-msgstr "de"
+msgstr "av"
 
 #: frontend/src/metabase/containers/Overworld.jsx:91
 msgid "Don't tell anyone, but you're my favorite."
-msgstr "No se lo digas a nadie, pero eres mi favorito."
+msgstr "Berätta inte för någon, men du är min favorit."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:85
 msgid "Once you connect your own data, I can show you some automatic explorations called x-rays. Here are some examples with sample data."
-msgstr "En cuanto conectas tus propios datos, puedo mostrarte algunas exploraciones automáticas llamadas rayos-X. Aquí hay algunos ejemplos con datos de muestra."
+msgstr "När du väl kopplar dina egna data kan jag göra några automatiska visningar kallade genomlysningar. Här är några exemel med testdata."
 
 #: frontend/src/metabase/containers/Overworld.jsx:180
 #: frontend/src/metabase/containers/Overworld.jsx:384
 msgid "Start here"
-msgstr "Empieza aquí"
+msgstr "Börja här"
 
 #: frontend/src/metabase/containers/Overworld.jsx:379
 #: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
-msgstr "Nuestra Analítica"
+msgstr "Våra analyser"
 
 #: frontend/src/metabase/containers/Overworld.jsx:248
 msgid "Browse all items"
-msgstr "Ver todos los elementos"
+msgstr "Bläddra igenom allt"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:117
 msgid "Replace or save as new?"
-msgstr "¿Reemplazar o guardar como nuevo?"
+msgstr "Ersätta eller spara som ny?"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace original question, \"{0}\""
-msgstr "Reemplazar la pregunta original, \"{0}\""
+msgstr "Ersätta ursprunglig fråga, \"{0}\""
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:171
 msgid "Save as new question"
-msgstr "Guardar como nueva pregunta"
+msgstr "Spara som en ny fråga"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:92
 msgid "First, save your question"
-msgstr "Primero, guarda tu pregunta"
+msgstr "Spara först din fråga"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
 msgid "Save question"
-msgstr "Guardar pregunta"
+msgstr "Spara fråga"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
 msgid "What is the name of your card?"
-msgstr "¿Cuál es el nombre de tu tarjeta?"
+msgstr "Vad kallas din lista?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
@@ -2868,7 +2856,7 @@ msgstr "¿Cuál es el nombre de tu tarjeta?"
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:211
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:26
 msgid "Description"
-msgstr "Descripción"
+msgstr "Beskrivning"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
@@ -2877,468 +2865,468 @@ msgstr "Descripción"
 #: frontend/src/metabase/entities/questions.js:107
 #: frontend/src/metabase/entities/snippets.js:31
 msgid "It's optional but oh, so helpful"
-msgstr "Es opcional pero, tan útil"
+msgstr "Det är valfritt, men till stor hjälp"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
-msgstr "¿En qué colección debería ir esto?"
+msgstr "Vilken samling ska detta tillhöra?"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:34
 msgid "modified"
-msgstr "modificado"
+msgstr "ändrad"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:34
 msgid "item"
-msgstr "elemento"
+msgstr "post"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
-msgstr "Deshacer"
+msgstr "Ångra"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:266
 msgid "Applying Question"
-msgstr "Aplicando Pregunta"
+msgstr "Lägg till fråga"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "That question isn't compatible"
-msgstr "Esa pregunta no es compatible"
+msgstr "Den frågan är inte kompatibel"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:309
 msgid "Search for a question"
-msgstr "Busca una pregunta"
+msgstr "Leta efter en fråga"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:343
 msgid "We're not sure if this question is compatible"
-msgstr "No estamos seguros si esta pregunta es compatible"
+msgstr "Vi är inte säkra på att denna fråga är kompatibel"
 
 #: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:43
 msgid "Archive Dashboard"
-msgstr "Archivar Cuadro de Mando"
+msgstr "Kontrollpanel arkiv"
 
 #: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
-msgstr "Asegúrate de hacer una selección para cada serie, o el filtro no funcionará en esta tarjeta."
+msgstr "Se till att göra ett urval i varje serie, annars kommer inte filtret att fungera i denna lista."
 
 #: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
 msgid "This dashboard is looking empty."
-msgstr "Este cuadro de mando parece estar vacío."
+msgstr "Kontrollpanelen verkar tom."
 
 #: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
 msgid "Add a question to start making it useful!"
-msgstr "¡Añade una pregunta para hacerlo útil!"
+msgstr "Lägg till en fråga för att göra den användbar."
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:38
 msgid "Daytime mode"
-msgstr "Modo Diurno"
+msgstr "Färgval dagtid"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:38
 msgid "Nighttime mode"
-msgstr "Modo Nocturno"
+msgstr "Färgval kvällstid"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:56
 msgid "Exit fullscreen"
-msgstr "Desactivar Pantalla Completa"
+msgstr "Stäng fullskärmsläge"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:56
 msgid "Enter fullscreen"
-msgstr "Activar Pantalla Completa"
+msgstr "Öppna fullskärmsläge"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
-msgstr "Guardando…"
+msgstr "Sparar..."
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:220
 msgid "Add a question"
-msgstr "Añade una pregunta"
+msgstr "Lägg till en fråga"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:223
 msgid "Add a question to this dashboard"
-msgstr "Añade una pregunta a este cuadro de mando"
+msgstr "Lägg till en fråga till denna kontrollpanel"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
 msgid "Add a filter"
-msgstr "Añadir filtro"
+msgstr "Lägg till ett filter"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
-msgstr "Parámetros"
+msgstr "Parametrar"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
 msgid "Add a text box"
-msgstr "Añade una caja de texto"
+msgstr "Lägg till en textruta"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:314
 msgid "Move dashboard"
-msgstr "Mover cuadro de mando"
+msgstr "Flytta instrumentpanel"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
 msgid "Edit dashboard"
-msgstr "Editar Cuadro de Mando"
+msgstr "Redigera instrumentpanel"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:307
 msgid "Edit Dashboard Layout"
-msgstr "Editar Disposición del Cuadro de Mando"
+msgstr "Redigera instrumentpanelens utseende"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:365
 msgid "You are editing a dashboard"
-msgstr "Estás editando un cuadro de mando"
+msgstr "Du redigerar en instrumentpanel"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:370
 msgid "Select the field that should be filtered for each card"
-msgstr "Selecciona el campo que debe filtrarse para cada tarjeta"
+msgstr "Välj fältet som ska filtreras för varje lista"
 
 #: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
-msgstr "Mover cuadro de mando a..."
+msgstr "Flytta instrumentpanel till..."
 
 #: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
-msgstr "Cuadro de Mando movido a {0}"
+msgstr "Instrumentpanel flyttad till {0}"
 
 #: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
 msgid "What do you want to filter?"
-msgstr "¿Qué quieres filtrar?"
+msgstr "Vad vill du filtrera?"
 
 #: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
 msgid "What kind of filter?"
-msgstr "¿Qué tipo de filtro?"
+msgstr "Vilken sorts filter?"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:242
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:250
 msgid "Off"
-msgstr "Apagado"
+msgstr "Av"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:14
 msgid "1 minute"
-msgstr "1 minuto"
+msgstr "1 minut"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:15
 msgid "5 minutes"
-msgstr "5 minutos"
+msgstr "5 minuter"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:16
 msgid "10 minutes"
-msgstr "10 minutos"
+msgstr "10 minuter"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:17
 msgid "15 minutes"
-msgstr "15 minutos"
+msgstr "15 minuter"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:18
 msgid "30 minutes"
-msgstr "30 minutos"
+msgstr "30 minuter"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:19
 msgid "60 minutes"
-msgstr "60 minutos"
+msgstr "60 minuter"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:51
 msgid "Auto-refresh"
-msgstr "Auto-Refresco"
+msgstr "Automatiskt uppdatering"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:57
 msgid "Refreshing in"
-msgstr "Actualizando en"
+msgstr "Uppdateras om"
 
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:30
 msgid "Remove this question?"
-msgstr "¿Eliminar esta pregunta?"
+msgstr "Ta bort denna fråga?"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
-msgstr "Se ha guardado tu cuadro de mando."
+msgstr "Din instrumentpanel har sparats"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:740
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
-msgstr "Verlo"
+msgstr "Visa den"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
-msgstr "Guardalo"
+msgstr "Spara detta"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
-msgstr "Mostrar más sobre este/a"
+msgstr "Visa mer om detta"
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
-msgstr "Esta tarjeta no tiene campos ni parámetros que coincidan con este tipo de parámetro."
+msgstr "Denna lista har inga fält eller parametrar som kan mappas till denna parametertyp."
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
-msgstr "Los valores en este campo no coinciden con los valores de ningún otro campo que hayas elegido."
+msgstr "Värdena i detta fält överlappar inte värdena i något annat valt fält."
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
-msgstr "No hay campos válidos"
+msgstr "Inga giltiga fält"
 
 #: frontend/src/metabase/entities/collections.js:98
 msgid "Name must be 100 characters or less"
-msgstr "El nombre debe tener 100 caracteres o menos"
+msgstr "Namnet får bara vara max 100 tecken"
 
 #: frontend/src/metabase/entities/collections.js:112
 msgid "Color is required"
-msgstr "Color es obligatorio"
+msgstr "Färg krävs"
 
 #: frontend/src/metabase/entities/dashboards.js:143
 msgid "What is the name of your dashboard?"
-msgstr "¿Cuál es el nombre de tu cuadro de mando?"
+msgstr "Vad kallas din instrumentpanel?"
 
 #: frontend/src/metabase/home/components/Activity.jsx:95
 msgid "did some super awesome stuff that's hard to describe"
-msgstr "he hecho algunas cosas geniales que son difíciles de describir"
+msgstr "gjorde något fantastiskt som är svårt att förklara"
 
 #: frontend/src/metabase/home/components/Activity.jsx:104
 #: frontend/src/metabase/home/components/Activity.jsx:119
 msgid "created an alert about - "
-msgstr "creado una alerta sobre - "
+msgstr "skapade en varning om"
 
 #: frontend/src/metabase/home/components/Activity.jsx:129
 #: frontend/src/metabase/home/components/Activity.jsx:144
 msgid "deleted an alert about - "
-msgstr "eliminado una alerta sobre - "
+msgstr "tog bort en varning om"
 
 #: frontend/src/metabase/home/components/Activity.jsx:155
 msgid "saved a question about "
-msgstr "guardado una pregunta sobre"
+msgstr "sparade en fråga om"
 
 #: frontend/src/metabase/home/components/Activity.jsx:168
 msgid "saved a question"
-msgstr "guardado una pregunta"
+msgstr "sparade en fråga"
 
 #: frontend/src/metabase/home/components/Activity.jsx:172
 msgid "deleted a question"
-msgstr "eliminado una pregunta"
+msgstr "tog bort en fråga"
 
 #: frontend/src/metabase/home/components/Activity.jsx:175
 msgid "created a dashboard"
-msgstr "creado un cuadro de mando"
+msgstr "skapade en instrumentpanel"
 
 #: frontend/src/metabase/home/components/Activity.jsx:178
 msgid "deleted a dashboard"
-msgstr "eliminado un cuadro de mando"
+msgstr "tog bort en instrumentpanel"
 
 #: frontend/src/metabase/home/components/Activity.jsx:184
 #: frontend/src/metabase/home/components/Activity.jsx:199
 msgid "added a question to the dashboard - "
-msgstr "añadido una pregunta al cuadro de mando - "
+msgstr "la till en fråga på instrumentpanelen"
 
 #: frontend/src/metabase/home/components/Activity.jsx:209
 #: frontend/src/metabase/home/components/Activity.jsx:224
 msgid "removed a question from the dashboard - "
-msgstr "eliminado una pregunta del cuadro de mando - "
+msgstr "tog bort en fråga från instrumentpanelen"
 
 #: frontend/src/metabase/home/components/Activity.jsx:234
 #: frontend/src/metabase/home/components/Activity.jsx:241
 msgid "received the latest data from"
-msgstr "recibido los últimos datos de"
+msgstr "mottog senaste data från"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
 msgid "Unknown"
-msgstr "Desconocido"
+msgstr "Okänd"
 
 #: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Hello World!"
-msgstr "¡Hola Mundo!"
+msgstr "Hej världen!"
 
 #: frontend/src/metabase/home/components/Activity.jsx:255
 msgid "Metabase is up and running."
-msgstr "Metabase está funcionando."
+msgstr "Metabase är igång."
 
 #: frontend/src/metabase/home/components/Activity.jsx:261
 #: frontend/src/metabase/home/components/Activity.jsx:291
 msgid "added the metric "
-msgstr "añadido la métrica"
+msgstr "la till måttet"
 
 #: frontend/src/metabase/home/components/Activity.jsx:275
 #: frontend/src/metabase/home/components/Activity.jsx:365
 msgid " to the "
-msgstr "a la"
+msgstr "till"
 
 #: frontend/src/metabase/home/components/Activity.jsx:285
 #: frontend/src/metabase/home/components/Activity.jsx:325
 #: frontend/src/metabase/home/components/Activity.jsx:375
 #: frontend/src/metabase/home/components/Activity.jsx:416
 msgid " table"
-msgstr "tabla"
+msgstr "tabellen"
 
 #: frontend/src/metabase/home/components/Activity.jsx:301
 #: frontend/src/metabase/home/components/Activity.jsx:331
 msgid "made changes to the metric "
-msgstr "ha hecho cambios a la métrica"
+msgstr "gjorde ändringar i måttet"
 
 #: frontend/src/metabase/home/components/Activity.jsx:315
 #: frontend/src/metabase/home/components/Activity.jsx:406
 msgid " in the "
-msgstr "en el"
+msgstr "i"
 
 #: frontend/src/metabase/home/components/Activity.jsx:338
 msgid "removed the metric "
-msgstr "eliminado la métrica"
+msgstr "tog bort måttet"
 
 #: frontend/src/metabase/home/components/Activity.jsx:341
 msgid "created a pulse"
-msgstr "pulso creado"
+msgstr "skapade en ögonblicksbild"
 
 #: frontend/src/metabase/home/components/Activity.jsx:344
 msgid "deleted a pulse"
-msgstr "pulso eliminado"
+msgstr "tog bort en ögonblicksbild"
 
 #: frontend/src/metabase/home/components/Activity.jsx:350
 #: frontend/src/metabase/home/components/Activity.jsx:381
 msgid "added the filter"
-msgstr "filtro añadido"
+msgstr "la till filtret"
 
 #: frontend/src/metabase/home/components/Activity.jsx:391
 #: frontend/src/metabase/home/components/Activity.jsx:422
 msgid "made changes to the filter"
-msgstr "ha hecho cambios al filtro"
+msgstr "gjorde ändringar i filtret"
 
 #: frontend/src/metabase/home/components/Activity.jsx:429
 msgid "removed the filter {0}"
-msgstr "eliminado el filtro {0}"
+msgstr "tog bort filtret {0}"
 
 #: frontend/src/metabase/home/components/Activity.jsx:432
 msgid "joined!"
-msgstr "¡se ha unido!"
+msgstr "sammanslagna!"
 
 #: frontend/src/metabase/home/components/Activity.jsx:532
 msgid "Hmmm, looks like nothing has happened yet."
-msgstr "Hmmm, parece que nada ha pasado aún."
+msgstr "Hmmm, det ser ut som om inget hänt ännu."
 
 #: frontend/src/metabase/home/components/Activity.jsx:535
 msgid "Save a question and get this baby going!"
-msgstr "¡Guarda una pregunta y haz que esto funcione!"
+msgstr "Spara en fråga och kom igång!"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:19
 msgid "Ask questions and explore"
-msgstr "Haz preguntas y explora"
+msgstr "Ställ frågor och utforska"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:20
 msgid "Click on charts or tables to explore, or ask a new question using the easy interface or the powerful SQL editor."
-msgstr "Haz clic en cuadros o tablas para explorar, o haz una nueva pregunta usando el interfaz sencillo o el potente editor SQL."
+msgstr "Klicka på kartor eller tabeller att utforska, eller ställ en ny fråga med hjälp av det enkla gränssnittet eller den kraftfulla SQL-editorn."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:30
 msgid "Make your own charts"
-msgstr "Crea tus propios gráficos"
+msgstr "Skapa dina egna kartor"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:31
 msgid "Create line charts, scatter plots, maps, and more."
-msgstr "Crea gráficos de líneas, gráficos de dispersión, mapas y más."
+msgstr "Skapa diagram med kurvor, punkter, kartor med mera."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:41
 msgid "Share what you find"
-msgstr "Comparte lo que encuentres"
+msgstr "Dela det du hittar"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:42
 msgid "Create powerful and flexible dashboards, and send regular updates via email or Slack."
-msgstr "Crea cuadros de mando potentes y flexibles, y envía actualizaciones periódicas por correo electrónico o Slack."
+msgstr "Skapa kraftfulla och flexibla instrumentpaneler och skickar regelbundna uppdateringar via epost eller Slack."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
 msgid "Let's go"
-msgstr "Vamos allá"
+msgstr "Då kör vi"
 
 #: frontend/src/metabase/home/components/NextStep.jsx:34
 msgid "Setup Tip"
-msgstr "Consejo de configuración"
+msgstr "Inställningstips"
 
 #: frontend/src/metabase/home/components/NextStep.jsx:40
 msgid "View all"
-msgstr "Ver todos"
+msgstr "Visa alla"
 
 #: frontend/src/metabase/home/components/RecentViews.jsx:40
 msgid "Recently Viewed"
-msgstr "Visto Recientemente"
+msgstr "Nyligen visade"
 
 #: frontend/src/metabase/home/components/RecentViews.jsx:77
 msgid "You haven't looked at any dashboards or questions recently"
-msgstr "No has consultado ningún cuadro de mando o pregunta recientemente"
+msgstr "Du har inte tittat på några instrumentpaneler eller frågor nyligen"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
-msgstr "{0} elemento(s) seleccionado(s)"
+msgstr "{0} poster valda"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 msgid "Unarchive"
-msgstr "Desarchivar"
+msgstr "Av-arkivera"
 
 #: frontend/src/metabase/home/containers/HomepageApp.jsx:77
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:59
 msgid "Activity"
-msgstr "Actividad"
+msgstr "Aktivitet"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:31
 msgid "Results for \"{0}\""
-msgstr "Resultados de \"{0}\""
+msgstr "Resultat för \"{0}\""
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:138
 msgid "Pulse"
-msgstr "Pulso"
+msgstr "Ögonblicksbild"
 
 #: frontend/src/metabase/lib/core.js:8
 msgid "Entity Key"
-msgstr "Clave Entidad"
+msgstr "Enhetens nyckel"
 
 #: frontend/src/metabase/lib/core.js:9 frontend/src/metabase/lib/core.js:15
 #: frontend/src/metabase/lib/core.js:21
 msgid "Overall Row"
-msgstr "Fila General"
+msgstr "Övergripande rad"
 
 #: frontend/src/metabase/lib/core.js:10
 msgid "The primary key for this table."
-msgstr "La clave principal para esta tabla."
+msgstr "Den primära nyckeln för den här tabellen."
 
 #: frontend/src/metabase/lib/core.js:14
 msgid "Entity Name"
-msgstr "Nombre Entidad"
+msgstr "Enhetens namn"
 
 #: frontend/src/metabase/lib/core.js:16
 msgid "The \"name\" of each record. Usually a column called \"name\", \"title\", etc."
-msgstr "El \"nombre\" de cada registro. Por lo general, una columna llamada \"nombre\", \"título\", etc."
+msgstr "\"Namnet\" på varje post. Vanligen en kolumn kallad \"namn\", \"titel\" osv."
 
 #: frontend/src/metabase/lib/core.js:20
 msgid "Foreign Key"
-msgstr "Clave Foránea"
+msgstr "Extern nyckel"
 
 #: frontend/src/metabase/lib/core.js:22
 msgid "Points to another table to make a connection."
-msgstr "Referencia otra tabla para establecer una conexión."
+msgstr "Pekar på en annan tabell för att koppla ihop."
 
 #: frontend/src/metabase/lib/core.js:257
 msgid "Avatar Image URL"
-msgstr "URL Avatar"
+msgstr "URL för Avatar-bild"
 
 #: frontend/src/metabase/lib/core.js:29 frontend/src/metabase/lib/core.js:34
 #: frontend/src/metabase/lib/core.js:39 frontend/src/metabase/lib/core.js:44
 #: frontend/src/metabase/lib/core.js:49
 msgid "Common"
-msgstr "Común"
+msgstr "Vanlig"
 
 #: frontend/src/metabase/lib/core.js:28
 #: frontend/src/metabase/meta/Dashboard.js:86
 #: frontend/src/metabase/modes/components/drill/PivotByCategoryDrill.jsx:10
 msgid "Category"
-msgstr "Categoría"
+msgstr "Kategori"
 
 #: frontend/src/metabase/lib/core.js:55
 #: frontend/src/metabase/meta/Dashboard.js:66
 msgid "City"
-msgstr "Ciudad"
+msgstr "Stad"
 
 #: frontend/src/metabase/lib/core.js:60
 #: frontend/src/metabase/meta/Dashboard.js:78
 msgid "Country"
-msgstr "País"
+msgstr "Land"
 
 #: frontend/src/metabase/lib/core.js:240
 msgid "Enum"
@@ -3346,11 +3334,11 @@ msgstr "Enum"
 
 #: frontend/src/metabase/lib/core.js:262
 msgid "Image URL"
-msgstr "URL Imagen"
+msgstr "URL för bild"
 
 #: frontend/src/metabase/lib/core.js:274
 msgid "Field containing JSON"
-msgstr "Campo que contiene JSON"
+msgstr "Fält innehållande JSON"
 
 #: frontend/src/metabase/lib/core.js:65
 msgid "Latitude"
@@ -3364,100 +3352,99 @@ msgstr "Longitud"
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:45
 msgid "Number"
-msgstr "Número"
+msgstr "Nummer"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:19
 #: frontend/src/metabase/lib/core.js:75
 #: frontend/src/metabase/meta/Dashboard.js:70
 msgid "State"
-msgstr "Provincia"
+msgstr "Stat"
 
 #: frontend/src/metabase/lib/core.js:233
 msgid "UNIX Timestamp (Seconds)"
-msgstr "Marca de tiempo UNIX (Segundos)"
+msgstr "Unix-tidsstämpel (sekunder)"
 
 #: frontend/src/metabase/lib/core.js:228
 msgid "UNIX Timestamp (Milliseconds)"
-msgstr "Marca de tiempo UNIX (Milisegundos)"
+msgstr "Unix-tidsstämpel (millisekunder)"
 
 #: frontend/src/metabase/lib/core.js:80
 msgid "Zip Code"
-msgstr "Código Postal"
+msgstr "Postnummer"
 
 #: frontend/src/metabase/lib/core.js:119
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
 msgid "Quantity"
-msgstr "Cantidad"
+msgstr "Kvantitet"
 
 #: frontend/src/metabase/lib/core.js:107
 msgid "Income"
-msgstr "Ingreso"
+msgstr "Inkomst"
 
 #: frontend/src/metabase/lib/core.js:97
 msgid "Discount"
-msgstr "Descuento"
+msgstr "Rabatt"
 
-#. Sé que parece una traducción muy literal, pero no sería una traducción más acertada "Sello de tiempo de creación"?
 #: frontend/src/metabase/lib/core.js:193
 msgid "Creation timestamp"
-msgstr "Fecha y Hora de Creación"
+msgstr "Skapad tidsstämpel"
 
 #: frontend/src/metabase/lib/core.js:188
 msgid "Creation time"
-msgstr "Hora de Creación"
+msgstr "Skapad klockslag"
 
 #: frontend/src/metabase/lib/core.js:183
 msgid "Creation date"
-msgstr "Fecha de Creación"
+msgstr "Skapad datum"
 
 #: frontend/src/metabase/lib/core.js:245
 msgid "Product"
-msgstr "Producto"
+msgstr "Produkt"
 
 #: frontend/src/metabase/lib/core.js:161
 msgid "User"
-msgstr "Usuario"
+msgstr "Användare"
 
 #: frontend/src/metabase/lib/core.js:250
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
 msgid "Source"
-msgstr "Fuente"
+msgstr "Källa"
 
 #: frontend/src/metabase/lib/core.js:112
 msgid "Price"
-msgstr "Precio"
+msgstr "Pris"
 
 #: frontend/src/metabase/lib/core.js:223
 msgid "Join timestamp"
-msgstr "Unir por Tiempo"
+msgstr "Tidsstämpel för sammanslagning"
 
 #: frontend/src/metabase/lib/core.js:218
 msgid "Join time"
-msgstr "Unir por Tiempo"
+msgstr "Sammanslagen klockslag"
 
 #: frontend/src/metabase/lib/core.js:213
 msgid "Join date"
-msgstr "Unir por Fecha"
+msgstr "Sammanslagen datum"
 
 #: frontend/src/metabase/lib/core.js:129
 msgid "Share"
-msgstr "Compartir"
+msgstr "Dela"
 
 #: frontend/src/metabase/lib/core.js:151
 msgid "Owner"
-msgstr "Propietario"
+msgstr "Ägare"
 
 #: frontend/src/metabase/lib/core.js:141
 msgid "Company"
-msgstr "Empresa"
+msgstr "Företag"
 
 #: frontend/src/metabase/lib/core.js:156
 msgid "Subscription"
-msgstr "Suscripción"
+msgstr "Prenumeration"
 
 #: frontend/src/metabase/lib/core.js:124
 msgid "Score"
-msgstr "Puntuación"
+msgstr "Poäng"
 
 #: frontend/src/metabase/lib/core.js:48
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
@@ -3465,62 +3452,62 @@ msgstr "Puntuación"
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
-msgstr "Título"
+msgstr "Titel"
 
 #: frontend/src/metabase/lib/core.js:33
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
 msgid "Comment"
-msgstr "Comentario"
+msgstr "Kommentar"
 
 #: frontend/src/metabase/lib/core.js:87
 msgid "Cost"
-msgstr "Coste"
+msgstr "Kostnad"
 
 #: frontend/src/metabase/lib/core.js:102
 msgid "Gross margin"
-msgstr "Margen Bruto"
+msgstr "Bruttomarginal"
 
 #: frontend/src/metabase/lib/core.js:136
 msgid "Birthday"
-msgstr "Cumpleaños"
+msgstr "Födelsedag"
 
 #: frontend/src/metabase/lib/core.js:285
 msgid "Search box"
-msgstr "Caja de Búsqueda"
+msgstr "Sökruta"
 
 #: frontend/src/metabase/lib/core.js:286
 msgid "A list of all values"
-msgstr "Una lista con todos los valores"
+msgstr "En lista över alla värden"
 
 #: frontend/src/metabase/lib/core.js:287
 msgid "Plain input box"
-msgstr "Caja de Texto"
+msgstr "Enkel textruta"
 
 #: frontend/src/metabase/lib/core.js:293
 msgid "Everywhere"
-msgstr "En todas partes"
+msgstr "Överallt"
 
 #: frontend/src/metabase/lib/core.js:294
 msgid "The default setting. This field will be displayed normally in tables and charts."
-msgstr "La configuración predeterminada. Este campo se mostrará normalmente en tablas y gráficos."
+msgstr "Förvald inställning. Detta fält kommer normalt att visas i tabeller och diagram"
 
 #: frontend/src/metabase/lib/core.js:254
 msgid "Only in Detail Views"
-msgstr "Solo en vistas detalladas"
+msgstr "Bara i detaljbilder"
 
 #: frontend/src/metabase/lib/core.js:299
 msgid "This field will only be displayed when viewing the details of a single record. Use this for information that's lengthy or that isn't useful in a table or chart."
-msgstr "Este campo solo se mostrará cuando veas los detalles de un solo registro. Úsalo para obtener información larga o que no sea útil en una tabla o gráfico."
+msgstr "Detta fält kommer bara att visas i detaljbild av en enskild post. Använd detta för information som är omfattande eller som inte är användbart i en tabeller eller ett diagram."
 
 #: frontend/src/metabase/lib/core.js:259
 msgid "Do Not Include"
-msgstr "No Incluir"
+msgstr "Inkludera inte denna"
 
 #: frontend/src/metabase/lib/core.js:260
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
-msgstr "Metabase nunca recuperará este campo. Úsalo para información sensible o irrelevante."
+msgstr "Metabase kommer aldrig att hämta detta fält. Använd detta för känslig eller irrelevant information."
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
@@ -3533,189 +3520,188 @@ msgstr "Metabase nunca recuperará este campo. Úsalo para información sensible
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "Count"
-msgstr "Contar"
+msgstr "Antal"
 
 #: frontend/src/metabase/lib/expressions/config.js:8
 msgid "CumulativeCount"
-msgstr "RecuentoAcumulativo"
+msgstr "Summerat antal"
 
 #: frontend/src/metabase/lib/schema_metadata.js:485
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
-msgstr "Suma"
+msgstr "Summa"
 
 #: frontend/src/metabase/lib/expressions/config.js:10
 msgid "CumulativeSum"
-msgstr "SumaAcumulativa"
+msgstr "Sammanslagen summa"
 
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Distinct"
-msgstr "Distinto"
+msgstr "Distinkt"
 
-#. With accents a problem occured, I removed the accents (temporarily ?)
 #: frontend/src/metabase/lib/expressions/config.js:12
 msgid "StandardDeviation"
-msgstr "DesviacionEstandar"
+msgstr "Standardavvikelse"
 
 #: frontend/src/metabase/lib/schema_metadata.js:494
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
-msgstr "Media"
+msgstr "Genomsnittlig"
 
 #: frontend/src/metabase/lib/schema_metadata.js:539
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
-msgstr "Mín"
+msgstr "Min"
 
 #: frontend/src/metabase/lib/schema_metadata.js:548
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
 msgid "Max"
-msgstr "Máx"
+msgstr "Max"
 
 #: frontend/src/metabase/lib/expressions/parser.js:373
 msgid "sad sad panda, lexing errors detected"
-msgstr "triste panda triste, errores léxicos detectados"
+msgstr "ledsen panda, stavfel hittades"
 
 #: frontend/src/metabase/lib/formatting.js:832
 msgid "{0} second"
 msgid_plural "{0} seconds"
-msgstr[0] "{0} segundo"
-msgstr[1] "{0} segundos"
+msgstr[0] "{0} sekund"
+msgstr[1] "{0} sekunder"
 
 #: frontend/src/metabase/lib/formatting.js:835
 msgid "{0} minute"
 msgid_plural "{0} minutes"
-msgstr[0] "{0} minuto"
-msgstr[1] "{0} minutos"
+msgstr[0] "{0} minut"
+msgstr[1] "{0} minuter"
 
 #: frontend/src/metabase/lib/greeting.js:4
 msgid "Hey there"
-msgstr "Hola"
+msgstr "Hallå där"
 
 #: frontend/src/metabase/lib/greeting.js:5
 #: frontend/src/metabase/lib/greeting.js:29
 msgid "How's it going"
-msgstr "¿Cómo te va"
+msgstr "Hur är läget"
 
 #: frontend/src/metabase/lib/greeting.js:6
 msgid "Howdy"
-msgstr "Hola"
+msgstr "Hallå"
 
 #: frontend/src/metabase/lib/greeting.js:7
 msgid "Greetings"
-msgstr "Saludos"
+msgstr "Välkommen"
 
 #: frontend/src/metabase/lib/greeting.js:8
 msgid "Good to see you"
-msgstr "Que bueno verte"
+msgstr "Trevlig att se dig"
 
 #: frontend/src/metabase/lib/greeting.js:12
 msgid "What do you want to know?"
-msgstr "¿Que quieres saber?"
+msgstr "Vad vill du veta?"
 
 #: frontend/src/metabase/lib/greeting.js:13
 msgid "What's on your mind?"
-msgstr "¿Qué tienes en mente?"
+msgstr "Vad har du på hjärtat?"
 
 #: frontend/src/metabase/lib/greeting.js:14
 msgid "What do you want to find out?"
-msgstr "¿Qué quieres saber?"
+msgstr "Vad vill du hitta?"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
 #: frontend/src/metabase/lib/schema_metadata.js:467
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
-msgstr "Datos brutos"
+msgstr "Rådata"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
 #: frontend/src/metabase/lib/schema_metadata.js:521
 msgid "Cumulative count"
-msgstr "Recuento acumulativo"
+msgstr "Summerat antal"
 
 #: frontend/src/metabase/lib/query/description.js:82
 #: frontend/src/metabase/lib/query/description.js:266
 msgid "Average of "
-msgstr "Media de"
+msgstr "Genomsnitt av "
 
 #: frontend/src/metabase/lib/query/description.js:87
 #: frontend/src/metabase/lib/query/description.js:268
 msgid "Distinct values of "
-msgstr "Valores distintos de"
+msgstr "Distinkt värde av "
 
 #: frontend/src/metabase/lib/query/description.js:92
 #: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
-msgstr "Desviación estándar de"
+msgstr "Standardavvikelse av "
 
 #: frontend/src/metabase/lib/query/description.js:97
 #: frontend/src/metabase/lib/query/description.js:272
 msgid "Sum of "
-msgstr "Suma de"
+msgstr "Summa av "
 
 #: frontend/src/metabase/lib/query/description.js:102
 #: frontend/src/metabase/lib/query/description.js:274
 msgid "Cumulative sum of "
-msgstr "Suma acumulativa de"
+msgstr "Totalsumma av "
 
 #: frontend/src/metabase/lib/query/description.js:107
 #: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
-msgstr "Máximo de"
+msgstr "Maxvärde av "
 
 #: frontend/src/metabase/lib/query/description.js:112
 #: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
-msgstr "Mínimo de"
+msgstr "Min.värde av "
 
 #: frontend/src/metabase/lib/query/description.js:126
 #: frontend/src/metabase/lib/query/description.js:286
 msgid "Grouped by "
-msgstr "Agrupado por"
+msgstr "Grupperad på "
 
 #: frontend/src/metabase/lib/query/description.js:140
 #: frontend/src/metabase/lib/query/description.js:295
 msgid "Filtered by "
-msgstr "Filtrado por"
+msgstr "Filtrerad på "
 
 #: frontend/src/metabase/lib/query/description.js:169
 #: frontend/src/metabase/lib/query/description.js:320
 msgid "Sorted by "
-msgstr "Ordenado por"
+msgstr "Sorterad på "
 
 #: frontend/src/metabase/lib/schema_metadata.js:237
 msgid "True"
-msgstr "Verdadero"
+msgstr "Sann"
 
 #: frontend/src/metabase/lib/schema_metadata.js:237
 msgid "False"
-msgstr "Falso"
+msgstr "Falsk"
 
 #: frontend/src/metabase/lib/schema_metadata.js:322
 msgid "Select longitude field"
-msgstr "Selecciona el campo de longitud"
+msgstr "Välj longitud-fält"
 
 #: frontend/src/metabase/lib/schema_metadata.js:323
 msgid "Enter upper latitude"
-msgstr "Latitud Superior"
+msgstr "Ange övre latitud"
 
 #: frontend/src/metabase/lib/schema_metadata.js:324
 msgid "Enter left longitude"
-msgstr "Longitud Izquierda"
+msgstr "Ange vänster longitud"
 
 #: frontend/src/metabase/lib/schema_metadata.js:325
 msgid "Enter lower latitude"
-msgstr "Latitud Inferior"
+msgstr "Ange nedre latitud"
 
 #: frontend/src/metabase/lib/schema_metadata.js:326
 msgid "Enter right longitude"
-msgstr "Longitud Derecha"
+msgstr "Ange höger longitud"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:539
 #: frontend/src/metabase-lib/lib/Dimension.js:541
@@ -3727,7 +3713,7 @@ msgstr "Longitud Derecha"
 #: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:417
 msgid "Is"
-msgstr "Es"
+msgstr "Är"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
 #: frontend/src/metabase/lib/schema_metadata.js:383
@@ -3735,7 +3721,7 @@ msgstr "Es"
 #: frontend/src/metabase/lib/schema_metadata.js:407
 #: frontend/src/metabase/lib/schema_metadata.js:413
 msgid "Is not"
-msgstr "No es"
+msgstr "Är inte"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:378
@@ -3745,7 +3731,7 @@ msgstr "No es"
 #: frontend/src/metabase/lib/schema_metadata.js:408
 #: frontend/src/metabase/lib/schema_metadata.js:418
 msgid "Is empty"
-msgstr "Vacío"
+msgstr "Är tom"
 
 #: frontend/src/metabase/lib/schema_metadata.js:365
 #: frontend/src/metabase/lib/schema_metadata.js:379
@@ -3755,281 +3741,279 @@ msgstr "Vacío"
 #: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/lib/schema_metadata.js:419
 msgid "Not empty"
-msgstr "No Vacío"
+msgstr "Inte tom"
 
 #: frontend/src/metabase/lib/schema_metadata.js:371
 msgid "Equal to"
-msgstr "Igual a"
+msgstr "Lika med"
 
 #: frontend/src/metabase/lib/schema_metadata.js:372
 msgid "Not equal to"
-msgstr "Distinto a"
+msgstr "Inte lika med"
 
 #: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Greater than"
-msgstr "Mayor que"
+msgstr "Större än"
 
 #: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Less than"
-msgstr "Menor que"
+msgstr "Mindre än"
 
 #: frontend/src/metabase/lib/schema_metadata.js:375
 #: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
-msgstr "Entre"
+msgstr "Mellan"
 
 #: frontend/src/metabase/lib/schema_metadata.js:376
 msgid "Greater than or equal to"
-msgstr "Mayor o igual a"
+msgstr "Större än eller lika med"
 
 #: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Less than or equal to"
-msgstr "Menos o igual a"
+msgstr "Mindre än eller lika med"
 
 #: frontend/src/metabase/lib/schema_metadata.js:384
 msgid "Contains"
-msgstr "Contiene"
+msgstr "Innehåller"
 
 #: frontend/src/metabase/lib/schema_metadata.js:385
 msgid "Does not contain"
-msgstr "No contiene"
+msgstr "Innehåller inte"
 
 #: frontend/src/metabase/lib/schema_metadata.js:388
 msgid "Starts with"
-msgstr "Empieza con"
+msgstr "Börjar med"
 
 #: frontend/src/metabase/lib/schema_metadata.js:389
 msgid "Ends with"
-msgstr "Termina en"
+msgstr "Slutar med"
 
 #: frontend/src/metabase/lib/schema_metadata.js:399
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
-msgstr "Antes"
+msgstr "Före"
 
 #: frontend/src/metabase/lib/schema_metadata.js:400
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
-msgstr "Después"
+msgstr "Efter"
 
 #: frontend/src/metabase/lib/schema_metadata.js:414
 msgid "Inside"
-msgstr "Dentro"
+msgstr "Innehåller"
 
 #: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Just a table with the rows in the answer, no additional operations."
-msgstr "Solo una tabla con las filas en la respuesta, sin operaciones adicionales."
+msgstr "Bara en tabell med raderna i svaret, inga fler moment"
 
 #: frontend/src/metabase/lib/schema_metadata.js:475
 msgid "Count of rows"
-msgstr "Número de filas"
+msgstr "Antal rader"
 
 #: frontend/src/metabase/lib/schema_metadata.js:477
 msgid "Total number of rows in the answer."
-msgstr "Número total de filas en la respuesta."
+msgstr "Totalt antal rader i svaret"
 
 #: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Sum of ..."
-msgstr "Suma de ..."
+msgstr "Summan av ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:486
 msgid "Sum of all the values of a column."
-msgstr "Suma de todos los valores de una columna."
+msgstr "Summan av alla värdena i en kolumn"
 
 #: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Average of ..."
-msgstr "Media de ..."
+msgstr "Genomsnitttet av ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:495
 msgid "Average of all the values of a column"
-msgstr "Promedio de todos los valores de una columna"
+msgstr "Genomsnittet av alla värden i en kolumn"
 
 #: frontend/src/metabase/lib/schema_metadata.js:502
 msgid "Number of distinct values of ..."
-msgstr "Número de valores distintos de ..."
+msgstr "Antal distinkta värden av ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:504
 msgid "Number of unique values of a column among all the rows in the answer."
-msgstr "Número de valores únicos de una columna entre todas las filas en la respuesta."
+msgstr "Antal unika värden i en kolumn jämsides med alla raderna i svaret"
 
 #: frontend/src/metabase/lib/schema_metadata.js:511
 msgid "Cumulative sum of ..."
-msgstr "Suma acumulada de ..."
+msgstr "Sammanslagen summa av ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
-msgstr "Suma aditiva de todos los valores de una columna.\n"
-" e.g. los ingresos totales a lo largo del tiempo"
+msgstr "Ökande summa av alla värden i en kolumn. \\n T.ex total intäkt över tid."
 
 #: frontend/src/metabase/lib/schema_metadata.js:520
 msgid "Cumulative count of rows"
-msgstr "Recuento acumulado de filas"
+msgstr "Sammanslaget antal rader"
 
 #: frontend/src/metabase/lib/schema_metadata.js:501
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
-msgstr "Recuento aditiva del número de filas.\n"
-" e.g. número total de ventas en el tiempo"
+msgstr "Ökande antal rader.\\n T.ex totalt antal försäljningar över tid"
 
 #: frontend/src/metabase/lib/schema_metadata.js:529
 msgid "Standard deviation of ..."
-msgstr "Desviación estándar de ..."
+msgstr "Standardavvikelse över ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:531
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
-msgstr "Número que expresa cuánto varían los valores de una columna entre todas las filas en la respuesta."
+msgstr "Siffra som visar hur mycket värdena i en kolumn avviker bland alla rader i svaret."
 
 #: frontend/src/metabase/lib/schema_metadata.js:538
 msgid "Minimum of ..."
-msgstr "Mínimo de ..."
+msgstr "Min.värde av ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Minimum value of a column"
-msgstr "Valor mínimo de una columna"
+msgstr "Min.värde av en kolumn"
 
 #: frontend/src/metabase/lib/schema_metadata.js:547
 msgid "Maximum of ..."
-msgstr "Máximo de ..."
+msgstr "Maxvärde av ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:549
 msgid "Maximum value of a column"
-msgstr "Valor máximo de una columna"
+msgstr "Maxvärde av en kolumn"
 
 #: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
-msgstr "Desglosar por dimensión"
+msgstr "Bryt ut utifrån mått"
 
 #: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
-msgstr "letra en minúsculas"
+msgstr "gemena"
 
 #: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
-msgstr "letra en mayúsculas"
+msgstr "versaler"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
-msgstr "número"
+msgstr "antal"
 
 #: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
-msgstr "carácter especial"
+msgstr "specialtecken"
 
 #: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
-msgstr "debe ser"
+msgstr "måste vara"
 
 #: frontend/src/metabase/lib/settings.js:120
 #: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
-msgstr "caracteres"
+msgstr "tecken lång"
 
 #: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
-msgstr "Debe ser"
+msgstr "Måste vara"
 
 #: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
-msgstr "e incluir"
+msgstr "och innehålla"
 
 #: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
-msgstr "cero"
+msgstr "noll"
 
 #: frontend/src/metabase/lib/utils.js:86
 msgid "one"
-msgstr "uno"
+msgstr "en"
 
 #: frontend/src/metabase/lib/utils.js:87
 msgid "two"
-msgstr "dos"
+msgstr "två"
 
 #: frontend/src/metabase/lib/utils.js:88
 msgid "three"
-msgstr "tres"
+msgstr "tre"
 
 #: frontend/src/metabase/lib/utils.js:89
 msgid "four"
-msgstr "cuatro"
+msgstr "fyra"
 
 #: frontend/src/metabase/lib/utils.js:90
 msgid "five"
-msgstr "cinco"
+msgstr "fem"
 
 #: frontend/src/metabase/lib/utils.js:91
 msgid "six"
-msgstr "seis"
+msgstr "sex"
 
 #: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
-msgstr "siete"
+msgstr "sju"
 
 #: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
-msgstr "ocho"
+msgstr "åtta"
 
 #: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
-msgstr "nueve"
+msgstr "nio"
 
 #: frontend/src/metabase/meta/Dashboard.js:35
 msgid "Month and Year"
-msgstr "Mes y Año"
+msgstr "Månad och år"
 
 #: frontend/src/metabase/meta/Dashboard.js:36
 msgid "Like January, 2016"
-msgstr "Como Enero 2016"
+msgstr "T.ex Januari, 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:40
 msgid "Quarter and Year"
-msgstr "Trimestre y Año"
+msgstr "Kvartal och år"
 
 #: frontend/src/metabase/meta/Dashboard.js:41
 msgid "Like Q1, 2016"
-msgstr "Como T1, 2016"
+msgstr "T.ex Q1, 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:45
 msgid "Single Date"
-msgstr "Fecha Unica"
+msgstr "Enskilt datum"
 
 #: frontend/src/metabase/meta/Dashboard.js:46
 msgid "Like January 31, 2016"
-msgstr "Como 31 de Enero, 2016"
+msgstr "T.ex 31:e januari 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:50
 msgid "Date Range"
-msgstr "Rango de Fechas"
+msgstr "Datum-intervall"
 
 #: frontend/src/metabase/meta/Dashboard.js:51
 msgid "Like December 25, 2015 - February 14, 2016"
-msgstr "Como 25 de Diciembre, 2015 - 14 de Febrero, 2016"
+msgstr "T.ex 25:e december 2015 - 14:e februari 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:55
 msgid "Relative Date"
-msgstr "Fecha Relativa"
+msgstr "Relativt datum"
 
 #: frontend/src/metabase/meta/Dashboard.js:56
 msgid "Like \"the last 7 days\" or \"this month\""
-msgstr "Como \"los últimos 7 días\" o \"este mes\""
+msgstr "T.ex \"de senaste 7 dagarna\" eller \"denna månad\""
 
 #: frontend/src/metabase/meta/Dashboard.js:60
 msgid "Date Filter"
-msgstr "Filtro de Fecha"
+msgstr "Datumfilter"
 
 #: frontend/src/metabase/meta/Dashboard.js:61
 msgid "All Options"
-msgstr "Todas las Opciones"
+msgstr "Alla val"
 
 #: frontend/src/metabase/meta/Dashboard.js:62
 msgid "Contains all of the above"
-msgstr "Contiene todo lo anterior"
+msgstr "Innehålla alla ovanstående"
 
 #: frontend/src/metabase/meta/Dashboard.js:74
 msgid "ZIP or Postal Code"
-msgstr "Código Postal"
+msgstr "Postnummer"
 
 #: frontend/src/metabase/meta/Dashboard.js:82
 #: frontend/src/metabase/meta/Dashboard.js:112
@@ -4039,11 +4023,11 @@ msgstr "ID"
 #: frontend/src/metabase/meta/Dashboard.js:100
 #: frontend/src/metabase/modes/components/drill/PivotByTimeDrill.jsx:9
 msgid "Time"
-msgstr "Tiempo"
+msgstr "Tid"
 
 #: frontend/src/metabase/meta/Dashboard.js:101
 msgid "Date range, relative date, time of day, etc."
-msgstr "Rango de fechas, fecha relativa, hora del día, etc."
+msgstr "Datum-intervall, relativt datum, klockslag osv."
 
 #: frontend/src/metabase/lib/core.js:56 frontend/src/metabase/lib/core.js:61
 #: frontend/src/metabase/lib/core.js:66 frontend/src/metabase/lib/core.js:71
@@ -4051,143 +4035,143 @@ msgstr "Rango de fechas, fecha relativa, hora del día, etc."
 #: frontend/src/metabase/meta/Dashboard.js:106
 #: frontend/src/metabase/modes/components/drill/PivotByLocationDrill.jsx:9
 msgid "Location"
-msgstr "Ubicación"
+msgstr "Plats"
 
 #: frontend/src/metabase/meta/Dashboard.js:107
 msgid "City, State, Country, ZIP code."
-msgstr "Ciudad, Provincia, País, Código Postal."
+msgstr "Stad, stat, land, postnummer."
 
 #: frontend/src/metabase/meta/Dashboard.js:113
 msgid "User ID, product ID, event ID, etc."
-msgstr "ID Usuario, ID Productio, ID Evento, etc."
+msgstr "Användar-id, produkt-id, händelse-id osv."
 
 #: frontend/src/metabase/meta/Dashboard.js:118
 msgid "Other Categories"
-msgstr "Otras Categorías"
+msgstr "Andra kategorier"
 
 #: frontend/src/metabase/meta/Dashboard.js:119
 msgid "Category, Type, Model, Rating, etc."
-msgstr "Categoría, Tipo, Modelo, Clasificación, etc."
+msgstr "Kategori, typ, modell, värdering osv."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:43
 #: frontend/src/metabase/user/components/UserSettings.jsx:56
 msgid "Account settings"
-msgstr "Configuración de la cuenta"
+msgstr "Konto-inställningar"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Exit admin"
-msgstr "Salir de Configuración"
+msgstr "Avsluta Admin"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:35
 msgid "Logs"
-msgstr "Logs"
+msgstr "Loggar"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:104
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:22
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:65
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:100
 msgid "Help"
-msgstr "Ayuda"
+msgstr "Hjälp"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:72
 msgid "About Metabase"
-msgstr "Sobre Metabase"
+msgstr "Om Metabase"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:78
 msgid "Sign out"
-msgstr "Salir"
+msgstr "Logga ut"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Thanks for using"
-msgstr "Gracias por utilizar"
+msgstr "Tack för att du använder"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:116
 msgid "You're on version"
-msgstr "Estás en la versión"
+msgstr "Du kör version"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:119
 msgid "Built on"
-msgstr "Construida el"
+msgstr "Byggd på"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:139
 msgid "is a Trademark of"
-msgstr "es una marca registrada de"
+msgstr "är ett varumärke från"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:141
 msgid "and is built with care in San Francisco, CA"
-msgstr "y está construido con cariño en San Francisco, CA"
+msgstr "och byggs med omsorg i San Francisco, CA"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:224
 msgid "Metabase Admin"
-msgstr "Configuración Metabase"
+msgstr "Metabase Admin"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:36
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:36
 msgid "Ask a question"
-msgstr "Haz una pregunta"
+msgstr "Ställ en fråga"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:379
 msgid "New dashboard"
-msgstr "Añadir nuevo Cuadro de Mando"
+msgstr "Ny instrumentpanel"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:385
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
-msgstr "Nuevo pulso"
+msgstr "Ny ögonblicksbild"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:323
 msgid "Reference"
-msgstr "Referencia"
+msgstr "Referens"
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
-msgstr "¿Qué Métrica?"
+msgstr "Vilket mått?"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Defining common metrics for your team makes it even easier to ask questions"
-msgstr "La definición de métricas comunes para tu equipo hace que sea aún más fácil hacer preguntas"
+msgstr "Genom att sätta upp gemensamma mått i din grupp blir det ännu enklare att ställa frågor"
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
-msgstr "Cómo crear métricas"
+msgstr "Hur man definierar mått"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:138
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
-msgstr "Consulta los datos a lo largo del tiempo, como un mapa, o gírelos para ayudarte a comprender las tendencias o los cambios."
+msgstr "Se data över tid, som en karta eller pivot-tabell för att hjälpa dig förstå trender och förändringar"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
 msgid "Custom"
-msgstr "Personalizado"
+msgstr "Anpassad"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:157
 msgid "New question"
-msgstr "Nueva pregunta"
+msgstr "Ny fråga"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:152
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
-msgstr "Utiliza el generador de preguntas para ver tendencias, listas de cosas o para crear tus propias métricas."
+msgstr "Använd enkel fråge-guide för att se trender, listor eller för att skapa dina egna mätningar."
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:110
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
-msgstr "Consulta nativa"
+msgstr "Inbyggd fråga"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:111
 msgid "For more complicated questions, you can write your own SQL or native query."
-msgstr "Para preguntas más complicadas puedes escribir tu propia consulta SQL o nativa."
+msgstr "För mera komplicerade frågor kan du skriva din egen SQL eller inbyggda fråga."
 
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
 msgid "Select a default value…"
-msgstr "Selecciona un valor por defecto…"
+msgstr "Sätt ett förvalt värde..."
 
 #: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
 #: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
-msgstr "Actualizar filtro"
+msgstr "Uppdatera filter"
 
 #: frontend/src/metabase/lib/query_time.js:112
 #: frontend/src/metabase/lib/query_time.js:123
@@ -4195,22 +4179,22 @@ msgstr "Actualizar filtro"
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
 #: src/metabase/pulse/render/datetime.clj
 msgid "Today"
-msgstr "Hoy"
+msgstr "Idag"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
 #: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
-msgstr "Ayer"
+msgstr "Igår"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:18
 msgid "Past 7 days"
-msgstr "Ultimos 7 días"
+msgstr "Senaste 7 dagarna"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:19
 msgid "Past 30 days"
-msgstr "Ultimos 30 días"
+msgstr "Senaste 30 dagarna"
 
 #: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
@@ -4218,8 +4202,8 @@ msgstr "Ultimos 30 días"
 #: src/metabase/api/table.clj
 msgid "Week"
 msgid_plural "Weeks"
-msgstr[0] "Semana"
-msgstr[1] "Semanas"
+msgstr[0] "Vecka"
+msgstr[1] "Veckor"
 
 #: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
@@ -4227,8 +4211,8 @@ msgstr[1] "Semanas"
 #: src/metabase/api/table.clj
 msgid "Month"
 msgid_plural "Months"
-msgstr[0] "Mes"
-msgstr[1] "Meses"
+msgstr[0] "Månad"
+msgstr[1] "Månader"
 
 #: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
@@ -4236,355 +4220,355 @@ msgstr[1] "Meses"
 #: src/metabase/api/table.clj
 msgid "Year"
 msgid_plural "Years"
-msgstr[0] "Año"
-msgstr[1] "Años"
+msgstr[0] "År"
+msgstr[1] "År"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:152
 msgid "Past 7 Days"
-msgstr "Ultimos 7 Días"
+msgstr "Senaste 7 dagarna"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:156
 msgid "Past 30 Days"
-msgstr "Ultimos 30 Días"
+msgstr "Senaste 30 dagarna"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:160
 msgid "Last Week"
-msgstr "Semana Pasada"
+msgstr "Förra veckan"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:164
 msgid "Last Month"
-msgstr "El mes pasado"
+msgstr "Förra månaden"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:168
 msgid "Last Year"
-msgstr "El año pasado"
+msgstr "Förra året"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:172
 msgid "This Week"
-msgstr "Esta Semana"
+msgstr "Denna vecka"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:176
 msgid "This Month"
-msgstr "Este Mes"
+msgstr "Denna månad"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:180
 msgid "This Year"
-msgstr "Este Año"
+msgstr "Detta år"
 
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
-msgstr "Introduce un valor..."
+msgstr "Ange ett värde..."
 
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:90
 msgid "Enter a default value..."
-msgstr "Introduce un valor predeterminado..."
+msgstr "Ange ett förvalt värde..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
 #: frontend/src/metabase/containers/Form.jsx:307
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
-msgstr "Ha ocurrido un error"
+msgstr "Ett fel uppstod"
 
 #: frontend/src/metabase/public/components/PublicNotFound.jsx:11
 msgid "Not found"
-msgstr "No encontrado"
+msgstr "Saknas"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:82
 msgid "You’ve made changes that need to be published before they will be reflected in your application embed."
-msgstr "Ha realizado cambios que deben publicarse antes de que se vean reflejados en la inserción de la aplicación."
+msgstr "Du har gjort ändringar som behöver publiceras innan de kommer att träda i kraft i din inbäddade applikation."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:83
 msgid "You will need to publish this {0} before you can embed it in another application."
-msgstr "Tendrás que publicar este {0} antes de poder incrustarlo en otra aplicación."
+msgstr "Du måste publicera denna {0} innan du kan bädda in den i en annan applikation."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:92
 msgid "Discard Changes"
-msgstr "Descartar Cambios"
+msgstr "Överge ändringar"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:99
 msgid "Updating..."
-msgstr "Actualizando..."
+msgstr "Uppdaterar..."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:100
 msgid "Updated"
-msgstr "Actualizado"
+msgstr "Uppdaterad"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:101
 msgid "Failed!"
-msgstr "¡Ha fallado!"
+msgstr "Misslyckades!"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:102
 msgid "Publish"
-msgstr "Publicar"
+msgstr "Publicera"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:111
 #: frontend/src/metabase/visualizations/lib/settings/column.js:345
 msgid "Code"
-msgstr "Código"
+msgstr "Kod"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:296
 msgid "Style"
-msgstr "Estilo"
+msgstr "Stil"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
-msgstr "¿Qué parámetros pueden usar los usuarios de este embebido?"
+msgstr "Vilka parametrar kan användare av denna inbäddning använda?"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
-msgstr "Este {0} aún no tiene parámetros para configurar."
+msgstr "Denna {0} har inga att parametrar att sätta upp ännu."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
-msgstr "Editable"
+msgstr "Ändringsbar"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
-msgstr "Bloqueado"
+msgstr "Låst"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:113
 msgid "Preview Locked Parameters"
-msgstr "Vista previa de los parámetros bloqueados"
+msgstr "Förhandsgranska låsta parametrar"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
-msgstr "Intenta pasar algunos valores a tus parámetros bloqueados aquí. Tu servidor tendrá que proporcionar los valores reales en el token firmado al usar esto de manera real."
+msgstr "Försök ange några värden till dina låsta parametrar här. Din server måste tillhandahålla de riktiga värdena i det signerade beviset när detta används på riktigt."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
-msgstr "Zona peligrosa"
+msgstr "Farlig mark"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
-msgstr "Esto deshabilitará la incrustación para este {0}."
+msgstr "Detta kommer att inaktivera inbäddning för denna {0}."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
-msgstr "No publicar"
+msgstr "Av-publicera"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:17
 msgid "Light"
-msgstr "Claro"
+msgstr "Ljus"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:18
 msgid "Dark"
-msgstr "Oscuro"
+msgstr "Mörk"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:37
 msgid "Border"
-msgstr "Borde"
+msgstr "Ram"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:62
 msgid "To embed this {0} in your application:"
-msgstr "Para insertar este {0} en tu aplicación"
+msgstr "För att inbädda denna {0} i din applikation:"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:64
 msgid "Insert this code snippet in your server code to generate the signed embedding URL "
-msgstr "Inserta este fragmento de código en tu código de servidor para generar la URL de inserción firmada"
+msgstr "Lägg in detta kodstycke i din serverkod för att skapa den signerade inbäddnings-URL:en "
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:87
 msgid "Then insert this code snippet in your HTML template or single page app."
-msgstr "A continuación, inserta este fragmento de código en tu plantilla HTML o aplicación de una sola página."
+msgstr "Lägg sedan in detta kodstycke i din HTML-mall eller enskilda sida."
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:94
 msgid "Embed code snippet for your HTML or Frontend Application"
-msgstr "Incrusta este fragmento de código en tu aplicación"
+msgstr "Inbädda kodstycke i din HTML eller ditt gränssnitt"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:101
 msgid "More {0}"
-msgstr "Más {0}"
+msgstr "Mer {0}"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:103
 msgid "examples on GitHub"
-msgstr "ejemplos en GitHub"
+msgstr "exempel på GitHub"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
-msgstr "Habilitar compartir"
+msgstr "Aktivera delning"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
-msgstr "¿Deshabilitar este enlace público?"
+msgstr "Inaktivera denna publika länk?"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
-msgstr "Esto hará que el enlace existente deje de funcionar. Puedes volver a habilitarlo, pero cuando lo hagas será un enlace diferente."
+msgstr "Detta kommer att göra att den befintliga länken slutar fungerar. Du kan aktivera den igen, men när du gör det kommer det att bli en annan länk."
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
-msgstr "Enlace público"
+msgstr "Publik länk"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
-msgstr "Comparte este {0} con personas que no tienen una cuenta de Metabase usando la siguiente URL:"
+msgstr "Dela denna {0} med människor som inte har ett Metabase-konto genom URL:en nedan:"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
-msgstr "Incrustación pública"
+msgstr "Publik inbäddning"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
-msgstr "Incrusta este {0} en publicaciones de blogs o páginas web al copiar y pegar este fragmento:"
+msgstr "Inbädda denna {0} i bloggar eller webbsidor genom att kopiera och klistra in detta stycke:"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
-msgstr "Incrustar este {0} en una aplicación"
+msgstr "Inbädda denna {0} i en applikation"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
-msgstr "Al integrar con tu servidor de aplicaciones, puedes proporcionar un/a {0} segura limitada a un usuario específico, cliente, organización, etc."
+msgstr "Genom att integrera med din applikationsservers kod kan du ge säker statistik begränsad till en specifik användare, kund, organisation osv."
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
-msgstr "Eliminar adjunto"
+msgstr "Ta bort bilaga"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
-msgstr "Adjuntar archivo con resultados"
+msgstr "Lägg till fil med resultatet"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
-msgstr "Esta pregunta se añadirá como un archivo adjunto"
+msgstr "Denna fråga kommer att läggas till som en bilaga"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
-msgstr "Esta pregunta no estará incluida en tu Pulso"
+msgstr "Denna fråga kommer inte att tas med i din ögonblicksbild"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
-msgstr "Este pulso ya no se enviará por correo electrónico a la dirección {1}"
+msgstr "Denna ögonblicksbild kommer inte längre att skickas med epost till {0} {1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
-msgstr[0] "{0} dirección"
-msgstr[1] "{0} direcciones"
+msgstr[0] "{0} adress"
+msgstr[1] "{0} adresser"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:102
 msgid "Slack channel {0} will no longer get this pulse {1}"
-msgstr "El canal Slack {0} ya no recibirá este pulso {1}"
+msgstr "Slack-kanal {0} kommer inte längre att få denna ögonblicksbild {1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
-msgstr "El canal {0} ya no recibirá este pulso {1}"
+msgstr "Kanal {0} kommer inte längre att få denna ögonblicksbild {1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
-msgstr "Edita un pulso"
+msgstr "Redigera ögonblicksbild"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
-msgstr "¿Qué es un Pulso?"
+msgstr "Vad är en ögonblicksbild?"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
-msgstr "Lo tengo"
+msgstr "Jag fattar"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
-msgstr "¿A dónde deberían ir estos datos?"
+msgstr "Var ska denna data in?"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
-msgstr "Desarchivando…"
+msgstr "Av-arkiverar..."
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
-msgstr "Ha fallado la recuperación"
+msgstr "Av-arkivering misslyckades"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
-msgstr "Desarchivado"
+msgstr "Av-arkiverad"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
-msgstr "Crea un pulso"
+msgstr "Skapa ögonblicksbild"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:91
 msgid "Attachment"
-msgstr "Adjunto"
+msgstr "Bilaga"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:105
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:112
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
-msgstr "Aviso"
+msgstr "Förhandsinformera"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:106
 msgid "We'll show the first 10 columns and 20 rows of this table in your Pulse. If you email this, we'll add a file attachment with all columns and up to 2,000 rows."
-msgstr "Mostraremos las primeras 10 columnas y 20 filas de esta tabla en tu Pulso. Si lo envías por correo electrónico, añadiremos un archivo adjunto con todas las columnas y hasta 2.000 filas."
+msgstr "Vi kommer att visa de första 10 kolumnerna och 20 raderna i denna tabell i din ögonblicksbild. Om du skickar detta med epost kommer vi att lägga till en bilaga med alla kolumner och upp till 2000 rader."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:113
 msgid "Raw data questions can only be included as email attachments"
-msgstr "Las preguntas de datos brutos solo se pueden incluir como archivos adjuntos de correo electrónico"
+msgstr "Rådata-frågor kan bara läggas som bilagor i epost"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:120
 msgid "Looks like this pulse is getting big"
-msgstr "Parece que este pulso está creciendo mucho"
+msgstr "Ser ut som om denna ögonblicksbild blir stor"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:121
 msgid "We recommend keeping pulses small and focused to help keep them digestible and useful to the whole team."
-msgstr "Recomendamos mantener los pulsos pequeños y enfocados para ayudar a mantenerlos digeribles y útiles para todo el equipo."
+msgstr "Vi rekommenderar att man behåller ögonblicksbild små och fokuserade för att göra dem lättlästa och användbara för hela gruppen."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:161
 #: frontend/src/metabase/query_builder/components/view/View.jsx:133
 msgid "Pick your data"
-msgstr "Elige tus datos"
+msgstr "Välj dina data"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:163
 msgid "Choose questions you'd like to send in this pulse"
-msgstr "Elige las preguntas que te gustaría enviar en este pulso"
+msgstr "Välj frågor som du vill skicka i denna ögonblicksbild"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
 msgid "Emails"
-msgstr "Emails"
+msgstr "Epost"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
 msgid "Slack messages"
-msgstr "Mensajes Slack"
+msgstr "Slack-meddelanden"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
-msgstr "Enviado"
+msgstr "Skickat"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
-msgstr "{0} se enviará a las"
+msgstr "{0} kommer att skickas"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
-msgstr "Mensajes"
+msgstr "Meddelanden"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
-msgstr "Enviar email ahora"
+msgstr "Skicka epost nu"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
-msgstr "Enviar a {0} ahora"
+msgstr "Skicka till {0} nu"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
-msgstr "Enviando…"
+msgstr "Skickar..."
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
-msgstr "Ha fallado el envío"
+msgstr "Sändning misslyckad"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
-msgstr "No se envió porque el pulso no tiene resultados."
+msgstr "Skickades inte eftersom ögonblicksbild inte har något innehåll"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
-msgstr "Pulso enviado"
+msgstr "Ögonblicksbild skickad"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
-msgstr "{0} debe ser configurado por un administrador."
+msgstr "{0} behöver sättas upp av en administratör."
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:299
 msgid "Slack"
@@ -4592,448 +4576,448 @@ msgstr "Slack"
 
 #: frontend/src/metabase/pulse/components/PulseEditCollection.jsx:12
 msgid "Which collection should this pulse live in?"
-msgstr "¿En qué colección debería estar este pulso?"
+msgstr "Vilken samling ska denna ögonblicksbild finnas i?"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:35
 msgid "Name your pulse"
-msgstr "Nombra tu pulso"
+msgstr "Ge namn på din ögonblicksbild"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:37
 msgid "Give your pulse a name to help others understand what it's about"
-msgstr "Dale un nombre a tu pulso para ayudar a otros a entender de qué se trata"
+msgstr "Ge din ögonblicksbild ett namn för att hjälpa andra förstå vad det handlar om"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:49
 msgid "Important metrics"
-msgstr "Métricas importantes"
+msgstr "Viktiga mått"
 
 #: frontend/src/metabase/pulse/components/PulseEditSkip.jsx:22
 msgid "Skip if no results"
-msgstr "Omitir si no hay resultados"
+msgstr "Hoppa över om resultatet är tomt"
 
 #: frontend/src/metabase/pulse/components/PulseEditSkip.jsx:24
 msgid "Skip a scheduled Pulse if none of its questions have any results"
-msgstr "Omitir un pulso programado si ninguna de sus preguntas tiene resultado"
+msgstr "Hoppa över en schemalagd ögonblicksbild om ingen av dess frågor har något resultat"
 
 #: frontend/src/metabase/pulse/components/RecipientPicker.jsx:65
 msgid "Enter email addresses you'd like this data to go to"
-msgstr "Introduce las direcciones de correo electrónico a las que quieres que vayan estos datos"
+msgstr "Ange epost-adresser som du vill skicka dessa data till."
 
 #: frontend/src/metabase/pulse/components/WhatsAPulse.jsx:16
 msgid "Help everyone on your team stay in sync with your data."
-msgstr "Ayuda a todos los de tu equipo a mantenerse sincronizados con tus datos."
+msgstr "Hjälp alla i din grupp att hålla sig ajour med dina data"
 
 #: frontend/src/metabase/pulse/components/WhatsAPulse.jsx:31
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
-msgstr "Los pulsos te permiten enviar datos de Metabase a correo electrónico o Slack en el horario que desees."
+msgstr "Ögonblicksbilder låter dig skicka data från Metabase via epost eller till Slack enligt angivet tidsschema."
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "After {0}"
-msgstr "Después de {0}"
+msgstr "Efter {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 msgid "Before {0}"
-msgstr "Antes de {0}"
+msgstr "Före {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
-msgstr "Vacío"
+msgstr "Är tom"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
-msgstr "No Vacío"
+msgstr "Inte tom"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
-msgstr "Todo el Tiempo"
+msgstr "Alltid"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
 msgid "Apply"
-msgstr "Aplicar"
+msgstr "Tillämpa"
 
 #: frontend/src/metabase/modes/components/actions/CommonMetricsAction.jsx:21
 msgid "View {0}"
-msgstr "Ver {0}"
+msgstr "Visa {0}"
 
 #: frontend/src/metabase/modes/components/actions/CompareWithTable.jsx:29
 msgid "Compare this with all rows in the table"
-msgstr "Compara esto con todas las filas en la tabla"
+msgstr "Jämför detta med alla rader i tabellen"
 
 #: frontend/src/metabase/modes/components/actions/CompoundQueryAction.jsx:14
 msgid "Analyze the results of this Query"
-msgstr "Analiza los resultados de esta consulta"
+msgstr "Analysera resultatet av denna fråga"
 
 #: frontend/src/metabase/modes/components/actions/CountByTimeAction.jsx:29
 msgid "Count of rows by time"
-msgstr "Número de filas por tiempo"
+msgstr "Antal rader över tid"
 
 #: frontend/src/metabase/modes/components/drill/PivotByDrill.jsx:52
 msgid "Break out by {0}"
-msgstr "Distribuir por {0}"
+msgstr "Bryt ut {0}"
 
 #: frontend/src/metabase/modes/components/actions/SummarizeBySegmentMetricAction.jsx:36
 msgid "Summarize this segment"
-msgstr "Resume este segmento"
+msgstr "Summera detta segment"
 
 #: frontend/src/metabase/modes/components/actions/UnderlyingDataAction.jsx:14
 msgid "View this as a table"
-msgstr "Ver esto como una tabla"
+msgstr "Visa detta som en tabell"
 
 #: frontend/src/metabase/modes/components/actions/UnderlyingRecordsAction.jsx:22
 msgid "View the underlying {0} records"
-msgstr "Ver los registros subyacentes de {0}"
+msgstr "Visa de underliggande {0} posterna"
 
 #: frontend/src/metabase/modes/components/actions/XRayCard.jsx:20
 msgid "X-Ray this question"
-msgstr "Aplica rayos-X a esta pregunta"
+msgstr "Genomlys denna fråga"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 msgid "X-ray {0} {1}"
-msgstr "Rayos-X {0} {1}"
+msgstr "Genomlysning {0} {1}"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "these"
-msgstr "estos"
+msgstr "dessa"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "this"
-msgstr "este"
+msgstr "denna"
 
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "Compare {0} {1} to the rest"
-msgstr "Compara {0} {1} con el resto"
+msgstr "Jämför {0} {1} med resten"
 
 #: frontend/src/metabase/modes/components/drill/DistributionDrill.jsx:35
 msgid "Distribution"
-msgstr "Distribución"
+msgstr "Distribution"
 
 #: frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx:38
 msgid "View details"
-msgstr "Ver detalles"
+msgstr "Visa detaljer"
 
 #: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
-msgstr "Ver los {1} de {0}"
+msgstr "Visa denna {0}s {1}"
 
 #: frontend/src/metabase/modes/components/drill/SortAction.jsx:42
 msgid "Ascending"
-msgstr "Ascendente"
+msgstr "Stigande"
 
 #: frontend/src/metabase/modes/components/drill/SortAction.jsx:50
 msgid "Descending"
-msgstr "Descendente"
+msgstr "Fallande"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js:43
 msgid "over time"
-msgstr "a través del tiempo."
+msgstr "över tid"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:22
 msgid "Avg"
-msgstr "Media"
+msgstr "Snitt"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:34
 msgid "Distincts"
-msgstr "Distintos"
+msgstr "Distinkta"
 
 #: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:55
 msgid "View this {0}"
 msgid_plural "View these {0}"
-msgstr[0] "Ver el {0}"
-msgstr[1] "Ver estos {0}"
+msgstr[0] "Visa denna {0}"
+msgstr[1] "Visa dessa {0}"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
-msgstr "Ampliar"
+msgstr "Zooma in"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
-msgstr "Expresión Personalizada"
+msgstr "Anpassat uttryck"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Common Metrics"
-msgstr "Métricas Comunes"
+msgstr "Vanliga mått"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:209
 msgid "Metabasics"
-msgstr "Metabasics"
+msgstr "Meta-grunder"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
-msgstr "Nombre (opcional)"
+msgstr "Namn (valfritt)"
 
 #: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:156
 msgid "Choose an aggregation"
-msgstr "Elige una agregación"
+msgstr "Välj en sammanslagning"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:100
 msgid "Set up your own alert"
-msgstr "Configura tu propia alerta"
+msgstr "Sätt upp din egen varningssignal"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
-msgstr "Dando de baja..."
+msgstr "Avslutar prenumeration..."
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
-msgstr "Error al darse de baja"
+msgstr "Kunde inte avsluta prenumeration"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
-msgstr "Darse de baja"
+msgstr "Avsluta prenumeration"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
-msgstr "Sin canal"
+msgstr "Ingen kanal"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
-msgstr "De acuerdo, has sido dado de baja"
+msgstr "Okej, din prenumeration är avslutad"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
-msgstr "Estás recibiendo las alertas de {0}"
+msgstr "Du abonnerar på {0}s varningssignaler"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
-msgstr "{0} has configurado una alerta"
+msgstr "{0} satte upp en varningssignal"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:160
 msgid "alerts"
-msgstr "alertas"
+msgstr "varningar"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:183
 msgid "Let's set up your alert"
-msgstr "Vamos a configurar tu alerta"
+msgstr "Låt oss sätta upp din varningssignal"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:214
 msgid "The wide world of alerts"
-msgstr "El amplio mundo de las alertas"
+msgstr "Den stora världen av varningar"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:215
 msgid "There are a few different kinds of alerts you can get"
-msgstr "Hay algunos tipos diferentes de alertas que puedes obtener"
+msgstr "Det finns några olika typer av varningar du kan få"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:229
 msgid "When a raw data question {0}"
-msgstr "Cuando una pregunta de datos {0}"
+msgstr "När en rådata-fråga {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:230
 msgid "returns any results"
-msgstr "arroja resultados"
+msgstr "ger några resultat"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:241
 msgid "When a line or bar {0}"
-msgstr "Cuando una línea o barra {0}"
+msgstr "När en linje eller stapel {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:242
 msgid "crosses a goal line"
-msgstr "supera un objetivo"
+msgstr "passerar en mållinje"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:253
 msgid "When a progress bar {0}"
-msgstr "Cuando una barra de progreso {0}"
+msgstr "När en förloppsindikator {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:254
 msgid "reaches its goal"
-msgstr "alcanza su objetivo"
+msgstr "når sitt mål"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:262
 msgid "Set up an alert"
-msgstr "Crea una alerta"
+msgstr "Sätt upp en varning"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:331
 msgid "Edit your alert"
-msgstr "Edita tu alerta"
+msgstr "Redigera din varning"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:331
 msgid "Edit alert"
-msgstr "Editar alerta"
+msgstr "Redigera varning"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
-msgstr "Esta alerta ya no se enviará por correo electrónico a {0}."
+msgstr "Denna varning kommer inte längre att skickas till {0}."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
-msgstr "El canal Slack {0} ya no recibirá esta alerta."
+msgstr "Slack-kanal {0} kommer inte längre att få denna varning."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
-msgstr "El canal {0} ya no recibirá esta alerta."
+msgstr "Kanal {0} kommer inte längre att få denna varning."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
-msgstr "Elimina esta alerta"
+msgstr "Radera denna varning"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
-msgstr "Detener el envío y elimina esta alerta. No se puede deshacer, así que ten cuidado."
+msgstr "Avsluta sändning och ta bort denna varning. Det går inte att ångra, så var försiktig."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
-msgstr "¿Eliminar esta alerta?"
+msgstr "Radera denna varning?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
-msgstr "Avísame cuando la línea…"
+msgstr "Varna mig när linjen..."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
-msgstr "Avísame cuando la barra de progreso…"
+msgstr "Varna mig när förloppsindikatorn..."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
-msgstr "Va por encima de la línea de objetivo"
+msgstr "Gå över mållinjen"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
-msgstr "Llega al objetivo"
+msgstr "Når målet"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
-msgstr "Va por debajo de la línea de objetivo"
+msgstr "Går under mållinjen"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
-msgstr "Va por debajo del objetivo"
+msgstr "Går under målet"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
-msgstr "¿La primera vez que cruza, o cada vez?"
+msgstr "Första gången den passerar eller varje gång?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
-msgstr "¿La primera vez que alcanza el objetivo, o cada vez?"
+msgstr "Den första gången den når mål eller varje gång?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
-msgstr "La primera vez"
+msgstr "Den första gången"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
-msgstr "Cada vez"
+msgstr "Varje gång"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
-msgstr "¿A dónde quieres enviar estas alertas?"
+msgstr "Vart vill du skicka dessa varningar?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
-msgstr "Envía emails de alerta a:"
+msgstr "Skicka varningar till:"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
-msgstr "{0} Las alertas basadas en objetivos aún no son compatibles para gráficos con más de una línea, por lo que esta alerta se enviará siempre que el gráfico tenga {1}."
+msgstr "{0} målorienterade varningar stöds inte ännu för diagram med mer än en linje, så denna varning kommer att skicka när diagrammet har {1}."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 #: src/metabase/pulse.clj
 msgid "results"
-msgstr "resultados"
+msgstr "resultat"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
-msgstr "{0} Este tipo de alerta es más útil cuando tu pregunta {1} no arroja ningún resultado, pero quieres saber cuándo lo hace."
+msgstr "{0} Denna sortens varning är mest användbar när din sparade fråga inte {1} ger några resultat, men du vill veta när den gör det."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
-msgstr "Consejo:"
+msgstr "Tips"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
-msgstr "generalmente"
+msgstr "vanligen"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:61
 msgid "Pick a segment or table"
-msgstr "Elige un segmento o tabla"
+msgstr "Välj ett segment eller en tabell"
 
 #: frontend/src/metabase/entities/databases/forms.js:260
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
-msgstr "Selecciona una base de datos"
+msgstr "Välj en databas"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:85
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:31
 msgid "Select..."
-msgstr "Seleccionar..."
+msgstr "Välj..."
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
 msgid "Select a table"
-msgstr "Selecciona una tabla"
+msgstr "Välj en tabell"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:926
 msgid "No tables found in this database."
-msgstr "No se encontraron tablas en esta base de datos."
+msgstr "Tabeller saknas i denna databas"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:901
 msgid "Is a question missing?"
-msgstr "¿Falta una pregunta?"
+msgstr "Saknas en fråga?"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:909
 msgid "Learn more about nested queries"
-msgstr "Obtén más información sobre consultas anidadas"
+msgstr "Upptäck mer om nästlade frågor"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:951
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:40
 msgid "Fields"
-msgstr "Campos"
+msgstr "Fält"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:977
 msgid "No segments were found."
-msgstr "No se encontraron segmentos"
+msgstr "Inga segment hittade"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:1000
 msgid "Find a segment"
-msgstr "Encuentra un segmento"
+msgstr "Hitta ett segment"
 
 #: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
-msgstr "Ver menos"
+msgstr "Visa mindre"
 
 #: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
-msgstr "Ver más"
+msgstr "Visa mer"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:112
 msgid "Pick a field to sort by"
-msgstr "Elige un campo para ordenar por"
+msgstr "Välj ett fält att sortera på"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
-msgstr "Ordenar"
+msgstr "Sortera"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
-msgstr "Límite de filas"
+msgstr "Radgräns"
 
 #: frontend/src/metabase/query_builder/components/FieldName.jsx:72
 msgid "Unknown Field"
-msgstr "Campo Desconocido"
+msgstr "Okänt fält"
 
 #: frontend/src/metabase/query_builder/components/FieldName.jsx:75
 msgid "field"
-msgstr "campo"
+msgstr "fält"
 
 #: frontend/src/metabase/query_builder/components/Filter.jsx:117
 msgid "Matches"
-msgstr "Conincidencias"
+msgstr "Matchar"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:135
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
-msgstr "Añade filtros para limitar tu respuesta"
+msgstr "Lägg till filter för att begränsa svaret"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
-msgstr "Añadir una agrupación"
+msgstr "Lägg till en gruppering"
 
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:37
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:313
@@ -5052,107 +5036,107 @@ msgstr "Añadir una agrupación"
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Data"
-msgstr "Datos"
+msgstr "Data"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:340
 msgid "Filtered by"
-msgstr "Filtrado por"
+msgstr "Filtrerad på"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:357
 msgid "View"
-msgstr "Ver"
+msgstr "Visa"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:374
 msgid "Grouped By"
-msgstr "Agrupado por"
+msgstr "Grupperad på"
 
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
-msgstr "Ninguno"
+msgstr "Inga"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
 msgid "This question is written in {0}."
-msgstr "Esta pregunta está escrita en {0}"
+msgstr "Denna fråga är skriven i {0}."
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
-msgstr "Esconder Editor"
+msgstr "Dölj editor"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
-msgstr "Esconder Consulta"
+msgstr "Dölj fråga"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
 msgid "Open Editor"
-msgstr "Abrir Editor"
+msgstr "Öppna editor"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:482
 msgid "Show Query"
-msgstr "Mostrar Consulta"
+msgstr "Visa fråga"
 
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "This metric has been retired.  It's no longer available for use."
-msgstr "Esta métrica ha sido retirada. Ya no está disponible para su uso."
+msgstr "Detta mått är inte aktivt. Det går inte längre att använda."
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:34
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:46
 msgid "Download full results"
-msgstr "Descarga los resultados completos"
+msgstr "Ladda ner hela resultatet"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:35
 msgid "Download this data"
-msgstr "Descargar esta información"
+msgstr "Ladda ner denna data"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:46
 msgid "Warning"
-msgstr "Aviso"
+msgstr "Varning"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
-msgstr "Tu respuesta tiene una gran cantidad de filas, por lo que podría tardar un tiempo en descargarse."
+msgstr "Ditt svar har ett stort antal rader, så det kan ta en stund att ladda ner."
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
-msgstr "El tamaño máximo de descarga es de 1 millón de filas."
+msgstr "Max antal rader att ladda ned är 1 miljon."
 
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:11
 msgid "Edit question"
-msgstr "Editar pregunta"
+msgstr "Redigera fråga"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:249
 msgid "SAVE CHANGES"
-msgstr "GUARDAR CAMBIOS"
+msgstr "SPARA ÄNDRINGAR"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:263
 msgid "CANCEL"
-msgstr "CANCELAR"
+msgstr "AVBRYT"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:276
 msgid "Move question"
-msgstr "Mover pregunta"
+msgstr "Flytta fråga"
 
 #: frontend/src/metabase/query_builder/components/QueryModals.jsx:155
 msgid "Which collection should this be in?"
-msgstr "¿En qué colección debería estar esto?"
+msgstr "Vilken samling ska denna vara i?"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:85
 #: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
-msgstr "Variables"
+msgstr "Variabler"
 
 #: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
-msgstr "Conoce tus datos"
+msgstr "Upptäck dina data"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:460
 msgid "Alerts are on"
-msgstr "Las alertas están activadas"
+msgstr "Varningar är aktiva"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:522
 msgid "started from"
-msgstr "iniciado desde"
+msgstr "började"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:48
 msgid "SQL"
@@ -5160,169 +5144,169 @@ msgstr "SQL"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:48
 msgid "native query"
-msgstr "consulta nativa"
+msgstr "Inbyggd fråga"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:52
 msgid "Not Supported"
-msgstr "No Soportado"
+msgstr "Stöds inte"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:58
 msgid "View the {0}"
-msgstr "Ver el {0}"
+msgstr "Visa {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:59
 msgid "Switch to {0}"
-msgstr "Cambiar a {0}"
+msgstr "Byt till {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:62
 msgid "Switch to Builder"
-msgstr "Cambiar al Editor"
+msgstr "Byt till generatorn"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:87
 msgid "{0} for this question"
-msgstr "{0} de esta pregunta"
+msgstr "{0} för denna fråga"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:111
 msgid "Convert this question to {0}"
-msgstr "Convertir esta pregunta en {0}"
+msgstr "Konvertera denna fråga till {0}"
 
 #: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:16
 msgid "This question will take approximately {0} to refresh"
-msgstr "Esta pregunta se actualizará en aproximadamente {0}"
+msgstr "Denna fråga kommer att ta uppskattningsvis {0} att ladda om"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
-msgstr "Actualizado hace {0}"
+msgstr "Uppdaterade {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:141
 msgid "row"
 msgid_plural "rows"
-msgstr[0] "fila"
-msgstr[1] "filas"
+msgstr[0] "rad"
+msgstr[1] "rader"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:148
 msgid "Showing first {0} {1}"
-msgstr "Mostrando primeras {0} {1}"
+msgstr "Visa första {0} {1}"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:151
 msgid "Showing {0} {1}"
-msgstr "Mostrando {0} {1}"
+msgstr "Visar {0} {1}"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
-msgstr "Haciendo ciencia"
+msgstr "Analyserar"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
-msgstr "Si me das algunos datos puedo mostrarte algo genial. ¡Ejecuta una consulta!"
+msgstr "Om du ger mig lite data kan jag visa dig något häftigt! Kör en fråga!"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:299
 msgid "How do I use this thing?"
-msgstr "¿Cómo uso esta cosa?"
+msgstr "Hur använder jag detta?"
 
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:45
 msgid "Get Answer"
-msgstr "Obtener Respuesta"
+msgstr "Få svaret"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:12
 msgid "It's okay to play around with saved questions"
-msgstr "Puedes jugar con preguntas guardadas"
+msgstr "Det är ok att leka med sparade frågor"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:14
 msgid "You won't make any permanent changes to a saved question unless you click the edit icon in the top-right."
-msgstr "No harás ningún cambio permanente en una pregunta guardada a menos que hagas clic en el icono de edición en la esquina superior derecha."
+msgstr "Du kan bara göra permanenta ändringar i en sparad fråga om du klickar på editeringsikonen längst upp till höger."
 
 #: frontend/src/metabase/query_builder/components/SearchBar.jsx:28
 msgid "Search for"
-msgstr "Buscar"
+msgstr "Leta efter"
 
 #: frontend/src/metabase/query_builder/components/SelectionModule.jsx:158
 msgid "Advanced..."
-msgstr "Avanzado..."
+msgstr "Avancerat..."
 
 #: frontend/src/metabase/query_builder/components/SelectionModule.jsx:167
 msgid "Sorry. Something went wrong."
-msgstr "Lo siento. Algo salió mal."
+msgstr "Ursäkta, något gick fel..."
 
 #: frontend/src/metabase/query_builder/components/TimeGroupingPopover.jsx:40
 msgid "Group time by"
-msgstr "Agrupar tiempo por"
+msgstr "Gruppera tid på"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
-msgstr "Tu pregunta tardó demasiado tiempo"
+msgstr "Din fråga tog för lång tid"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
-msgstr "No obtuvimos una respuesta de tu base de datos a tiempo, así que tuvimos que parar.Puedes volver a intentarlo en un minuto, o si el problema persiste, puedes enviar un correo electrónico a un administrador para avisarle."
+msgstr "Vi fick inget svar från din databas i tid, så vi fick avbryta. Du kan försöka igen om någon minut. Om problemet kvarstår kan du skicka epost till en administratör för att informera."
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
-msgstr "Estamos experimentando problemas con el servidor"
+msgstr "Vi har serverproblem"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
-msgstr "Intenta actualizar la página después de esperar uno o dos minutos. Si el problema persiste, te recomendamos que te pongas en contacto con un administrador."
+msgstr "Försöka ladda om sidan efter att du väntat någon minut. Om problemet kvarstår rekommenderas du ta kontakt med en administratör."
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
-msgstr "Hubo un problema con tu pregunta"
+msgstr "Ett problem uppstod med din fråga."
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
-msgstr "La mayoría de las veces esto es causado por una selección no válida o un valor de entrada incorrecto.Revisa tus entradas y vuelva a intentar la consulta."
+msgstr "För det mesta beror detta på en felaktig selektion eller felaktigt indatavärde. Kontrollera vad du angett och försök köra om frågan."
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
-msgstr "Esta puede ser la respuesta que estás buscando. De lo contrario, intenta eliminar o cambiar tus filtros para que sean menos específicos."
+msgstr "Detta kan vara det svar du söker. Om inte, kan du ta bort eller ändra dina filter för att göra dem mer trubbiga."
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
-msgstr "También puedes {0} cuando hay algunos resultados."
+msgstr "Du kan också {0} när det finns några resultat tillgängliga."
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
-msgstr "recibir una alerta"
+msgstr "Få en varning"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:77
 msgid "Back to last run"
-msgstr "Volver a la última ejecución"
+msgstr "Tillbaka till senaste körningen"
 
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:194
 msgid "Visualization"
-msgstr "Visualización"
+msgstr "Visualisering"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
 msgid "No description set."
-msgstr "Sin descripción"
+msgstr "Ingen beskrivning gjord"
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
 msgid "Use for current question"
-msgstr "Usar para la pregunta actual"
+msgstr "Använd för nuvarande fråga"
 
 #: frontend/src/metabase/reference/components/UsefulQuestions.jsx:14
 msgid "Potentially useful questions"
-msgstr "Preguntas potencialmente útiles"
+msgstr "Eventuellt användbara frågor"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
-msgstr "Agrupar por {0}"
+msgstr "Grupperat på {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:165
 msgid "Sum of all values of {0}"
-msgstr "Suma de todos los valores de {0}"
+msgstr "Summan av alla värden för {0}"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:63
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:51
 msgid "All distinct values of {0}"
-msgstr "Todos los valores distintos de {0}"
+msgstr "Alla distinkta värden på {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
-msgstr "Número de {0} agrupadas por {1}"
+msgstr "Antal {0} grupperade på {1}"
 
 #: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
@@ -5334,335 +5318,335 @@ msgstr "Número de {0} agrupadas por {1}"
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:24
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:23
 msgid "Data Reference"
-msgstr "Referencia de Datos"
+msgstr "Data-referens"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:13
 msgid "Learn more about your data structure to ask more useful questions"
-msgstr "Aprende más sobre tu estructura de datos para hacer preguntas más útiles"
+msgstr "Lär dig mer om din data-struktur för att ställa mer användbara frågor"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
-msgstr "No se pudieron encontrar los metadatos de la tabla antes de crear una nueva pregunta"
+msgstr "Kunde inte hitta tabellens beskrivning för att kunna påbörja en ny fråga"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
-msgstr "Ver {0}"
+msgstr "Visa {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
 msgid "Metric Definition"
-msgstr "Definición de Métrica"
+msgstr "Mått-definitioner"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
-msgstr "Filtrar por {0}"
+msgstr "Filtrera på {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:38
 msgid "Number of {0}"
-msgstr "Número de {0}"
+msgstr "Antal {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:48
 msgid "See all {0}"
-msgstr "Ver todos los {0}"
+msgstr "Visa alla {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
 msgid "Segment Definition"
-msgstr "Definición de Segmento"
+msgstr "Segment-definitioner"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
 msgid "An error occurred loading the table"
-msgstr "Se produjo un error al cargar la tabla"
+msgstr "Ett fel uppstod när tabellen laddades"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:74
 msgid "See the raw data for {0}"
-msgstr "Ver los datos de {0}"
+msgstr "Visa rådata för {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
 msgid "More"
-msgstr "Más"
+msgstr "Mer"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:216
 msgid "Invalid expression"
-msgstr "Expresión inválida"
+msgstr "Ogiltigt uttryck"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:282
 msgid "unknown error"
-msgstr "error no controlado"
+msgstr "okänt fel"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:53
 msgid "Field formula"
-msgstr "Fórmula de campo"
+msgstr "Fältdefinition"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:64
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
-msgstr "Piensa en esto como algo parecido a escribir una fórmula en un programa de hoja de cálculo: puedes usar números, campos de esta tabla, símbolos matemáticos como + y algunas funciones. Así puedes escribir algo como Subtotal - Cost."
+msgstr "Tänk på detta som att skriva en formel i ett kalkyprogram. Du kan använda siffror, fält i tabellen, matematiska symboler som +, och några funktioner. Så du skulle kunna skriva något i stil med Subtotal - kost."
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
 msgid "Learn more"
-msgstr "Aprende más"
+msgstr "Mer info"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:77
 msgid "Give it a name"
-msgstr "Dale un nombre"
+msgstr "Ge den ett namn"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
 msgid "Something nice and descriptive"
-msgstr "Algo agradable y descriptivo"
+msgstr "Något trevligt och beskrivande"
 
 #: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:60
 msgid "Add a custom field"
-msgstr "Añadir un campo personalizado"
+msgstr "Lägg till ett anpassat fält"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:17
 msgid "Include {0}"
-msgstr "Incluir {0}"
+msgstr "Ta med {0}"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:19
 msgid "Case sensitive"
-msgstr "Distingue mayúsculas y minúsculas"
+msgstr "Skilj på versaler och gemena"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:23
 msgid "today"
-msgstr "hoy"
+msgstr "idag"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:24
 msgid "this week"
-msgstr "esta semana"
+msgstr "denna vecka"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:25
 msgid "this month"
-msgstr "este mes"
+msgstr "denna månad"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:26
 msgid "this year"
-msgstr "este año"
+msgstr "detta år"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:27
 msgid "this minute"
-msgstr "este minuto"
+msgstr "denna minut"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:28
 msgid "this hour"
-msgstr "esta hora"
+msgstr "denna timme"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:290
 msgid "not implemented {0}"
-msgstr "{0} no está implementado"
+msgstr "inte implementerad {0}"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:291
 msgid "true"
-msgstr "verdadero"
+msgstr "sant"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:291
 msgid "false"
-msgstr "falso"
+msgstr "falskt"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
-msgstr "Añadir filtro"
+msgstr "Lägg till filter"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
 msgid "Item"
-msgstr "Elemento"
+msgstr "Post"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
-msgstr "Anterior"
+msgstr "Föregående"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
-msgstr "Actual"
+msgstr "Nuvarande"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:257
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
-msgstr "Activado"
+msgstr "På"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx:47
 msgid "Enter desired number"
-msgstr "Introduce el número deseado"
+msgstr "Ange önskad siffra"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:161
 msgid "Empty"
-msgstr "Vacío"
+msgstr "Tom"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:119
 msgid "Find a value"
-msgstr "Encuentra un valor"
+msgstr "Hitta ett värde"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:113
 msgid "Hide calendar"
-msgstr "Esconder calendario"
+msgstr "Dölj kalender"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:113
 msgid "Show calendar"
-msgstr "Mostrar calendario"
+msgstr "Visa kalender"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx:97
 msgid "You can enter multiple values separated by commas"
-msgstr "Puedes introducir varios valores separados por comas"
+msgstr "Du kan ange flera värden åtskilda av komma-tecken."
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx:38
 msgid "Enter desired text"
-msgstr "Introduce el texto deseado"
+msgstr "Ange önskad text"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:210
 msgid "Try it"
-msgstr "Pruébalo"
+msgstr "Prova den"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:243
 msgid "What's this for?"
-msgstr "¿Para qué sirve esto?"
+msgstr "Vad används detta till?"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:245
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
-msgstr "Las variables en las consultas nativas te permiten reemplazar dinámicamente los valores en tus consultas utilizando elementos de filtro o a través de la URL."
+msgstr "Variabler i inbyggda frågor låter dig dynamiskt ersätta värden i dina frågor med hjälp av filter-rutor eller via URL:en."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
-msgstr "{0} crea una variable en esta plantilla SQL llamada \"nombre_variable\". Puedes asignar tipos a las variables en el panel lateral, lo que cambia su comportamiento. Todos los tipos de variables que no sean \"Filtro de Campo\" provocarán automáticamente que se coloque un elemento de filtro en esta pregunta; con Filtros de Campo, esto es opcional. Cuando se rellena este elemento de filtro, ese valor reemplaza a la variable en la plantilla SQL."
+msgstr "{0} skapar en variabel i denna SQL-mall som kallas \"variabel-namn\". Variabler kan ges typer i sidopanelen som förändrar hur de uppför sig. Alla variabel-typer förutom \"Fält-filter\" kommer automatiskt att visa en Filter-ruta i denna fråga. När det gäller Fält-filter är detta valfritt. När filter-rutan fylls i ersätter detta värdet i SQL-mallen."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:259
 msgid "Field Filters"
-msgstr "Filtros de Campo"
+msgstr "Fält-filter"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
-msgstr "Darle a una variable el tipo \"Filtro de campo\" te permite vincular las tarjetas SQL con los elementos de filtro en los cuadros de mando o usar más tipos de elementos de filtro en tu pregunta de SQL. Una variable de filtro de campo inserta SQL similar a la generada por el generador de consultas GUI cuando se añaden filtros en columnas existentes."
+msgstr "Genom att ge en variabel en fältfiltertyp kan du länka SQL-listor till filter i instrumentpanel-rutor eller använda flera typer av filter-rutor till dina SQL-frågor. En fältfilter-variabel lägger till SQL liknande den som genereras av den grafiska frågeguiden när man lägger till filter på befintliga kolumner."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:264
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
-msgstr "Al añadir una variable de Filtro de campo, deberás asignarla a un campo específico. A continuación, puedes optar por mostrar un elemento de filtro en tu pregunta, pero incluso si no lo haces, ahora puedes asignar tu variable de Filtro de campo a un filtro de cuadro de mando al agregar esta pregunta al mismo. Los filtros de campo deben usarse dentro de una cláusula \"WHERE\"."
+msgstr "När du lägger till en fältfilter-variabel behöver du koppla den till ett specifikt fält. Du kan sedan välja att visa en filter-ruta i din fråga. Men även om du inte väljer detta, kan du koppla din fältfilter-variabel till ett instrumentpanel-filter när frågan läggs till. Fältfilter bör läggas inuti WHERE-satsen."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:271
 msgid "Optional Clauses"
-msgstr "Cláusulas opcionales"
+msgstr "Valfria delar"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:132
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
-msgstr "los corchetes alrededor de un {0} crean una cláusula opcional en la plantilla. Si se establece la \"variable\", entonces la cláusula completa se coloca en la plantilla. Si no, entonces se ignora toda la cláusula."
+msgstr "Hakparenteser runt en {0} skapar en valfri del i mallen. Om \"variabel\" är satt kommer delen att tas med i mallen. Om inte kommer den att uteslutas."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:283
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
-msgstr "Para utilizar varias cláusulas opcionales, puedes incluir al menos una cláusula WHERE no opcional seguida de cláusulas opcionales que comiencen con \"AND\"."
+msgstr "För att använda flera valfria delar kan du ta med minst en icke valfri WHERE-sats följd av valfria delar som börjar med AND."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:301
 msgid "Read the full documentation"
-msgstr "Lee la documentación completa"
+msgstr "Läs hela dokumentationen."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:133
 msgid "Filter label"
-msgstr "Filtro de Etiqueta"
+msgstr "Namn på filter"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:134
 msgid "Variable type"
-msgstr "Tipo de Variable"
+msgstr "Variabeltyp"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:143
 msgid "Text"
-msgstr "Texto"
+msgstr "Text"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
 msgid "Date"
-msgstr "Fecha"
+msgstr "Datum"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
 msgid "Field Filter"
-msgstr "Filtro de Campo"
+msgstr "Fältfilter"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Field to map to"
-msgstr "Campo para mapear a"
+msgstr "Fält att koppla"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:180
 msgid "Filter widget type"
-msgstr "Tipo de filtro"
+msgstr "Typ av filterruta"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
 msgid "Required?"
-msgstr "¿Obligatorio?"
+msgstr "Obligatorisk?"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
 msgid "Default filter widget value"
-msgstr "Valor por defecto del filtro"
+msgstr "Förvald värde i filter-ruta"
 
 #: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
-msgstr "¿Archivar esta pregunta?"
+msgstr "Arkivera denna fråga?"
 
 #: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
-msgstr "Esta pregunta se eliminará de cualquier cuadro de mando o pulso que lo usen."
+msgstr "Denna fråga kommer att tas bort från instrumentpaneler och ögonblicksbilder som använder den."
 
 #: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
 msgid "Question"
-msgstr "Pregunta"
+msgstr "Fråga"
 
 #: frontend/src/metabase/dashboard/components/AddToDashSelectQuestionModal.jsx:31
 msgid "Pick a question to add"
-msgstr "Elige una pregunta para añadir"
+msgstr "Välj en fråga att lägga till"
 
 #: frontend/src/metabase/reference/components/EditHeader.jsx:19
 msgid "You are editing this page"
-msgstr "Estás editando esta página"
+msgstr "Du redigerar denna sida"
 
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:78
 #: frontend/src/metabase/reference/components/ReferenceHeader.jsx:45
 msgid "See this {0}"
-msgstr "Ver este {0}"
+msgstr "Visa denna {0}"
 
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
-msgstr "Un subconjunto de"
+msgstr "En delmängd av"
 
 #: frontend/src/metabase/reference/components/Field.jsx:48
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:31
 msgid "Select a field type"
-msgstr "Selecciona un tipo de campo"
+msgstr "Välj en fälttyp"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:85
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:36
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:54
 msgid "No field type"
-msgstr "Sin tipo de campo"
+msgstr "Ingen fälttyp"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/SummarizeStep.jsx:26
 msgid "by"
-msgstr "por"
+msgstr "av"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
 #: frontend/src/metabase/reference/databases/FieldList.jsx:156
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:157
 msgid "Field type"
-msgstr "Tipo campo"
+msgstr "Fälttyp"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
-msgstr "Selecciona una Clabe foránea"
+msgstr "Välj en extern nyckel"
 
 #: frontend/src/metabase/reference/components/Formula.jsx:56
 msgid "View the {0} formula"
-msgstr "Ver la fórmula de {0}"
+msgstr "Visa formeln {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:80
 msgid "Why this {0} is important"
-msgstr "Por qué este {0} es importante"
+msgstr "Varför denna {0} är viktig"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:81
 msgid "Why this {0} is interesting"
-msgstr "Por qué este {0} es interesante"
+msgstr "Varför denna {0} är intressant"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:87
 msgid "Nothing important yet"
-msgstr "Nada importante todavía"
+msgstr "Inget viktigt ännu"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:172
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:237
@@ -5671,11 +5655,11 @@ msgstr "Nada importante todavía"
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:248
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:233
 msgid "Nothing interesting yet"
-msgstr "Nada interesante todavía"
+msgstr "Inget intressant ännu"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:93
 msgid "Things to be aware of about this {0}"
-msgstr "Cosas a tener en cuenta acerca de este {0}"
+msgstr "Saker att tänka på gällande denna {0}"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:182
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:247
@@ -5684,77 +5668,77 @@ msgstr "Cosas a tener en cuenta acerca de este {0}"
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:258
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:243
 msgid "Nothing to be aware of yet"
-msgstr "Nada de lo que estar enterado todavía"
+msgstr "Inget som behöver uppmärksammas ännu"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:103
 msgid "Explore this metric"
-msgstr "Explora esta métrica"
+msgstr "Utforska detta mått"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:105
 msgid "View this metric"
-msgstr "Ver esta métrica"
+msgstr "Visa detta mått"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:112
 msgid "By {0}"
-msgstr "Por {0}"
+msgstr "av {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:146
 msgid "Remove item"
-msgstr "Eliminar elemento"
+msgstr "Ta bort post"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:155
 msgid "Why is this dashboard the most important?"
-msgstr "¿Por qué este cuadro de mando es el más importante?"
+msgstr "Varför är denna instrumentpanel den viktigaste?"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:156
 msgid "What is useful or interesting about this {0}?"
-msgstr "¿Qué es útil o interesante sobre este {0}?"
+msgstr "Vad är användbart eller intressant när det gäller {0}?"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:160
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:174
 msgid "Write something helpful here"
-msgstr "Escribe algo útil aquí"
+msgstr "Skriv något informativt här"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:169
 msgid "Is there anything users of this dashboard should be aware of?"
-msgstr "¿Hay algo que los usuarios de este cuadro de mando deben tener en cuenta?"
+msgstr "Finns det något som användare av denna instrumentpanel behöver uppmärksamma?"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:170
 msgid "Anything users should be aware of about this {0}?"
-msgstr "¿Hay alguna cosa que los usuarios deben saber sobre este {0}?"
+msgstr "Finns det något som användare behöver känna till när det gäller denna {0}?"
 
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:26
 msgid "Which 2-3 fields do you usually group this metric by?"
-msgstr "¿Con qué 2-3 campos se agrupa normalmente esta métrica?"
+msgstr "Vilka 2-3 fält grupperar du vanligtvis detta mått mot?"
 
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:25
 msgid "This is the perfect place to start if you’re new to your company’s data, or if you just want to check in on what’s going on."
-msgstr "Este es el lugar perfecto para comenzar si eres nuevo en los datos de tu empresa, o si solo deseas verificar lo que está sucediendo."
+msgstr "Detta är det perfekta stället att börja om du precis börjat titta på ditt företags data, eller om du bara vill se vad som är på gång."
 
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:52
 msgid "Most useful fields to group this metric by"
-msgstr "Campos más útiles para agrupar esta métrica"
+msgstr "De mest användbara fälten att gruppera detta mått mot"
 
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:32
 msgid "Reason for changes"
-msgstr "Motivo del cambio"
+msgstr "Anledning till ändring"
 
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:36
 msgid "Leave a note to explain what changes you made and why they were required"
-msgstr "Deja una nota para explicar qué cambios ha realizado y por qué fueron necesarios"
+msgstr "Skriv en anteckning för att beskriva vilka ändringar du gjorde och varför de behövdes"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:170
 msgid "Why this database is interesting"
-msgstr "Por qué esta base de datos es interesante"
+msgstr "Varför denna databas är intressant"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:180
 msgid "Things to be aware of about this database"
-msgstr "Cosas a tener en cuenta acerca de esta base de datos"
+msgstr "Saker att tänka på när det gäller denna databas"
 
 #: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
-msgstr "Bases de datos y tablas"
+msgstr "Databaser och tabeller"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:28
@@ -5768,966 +5752,964 @@ msgstr "Bases de datos y tablas"
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:31
 msgid "Details"
-msgstr "Detalles"
+msgstr "Detaljer"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
 #: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
-msgstr "Tablas en {0}"
+msgstr "Tabeller i {0}"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:226
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:204
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:222
 msgid "Actual name in database"
-msgstr "Nombre real en la base de datos"
+msgstr "Verkligt namn i databasen"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:235
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:231
 msgid "Why this field is interesting"
-msgstr "Por qué este campo es interesante"
+msgstr "Varför detta fält är intressant"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:245
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:241
 msgid "Things to be aware of about this field"
-msgstr "Cosas a tener en cuenta sobre este campo"
+msgstr "Saker att tänka på när det gäller detta fält"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:257
 #: frontend/src/metabase/reference/databases/FieldList.jsx:159
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:253
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:160
 msgid "Data type"
-msgstr "Tipo de dato"
+msgstr "Datatyp"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:39
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:39
 msgid "Fields in this table will appear here as they're added"
-msgstr "Los campos en esta tabla aparecerán aquí a medida que se añadan"
+msgstr "Fält i denna tabell kommer att visas här vartefter de läggs till"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:137
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
-msgstr "Campos en {0}"
+msgstr "Fält i {0}"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:153
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:154
 msgid "Field name"
-msgstr "Nombre de campo"
+msgstr "Fältnamn"
 
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:46
 msgid "X-ray this field"
-msgstr "Aplica rayos-X a este campo"
+msgstr "Genomlys detta fält"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:8
 msgid "Metabase is no fun without any data"
-msgstr "Metabase no es divertido sin datos"
+msgstr "Metabase är inte roligt utan några data"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:9
 msgid "Your databases will appear here once you connect one"
-msgstr "Tus bases de datos aparecerán aquí una vez que conectes una"
+msgstr "Din databas kommer att visas här när du kopplat den"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:10
 msgid "Databases will appear here once your admins have added some"
-msgstr "Las bases de datos aparecerán aquí una vez que los administradores hayan añadido algunas"
+msgstr "Databaser kommer att visas här när administratören har lagt till dem"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:12
 msgid "Connect a database"
-msgstr "Conecta una base de datos"
+msgstr "Koppla en databas"
 
 #. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
 #. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
-msgstr "Número de {0}"
+msgstr "Antal {0}"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:47
 msgid "See raw data for {0}"
-msgstr "Ver datos de {0}"
+msgstr "Visa rådata för {0}"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:213
 msgid "Why this table is interesting"
-msgstr "Por qué esta tabla es interesante"
+msgstr "Varför denna tabell är intressant"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:223
 msgid "Things to be aware of about this table"
-msgstr "Cosas a tener en cuenta sobre esta tabla"
+msgstr "Saker att tänka på när det gäller denna tabell"
 
 #: frontend/src/metabase/reference/databases/TableList.jsx:29
 msgid "Tables in this database will appear here as they're added"
-msgstr "Las tablas en esta base de datos aparecerán aquí cuando se añadan"
+msgstr "Tabeller i denna databas kommer att visas här i den takt de läggs till"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:33
 msgid "Questions about this table will appear here as they're added"
-msgstr "Las preguntas sobre esta tabla aparecerán aquí cuando se añadan"
+msgstr "Frågor om denna tabell kommer att visas här i den takt de läggs till"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:73
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:77
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:76
 msgid "Questions about {0}"
-msgstr "Preguntas sobre {0}"
+msgstr "Frågor om {0}"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
 msgid "Created {0} by {1}"
-msgstr "Creado hace {0} por {1}"
+msgstr "Skapad {0} av {1}"
 
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:40
 msgid "Fields in this table"
-msgstr "Campos en esta tabla"
+msgstr "Fält i denna tabell"
 
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:46
 msgid "Questions about this table"
-msgstr "Preguntas sobre esta tabla"
+msgstr "Frågor om denna tabell"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
-msgstr "Ayuda a tu equipo a empezar con tus datos."
+msgstr "Hjälp din grupp att komma igång med era data"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
-msgstr "Muestra a tu equipo lo que es más importante al elegir tu cuadro de mando, tus métricas y tus segmentos principales."
+msgstr "Visa din grupp vad som är viktigast genom att välja de översta instrumentpanelerna, måtten och segmenten."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
-msgstr "Empieza"
+msgstr "Komma igång"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
-msgstr "Nuestro cuadro de mando más importante"
+msgstr "Vår viktigast instrumentpanel"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
-msgstr "Números a los que prestamos atención"
+msgstr "Siffror vi har koll på"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
-msgstr "Las métricas son números destacados que le importan a tu empresa. A menudo representan un indicador central de cómo está funcionando el negocio."
+msgstr "Mått är viktiga siffror för ditt företag. De representerar ofta ett nyckeltal kopplat till hur affärerna går."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
-msgstr "Ver todas las métricas"
+msgstr "Visa alla mått"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
-msgstr "Segmentos y tablas"
+msgstr "Segment och tabeller"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:82
 msgid "Tables"
-msgstr "Tablas"
+msgstr "Tabeller"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
-msgstr "Los segmentos y tablas son los componentes básicos de los datos de tu empresa. Las tablas son colecciones de información sin formato mientras que los segmentos son trozos acotados con significados específico, como {0}"
+msgstr "Segment och tabeller är byggklotsarna till ditt företags data. Tabeller är samlingar av rå information medan segmenten är utvalda delar med speciella betydelser, som {0}"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
-msgstr "Las tablas son los componentes básicos de los datos de tu empresa."
+msgstr "Tabeller är byggklotsarna till ditt företags data."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
-msgstr "Ver todos los segmentos"
+msgstr "Visa alla segment"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
-msgstr "Ver todas las tablas"
+msgstr "Visa alla tabeller"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
-msgstr "Otras cosas que debes saber sobre nuestros datos"
+msgstr "Anna information om era data"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
-msgstr "Descubre más"
+msgstr "Ta reda på mer"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
-msgstr "Una buena manera de conocer tus datos es dedicarle un poco de tiempo a explorar las diferentes tablas y otra información disponible. Puedes tardar un poco, pero comenzarás a reconocer nombres y significados con el tiempo."
+msgstr "Ett bra sätt att lära känna era data är att lägga lite tid på att utforska de olika tabellerna och annan tillgänglig information. Det kan ta ett tag, men du kommer att börja känna igen namn och betydelser över tid."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
-msgstr "Explora nuestros datos"
+msgstr "Utforska våra data"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
-msgstr "¿Tienes una pregunta?"
+msgstr "Några frågor?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
-msgstr "Habla con {0}"
+msgstr "Kontakta {0}"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
-msgstr "Ayuda a los nuevos usuarios de Metabase a encontrar su camino."
+msgstr "Hjälp Metabase-användare att orientera sig."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
-msgstr "La guía de introducción destaca el cuadro de mando, las métricas, los segmentos y las tablas que más importan, e informa a los usuarios sobre cosas importantes que deberían saber antes de profundizar en los datos."
+msgstr "Start-guiden belyser instrumentpaneler, mått, segment och tabeller som är viktiga, och informerar era användare om viktiga saker de bör känna till innan de börjar gräva i data."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
-msgstr "¿Hay un cuadro de mando importante para tu equipo?"
+msgstr "Finns det en viktig instrumentpanel för er grupp?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
-msgstr "Crea un cuadro de mando ahora"
+msgstr "Skapa en instrumentpanel nu"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
-msgstr "¿Cuál es tu cuadro de mando más importante?"
+msgstr "Vilken är din viktigaste instrumentpanel?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
-msgstr "¿Tienes alguna métrica comúnmente referenciada?"
+msgstr "Har ni några gemensamma mått som används?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
-msgstr "Aprende a definir una métrica"
+msgstr "Lär dig att definiera ett mått"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
-msgstr "¿Cuáles son las 3-5 métricas más comúnmente referenciadas?"
+msgstr "Vilka är era 3-5 vanligaste mått?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
-msgstr "Añade otra métrica"
+msgstr "Lägg till ytterligare ett mått"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
-msgstr "¿Tienes algún segmento o tabla comúnmente referenciado?"
+msgstr "Har ni några vanliga använda segment eller tabeller?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
-msgstr "Aprenda a crear un segmento"
+msgstr "Lär dig att skapa ett segment"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
-msgstr "¿Cuáles son los 3-5 segmentos o tablas comúnmente referenciados que serían útiles paraesta audiencia?"
+msgstr "Vilka är de 3-5 vanligaste använda segment och tabeller som skulle vara användbara i detta forum?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
-msgstr "Añade otro segmento o tabla"
+msgstr "Lägg till ytterligare ett segment eller en tabell"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
-msgstr "¿Hay algo que tus usuarios deberían entender o saber antes de que comiencen a acceder a los datos?"
+msgstr "Finns det något annat era användare behöver förstå eller känna till innan de börjar accessa data?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
-msgstr "¿Qué debe saber un usuario de estos datos antes de que comiencen a acceder a ellos?"
+msgstr "Vad behöver en användare av detta data känna till innan de börjar använda det?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
-msgstr "Por ejemplo, las expectativas sobre la privacidad y el uso de datos, peligros comunes o malentendidos, información sobre el rendimiento del almacén de datos, avisos legales, etc."
+msgstr "T.ex förväntningar gällande sekretess och användning, vanliga fel eller missförstånd, information om serverprestanda, lagkrav osv."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
-msgstr "¿Hay alguien con quien tus usuarios puedan contactar si necesitan ayuda si están confundidos acerca de esta guía?"
+msgstr "Finns det någon era användare kan kontakta för att få hjälp om de blir förvirrade av denna guide?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
-msgstr "¿A quién deben contactar los usuarios para obtener ayuda si están confundidos acerca de esta información?"
+msgstr "Vem ska era användare kontakt för att få hjälp om de blir förvirrade av detta data?"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:76
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:97
 msgid "Please enter a revision message"
-msgstr "Por favor añade un mensaje de revisión"
+msgstr "Ange ett versionsmeddelande"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
-msgstr "Por qué esta métrica es interesante"
+msgstr "Varför detta mått är intressant"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
-msgstr "Cosas a tener en cuenta acerca de esta métrica"
+msgstr "Saker att tänka på när det gäller detta mått"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
-msgstr "Cómo se calcula esta métrica"
+msgstr "Hur detta mått räknas ut"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:240
 msgid "Nothing on how it's calculated yet"
-msgstr "Nada sobre cómo se calculó aún"
+msgstr "Ingen information om hur det räknas ut ännu"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:297
 msgid "Other fields you can group this metric by"
-msgstr "Otros campos por los que puedes agrupar esta métrica"
+msgstr "Andra fält som du kan gruppera detta mått mot"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:298
 msgid "Fields you can group this metric by"
-msgstr "Campos por los que puedes agrupar esta métrica"
+msgstr "Fält som du kan gruppera mot detta mått"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:24
 msgid "Metrics are the official numbers that your team cares about"
-msgstr "Las métricas son los números oficiales de los que tu equipo se preocupa"
+msgstr "Mått är officiella siffror som din grupp bryr sig om"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Metrics will appear here once your admins have created some"
-msgstr "Las métricas aparecerán aquí una vez que tus administradores hayan creado algunas"
+msgstr "Mått kommer att synas här varter din administratör skapar dem"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:28
 msgid "Learn how to create metrics"
-msgstr "Aprende cómo crear métricas"
+msgstr "Lär dig skapa mått"
 
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:34
 msgid "Questions about this metric will appear here as they're added"
-msgstr "Las preguntas sobre esta métrica aparecerán aquí cuando se añadan"
+msgstr "Frågor om detta mått kommer att synas här när de lagts till"
 
 #: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:29
 msgid "There are no revisions for this metric"
-msgstr "No hay revisiones para esta métrica"
+msgstr "Det finns inga versioner av detta mått"
 
 #: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:52
 #: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:90
 msgid "Revision history for {0}"
-msgstr "Historial de revisiones de {0}"
+msgstr "Versionshistorik för {0}"
 
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:44
 msgid "X-ray this metric"
-msgstr "Aplica rayos-X a esta métrica"
+msgstr "Genomlys detta mått"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:246
 msgid "Why this Segment is interesting"
-msgstr "Por qué este segmento es interesante"
+msgstr "Varför detta segment är intressant"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:256
 msgid "Things to be aware of about this Segment"
-msgstr "Cosas a tener en cuenta sobre este segmento"
+msgstr "Saker att tänka på när det gäller detta mått"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:23
 msgid "Segments are interesting subsets of tables"
-msgstr "Los segmentos son subconjuntos interesantes de tablas"
+msgstr "Segment är intressanta delmängder av tabeller"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Defining common segments for your team makes it even easier to ask questions"
-msgstr "La definición de segmentos comunes para tu equipo hace que sea aún más fácil hacer preguntas"
+msgstr "Genom att definiera vanliga segment för er grupp gör du det ännu enklare att ställa frågor"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Segments will appear here once your admins have created some"
-msgstr "Los segmentos aparecerán aquí una vez que los administradores hayan creado algunos"
+msgstr "Segment kommer att visas här när din administratör lagt upp dem"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:27
 msgid "Learn how to create segments"
-msgstr "Aprende a crear segmentos"
+msgstr "Lär dig skapa segment"
 
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:34
 msgid "Questions about this segment will appear here as they're added"
-msgstr "Las preguntas sobre este segmento aparecerán aquí cuando se añadan"
+msgstr "Frågor om detta segment kommer att visas här när de lagts till"
 
 #: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:28
 msgid "There are no revisions for this segment"
-msgstr "No hay revisiones para este segmento"
+msgstr "Det finns inga versioner att detta mått"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:37
 msgid "Fields in this segment"
-msgstr "Campos en este segmento"
+msgstr "Fält i detta segment"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:43
 msgid "Questions about this segment"
-msgstr "Preguntas sobre este segmento"
+msgstr "Frågor om detta segment"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:50
 msgid "X-ray this segment"
-msgstr "Aplica rayos-X a este segmento"
+msgstr "Genomlys detta segment"
 
 #: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
 msgid "Login"
-msgstr "Iniciar sesión"
+msgstr "Inloggning"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:303
 #: frontend/src/metabase/containers/ItemPicker.jsx:115
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
 #: frontend/src/metabase/routes.jsx:195
 msgid "Search"
-msgstr "Buscar"
+msgstr "Sök"
 
 #: frontend/src/metabase/routes.jsx:214
 msgid "Dashboard"
-msgstr "Cuadro de Mando"
+msgstr "Instrumentpanel"
 
 #: frontend/src/metabase/routes.jsx:227
 msgid "New Question"
-msgstr "Nueva Pregunta"
+msgstr "Ny fråga"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:127
 msgid "Select the type of Database you use"
-msgstr "Selecciona el tipo de base de datos que utilizas"
+msgstr "Välj den databas du vill använda"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:103
 msgid "Add your data"
-msgstr "Añade tus datos"
+msgstr "Lägg till dina data"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:107
 msgid "I'll add my own data later"
-msgstr "Añadiré mis propios datos más tarde"
+msgstr "Jag lägger till mina data senare"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:108
 msgid "Connecting to {0}"
-msgstr "Conectando con {0}"
+msgstr "Ansluter till {0}"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:130
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
-msgstr "Necesitarás información sobre tu base de datos, como el nombre de usuario y la contraseña. Si no tienes eso ahora mismo, Metabase también viene con un conjunto de datos de muestra con los que puedes empezar."
+msgstr "Du kommer att behöva en del information om din database, som t.ex användarnamn och lösenord. Om du inte har det just nu, har Metabase också exempeldata som du kan komma igång med."
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my data later"
-msgstr "Añadiré mis datos más tarde"
+msgstr "Jag lägger till mina data senare"
 
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:42
 msgid "Control automatic scans"
-msgstr "Control de escaneos automáticos"
+msgstr "Styr automatiska sökningar"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:59
 msgid "Usage data preferences"
-msgstr "Preferencias de uso de datos"
+msgstr "Alternativ för användningshistorik"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:62
 msgid "Thanks for helping us improve"
-msgstr "Gracias por ayudarnos a mejorar"
+msgstr "Tack för att du hjälper oss bli bättre"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:63
 msgid "We won't collect any usage events"
-msgstr "No recopilaremos ningún evento de uso"
+msgstr "Vi kommer inte att samla in någon användningsstatistik"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:88
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
-msgstr "Para ayudarnos a mejorar Metabase, nos gustaría recopilar cierta información sobre el uso a través de Google Analytics."
+msgstr "För att kunna göra Metabase bättre skulle vi vilja samla in vissa data om användning via Google Analytics"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Here's a full list of everything we track and why."
-msgstr "Aquí hay una lista completa de todo lo que rastreamos y por qué."
+msgstr "Här är en fullständig lista över vad vi spårar och varför."
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
 msgid "Allow Metabase to anonymously collect usage events"
-msgstr "Permitir que Metabase recopile eventos de uso de forma anónima"
+msgstr "Tillåt Metabase att samla in anonym användningsdata"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
 msgid "Metabase {0} collects anything about your data or question results."
-msgstr "Metabase {0} recopila información sobre tus datos o resultados de preguntas."
+msgstr "Metabase {0} samlar in allt om din data och frågeresultat"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
 msgid "never"
-msgstr "nunca"
+msgstr "aldrig"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:119
 msgid "All collection is completely anonymous."
-msgstr "Toda la información obtenida es completamente anónima."
+msgstr "All insamling är helt anonym"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
-msgstr "La recopilación puede desactivarse en cualquier momento en la sección de configuración."
+msgstr "Insamling kan när som helst slås av i admin-inställningarna."
 
 #: frontend/src/metabase/setup/components/Setup.jsx:59
 msgid "If you feel stuck"
-msgstr "Si te sientes abrumado"
+msgstr "Om du har fastnat"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:64
 msgid "our getting started guide"
-msgstr "nuestra guía de inicio"
+msgstr "vår start-guide"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:65
 msgid "is just a click away."
-msgstr "esta a un solo click."
+msgstr "når du med bara ett klick"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:111
 msgid "Welcome to Metabase"
-msgstr "Bienvenid@ a Metabase"
+msgstr "Välkommen till Metabase"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:112
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
-msgstr "Parece que todo está funcionando. ¡Ahora vamos a conocerte, conectarte con tus datos y comenzar a encontrarte algunas respuestas!"
+msgstr "Det ser ut som allting fungerar. Låt oss nu lära känna dig, samla ihop data och börja hitta svar!"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:116
 msgid "Let's get started"
-msgstr "Empecemos"
+msgstr "Låt oss komma igång"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:166
 msgid "You're all set up!"
-msgstr "¡Estás listo!"
+msgstr "Nu är allt klart!"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:177
 msgid "Take me to Metabase"
-msgstr "Llévame a Metabase"
+msgstr "Gå vidare till Metabase"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:49
 msgid "What should we call you?"
-msgstr "¿Cómo deberíamos llamarte?"
+msgstr "Vad ska vi kalla dig?"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:156
 msgid "Hi, {0}. nice to meet you!"
-msgstr "Hola {0}, ¡Encantado de conocerte!"
+msgstr "Hej {0}, trevligt att träffas!"
 
 #: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
-msgstr "Crea una contraseña"
+msgstr "Skapa ett lösenord"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:44
 #: frontend/src/metabase/entities/users/forms.js:50
 #: frontend/src/metabase/entities/users/forms.js:97
 msgid "Shhh..."
-msgstr "Shhh..."
+msgstr "Schhh..."
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:265
 msgid "Confirm password"
-msgstr "Confirma la contraseña"
+msgstr "Bekräfta lösenord"
 
 #: frontend/src/metabase/entities/users/forms.js:57
 msgid "Shhh... but one more time so we get it right"
-msgstr "Shhh... otra vez, para asegurarnos que lo hacemos bien"
+msgstr "Schhh...men en gång till så vi får det rätt"
 
 #: frontend/src/metabase/entities/users/forms.js:85
 msgid "Your company or team name"
-msgstr "El nombre de tu empresa o equipo"
+msgstr "Ditt företags- eller gruppnamn"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:291
 msgid "Department of awesome"
-msgstr "Departamento impresionante"
+msgstr "Den fantastiska avdelningen"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:26
 msgid "Metabot is admiring your integers…"
-msgstr "Metabot está admirando tus enteros…"
+msgstr "Metabot beundrar dina heltal"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:27
 msgid "Metabot is performing billions of differential equations…"
-msgstr "Metabot está realizando miles de millones de ecuaciones diferenciales…"
+msgstr "Metabot genomför milljarder av olika ekvationer..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:28
 msgid "Metabot is doing science…"
-msgstr "Metabot está haciendo ciencia…"
+msgstr "Metabot kalkylerar..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:29
 msgid "Metabot is checking out your metrics…"
-msgstr "Metabot está revisando tus métricas…"
+msgstr "Metabot kontrollerar dina mått"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:30
 msgid "Metabot is looking for trends and outliers…"
-msgstr "Metabot está buscando tendencias y valores atípicos…"
+msgstr "Metabot letar efter trender och värden som sticker ut"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:31
 msgid "Metabot is consulting the quantum abacus…"
-msgstr "Metabot está consultando el ábaco cuántico…"
+msgstr "Metabot konsulterar kvant-abacus"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:32
 msgid "Metabot is feeling pretty good about all this…"
-msgstr "Metabot se siente bien con todo esto…"
+msgstr "Metabot tycker det hela känns bra.."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:52
 msgid "We’ll show you some interesting explorations of your data in\n"
 "just a few minutes."
-msgstr "Te mostraremos algunas exploraciones interesantes de tus datos\n"
-"en solo unos minutos."
+msgstr "Vi ska visa några intressanta fynd i dina data om bara ett par minuter"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:72
 msgid "This seems to be taking a while. In the meantime, you can check out one of these example explorations to see what Metabase can do for you."
-msgstr "Esto parece que está tardando un tiempo. Mientras tanto, puedes ver una de estas exploraciones de ejemplo para ver lo qué Metabase puede hacer por ti."
+msgstr "Detta verkar ta en stund. Under tiden kan du se några exempel på utforskande som Metabase kan göra för dig."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:86
 msgid "I took a look at the data you just connected, and I have some explorations of interesting things I found. Hope you like them!"
-msgstr "He revisado los datos que acabas de conectar, y tengo algunas exploraciones de cosas interesantes que he encontrado. ¡Espero que te gusten!"
+msgstr "Jag tog en titt på data du just kopplat upp och jag har några rön och intressanta fynd som jag hittat. Hoppas du tycker om dem!"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:98
 msgid "I'm done exploring for now"
-msgstr "He terminado de explorar por ahora"
+msgstr "Nu har jag utforskat klart för tillfället"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:20
 msgid "Welcome to the Query Builder!"
-msgstr "¡Bienvenido al Generador de Consultas!"
+msgstr "Välkommen till frågeguiden"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:22
 msgid "The Query Builder lets you assemble questions (or \"queries\") to ask about your data."
-msgstr "El generador de consultas te permite construir preguntas (o \"consultas\") para indagar sobre tus datos."
+msgstr "Frågeguiden låter dig sätta ihop frågor mot dina data"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:26
 msgid "Tell me more"
-msgstr "Dime más"
+msgstr "Berätta mer"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:43
 msgid "Start by picking the table with the data that you have a question about."
-msgstr "Empieza escogiendo la tabla con los datos sobre los que tienes una pregunta."
+msgstr "Börja genom att välja tabellen med data som du vill fråga om"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:45
 msgid "Go ahead and select the \"Orders\" table from the dropdown menu."
-msgstr "Adelante y selecciona la tabla  \"Pedidos\" en el menú desplegable."
+msgstr "Fortsätt genom att välja tabellen Orders från rullgardinsmenyn."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:78
 msgid "Filter your data to get just what you want."
-msgstr "Filtra tus datos para obtener exactamente lo que quieres."
+msgstr "Filtrera dina data för att få exakt det du vill ha"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:79
 msgid "Click the plus button and select the \"Created At\" field."
-msgstr "Haz clic en el botón más y selecciona el campo \"Created At\"."
+msgstr "Klicka på plus-knappen och välj fältet Created At."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:93
 msgid "Here we can pick how many days we want to see data for, try 10"
-msgstr "Aquí podemos elegir cuántos días queremos ver los datos, intenta con 10"
+msgstr "Här kan vi välja hur många dagar vi vill se data för. Prova med 10"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:116
 msgid "Here's where you can choose to add or average your data, count the number of rows in the table, or just view the raw data."
-msgstr "Aquí es donde puedes elegir agregar o promediar tus datos, contar el número de filas en la tabla, o simplemente ver los datos sin procesar."
+msgstr "Här kan du välja att lägga till eller ta genomsnitt av dina data, räkna antal rader i tabellen eller bara visa rådata."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:118
 msgid "Try it: click on <strong>Raw Data</strong> to change it to <strong>Count of rows</strong> so we can count how many orders there are in this table."
-msgstr "Pruébalo: haz clic en <strong>Datos brutos</ strong> para cambiarlo a <strong>Número de filas</ strong> para que podamos contar cuántas órdenes hay en esta tabla."
+msgstr "Prova den: Klicka på <strong>Rådata</strong> för att ändra den till <strong>Antal rader</strong> så att vi kan räkna hur många order det finns i denna tabell."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:142
 msgid "Add a grouping to break out your results by category, day, month, and more."
-msgstr "Añade una agrupación para dividir tus resultados por categoría, día, mes y más."
+msgstr "Lägg till en gruppering för att dela upp dina resultat på kategori, dag, månad och mer."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:144
 msgid "Let's do it: click on <strong>Add a grouping</strong>, and choose <strong>Created At: by Week</strong>."
-msgstr "Hagámoslo: haz clic en <strong>Añadir una agrupación</ strong> y elige <strong>Created At: por semana</ strong>."
+msgstr "Då fortsätter vi. Klicka på <strong>Lägg till en gruppering</strong>, och välj <strong>Created At: veckovis</strong>."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:152
 msgid "Click on \"by day\" to change it to \"Week.\""
-msgstr "Haz clic en \"por día\" para cambiarlo a \"Semana\"."
+msgstr "Klicka på \"dagligen\" för att ändra det till \"vecka\""
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:173
 msgid "Run Your Query."
-msgstr "Ejecuta tu consulta."
+msgstr "Kör din fråga."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:175
 msgid "You're doing so well! Click <strong>Run query</strong> to get your results!"
-msgstr "¡Lo estás haciendo muy bien! Haz clic en <strong>Ejecutar consulta</ strong> para obtener tus resultados."
+msgstr "Det gick ju bra! Klicka på <strong>Kör fråga</strong> för att få dina resultat!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:192
 msgid "You can view your results as a chart instead of a table."
-msgstr "Puedes ver sus resultados como un gráfico en lugar de una tabla."
+msgstr "Du kan visa resultat som ett diagram istället för en tabell."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:194
 msgid "Everbody likes charts! Click the <strong>Visualization</strong> dropdown and select <strong>Line</strong>."
-msgstr "A todos nos gustan las gráficas! Haz clic en el menú desplegable <strong>Visualización</ strong> y selecciona <strong>Línea</ strong>."
+msgstr "Alla tycker om diagram. Klicka på val <strong>Visualisering</strong> och välj <strong>Linje</strong>"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:216
 msgid "Well done!"
-msgstr "¡Muy bien!"
+msgstr "Bra jobbat!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:218
 msgid "That's all! If you still have questions, check out our"
-msgstr "¡Eso es todo! Si aún tienes preguntas, revisas nuestra"
+msgstr "Det var allt! Om du fortfarande har frågor, titta i vår"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:223
 msgid "User's Guide"
-msgstr "Guía del Usuario"
+msgstr "Användarguide"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:223
 msgid "Have fun exploring your data!"
-msgstr "¡Diviértete explorando tus datos!"
+msgstr "Ha det så roligt när du utforskar dina data!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:226
 msgid "Thanks"
-msgstr "Gracias"
+msgstr "Tack"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:235
 msgid "Save Your Questions"
-msgstr "Guarda tus preguntas"
+msgstr "Spara dina frågor"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:237
 msgid "By the way, you can save your questions so you can refer to them later. Saved Questions can also be put into dashboards or Pulses."
-msgstr "Por cierto, puedes guardar tus preguntas para que puedas consultarlas más tarde.Las preguntas guardadas también se pueden poner en cuadros de mando o pulsos."
+msgstr "Förresten, du kan spara dina frågor för att referera till dem senare. Sparade frågor kan också läggas på instrumentpaneler och ögonblicksbilder"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:241
 msgid "Sounds good"
-msgstr "Suena bien"
+msgstr "Låter bra"
 
 #: frontend/src/metabase/tutorial/Tutorial.jsx:248
 msgid "Whoops!"
-msgstr "¡¡uy!!"
+msgstr "Hoppsan!"
 
 #: frontend/src/metabase/tutorial/Tutorial.jsx:249
 msgid "Sorry, it looks like something went wrong. Please try restarting the tutorial in a minute."
-msgstr "Lo siento, parece que algo salió mal. Intenta reiniciar el tutorial en un minuto."
+msgstr "Ursäkta, det ser ut som om något gick fel. Försök att starta om guiden om en minut."
 
 #: frontend/src/metabase/user/actions.js:34
 msgid "Password updated successfully!"
-msgstr "¡Contraseña actualizada correctamente!"
+msgstr "Lösenordet uppdaterat!"
 
 #: frontend/src/metabase/user/actions.js:53
 msgid "Account updated successfully!"
-msgstr "¡Cuenta actualizada con éxito!"
+msgstr "Kontot uppdaterat!"
 
 #: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
-msgstr "Contraseña actual"
+msgstr "Nuvarande lösenord"
 
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:137
 msgid "Sign in with Google Email address"
-msgstr "Inicia sesión con la dirección de correo electrónico de Google"
+msgstr "Logga in med epost-adress från Google"
 
 #: frontend/src/metabase/user/components/UserSettings.jsx:65
 msgid "User Details"
-msgstr "Detalles Usuario"
+msgstr "Användaruppgifter"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:344
 msgid "Reset to defaults"
-msgstr "Restablecer los valores predeterminados"
+msgstr "Återställ förval"
 
 #: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:167
 msgid "unknown map"
-msgstr "mapa desconocido"
+msgstr "okänd karta"
 
 #: frontend/src/metabase/visualizations/components/LeafletGridHeatMap.jsx:26
 msgid "Grid map requires binned longitude/latitude."
-msgstr "El mapa de cuadrícula requiere longitud/latitud agrupada."
+msgstr "Kartor med rutor kräver longitud/latitud"
 
 #: frontend/src/metabase/visualizations/components/LegendVertical.jsx:117
 msgid "more"
-msgstr "más"
+msgstr "mer"
 
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
-msgstr "¿Qué campos quieres usar para los ejes X e Y?"
+msgstr "Vilka fält vill du använda för X- och Y-axlar?"
 
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
-msgstr "Elige campos"
+msgstr "Väl fält"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:234
 msgid "Save as default view"
-msgstr "Guardar como vista predeterminada"
+msgstr "Spara som förvald vy"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Draw box to filter"
-msgstr "Dibujar cuadro para filtrar"
+msgstr "Drag ruta till filter"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Cancel filter"
-msgstr "Cancelar Filtro"
+msgstr "Avbryt filter"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:47
 msgid "Pin Map"
-msgstr "Mapa de Pin"
+msgstr "Knappnålskarta"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
 msgid "Unset"
-msgstr "Desmarcar"
+msgstr "Avmarkera"
 
 #: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
 msgid "Rows {0}-{1} of {2}"
-msgstr "Filas {0}-{1} de {2}"
+msgstr "Raderna {0}-{1} av {2}"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:206
 msgid "Data truncated to {0} rows."
-msgstr "Datos truncados a {0} filas."
+msgstr "Datat förkortades till {0} rader."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:403
 msgid "Could not find visualization"
-msgstr "No se pudo encontrar la visualización"
+msgstr "Kunde inte visa grafiskt"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:410
 msgid "Could not display this chart with this data."
-msgstr "No se pudo mostrar este gráfico con esta información."
+msgstr "Kunde inte visa diagrammet med denna data"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:533
 msgid "No results!"
-msgstr "¡Sin resultados!"
+msgstr "Inga resultat!"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:554
 msgid "Still Waiting..."
-msgstr "Esperando..."
+msgstr "Väntar fortfarande..."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:557
 msgid "This usually takes an average of {0}."
-msgstr "Esto suele tardar unos {0}."
+msgstr "Detta tar oftas ungefär {0}."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:563
 msgid "(This is a bit long for a dashboard)"
-msgstr "(Es un poco largo para un cuadro de mando)"
+msgstr "Detta är lite långt för en instrumentpanel"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:503
 msgid "This is usually pretty fast but seems to be taking awhile right now."
-msgstr "Esto suele ser bastante rápido, pero parece estar tardando en este momento."
+msgstr "Detta brukar gå fort, men det verkar ta en stund just nu."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "Select a field"
-msgstr "Selecciona un campo"
+msgstr "Välj ett fält"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:45
 msgid "error"
-msgstr "error"
+msgstr "fel"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:117
 msgid "Click and drag to change their order"
-msgstr "Pulsa y arrastra para cambiar el orden"
+msgstr "Klicka och dra för att ändra ordningen"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:130
 msgid "Add fields from the list below"
-msgstr "Añade campos de la lista inferior"
+msgstr "Lägg till fält från listan nedan"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:24
 msgid "less than"
-msgstr "menor que"
+msgstr "mindre än"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:25
 msgid "greater than"
-msgstr "mayor que"
+msgstr "större än"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:26
 msgid "less than or equal to"
-msgstr "menor o igual a"
+msgstr "mindre än eller lika med"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:27
 msgid "greater than or equal to"
-msgstr "nayor o igual a"
+msgstr "större än eller lika med"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:28
 msgid "equal to"
-msgstr "igual a"
+msgstr "lika med"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:29
 msgid "not equal to"
-msgstr "distinto a"
+msgstr "inte lika med"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:191
 msgid "Conditional formatting"
-msgstr "Formato condicional"
+msgstr "villkorad formattering"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:193
 msgid "You can add rules to make the cells in this table change color if\n"
 "they meet certain conditions."
-msgstr "Puedes añadir reglas para hacer que las celdas de esta tabla cambien\n"
-"de color si cumplen ciertas condiciones."
+msgstr "Du kan lägga till regler för att ändra färg på tabellens celler om de uppfyller vissa villkor"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:203
 msgid "Add a rule"
-msgstr "Añade una regla"
+msgstr "Lägg till en regel"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:208
 msgid "Rules will be applied in this order"
-msgstr "Las reglas se aplicarán en este orden"
+msgstr "Regler kommer att tillämpas i denna ordning"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:209
 msgid "Click and drag to reorder."
-msgstr "Pulsa y arrastra para cambiar el orden"
+msgstr "Klicka och dra för att ändra ordning"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:242
 msgid "No columns selected"
-msgstr "Ninguna columna seleccionada"
+msgstr "Inga kolumner valda"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:290
 msgid "Cells in this column will be tinted based on their values."
-msgstr "Las celdas en esta columna se colorearán según sus valores."
+msgstr "Celler i denna kolumn kommer att färgas beroende på värde"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:279
 msgid "When a cell in these columns is {0} it will be tinted this color."
-msgstr "Cuando una celda en estas columnas es {0}, estará teñida de este color."
+msgstr "När en cell i dessa kolumner är {0} kommer den att färgas med denna färg"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:313
 msgid "Which columns should be affected?"
-msgstr "¿A qué columnas se aplica?"
+msgstr "Vilka kolumner ska beröras?"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:335
 msgid "Formatting style"
-msgstr "Estilo de formato"
+msgstr "Formatteringsstil"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:339
 msgid "Single color"
-msgstr "Color único"
+msgstr "Ren färg"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:340
 msgid "Color range"
-msgstr "Rango de Color"
+msgstr "Färgintervall"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:312
 msgid "When a cell in this column is…"
-msgstr "Cuando una celda en esta columna es…"
+msgstr "När en cell i denna kolumn är.."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:376
 msgid "…turn its background this color:"
-msgstr "…pinta el fondo de este color:"
+msgstr "..växla dess bakgrund till denna färg:"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:382
 msgid "Highlight the whole row"
-msgstr "Resalta la fila entera"
+msgstr "Markera hela raden"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
 msgid "Colors"
-msgstr "Colores"
+msgstr "Färger"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:404
 msgid "Start the range at"
-msgstr "Empieza el rango en"
+msgstr "Börja intervallet på"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:409
 msgid "Smallest value in this column"
-msgstr "El valor más pequeño en esta columna"
+msgstr "Lägsta värdet i denna kolumn"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:411
 msgid "Smallest value in each column"
-msgstr "El valor más pequeño en cada columna"
+msgstr "Lägsta värdet i varje kolumn"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:413
 msgid "Smallest value in all of these columns"
-msgstr "El valor más pequeño en todas estas columnas"
+msgstr "Lägstsa värdet i alla dessa kolumner"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:417
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:441
 msgid "Custom value"
-msgstr "Valor personalizado"
+msgstr "Valfritt värde"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:428
 msgid "End the range at"
-msgstr "Finaliza el rango en"
+msgstr "Avsluta intervallet på"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:433
 msgid "Largest value in this column"
-msgstr "El valor más grande en esta columna"
+msgstr "Högsta värdet i denna kolumn"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:435
 msgid "Largest value in each column"
-msgstr "El valor más grande en cada columna"
+msgstr "Högsta värdet i varje kolumn"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:437
 msgid "Largest value in all of these columns"
-msgstr "El valor más grande en todas estas columnas"
+msgstr "Högsta värdet i alla dessa kolumner"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:471
 msgid "Add rule"
-msgstr "Añadir regla"
+msgstr "Lägg till regel"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:471
 msgid "Update rule"
-msgstr "Actualizar regla"
+msgstr "Uppdatera regel"
 
 #: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
-msgstr "Visualización Vacía"
+msgstr "Visualiseringen är tom"
 
 #: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
-msgstr "La visualización debe definir una variable estática 'identificadora':"
+msgstr "Visualiseringen måste definiera en statisk variabel som \"identifiering\": "
 
 #: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
-msgstr "La visualización con ese identificador ya está registrada:"
+msgstr "Visualisering med den identifieraren finns redan registrerad: "
 
 #: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
-msgstr "No hay visualización para {0}"
+msgstr "Ingen visualisering för {0}"
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
-msgstr "\"{0}\" es un campo no agregado: si tienes más de un valor en un punto en el eje X, los valores se sumarán."
+msgstr "{0} är ett sammansatt fält: om det har mer än ett värde på ett ställe på x-axeln kommer värdena att slås samman."
 
 #: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:93
 msgid "This chart type requires at least 2 columns."
-msgstr "Este tipo de gráfico requiere al menos 2 columnas."
+msgstr "Denna diagramtyp kräver minst två kolumner."
 
 #: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:98
 msgid "This chart type doesn't support more than {0} series of data."
-msgstr "Este tipo de gráfico no admite más de {0} series de datos."
+msgstr "Detta diagram kan inte hantera mer än {0} dataserier."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:297
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
-msgstr "Objetivo"
+msgstr "Mål"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
-msgstr "Vaya! Los datos de tu consulta no se ajustan a la opción de visualización elegida. Esta visualización requiere al menos {0} {1} de datos."
+msgstr "Såklart! Datat i din fråga passar inte denna visning. Den kräver minst {0} {1} data."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
@@ -6749,197 +6731,197 @@ msgstr "Vaya! Los datos de tu consulta no se ajustan a la opción de visualizaci
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
-msgstr "columna"
+msgstr "kolumn"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:23
 msgid "No dice. We have {0} data {1} to show and that's not enough for this visualization."
-msgstr "No hay suerte. Tenemos {0} datos {1} para mostrar pero no es suficiente para esta visualización."
+msgstr "Omöjligt. Vi har {0} data {1} att visa och det räcker inte för denna visualisering."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:23
 msgid "point"
 msgid_plural "points"
-msgstr[0] "punto"
-msgstr[1] "puntos"
+msgstr[0] "punkt"
+msgstr[1] "punkter"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:35
 msgid "Bummer. We can't actually do a pin map for this data because we require both a latitude and longitude column."
-msgstr "Vaya. No podemos hacer un mapa de pin para estos datos porque necesitamos una columna de latitud y longitud."
+msgstr "Äsch. Vi kan inte visa en knappnålskarta för denna data eftersom vi behöver både latitud- och longitud-kolumn."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:55
 msgid "Please configure this chart in the chart settings"
-msgstr "Por favor, configura este gráfico en la configuración del gráfico"
+msgstr "Konfigurera detta diagram i diagram-inställningarna"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:57
 msgid "Edit Settings"
-msgstr "Editar Configuración"
+msgstr "Redigera inställningar"
 
 #: frontend/src/metabase/visualizations/lib/fill_data.js:39
 msgid "xValues missing!"
-msgstr "¡Faltan valores x!"
+msgstr "X-värden saknas!"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
 msgid "X-axis"
-msgstr "Eje-X"
+msgstr "X-axeln"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
-msgstr "Añade un desglose de series..."
+msgstr "Lägg till en talföljd för utbrytning"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
 msgid "Y-axis"
-msgstr "Eje-Y"
+msgstr "Y-axeln"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
-msgstr "Añade otra serie..."
+msgstr "Lägg till ytterligare en talföljd"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
-msgstr "Tamaño de burbuja"
+msgstr "Bubbel-storlek"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
 #: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
 msgid "Line"
-msgstr "Línea"
+msgstr "Linje"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:72
 msgid "Curve"
-msgstr "Curva"
+msgstr "Kurva"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
-msgstr "Paso"
+msgstr "Steg"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:170
 msgid "Show point markers on lines"
-msgstr "Mostrar marcadores de puntos en líneas"
+msgstr "Visa punktmarkörer på linjer"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
-msgstr "Apilado"
+msgstr "Stapling"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
-msgstr "No Apilado"
+msgstr "Stapla inte"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
-msgstr "Apilar"
+msgstr "Stapel"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
-msgstr "Apilado - 100%"
+msgstr "Stapel - 100%"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
-msgstr "Mostrar objetivo"
+msgstr "Visa mål"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
-msgstr "Valor del Objetivo"
+msgstr "Målvärde"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:103
 msgid "Replace missing values with"
-msgstr "Reemplazar los valores faltantes con"
+msgstr "Ersätt saknade värden med"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:107
 msgid "Zero"
-msgstr "Cero"
+msgstr "Noll"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:108
 msgid "Nothing"
-msgstr "Nada"
+msgstr "Inget"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:109
 msgid "Linear Interpolated"
-msgstr "Lineal Interpolado"
+msgstr "Linjär interpolation"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
-msgstr "Escala Eje-X"
+msgstr "Skala på X-axel"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
-msgstr "Series de tiempo"
+msgstr "Tidsserier"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:425
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:443
 msgid "Linear"
-msgstr "Lineal"
+msgstr "Linjär"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:444
 msgid "Power"
-msgstr "Exponente"
+msgstr "Dignitet"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:428
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:445
 msgid "Log"
-msgstr "Logarítmico"
+msgstr "Log"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:430
 msgid "Histogram"
-msgstr "Histograma"
+msgstr "Histogram"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
-msgstr "Ordinal"
+msgstr "Ordningstal"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
-msgstr "Escala Eje-Y"
+msgstr "Skala på Y-axel"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
-msgstr "Mostrar línea y marcas del Eje-X"
+msgstr "Visa x-axelns linje och markeringar"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:349
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:457
 msgid "Compact"
-msgstr "Compacto"
+msgstr "Kompakt"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:458
 msgid "Rotate 45°"
-msgstr "Rotar 45°"
+msgstr "Rotera 45°"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:459
 msgid "Rotate 90°"
-msgstr "Rotar 90°"
+msgstr "Rotera 90°"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:466
 msgid "Show y-axis line and marks"
-msgstr "Mostrar línea y marcas del Eje-Y"
+msgstr "Visa y-axelns linje och markeringar"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Auto y-axis range"
-msgstr "Rango del Eje-Y automático"
+msgstr "Automatiskt omfång på y-axeln"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:522
 msgid "Use a split y-axis when necessary"
-msgstr "Utiliza un Eje-Y dividido cuando sea necesario"
+msgstr "Använd en delad y-axel när så krävs"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:529
 msgid "Show label on x-axis"
-msgstr "Mostrar etiqueta en el Eje-X"
+msgstr "Visa benämningar på x-axeln"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:535
 msgid "X-axis label"
-msgstr "Etiqueta Eje-X"
+msgstr "Benämning på x-axeln"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:544
 msgid "Show label on y-axis"
-msgstr "Mostrar etiqueta en el Eje-Y"
+msgstr "Visa benämningar på y-axeln"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:550
 msgid "Y-axis label"
-msgstr "Etiqueta Eje-Y"
+msgstr "Benämning på y-axeln"
 
 #: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Standard Deviation"
-msgstr "Desviación Estándar"
+msgstr "Standardavvikelse"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
 #: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
@@ -6948,120 +6930,120 @@ msgstr "Area"
 
 #: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
 msgid "area chart"
-msgstr "Gráfico de área"
+msgstr "Area-diagram"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
 #: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
 msgid "Bar"
-msgstr "Barra"
+msgstr "Stapel"
 
 #: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
 msgid "bar chart"
-msgstr "Gráfico de barras"
+msgstr "Stapeldiagram"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
-msgstr "¿Qué campos quieres usar?"
+msgstr "Vilka fält vill du använda?"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
-msgstr "Embudo"
+msgstr "Tratt"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
 msgid "Measure"
-msgstr "Medida"
+msgstr "Mätetal"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
-msgstr "Tipo Embudo"
+msgstr "Typ av tratt"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
-msgstr "Gráfico de barras"
+msgstr "Stapeldiagram"
 
 #: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
 msgid "line chart"
-msgstr "Gráfico de líneas"
+msgstr "linje-diagram"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
 msgid "Please select longitude and latitude columns in the chart settings."
-msgstr "Selecciona las columnas de longitud y latitud en la configuración del gráfico."
+msgstr "Välj kolumner för longitud och latitud i diagraminställningarna"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
 msgid "Please select a region map."
-msgstr "Por favor, selecciona un mapa de la región."
+msgstr "Välj en region-karta"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
 msgid "Please select region and metric columns in the chart settings."
-msgstr "Selecciona las columnas de región y métricas en la configuración del gráfico."
+msgstr "Välj region- och mått-kolumner i diagraminställningarna"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
 msgid "Map"
-msgstr "Mapa"
+msgstr "Karta"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
 msgid "Map type"
-msgstr "Tipo mapa"
+msgstr "Karttyp"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
 msgid "Region map"
-msgstr "Mapa de la región"
+msgstr "Regionkarta"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
 msgid "Pin map"
-msgstr "Mapa de pin"
+msgstr "Knappnålskarta"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
 msgid "Pin type"
-msgstr "Tipo Pin"
+msgstr "Knappnålstyp"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Tiles"
-msgstr "Baldosas"
+msgstr "Plattor"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
 msgid "Markers"
-msgstr "Marcadores"
+msgstr "Markörer"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
 msgid "Latitude field"
-msgstr "Campo Latitud"
+msgstr "Latitud-fält"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
 msgid "Longitude field"
-msgstr "Campo Longitud"
+msgstr "Longitud-fält"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
 msgid "Metric field"
-msgstr "Campo Métrica"
+msgstr "Meter-fält"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
 msgid "Region field"
-msgstr "Campo Región"
+msgstr "Region-fält"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
 msgid "Radius"
-msgstr "Radio"
+msgstr "Radie"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
 msgid "Blur"
-msgstr "Difuminar"
+msgstr "Suddighet"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
 msgid "Min Opacity"
-msgstr "Opacidad Mínima"
+msgstr "Minsta genomskinlighet"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
 msgid "Max Zoom"
-msgstr "Acercamiento Máximo"
+msgstr "Maximal zoom"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:234
 msgid "No relationships found."
-msgstr "No se encontraron relaciones."
+msgstr "Hittade inga relationer"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:272
 msgid "via {0}"
@@ -7069,394 +7051,394 @@ msgstr "via {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
 msgid "This {0} is connected to:"
-msgstr "Esta {0} está conectada a:"
+msgstr "Denna {0} är kopplad till:"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "Object Detail"
-msgstr "Detalle del Objeto"
+msgstr "Objektdetaljer"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:93
 msgid "object"
-msgstr "objeto"
+msgstr "objekt"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
 msgid "Total"
-msgstr "Total"
+msgstr "Totalt"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
 msgid "Which columns do you want to use?"
-msgstr "¿Qué columnas quieres usar?"
+msgstr "Vilka kolumner vill du använda?"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
 msgid "Pie"
-msgstr "Pastel"
+msgstr "Paj"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
 msgid "Dimension"
-msgstr "Dimensión"
+msgstr "Dimension"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
 msgid "Show legend"
-msgstr "Mostrar Leyenda"
+msgstr "Visa teckenförklaring"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
 msgid "Show percentages in legend"
-msgstr "Mostrar porcentajes en la leyenda"
+msgstr "Visa procenttal i teckenförklaring"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
 msgid "Minimum slice percentage"
-msgstr "Porcentaje mínimo de porción"
+msgstr "Minsta procenttal i pajdel"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
-msgstr "Objetivo conseguido"
+msgstr "Målet nått"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
-msgstr "Objetivo superado"
+msgstr "Mål överskridet"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
-msgstr "Objetivo {0}"
+msgstr "Mål {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
-msgstr "La visualización del progreso requiere un número."
+msgstr "Visualisering av framsteg kräver en siffra"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:27
 msgid "Progress"
-msgstr "Progreso"
+msgstr "Framsteg"
 
 #: frontend/src/metabase/entities/collections.js:109
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
-msgstr "Color"
+msgstr "Färg"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row Chart"
-msgstr "Gráfico de Filas"
+msgstr "Rad-diagram"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
 msgid "row chart"
-msgstr "gráfico de filas"
+msgstr "rad-diagram"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:381
 msgid "Separator style"
-msgstr "Estilo separador"
+msgstr "Avdelare"
 
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:88
 msgid "Number of decimal places"
-msgstr "Número de decimales"
+msgstr "Antal decimaler"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:405
 msgid "Add a prefix"
-msgstr "Añade un prefijo"
+msgstr "Lägg till ett prefix"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:409
 msgid "Add a suffix"
-msgstr "Añade un sufijo"
+msgstr "Lägg till ett suffix"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:398
 msgid "Multiply by a number"
-msgstr "Multiplicar por un número"
+msgstr "Multiplicera med en siffra"
 
 #: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
 msgid "Scatter"
-msgstr "Dispersión"
+msgstr "Spridning"
 
 #: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
 msgid "scatter plot"
-msgstr "gráfico de dispersión"
+msgstr "spridningspunkt"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
 msgid "Pivot the table"
-msgstr "Pivote la tabla"
+msgstr "Tillämpa pivot på tabell"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:73
 msgid "Visible fields"
-msgstr "Campos visibles"
+msgstr "Synliga fält"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
 msgid "Write here, and use Markdown if you'd like"
-msgstr "Escribe aquí. Puedes utilizar Markdown"
+msgstr "Skriv här och använd märktext om du vill"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
 msgid "Vertical Alignment"
-msgstr "Alineamiento Vertical"
+msgstr "Vertikal placering"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:77
 msgid "Top"
-msgstr "Arriba:"
+msgstr "Toppen"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:78
 msgid "Middle"
-msgstr "Medio"
+msgstr "Mitten"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:79
 msgid "Bottom"
-msgstr "Abajo"
+msgstr "Botten"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:86
 msgid "Horizontal Alignment"
-msgstr "Alineamiento Horizontal"
+msgstr "Horisontal placering"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:126
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:90
 msgid "Left"
-msgstr "Izquierda"
+msgstr "Vänster"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:91
 msgid "Center"
-msgstr "Centro"
+msgstr "Centrerad"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:127
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:92
 msgid "Right"
-msgstr "Derecho"
+msgstr "Höger"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:99
 msgid "Show background"
-msgstr "Mostrar fondo"
+msgstr "Visa bakgrund"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:760
 msgid "{0} bin"
 msgid_plural "{0} bins"
-msgstr[0] "{0} agrupación"
-msgstr[1] "{0} agrupaciones"
+msgstr[0] "behållare {0}"
+msgstr[1] "behållarna {0}"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:766
 msgid "Auto binned"
-msgstr "Agrupación Auto"
+msgstr "Automatiskt lagd i behållare"
 
 #: src/metabase/api/alert.clj
 msgid "DELETE /api/alert/:id is deprecated. Instead, change its `archived` value via PUT /api/alert/:id."
-msgstr "DELETE /api/alert/:id esta descontinuado. Cambia el valor de `archived` via PUT /api/alert/:id."
+msgstr "DELETE /api/alert/:id är föråldrat. Ändra istället dess arkiverad-värde via PUT /api/alert/:id."
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid show value"
-msgstr "valor no válido para el campo mostrar"
+msgstr "felaktigt visningsvärde"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid value for prefix"
-msgstr "valor no válido para el prefijo"
+msgstr "felaktigt värde för prefix"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid value for rule name"
-msgstr "valor no válido para nombre de regla"
+msgstr "felaktigt värde för regelnamn"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "value couldn''t be parsed as base64 encoded JSON"
-msgstr "valor no se pudo analizar como JSON codificado base64"
+msgstr "värdet kunde inte tolkas som JSON base64 encoded"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "Invalid entity type"
-msgstr "Tipo de entidad inválida"
+msgstr "Felaktig entitetstyp"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "Invalid comparison entity type. Can only be one of \"table\", \"segment\", or \"adhoc\""
-msgstr "Tipo de entidad de comparación inválida. Solo puede ser \"tabla\", \"segmento\" o \"adhoc\""
+msgstr "Felaktig jämförelsetyp - kan bara vara \"tabell\", \"segment\" eller \"adhoc\""
 
 #: src/metabase/query_processor/async.clj
 msgid "Error running query to determine Card result metadata:"
-msgstr "Error determinando el tipo de resultado de la tarjeta"
+msgstr "Fel vid körning av fråga för att fastställa metadata för lista"
 
 #: src/metabase/api/card.clj
 msgid "DELETE /api/card/:id is deprecated. Instead, change its `archived` value via PUT /api/card/:id."
-msgstr "DELETE /api/card/:id esta descontinuado. Cambia el valor de `archived` via PUT /api/card/:id."
+msgstr "DELETE /api/card/:id är föråldrat. Ändra istället dess arkiverad-värde via PUT /api/card/:id."
 
 #: src/metabase/api/common.clj src/metabase/api/common/internal.clj
 msgid "Invalid field: {0}"
-msgstr "Campo inválido: {0}"
+msgstr "Felaktigt fält {0}"
 
 #: src/metabase/api/common.clj
 msgid "Invalid value ''{0}'' for ''{1}'': {2}"
-msgstr "Valor inválido ''{0}'' para ''{1}'': {2}"
+msgstr "Felaktigt värde \"{0}\" för \"{1}\": {2}"
 
 #: src/metabase/api/common.clj
 msgid "must be one of: {0}"
-msgstr "debe ser uno de: {0}"
+msgstr "måste vara en av: {0}"
 
 #: src/metabase/api/common.clj
 msgid "Invalid Request."
-msgstr "Petición inválida."
+msgstr "Felaktig begäran"
 
 #: src/metabase/api/common.clj
 msgid "Not found."
-msgstr "No encontrado."
+msgstr "Hittades inte"
 
 #: src/metabase/api/common.clj
 msgid "You don''t have permissions to do that."
-msgstr "Lo siento, no tienes permiso para hacer eso."
+msgstr "Du har inte rättighet att göra det."
 
 #: src/metabase/api/common.clj
 msgid "Internal server error."
-msgstr "Error de servidor interno."
+msgstr "Internt serverfel."
 
 #: src/metabase/api/common.clj
 msgid "Warning: endpoint {0}/{1} does not have a docstring."
-msgstr "Aviso: la llamada {0}/{1} no tiene un docstring"
+msgstr "Varning: ändpunkten {0}/{1} har ingen \"docstring\"."
 
 #: src/metabase/api/common.clj
 msgid "starting streaming request"
-msgstr "iniciando streaming"
+msgstr "startar strömningsbegäran"
 
 #: src/metabase/async/api_response.clj
 msgid "connection closed, canceling request"
-msgstr "iniciando la solicitud de transmisión"
+msgstr "förbindelsen stängd, avbryter begäran"
 
 #. a newline padding character as it's harmless and will allow us to check if the client is connected. If
 #. sending this character fails because the connection is closed, the chan will then close.  Newlines are
 #. no-ops when reading JSON which this depends upon.
 #: src/metabase/async/api_response.clj
 msgid "Response not ready, writing one byte & sleeping..."
-msgstr "La respuesta no está lista, escribiendo un byte y esperando..."
+msgstr "Svaret inte tillgängligt, skriver en byte & pausar"
 
 #: src/metabase/api/common.clj
 msgid "Public sharing is not enabled."
-msgstr "La compartición pública no está habilitada."
+msgstr "Publik delning är inte aktiverad"
 
 #: src/metabase/api/common.clj
 msgid "Embedding is not enabled."
-msgstr "La incrustación no está habilitada."
+msgstr "Inbäddning är inte aktiverad"
 
 #: src/metabase/api/common.clj
 msgid "The object has been archived."
-msgstr "El objeto ha sido archivado."
+msgstr "Objektet har arkiverats."
 
 #: src/metabase/api/common/internal.clj
 msgid "Attempted to return a boolean as an API response. This is not allowed!"
-msgstr "Se ha intentado devolver un booleano como respuesta de API. ¡Esto no esta permitido!"
+msgstr "Försökte returnera en bolean som ett API-svar. Detta är inte tillåtet!"
 
 #: src/metabase/api/dataset.clj
 msgid "Source query for this query is Card {0}"
-msgstr "La consulta base de esta consulta es Tarjeta {0}"
+msgstr "Källfråga för detta är listan {0}"
 
 #: src/metabase/api/dataset.clj
 msgid "Invalid export format: {0}"
-msgstr "Formato de exportación inválido: {0}"
+msgstr "Felaktigt exportformat: {0}"
 
 #: src/metabase/api/geojson.clj
 msgid "Invalid JSON URL or resource: {0}"
-msgstr "Recurso o URL JSON no válido: {0}"
+msgstr "Felaktig JSON-URL eller resurs: {0}"
 
 #: src/metabase/api/geojson.clj
 msgid "JSON containing information about custom GeoJSON files for use in map visualizations instead of the default US State or World GeoJSON."
-msgstr "JSON que contiene información sobre archivos GeoJSON personalizados para su uso en visualizaciones de mapas en lugar del GeoJSON por defecto de EEUU o el Mundo."
+msgstr "JSON innehållande information om anpassade GeoJSON-filer för användning i kartvisningar istället för förvalt Amerikanska stater eller World GeoJSON."
 
 #: src/metabase/api/geojson.clj
 msgid "Invalid custom GeoJSON key: {0}"
-msgstr "Clave personalizada GeoJSON inválida: {0}"
+msgstr "Felaktig anpassad GeoJSON-nyckel: {0}"
 
 #. ...but if we *still* couldn't find a match, throw an Exception, because we don't want people
 #. trying to inject new params
 #: src/metabase/api/public.clj
 msgid "Invalid param: {0}"
-msgstr "Parámetro inválido: {0}"
+msgstr "Felaktig parameter: {0}"
 
 #: src/metabase/api/pulse.clj
 msgid "DELETE /api/pulse/:id is deprecated. Instead, change its `archived` value via PUT /api/pulse/:id."
-msgstr "DELETE /api/pulse/:id esta descontinuado. Cambia el valor de `archived` via PUT /api/pulse/:id."
+msgstr "DELETE /api/pulse/:id är föråldrad. Ändra istället dess arkiverad-värde med PUT /api/pulse/:id."
 
 #: src/metabase/api/routes.clj
 msgid "API endpoint does not exist."
-msgstr "No existe este servicio API"
+msgstr "API-ändpunkt existerar inte."
 
 #: src/metabase/api/session.clj
 msgid "Password did not match stored password."
-msgstr "La contraseña no coincide con la almacenada"
+msgstr "Lösenordet matchar inte det lagrade lösenordet."
 
 #: src/metabase/api/session.clj
 msgid "did not match stored password"
-msgstr "no coincide con la contraseña almacenada"
+msgstr "matchade inte lagrat lösenord"
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fallback to local authentication {0}"
-msgstr "Problema al conectar con el servidor LDAP, se recurrirá a la autentificación local {0}"
+msgstr "Problem med att ansluta till LDAP-server, kommer att återgå till lokal autentisering {0}"
 
 #: src/metabase/api/session.clj
 msgid "Invalid reset token"
-msgstr "Token de reinicio inválido"
+msgstr "Felaktigt återställningsbevis"
 
 #: src/metabase/api/session.clj
 msgid "Client ID for Google Auth SSO. If this is set, Google Auth is considered to be enabled."
-msgstr "ID de cliente para Google Auth SSO. Si esto está configurado, Google Auth se considera habilitado."
+msgstr "Klient-ID för Google Auth SSO. Om detta är satt förutsätts Google Auth vara aktiverat."
 
 #: src/metabase/api/session.clj
 msgid "When set, allow users to sign up on their own if their Google account email address is from this domain."
-msgstr "Permite que los usuarios se registren solos si la dirección de correo electrónico de su cuenta de Google es de este dominio."
+msgstr "När det är satt, tillåt använder att själva registrera sig om deras Google-epostadress tillhör denna domän."
 
 #: src/metabase/api/session.clj
 msgid "Invalid Google Auth token."
-msgstr "Token de autenticación de Google no válido"
+msgstr "Felaktig Google Auth-bevis"
 
 #: src/metabase/api/session.clj
 msgid "Email is not verified."
-msgstr "Correo no verificado."
+msgstr "Epost-adressen är inte verifierad"
 
 #: src/metabase/api/session.clj
 msgid "You''ll need an administrator to create a Metabase account before you can use Google to log in."
-msgstr "Necesitarás un administrador para crear una cuenta Metabase antes de poder usar Google para iniciar sesión."
+msgstr "Du behöver en administratör för att skapa ett Metabase-konto innan du kan använda Google för att logga in."
 
 #: src/metabase/api/session.clj
 msgid "Successfully authenticated Google Auth token for: {0} {1}"
-msgstr "Se ha autentificado con éxito el token de Google Auth para: {0} {1}"
+msgstr "Skapade autentiserad Google Auth-bevis för: {0} {1}"
 
 #: src/metabase/api/setup.clj
 msgid "Add a database"
-msgstr "Añade una Base de Datos"
+msgstr "Lägg  till en databas"
 
 #: src/metabase/api/setup.clj
 msgid "Get connected"
-msgstr "Conectarse"
+msgstr "Koppla upp dig"
 
 #: src/metabase/api/setup.clj
 msgid "Connect to your data so your whole team can start to explore."
-msgstr "Conecta tus datos para que todo el equipo pueda comenzar a explorar."
+msgstr "Koppla dina data så hela din grupp kan börja utforska."
 
 #: src/metabase/api/setup.clj
 msgid "Set up email"
-msgstr "Configura el email"
+msgstr "Sätt upp epost"
 
 #: src/metabase/api/setup.clj
 msgid "Add email credentials so you can more easily invite team members and get updates via Pulses."
-msgstr "Añade credenciales de correo electrónico para que puedas invitar más fácilmente a los miembros del equipo y obtener actualizaciones a través de Pulsos."
+msgstr "Lägg till epost-inställningar så att du lättare kan bjuda in gruppmedlemmar och få uppdateringar via ögonblicksbilder."
 
 #: src/metabase/api/setup.clj
 msgid "Set Slack credentials"
-msgstr "Establecer credenciales de Slack"
+msgstr "Sätt upp Slack-inställningar"
 
 #: src/metabase/api/setup.clj
 msgid "Does your team use Slack? If so, you can send automated updates via pulses and ask questions with MetaBot."
-msgstr "¿Tu equipo usa Slack? Si es así, puedes enviar actualizaciones automáticas por pulsos y hacer preguntas con MetaBot."
+msgstr "Använder din grupp Slack? Isåfall kan du skicka automatiska uppdateringar via ögonblicksbilder och ställa frågor via Metabot."
 
 #: src/metabase/api/setup.clj
 msgid "Invite team members"
-msgstr "Invitar a miembros del equipo"
+msgstr "Bjud in gruppmedlemmar"
 
 #: src/metabase/api/setup.clj
 msgid "Share answers and data with the rest of your team."
-msgstr "Comparte respuestas y datos con el resto de tu equipo."
+msgstr "Dela svar och data med resten av din grupp."
 
 #: src/metabase/api/setup.clj
 msgid "Hide irrelevant tables"
-msgstr "Ocultar tablas irrelevantes"
+msgstr "Dölj irrelevanta tabeller"
 
 #: src/metabase/api/setup.clj
 msgid "Curate your data"
-msgstr "Mima tus datos"
+msgstr "Korrigera dina data"
 
 #: src/metabase/api/setup.clj
 msgid "If your data contains technical or irrelevant info you can hide it."
-msgstr "Si tus datos contienen información técnica o irrelevante, puedes ocultarla."
+msgstr "Om dina data innehåller teknisk eller irrelevant information kan du dölja det."
 
 #: src/metabase/api/setup.clj
 msgid "Organize questions"
-msgstr "Organizar preguntas"
+msgstr "Organisera frågor"
 
 #: src/metabase/api/setup.clj
 msgid "Have a lot of saved questions in {0}? Create collections to help manage them and add context."
-msgstr "¿Tienes muchas preguntas guardadas en {0}? Crea colecciones para ayudar a administrarlas y añadir contexto."
+msgstr "Har du ett stort antal frågor sparade i {0}? Skapa samlingar för att hantera dem och lägga till beskrivningar"
 
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
@@ -7470,1826 +7452,1824 @@ msgstr "Metabase"
 
 #: src/metabase/api/setup.clj
 msgid "Create metrics"
-msgstr "Crear métricas"
+msgstr "Skapa mått"
 
 #: src/metabase/api/setup.clj
 msgid "Define canonical metrics to make it easier for the rest of your team to get the right answers."
-msgstr "Define métricas canónicas para que el resto de tu equipo obtenga las respuestas correctas."
+msgstr "Definiera styrande mått för att göra det enklare för resten av din grupp att få rätt svar."
 
 #: src/metabase/api/setup.clj
 msgid "Create segments"
-msgstr "Crear segmentos"
+msgstr "Skapa segment"
 
 #: src/metabase/api/setup.clj
 msgid "Keep everyone on the same page by creating canonical sets of filters anyone can use while asking questions."
-msgstr "Mantiene a todos en la misma página mediante la creación de conjuntos canónicos de filtros que cualquier persona puede usar al hacer preguntas."
+msgstr "Håll alla på rätt sida genom att skapa styrande filter som alla kan använda när frågor ställs."
 
 #: src/metabase/api/table.clj
 msgid "Table ''{0}'' is now visible. Resyncing."
-msgstr "Ha aparecido la tabla ''{0}''. Sincronizando."
+msgstr "Tabell \"{0}\" är nu synlig. Synkar om."
 
 #: src/metabase/api/table.clj
 msgid "Auto bin"
-msgstr "Agrupación Auto"
+msgstr "Auto-behållare"
 
 #: src/metabase/api/table.clj
 msgid "Don''t bin"
-msgstr "Sin Agrupación"
+msgstr "Lägg ej i behållare"
 
 #: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
-msgstr[0] "Día"
-msgstr[1] "Días"
+msgstr[0] "Dag"
+msgstr[1] "Dagar"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
 #: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
-msgstr[0] "Minuto"
-msgstr[1] "Minutos"
+msgstr[0] "Minut"
+msgstr[1] "Minuter"
 
 #: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
-msgstr[0] "Hora"
-msgstr[1] "Horas"
+msgstr[0] "Timme"
+msgstr[1] "Timmar"
 
 #: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
-msgstr[0] "Trimestre"
-msgstr[1] "Trimestres"
+msgstr[0] "Kvartal"
+msgstr[1] "Kvartal"
 
 #: src/metabase/api/table.clj
 msgid "Minute of Hour"
-msgstr "Minuto de Hora"
+msgstr "Specifik minut"
 
 #: src/metabase/api/table.clj
 msgid "Hour of Day"
-msgstr "Hora del Día"
+msgstr "Specifik timme"
 
 #: src/metabase/api/table.clj
 msgid "Day of Week"
-msgstr "Día de la Semana"
+msgstr "Veckodag"
 
 #: src/metabase/api/table.clj
 msgid "Day of Month"
-msgstr "Día del Mes"
+msgstr "Dag i månaden"
 
 #: src/metabase/api/table.clj
 msgid "Day of Year"
-msgstr "Día del Año"
+msgstr "Dag i året"
 
 #: src/metabase/api/table.clj
 msgid "Week of Year"
-msgstr "Semana del Año"
+msgstr "Vecka"
 
 #: src/metabase/api/table.clj
 msgid "Month of Year"
-msgstr "Mes del Año"
+msgstr "Månad"
 
 #: src/metabase/api/table.clj
 msgid "Quarter of Year"
-msgstr "Trimestre del Año"
+msgstr "Kvartal"
 
 #: src/metabase/api/table.clj
 msgid "10 bins"
-msgstr "10 agrupaciones"
+msgstr "10 behållare"
 
 #: src/metabase/api/table.clj
 msgid "50 bins"
-msgstr "50 agrupaciones"
+msgstr "50 behållare"
 
 #: src/metabase/api/table.clj
 msgid "100 bins"
-msgstr "100 agrupaciones"
+msgstr "100 behållare"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 0.1 degrees"
-msgstr "Agrupa cada 0.1 grados"
+msgstr "Behållare varje 0.1 grader"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 1 degree"
-msgstr "Agrupa cada 1 grado"
+msgstr "Behållare varje grad"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 10 degrees"
-msgstr "Agrupa cada 10 grados"
+msgstr "Behållare varje 10 grader"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 20 degrees"
-msgstr "Agrupa cada 20 grados"
+msgstr "Behållare varje 20 grader"
 
 #. returns `true` if successful -- see JavaDoc
 #: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
-msgstr "¡No se encontró un escritor de imágenes apropiado!"
+msgstr "Inget passande bildverktyg hittades"
 
 #: src/metabase/api/user.clj
 msgid "Email address already in use."
-msgstr "Dirección de Email ya en uso"
+msgstr "Epost-adressen används redan."
 
 #: src/metabase/api/user.clj
 msgid "Email address already associated to another user."
-msgstr "Dirección de Email asociado a otro usuario"
+msgstr "Epost-adressen är redan kopplad till en annan användare."
 
 #: src/metabase/api/user.clj
 msgid "Not able to reactivate an active user"
-msgstr "No se puede activar un usuario activo"
+msgstr "Kan inte åter-aktivera en aktiv användare"
 
 #: src/metabase/api/user.clj
 msgid "Invalid password"
-msgstr "Contraseña inválida"
+msgstr "Felaktigt lösenord"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "All {0}"
-msgstr "Todos los {0}"
+msgstr "Alla {0}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "{0}, all {1}"
-msgstr "{0}, todos {1}"
+msgstr "{0}, alla {1}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "Comparison of {0} and {1}"
-msgstr "Comparativa de {0} y {1}"
+msgstr "Jämförelse mellan {0} och {1}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "Automatically generated comparison dashboard comparing {0} and {1}"
-msgstr "Crea automáticamente comparativas de {0} y {1}"
+msgstr "Automatiskt skapad jämförelse-panel som jämför {0} och {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "sum"
-msgstr "suma"
+msgstr "summa"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "average"
-msgstr "media"
+msgstr "genomsnittlig"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "minumum"
-msgstr "mínimo"
+msgstr "minimum"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "maximum"
-msgstr "máximo"
+msgstr "maximum"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "distinct count"
-msgstr "Cuenta distinta"
+msgstr "distinkt antal"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "standard deviation"
-msgstr "desviación estándar"
+msgstr "standardavvikelse"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "cumulative count"
-msgstr "recuento acumulativo"
+msgstr "ackumulerat antal"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "cumulative sum"
-msgstr "suma acumulativa"
+msgstr "ackumulerad summa"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} and {1}"
-msgstr "{0} y {1}"
+msgstr "{0} och {1}"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
-msgstr "{0} de {1}"
+msgstr "{0} av {1}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
-msgstr "{0} por {1}"
+msgstr "{0} mot {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} in the {1} segment"
-msgstr "{0} en el segmento {1}"
+msgstr "{0} i segment {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} segment"
-msgstr "{0} segmento"
+msgstr "segment {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
 msgid_plural "{0} metrics"
-msgstr[0] "{0} métrica"
-msgstr[1] "{0} métricas"
+msgstr[0] "mätetal {0}"
+msgstr[1] "mätetalen {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
-msgstr "{0} campo"
+msgstr "fält {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "\"{0}\" question"
-msgstr "\"{0}\" pregunta"
+msgstr "fråga {0}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Compare with {0}"
-msgstr "Compara con {0}"
+msgstr "Jämför med {0}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Compare with entire dataset"
-msgstr "Compara con todos los datos"
+msgstr "Jämför med hela dataset"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Applying heuristic %s to %s."
-msgstr "Aplicando heurística %s a %s."
+msgstr "Tillämpa heuristik %s till %s."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Dimensions bindings:n%s"
-msgstr "Enlaces de dimensiones:n%s"
+msgstr "Dimensionsgränser:n%s"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Using definitions:nMetrics:n%snFilters:n%s"
-msgstr "Usando definicioness:nMétricas:n%snFiltros:n%s"
+msgstr "Använder definitionerna:nMetrics:n%snFilter:n%s"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Can''t create dashboard for {0}"
-msgstr "No se puede crear un cuadro de mando para {0}"
+msgstr "Kan inte skapa instrumentpanel för {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}st"
-msgstr "{0}º"
+msgstr "{0}sta"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}nd"
-msgstr "{0}º"
+msgstr "{0}dra"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}rd"
-msgstr "{0}º"
+msgstr "{0}dje"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}th"
-msgstr "{0}º"
+msgstr "{0}rde"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "at {0}"
-msgstr "via {0}"
+msgstr "vid {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "on {0}"
-msgstr "en {0}"
+msgstr "på {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in {0} week - {1}"
-msgstr "en {0} semana - {1}"
+msgstr "i vecka {0} - {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in {0}"
-msgstr "en {0}"
+msgstr "i {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in Q{0} - {1}"
-msgstr "in T{0} {1}"
+msgstr "i Q{0} - {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Q{0}"
-msgstr "T{0}"
+msgstr "Q{0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is {1}"
-msgstr "{0} es {1}"
+msgstr "{0} är {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is between {1} and {2}"
-msgstr "{0} está entre {1} y {2}"
+msgstr "{0} ligger mellan {1} och {2}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is between {1} and {2}; and {3} is between {4} and {5}"
-msgstr "{0} está entre {1} y {2} y {3} está entre {4} y {5}"
+msgstr "{0} ligger mellan {1} och {2}; och {3} ligger mellan {4} och {5}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "where {0}"
-msgstr "donde {0}"
+msgstr "där {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "A closer look at {0}"
-msgstr "Ver más detalles de {0}"
+msgstr "En närmare titt på {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "A closer look at the {0}"
-msgstr "Ver más detalles de {0}"
+msgstr "En närmare titt på den {0}"
 
 #: src/metabase/automagic_dashboards/populate.clj
 msgid "Adding %s cards to dashboard %s:n%s"
-msgstr "Añadiendo %s tarjetas al Cuadro de Mando %s:n%s"
+msgstr "Lägger till %s listor till kontrollpanelen %s:n%s"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "0 <= score <= {0}"
-msgstr "0 <= puntuación <= {0}"
+msgstr "0 <= ställning <= {0}"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "1 <= width <= {0}"
-msgstr "1 <= anchura <= {0}"
+msgstr "1 <> bredd <= {0}"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid metrics references"
-msgstr "Referencias de métricas válidas"
+msgstr "Giltiga måttreferenser"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid filters references"
-msgstr "Referencias de filtros válidos"
+msgstr "Giltiga filterreferenser"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid group references"
-msgstr "Referencias de grupos válidos"
+msgstr "Giltiga gruppreferencer"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid order_by references"
-msgstr "Referencias de ordenación válidas"
+msgstr "Giltiga sorteringsreferenser"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid dashboard filters references"
-msgstr "Referencias de filtros de cuadros de mando válidas"
+msgstr "Giltiga referenser till instrumentpanel-filter"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid dimension references"
-msgstr "Referencias de dimensiones válidas"
+msgstr "Giltiga referenser till dimensioner"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid card dimension references"
-msgstr "Referencias de dimensiones de tarjeta válidas"
+msgstr "Giltiga referenser till list-dimensioner"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Error parsing %s:n%s"
-msgstr "Error procesando %s:n%s"
+msgstr "Fel vid tolkning %s:n%s"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "No user found with email address ''{0}''. "
-msgstr "No se ha encontrado un usuario con email ''{0}''. "
+msgstr "Inget användare hittades med epost-adress \"{0}\". "
 
 #: src/metabase/cmd/reset_password.clj
 msgid "Please check the spelling and try again."
-msgstr "Por favor, verifícalo e intenta de nuevo"
+msgstr "Kontrollera stavningen och försök igen."
 
 #: src/metabase/cmd/reset_password.clj
 msgid "Resetting password for {0}..."
-msgstr "Restableciendo la contraseña de {0} ..."
+msgstr "Återställer lösenord för {0}..."
 
 #: src/metabase/cmd/reset_password.clj
 msgid "OK [[[{0}]]]"
-msgstr "VALE [[[{0}]]]"
+msgstr "OK [[[{0}]]]"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "FAIL [[[{0}]]]"
-msgstr "FALLO [[[{0}]]]"
+msgstr "MISSLYCKAD [[[{0}]]]"
 
 #: src/metabase/core.clj
 msgid "Please use the following URL to setup your Metabase installation:"
-msgstr "Utiliza la siguiente URL para configurar tu instalación de Metabase:"
+msgstr "Använd följande URL för att färdigställa din Metabase-installation"
 
 #: src/metabase/core.clj
 msgid "Metabase Shutting Down ..."
-msgstr "Apagando Metabase ..."
+msgstr "Metabase stängs ner..."
 
 #: src/metabase/core.clj
 msgid "Metabase Shutdown COMPLETE"
-msgstr "Metabase apagado correctamente"
+msgstr "Metabase nedstängd"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase version {0} ..."
-msgstr "Iniciando Metabase {0} ..."
+msgstr "Startar Metabase version {0}..."
 
 #: src/metabase/core.clj
 msgid "System timezone is ''{0}'' ..."
-msgstr "La zona horaria del sistema es ''{0}'' ..."
+msgstr "Systemets tidzon är \"{0}\"..."
 
 #. startup database.  validates connection & runs any necessary migrations
 #: src/metabase/core.clj
 msgid "Setting up and migrating Metabase DB. Please sit tight, this may take a minute..."
-msgstr "Configurando y migrando la base de datos de Metabase. Por favor, siéntate, esto puede tardar unos minutos ..."
+msgstr "Sätter upp och migrerar Metabase databas. Vänta - det kan ta en stund..."
 
 #: src/metabase/core.clj
 msgid "Looks like this is a new installation ... preparing setup wizard"
-msgstr "Parece que es una instalación nueva ... iniciando el asistente de configuración"
+msgstr "Det ser ut som om detta är en ny installation ... förbereder installationsguiden"
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization COMPLETE"
-msgstr "Inicialización de Metabase COMPLETADA"
+msgstr "Metabase uppsättning är klar"
 
 #: src/metabase/server.clj
 msgid "Launching Embedded Jetty Webserver with config:"
-msgstr "Iniciando el servidor embebido Jetty con la configuración:"
+msgstr "Startar inbyggda Jetty Webserver med konfiguration:"
 
 #: src/metabase/server.clj
 msgid "Shutting Down Embedded Jetty Webserver"
-msgstr "Apagando el servidor Jetty embebido"
+msgstr "Stänger ner inbyggd Jetty Webserver"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase in STANDALONE mode"
-msgstr "Iniciando Metabase en modo INDEPENDIENTE"
+msgstr "Startar Metabase i fristående läge"
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization FAILED"
-msgstr "La inicialización de Metabase ha FALLADO"
+msgstr "Metabase kunde inte startas upp"
 
 #: src/metabase/db/liquibase.clj
 msgid "Database has migration lock; cannot run migrations."
-msgstr "La base de datos tiene un bloqueo de migración por lo que no podemos actualizar."
+msgstr "Databasen är låst för migrering - kan inte köra migrering."
 
 #: src/metabase/db/liquibase.clj
 msgid "You can force-release these locks by running `java -jar metabase.jar migrate release-locks`."
-msgstr "Puedes forzar la liberación de estos bloqueos ejecutando `java -jar metabase.jar migrate release-locks`."
+msgstr "Du kan tvinga bort dessa låsningar genom att köra java -jar metabase.jar migrate release-locks"
 
 #: src/metabase/db/liquibase.clj
 msgid "Checking if Database has unrun migrations..."
-msgstr "Comprobando si la base de datos tiene migraciones sin terminar..."
+msgstr "Kontrollerar om databasen har ej genomförda migreringar..."
 
 #: src/metabase/db/liquibase.clj
 msgid "Database has unrun migrations. Waiting for migration lock to be cleared..."
-msgstr "La base de datos tiene migraciones sin terminar. Esperando a que se borre el bloqueo de migración..."
+msgstr "Databasen har ej genomförda migreringar. Väntar på att lås för migrering ska tas bort..."
 
 #: src/metabase/db/liquibase.clj
 msgid "Migration lock is cleared. Running migrations..."
-msgstr "Se ha eliminado el bloqueo de migración. Ejecutando migraciones..."
+msgstr "Migreringslåset borttaget. Kör migreringar..."
 
 #: src/metabase/db/liquibase.clj
 msgid "Migration lock cleared, but nothing to do here! Migrations were finished by another instance."
-msgstr "Se borró el bloqueo de migración, ¡pero no hay nada que hacer aquí! Las migraciones fueron terminadas por otra instancia."
+msgstr "Migreringslåset borttaget, men inget mer att göra. Migreringarna gjordes klara av en annan instans."
 
 #. Set up liquibase and let it do its thing
 #: src/metabase/db.clj
 msgid "Setting up Liquibase..."
-msgstr "Preparando Liquibase..."
+msgstr "Sätter upp Liquibase..."
 
 #: src/metabase/db.clj
 msgid "Liquibase is ready."
-msgstr "Liquibase preparado"
+msgstr "Liquibase är klar."
 
 #: src/metabase/db.clj
 msgid "Verifying {0} Database Connection ..."
-msgstr "Verificando la conexión a la base de datos {0} ..."
+msgstr "Verifierar databasanslutning för {0}..."
 
 #: src/metabase/db.clj
 msgid "Verify Database Connection ... "
-msgstr "Verifica la conexión a la base de datos ... "
+msgstr "Verifierar databasanslutning ... "
 
 #: src/metabase/db.clj
 msgid "Running Database Migrations..."
-msgstr "Ejecutando migraciones de la base de datos..."
+msgstr "Kör databas-migreringar..."
 
 #: src/metabase/db.clj
 msgid "Database Migrations Current ... "
-msgstr "Migraciones de la base de datos actuales ..."
+msgstr "Datatas-migreringar, nu körs... "
 
 #: src/metabase/driver/common.clj
 msgid "Hmm, we couldn''t connect to the database."
-msgstr "Hmm, no he podido conectar con la base de datos."
+msgstr "Hmmm, vi kunde inte ansluta  till databasen."
 
 #: src/metabase/driver/common.clj
 msgid "Make sure your host and port settings are correct"
-msgstr "Asegúrate de que la configuración del host y del puerto sean correctas"
+msgstr "Se till att din värd- och portinställningar är korrekta"
 
 #: src/metabase/driver/common.clj
 msgid "We couldn''t connect to the ssh tunnel host."
-msgstr "no he podido conectar con el servidor del tunel ssh"
+msgstr "Vi kunden inte ansluta till ssh-tunnelns värd"
 
 #: src/metabase/driver/common.clj
 msgid "Check the username, password."
-msgstr "Verifica el nombre de usuario/contraseña."
+msgstr "Kontrollera användarnamn och lösenord."
 
 #: src/metabase/driver/common.clj
 msgid "Check the hostname and port."
-msgstr "Verifica el servidor y puerto"
+msgstr "Kontrollera värd och port."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like the database name is incorrect."
-msgstr "Parece que el nombre de la base de datos es incorrecto"
+msgstr "Ser ut som om databasnamnet är felaktigt."
 
 #: src/metabase/driver/common.clj
 msgid "It looks like your host is invalid."
-msgstr "Parece que tu servidor no es válido"
+msgstr "Det ser ut som om din angivna värd är felaktig."
 
 #: src/metabase/driver/common.clj
 msgid "Please double-check it and try again."
-msgstr "Por favor, vuelve a verificarlo e intenta de nuevo"
+msgstr "Dubbelkolla och försök igen."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like your password is incorrect."
-msgstr "Parece que tu contraseña es incorrecta"
+msgstr "Ser ut som om ditt lösenord är fel."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like you forgot to enter your password."
-msgstr "Parece que olvidaste poner tu contraseña"
+msgstr "Ser ut som om du glömde ange lösenord."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like your username is incorrect."
-msgstr "Parece que tu nombre de usuario es incorrecto."
+msgstr "Ser ut som om ditt användarnamn är fel."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like the username or password is incorrect."
-msgstr "Parece que el nombre de usuario o la contraseña son incorrectos."
+msgstr "Ser ut som om användarnamn eller lösenord är fel."
 
 #. ## CONFIG
 #: src/metabase/driver.clj
 msgid "Connection timezone to use when executing queries. Defaults to system timezone."
-msgstr "Zona horaria de conexión que se utilizará al ejecutar consultas. El valor predeterminado es la zona horaria del sistema."
+msgstr "Tidszon att använda när frågor ställs. Systemets tidszon är förvald."
 
 #: src/metabase/driver.clj
 msgid "Registered driver {0} {1}"
-msgstr "Controlador registrado {0} {1}"
+msgstr "Registrerad drivrutin {0} {1}"
 
 #: src/metabase/driver.clj
 msgid "No -init-driver function found for ''{0}''"
-msgstr "No se ha encontrado ninguna función -init-driver para ''{0}''"
+msgstr "Hittade ingen uppstarts-drivrutin för \"{0}\""
 
 #: src/metabase/driver/common.clj
 msgid "Unable to parse date string ''{0}'' for database engine ''{1}''"
-msgstr "No se puede analizar la cadena de fecha ''{0}'' para el motor de base de datos ''{1}''"
+msgstr "Kan inte tolka strängen \"{0}\" för databasmotorn \"{1}\""
 
 #. all-NULL columns in DBs like Mongo w/o explicit types
 #: src/metabase/driver/common.clj
 msgid "Don''t know how to map class ''{0}'' to a Field base_type, falling back to :type/*."
-msgstr "No se cómo utilizar la clase ''{0}'' como tipo base de campo, volviendo a :type/*."
+msgstr "Vet inte hur man mappar klassen \"{0}\" till ett fälts bastyp, försöker med :type/*."
 
 #: src/metabase/driver/util.clj
 msgid "Failed to connect to database: {0}"
-msgstr "Error al conectarse a la base de datos: {0}"
+msgstr "Kunde inte ansluta till databasen: {0}"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Invalid BigQuery identifier: ''{0}''"
-msgstr "Identificador de BigQuery inválido: ''{0}''"
+msgstr "Felaktig identifierare för \"BigQuery\": \"{0}\""
 
 #: src/metabase/driver/bigquery.clj
 msgid "BigQuery statements can't be parameterized!"
-msgstr "Los comandos BigQuery no soportan parámetros!"
+msgstr "\"BigQuery\"-frågor kan inte parametersättas!"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone:"
-msgstr "No se pudo establecer la zona horaria:"
+msgstr "Kunde inte sätta tidszon:"
 
 #: src/metabase/driver/googleanalytics.clj
 msgid "You must enable the Google Analytics API. Use this link to go to the Google Developers Console: {0}"
-msgstr "Debes habilitar el API de Google Analytics. Utiliza este enlace para ir a la Consola de Desarrollo de Google: {0}"
+msgstr "Du måste aktivera Google Analytics API. Använd denna länk för att gå till Google Developers Consol: {0}"
 
 #: src/metabase/driver/h2.clj
 msgid "Running SQL queries against H2 databases using the default (admin) database user is forbidden."
-msgstr "Está prohibido ejecutar consultas SQL en bases de datos H2 utilizando el usuario de base de datos predeterminado (administrador)."
+msgstr "Att köra SQL-frågot mot H2-databaser med förvald (admin-) databasanvändare är inte tillåtet."
 
 #: src/metabase/driver/sparksql.clj
 msgid "Error: metabase.driver.FixedHiveDriver is registered, but JDBC does not seem to be using it."
-msgstr "Error: metabase.driver.FixedHiveDriver está registrado, pero parece que JDBC no lo está usando."
+msgstr "Fel: metabase.driver.FixedHiveDriver har registrerats, men JDBC verkar inte använda den."
 
 #: src/metabase/driver/sparksql.clj
 msgid "Found metabase.driver.FixedHiveDriver."
-msgstr "Se ha encontrado metabase.driver.FixedHiveDriver."
+msgstr "Hittade metabase.driver.FixedHiveDriver."
 
 #: src/metabase/driver/sparksql.clj
 msgid "Successfully registered metabase.driver.FixedHiveDriver with JDBC."
-msgstr "Se ha registrado metabase.driver.FixedHiveDriver con JDBC."
+msgstr "Lyckades registrera metabase.driver.FixedHiveDriver med JDBC."
 
 #. CONFIG
 #. TODO - smtp-port should be switched to type :integer
 #: src/metabase/email.clj
 msgid "Email address you want to use as the sender of Metabase."
-msgstr "Dirección de correo electrónico que quieres usar como remitente de Metabase."
+msgstr "Epost-adress som du vill använda som avsändare från Metabase."
 
 #: src/metabase/email.clj
 msgid "The address of the SMTP server that handles your emails."
-msgstr "La dirección del servidor SMTP que maneja tus correos electrónicos."
+msgstr "Adressen till SMTP-servern som hanterar din epost."
 
 #: src/metabase/email.clj
 msgid "SMTP username."
-msgstr "Usuario SMTP."
+msgstr "SMTP-användarnamn."
 
 #: src/metabase/email.clj
 msgid "SMTP password."
-msgstr "Contraseña SMTP."
+msgstr "SMTP-lösenord."
 
 #: src/metabase/email.clj
 msgid "The port your SMTP server uses for outgoing emails."
-msgstr "El puerto que usa tu servidor SMTP para los correos electrónicos salientes."
+msgstr "Porten din SMTP-server använder för utgående epost."
 
 #: src/metabase/email.clj
 msgid "SMTP secure connection protocol. (tls, ssl, starttls, or none)"
-msgstr "Protocolo de conexión segura SMTP. (tls, ssl, starttls, o ninguno)"
+msgstr "Säkerhetsprotokoll för SMTP. (tls, ssl, starttls eller inget)"
 
 #: src/metabase/email.clj
 msgid "none"
-msgstr "ninguno"
+msgstr "inget"
 
 #: src/metabase/email.clj
 msgid "SMTP host is not set."
-msgstr "El servidor SMTP no está configurado."
+msgstr "SMTP-värd är inte angiven."
 
 #: src/metabase/email.clj
 msgid "Failed to send email"
-msgstr "No se pudo enviar el correo electrónico"
+msgstr "Kunde inte skicka epost"
 
 #: src/metabase/email.clj
 msgid "Error testing SMTP connection"
-msgstr "Error al probar la conexión SMTP"
+msgstr "Fel vid test av SMTP-förbindelse"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Enable LDAP authentication."
-msgstr "Habilita la autenticación LDAP."
+msgstr "Aktivera LDAP-autentisering."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Server hostname."
-msgstr "Nombre servidor"
+msgstr "Serverns värdnamn"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Server port, usually 389 or 636 if SSL is used."
-msgstr "Puerto del servidor, generalmente 389 o 636 si se usa SSL."
+msgstr "Server-port, vanligen 389 eller 636 om SSL används."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Use SSL, TLS or plain text."
-msgstr "Utiliza SSL, TLS o texto sin formato."
+msgstr "Använd SSL, TLS eller vanlig text."
 
 #: src/metabase/integrations/ldap.clj
 msgid "The Distinguished Name to bind as (if any), this user will be used to lookup information about other users."
-msgstr "El nombre distinguido para enlazar como (si existe), este usuario se utilizará para buscar información sobre otros usuarios."
+msgstr "Det karakteriserande namnet att binda till (om det finns) - denna användare kommer att användas för att hitta information om andra användare."
 
 #: src/metabase/integrations/ldap.clj
 msgid "The password to bind with for the lookup user."
-msgstr "La contraseña para vincularse con el usuario de búsqueda."
+msgstr "Lösenordet att binda till användaren för sökning."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Search base for users. (Will be searched recursively)"
-msgstr "Base de búsqueda para usuarios. (Se buscará recursivamente)"
+msgstr "Sökbas för användare (kommer att avsökas rekursivt)"
 
 #: src/metabase/integrations/ldap.clj
 msgid "User lookup filter, the placeholder '{login}' will be replaced by the user supplied login."
-msgstr "Filtro de búsqueda de usuario, el marcador de posición '{login}' se reemplazará por el inicio de sesión proporcionado por el usuario."
+msgstr "Sökfilter för användare. Platshållaren '{login}' kommer att ersättas med den angivna inloggningen."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user's email. (usually ''mail'', ''email'' or ''userPrincipalName'')"
-msgstr "Atributo de correo electrónico del usuario. (generalmente ''correo'', ''correo electrónico'' o ''userPrincipalName'')"
+msgstr "Attribut att använda för användarens epost (vanligen \"mail\", \"email\" eller \"userPrincipalName\")."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user''s first name. (usually ''givenName'')"
-msgstr "Atributo a usar para el primer nombre del usuario. (generalmente ''givenName'')"
+msgstr "Attribut att använda för användarens förnamn (vanligen \"givenName\")"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user''s last name. (usually ''sn'')"
-msgstr "Atributo para usar para el apellido del usuario. (generalmente ''sn'')"
+msgstr "Attribut att använda för användarens efternamn (vanligen \"sn\")."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Enable group membership synchronization with LDAP."
-msgstr "Habilite la sincronización de membresía grupal con LDAP."
+msgstr "Aktivera synkronisering med LDAP-grupptillhörighet."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Search base for groups, not required if your LDAP directory provides a ''memberOf'' overlay. (Will be searched recursively)"
-msgstr "Base de búsqueda para grupos, no requerida si tu directorio LDAP proporciona una superposición ''memberOf''. (Se buscará recursivamente)"
+msgstr "Sökbas för grupper - inte nödvändigt om din LDAP-katalog tillhandahåller lager för \"memberOf\" (kommer att genomsökas rekursivt)."
 
 #. Should be in the form: {"cn=Some Group,dc=...": [1, 2, 3]} where keys are LDAP groups and values are lists of MB groups IDs
 #: src/metabase/integrations/ldap.clj
 msgid "JSON containing LDAP to Metabase group mappings."
-msgstr "JSON que contiene las correspondencia de LDAP a grupos de Metabase."
+msgstr "JSON innehållande mappning mellan LDAP- och Metabase-grupper."
 
 #. Define a setting which captures our Slack api token
 #: src/metabase/integrations/slack.clj
 msgid "Slack API bearer token obtained from https://api.slack.com/web#authentication"
-msgstr "Slack API bearer token obtenido de https://api.slack.com/web#authentication"
+msgstr "Slack API bearer-bevis erhållen från https://api.slack.com/web#authentication"
 
 #: src/metabase/metabot.clj
 msgid "Enable MetaBot, which lets you search for and view your saved questions directly via Slack."
-msgstr "Habilita MetaBot, que te permite buscar y ver tus preguntas guardadas directamente a través de Slack."
+msgstr "Aktivera Metabot, vilket låter dig avsöka och visa dina sparade frågor via Slack."
 
 #: src/metabase/metabot/instance.clj
 msgid "Last MetaBot checkin was {0} ago."
-msgstr "Ultimo acceso de MetaBot fue hace {0}"
+msgstr "Senaste Metabot-kontrollen gjord för {0} sedan."
 
 #: src/metabase/metabot/instance.clj
 msgid "This instance will now handle MetaBot duties."
-msgstr "Esta instalación ahora manejará tareas de MetaBot"
+msgstr "Denna instans kommer nu att hantera Metabot-arbete."
 
 #: src/metabase/metabot.clj
 msgid "Here''s what I can {0}:"
-msgstr "Esto es lo que puedo {0}:"
+msgstr "Detta kan jag  {0}:"
 
 #: src/metabase/metabot.clj
 msgid "I don''t know how to {0} `{1}`.n{2}"
-msgstr "No se como {0} `{1}`.n{2}"
+msgstr "Jag vet inte hur jag {0} `{1}`.n{2}"
 
 #: src/metabase/metabot/slack.clj
 msgid "Uh oh! :cry:n> {0}"
-msgstr "¡Oh! :cry:n>"
+msgstr "Oj! {0}"
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s your {0} most recent cards:n{1}"
-msgstr "Aquí están tus {0} tarjetas más recientes: n{1}"
+msgstr "Här är dina {0} senaste listor:n{1}"
 
 #: src/metabase/metabot/command.clj
 msgid "Could you be a little more specific? I found these cards with names that matched:n{0}"
-msgstr "¿Podrías ser un poco más específico? He encontrado estas tarjetas con nombres que coinciden: n{0}"
+msgstr "Kan du vara lite mera specifik? Jag hittade dessa listor med matchande namn:n{0}"
 
 #: src/metabase/metabot/command.clj
 msgid "I don''t know what Card `{0}` is. Give me a Card ID or name."
-msgstr "No sé lo qué es la Tarjeta `{0}`. Dame un ID o nombre de tarjeta."
+msgstr "Jag vet inte vad lista `{0}` är. Ge mig ett list-ID eller namn."
 
 #: src/metabase/metabot/command.clj
 msgid "Show which card? Give me a part of a card name or its ID and I can show it to you. If you don''t know which card you want, try `metabot list`."
-msgstr "¿Qué tarjeta mostrar? Dame una parte del nombre de una tarjeta o su ID y te lo puedo mostrar. Si no sabes qué tarjeta quieres, prueba con `metabot list`."
+msgstr "Visa vilken lista? Ge mig del av ett listnamn eller dess ID, så kan jag visa den. Om du inte vet vilken lista du vill ha, försök med `metabot list`."
 
 #: src/metabase/metabot/command.clj
 msgid "Ok, just a second..."
-msgstr "Vale, solo un segundo..."
+msgstr "OK, ett ögonblick..."
 
 #: src/metabase/metabot/command.clj
 msgid "Not Found"
-msgstr "No Encontrado"
+msgstr "Saknas"
 
 #: src/metabase/metabot/command.clj
 msgid "Loading Kanye quotes..."
-msgstr "Cargando citas de Kanye..."
+msgstr "Ladda Kanye-citat"
 
 #: src/metabase/metabot/events.clj
 msgid "Evaluating Metabot command:"
-msgstr "Evaluando el comando de Metabot:"
+msgstr "Utvärderar Metabot-kommandot:"
 
 #: src/metabase/metabot.clj
 msgid "Go home websocket, you're drunk."
-msgstr "El websocket esta borracho."
+msgstr "Gå och lägg dig websocket, du är full."
 
 #: src/metabase/metabot/websocket.clj
 msgid "Error launching metabot:"
-msgstr "Error al iniciar metabot:"
+msgstr "Fel vid start av metabot:"
 
 #: src/metabase/metabot/websocket.clj
 msgid "MetaBot WebSocket is closed. Reconnecting now."
-msgstr "MetaBot WebSocket está cerrado. Reconectando ahora."
+msgstr "MetaBot WebSocket är stängd. Försöker ansluta igen."
 
 #: src/metabase/metabot/websocket.clj
 msgid "Error connecting websocket:"
-msgstr "Error al conectar websocket:"
+msgstr "Fel vid anslutning websocket:"
 
 #: src/metabase/metabot/instance.clj
 msgid "This instance is performing MetaBot duties."
-msgstr "Esta instalación está manejando tareas de MetaBot"
+msgstr "Denna instans utför MetaBot-arbete."
 
 #: src/metabase/metabot/instance.clj
 msgid "Another instance is already handling MetaBot duties."
-msgstr "Otra instalación está manejando las tareas de MetaBot"
+msgstr "En annan instans hanterar redan MetaBot-arbete."
 
 #: src/metabase/metabot.clj
 msgid "Starting MetaBot threads..."
-msgstr "Iniciando hilos de MetaBot..."
+msgstr "Påbörjar MetaBot-trådar..."
 
 #: src/metabase/metabot.clj
 msgid "Stopping MetaBot...  🤖"
-msgstr "Parando MetaBot...  🤖"
+msgstr "Stoppar MetaBot...🤖"
 
 #: src/metabase/metabot.clj
 msgid "MetaBot already running. Killing the previous WebSocket listener first."
-msgstr "MetaBot ya se está ejecutando. Matando al oyente WebSocket previo primero."
+msgstr "MetaBot körs redan. Dödar den föregående WebSocket-lyssnaren först."
 
 #: src/metabase/middleware/security.clj
 msgid "Base-64 encoded public key for this site's SSL certificate."
-msgstr "Clave pública codificada en Base-64 para el certificado SSL de este sitio."
+msgstr "Base-64-kodad publik nyckel för denna sajts SSL-certifikat."
 
 #: src/metabase/middleware/security.clj
 msgid "Specify this to enable HTTP Public Key Pinning."
-msgstr "Especifica esto para habilitar la fijación de clave pública HTTP."
+msgstr "Ange detta för att aktivera koppling med HTTP publik nyckel"
 
 #: src/metabase/middleware/security.clj
 msgid "See {0} for more information."
-msgstr "Ver {0} para más información."
+msgstr "Se {0} för mera information."
 
 #: src/metabase/models/card.clj
 msgid "Cannot save Question: source query has circular references."
-msgstr "No se puede guardar la pregunta debido a referencias circulares."
+msgstr "Kan inte spara frågan: källfrågan har cirkulära referenser."
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
-msgstr "No existe la tarjeta {0}"
+msgstr "Listan {0} finns inte."
 
 #: src/metabase/models/card.clj
 msgid "You do not have permissions to run ad-hoc native queries against Database {0}."
-msgstr "Lo siento, no tienes permiso para ejecutar consultas directas en la base de datos {0}."
+msgstr "Du har inte rättighet att köra ad-hoc inbyggda frågor mot databasen {0}."
 
 #: src/metabase/models/collection.clj
 msgid "Invalid color"
-msgstr "Color inválido"
+msgstr "Felaktig färg"
 
 #: src/metabase/models/collection.clj
 msgid "must be a valid 6-character hex color code"
-msgstr "debe ser un código de color hexadecimal válido de 6 caracteres"
+msgstr "måste vara en giltig 6 teckens hexadecimal färgkod"
 
 #: src/metabase/models/collection.clj
 msgid "Collection name cannot be blank!"
-msgstr "¡El nombre de la colección no puede estar vacío!"
+msgstr "Samlingens namn får inte vara blank!"
 
 #: src/metabase/models/collection.clj
 msgid "cannot be blank"
-msgstr "no puede ser vacío"
+msgstr "får inte vara blank"
 
 #: src/metabase/models/collection.clj
 msgid "Invalid Collection location: path is invalid."
-msgstr "Ubicación de colección inválida: la ruta no es válida."
+msgstr "Felaktig plats för samlingen: sökvägen är felaktig."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Personal Collection."
-msgstr "No puedes mover una Colección Personal."
+msgstr "Du kan inte flytta en personlig samling."
 
 #: src/metabase/models/collection.clj
 msgid "Invalid Collection location: some or all ancestors do not exist."
-msgstr "Ubicación de colección inválida: uno o más antepasados no existen."
+msgstr "Felaktig plats för samligen: Några eller alla ursprung finns inte."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot archive the Root Collection."
-msgstr "¡No puedes archivar la Colección Raíz!"
+msgstr "Du kan inte arkivera Root-samlingen."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot archive a Personal Collection."
-msgstr "No puedes archivar una Colección Personal."
+msgstr "Du kan inte arkivera en personlig samling."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move the Root Collection."
-msgstr "¡No puedes mover la Colección Raíz!"
+msgstr "Du kan inte flytta root-samlingen."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection into itself or into one of its descendants."
-msgstr "No puedes mover una Colección dentro de si misma o dentro de uno de sus descendientes."
+msgstr "Du kan inte flytta en samling till sig själv eller till en av efterföljarna."
 
 #. first move this Collection
 #: src/metabase/models/collection.clj
 msgid "Moving Collection {0} and its descendants from {1} to {2}"
-msgstr "Moviendo la Colección {0} y sus descendientes de {1} a {2}"
+msgstr "Flyttar samling {0} och dess efterföljare från {1} till {2}"
 
 #: src/metabase/models/collection.clj
 msgid "You're not allowed to change the owner of a Personal Collection."
-msgstr "No está permitido cambiar el propietario de una Colección Personal."
+msgstr "Du tillåts inte ändra ägaren till en personlig samling."
 
 #: src/metabase/models/collection.clj
 msgid "You're not allowed to move a Personal Collection."
-msgstr "No tienes permiso para mover una Colección Personal."
+msgstr "Du tillåts inte flytta en personlig samling."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection and archive it at the same time."
-msgstr "No puedes mover y archivar una Colección al mismo tiempo."
+msgstr "Du kan inte flytta en samling och arkivera den på samma gång."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot delete a Personal Collection!"
-msgstr "¡No puedes eliminar una Colección Personal!"
+msgstr "Du kan inte ta bort en personlig samling!"
 
 #: src/metabase/models/collection.clj
 msgid "{0} {1}''s Personal Collection"
-msgstr "Colección Personal de {0} {1}"
+msgstr "{0} {1}s personliga samling"
 
 #: src/metabase/models/collection_revision.clj
 msgid "You cannot update a CollectionRevision!"
-msgstr "¡No puedes actualzar una revisión de Colección!"
+msgstr "Du kan inte uppdatera en revision för en samling!"
 
 #: src/metabase/models/field_values.clj
 msgid "Field {0} was previously automatically set to show a list widget, but now has {1} values."
-msgstr "El campo {0} se estableció automáticamente para mostrar una lista, pero ahora tiene {1} valores."
+msgstr "Fält {0} sattes tidigare automatiskt till en listruta, men har nu {1}-värden."
 
 #: src/metabase/models/field_values.clj
 msgid "Switching Field to use a search widget instead."
-msgstr "Cambio de campo para usar un elemento de búsqueda en su lugar."
+msgstr "Byter fält för att använda en sökruta istället."
 
 #: src/metabase/models/field_values.clj
 msgid "Storing updated FieldValues for Field {0}..."
-msgstr "Almacenando Valores de Campo actualizados para el campo {0} ..."
+msgstr "Lagrar uppdaterade fältvärden för fält {0}..."
 
 #: src/metabase/models/field_values.clj
 msgid "Storing FieldValues for Field {0}..."
-msgstr "Almacenando Valores de Campo para el campo {0} ..."
+msgstr "Lagrar fältvärden för fält {0}..."
 
 #: src/metabase/models/humanization.clj
 msgid "Metabase can attempt to transform your table and field names into more sensible, human-readable versions, e.g. \"somehorriblename\" becomes \"Some Horrible Name\"."
-msgstr "Metabase puede intentar transformar los nombres de tablas y campos en versiones más entendibles y legibles para el ser humano, p.e. \"unnombrehorrible\" se convierte en \"Un Nombre Horrible\". "
+msgstr "Metabase kan försök översätta din tabell och fältnamn till mera läsbara versionsnamn, t.ex \"någothemsktnamn\" blir \"Något hemskt namn\"."
 
 #: src/metabase/models/humanization.clj
 msgid "This doesn’t work all that well if the names are in a language other than English, however."
-msgstr "Sin embargo, esto no funciona muy bien si los nombres están en un idioma que no sea el inglés."
+msgstr "Detta fungerar inte så bra om namnen är på ett annat språk än engelska, dock."
 
 #: src/metabase/models/humanization.clj
 msgid "Do you want us to take a guess?"
-msgstr "¿Quieres que adivinemos?"
+msgstr "Vill du gissa?"
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot create or revoke permissions for the 'Admin' group."
-msgstr "No puedes crear o revocar permisos para el grupo 'Admin'."
+msgstr "Du kan inte skapa eller upphäva rättigheter för admin-gruppen."
 
 #: src/metabase/models/permissions.clj
 msgid "Invalid permissions object path: ''{0}''."
-msgstr "Ruta del objeto de permisos inválido: ''{0}''."
+msgstr "Felaktiga rättigheter för objektets sökväg: \"{0}\"."
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot update a permissions entry!"
-msgstr "¡No puedes actualizar una entrada de permisos!"
+msgstr "Du kan inte uppdatera en angiven rättighet!"
 
 #: src/metabase/models/permissions.clj
 msgid "Delete it and create a new one."
-msgstr "Elimínalo y crear uno nuevo."
+msgstr "Ta bort den och skapa en ny."
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot edit permissions for a Personal Collection or its descendants."
-msgstr "No puedes editar los permisos de una Colección personal ni sus descendientes."
+msgstr "Du kan inte ändra rättigheter för en personlig samling eller dess efterföljare."
 
 #: src/metabase/models/permissions.clj
 msgid "Looks like someone else edited the permissions and your data is out of date."
-msgstr "Parece que alguien más editó los permisos y tus datos están desactualizados."
+msgstr "Det ser ut som om någon annan ändrade rättigheterna och dina data är gamla."
 
 #: src/metabase/models/permissions.clj
 msgid "Please fetch new data and try again."
-msgstr "Por favor, obtiene nuevos datos e intenta de nuevo"
+msgstr "Hämta nya data och försök igen."
 
 #: src/metabase/models/permissions_group.clj
 msgid "Created magic permissions group ''{0}'' (ID = {1})"
-msgstr "Creado grupo de permisos mágicos ''{0}'' (ID = {1})"
+msgstr "Skapade magiska rättighetsgruppen \"{0}\" (ID = {1})"
 
 #: src/metabase/models/permissions_group.clj
 msgid "A group with that name already exists."
-msgstr "Ya existe un grupo con ese nombre"
+msgstr "Gruppens namn finns redan."
 
 #: src/metabase/models/permissions_group.clj
 msgid "You cannot edit or delete the ''{0}'' permissions group!"
-msgstr "¡No puedes editar o eliminar el grupo de permisos ''{0}''!"
+msgstr "Du kan inte ändra eller ta bort rättighetsgruppen \"{0}\"!"
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the 'MetaBot' group."
-msgstr "No puedes añadir o eliminar usuarios a/del grupo 'MetaBot'."
+msgstr "Du kan inte lägga till eller ta bort användare från MetaBot-gruppen."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the 'All Users' group."
-msgstr "No puedes añadir o eliminar usuarios a/del grupo 'All'."
+msgstr "Du kan inte lägga till eller ta bort användare till/från gruppen Alla användare."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot remove the last member of the 'Admin' group!"
-msgstr "¡No puedes eliminar al último miembro del grupo 'Admin'!"
+msgstr "Du kan inte ta bort den senaste medlemmen från admin-gruppen!"
 
 #: src/metabase/models/permissions_revision.clj
 msgid "You cannot update a PermissionsRevision!"
-msgstr "¡No puedes actualizar una revisión de permisos!"
+msgstr "Du kan inte uppdatera rättighets-revisionen!"
 
 #. if there's still not a Card, throw an Exception!
 #: src/metabase/models/pulse.clj
 msgid "Invalid Alert: Alert does not have a Card assoicated with it"
-msgstr "Alerta Inválida: no tiene asociada un tarjeta"
+msgstr "Felaktig varning: Varningen har inte en anknuten lista."
 
 #: src/metabase/models/pulse.clj
 msgid "value must be a map with the keys `{0}`, `{1}`, and `{2}`."
-msgstr "el valor debe ser un mapa con los índices `{0}`, `{1}`, and `{2}`."
+msgstr "värden måste innehålla nycklarna `{0}`, `{1}` och `{2}`."
 
 #: src/metabase/models/pulse.clj
 msgid "value must be a map with the following keys `({0})`"
-msgstr "el valor debe ser un mapa con los índices `({0})`."
+msgstr "värdet måste vara en mappning med följande nycklar `({0})`"
 
 #: src/metabase/models/query/permissions.clj
 msgid "Error calculating permissions for query: {0}"
-msgstr "Error calculando los permisos para la consulta: {0}"
+msgstr "Fel vid framräkning av rättigheter för frågan: {0}"
 
 #: src/metabase/models/query/permissions.clj
 msgid "Invalid query type: {0}"
-msgstr "Tipo de consulta inválida: {0}"
+msgstr "Felaktig frågetyp: {0}"
 
 #: src/metabase/models/query_execution.clj
 msgid "You cannot update a QueryExecution!"
-msgstr "¡No puedes actualizar una ejecución de consulta!"
+msgstr "Du kan inte uppdatera en frågekörning!"
 
 #: src/metabase/models/revision.clj
 msgid "You cannot update a Revision!"
-msgstr "¡No puedes actualizar una revisión!"
+msgstr "Du kan inte uppdatera en revision!"
 
 #: src/metabase/models/setting.clj
 msgid "Setting {0} does not exist.nFound: {1}"
-msgstr "El ajuste {0} no existe.\n"
-"Encontrado: {1}"
+msgstr "Inställningen {0} finns inte. nFound: {1}"
 
 #: src/metabase/models/setting/cache.clj
 msgid "Updating value of settings-last-updated in DB..."
-msgstr "Actualizando ulitmo cambio en configuración..."
+msgstr "Uppdaterar värdet på inställningen senast-uppdaterad i DB..."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Checking whether settings cache is out of date (requires DB call)..."
-msgstr "Comprobando si la memoria caché de configuración está desactualizada..."
+msgstr "Kontrollerar om cache är gammal (kräver DB-anrop)"
 
 #: src/metabase/models/setting/cache.clj
 msgid "Settings have been changed on another instance, and will be reloaded here."
-msgstr "La configuración se modificó en otra instancia y se volverá a cargar aquí."
+msgstr "Inställningarna har ändrats från en annan instans och kommer att laddas om här."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Refreshing Settings cache..."
-msgstr "Actualizando caché de Configuración"
+msgstr "Uppdaterar cache för inställningar..."
 
 #: src/metabase/models/setting.clj
 msgid "Invalid value for string: must be either \"true\" or \"false\" (case-insensitive)."
-msgstr "Valor no válido para la cadena: debe ser \"true\" o \"false\" (no distingue entre mayúsculas y minúsculas)"
+msgstr "Felaktigt värde för strängen - måste vara \"true\" eller \"false\" (versaler eller gemena)"
 
 #: src/metabase/models/setting.clj
 msgid "You cannot update `settings-last-updated` yourself! This is done automatically."
-msgstr "¡No puedes actualizar `settings-last-update` ! Esto se realiza automáticamente."
+msgstr "Du kan inte uppdatera värde på inställningen senast-uppdaterad! Detta görs automatiskt."
 
 #. go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
 #: src/metabase/models/setting.clj
 msgid "Error inserting a new Setting:"
-msgstr "Error insertando nueva configuración:"
+msgstr "Fel när ny inställning skulle sparas:"
 
 #: src/metabase/models/setting.clj
 msgid "Assuming Setting already exists in DB and updating existing value."
-msgstr "￼Asumiendo que la configuración ya existe en DB y actualizando el valor existente."
+msgstr "Förutsätter att inställningen redan finns i DB och uppdaterar befintligt värde."
 
 #: src/metabase/models/user.clj
 msgid "value must be a map with each value either a string or number."
-msgstr "el valor debe ser un mapa con valores numéricos o de cadena."
+msgstr "Värdet måste vara en karta med varje värde som antingen en sträng eller en siffra"
 
 #: src/metabase/plugins.clj
 msgid "Loading plugins in directory {0}..."
-msgstr "Cargando complementos en el directorio {0}..."
+msgstr "Laddar plugin:er i katalog {0}..."
 
 #: src/metabase/plugins.clj
 msgid "Loading plugin {0}... "
-msgstr "Cargando complemento {0}..."
+msgstr "Laddar plugin {0}... "
 
 #: src/metabase/plugins.clj
 msgid "It looks like you have some external dependencies in your Metabase plugins directory."
-msgstr "Parece que tienes algunas dependencias externas en tu directorio de complementos de Metabase."
+msgstr "Det ser ut som om du har några externa beroenden i ditt Metabase plugin-katalogen."
 
 #: src/metabase/plugins.clj
 msgid "With Java 9 or higher, Metabase cannot automatically add them to your classpath."
-msgstr "Con Java 9 o superior, Metabase no puede agregarlos automáticamente a tu classpath."
+msgstr "Med Java 9 eller högre kan inte Metabase automatiskt lägga till dem till din classpath."
 
 #: src/metabase/plugins.clj
 msgid "Instead, you should include them at launch with the -cp option. For example:"
-msgstr "En su lugar, debes incluirlos en el lanzamiento con la opción -cp. Por ejemplo:"
+msgstr "Istället bör du ta med dem vid start med valet -cp. Till exempel:"
 
 #: src/metabase/plugins.clj
 msgid "See https://metabase.com/docs/latest/operations-guide/start.html#java-versions for more details."
-msgstr "Ver https://metabase.com/docs/latest/operations-guide/start.html#java-versions para más detalles."
+msgstr "Se https://metabase.com/docs/latest/operations-guide/start.html#java-versions för fler detaljer."
 
 #: src/metabase/plugins.clj
 msgid "(If you're already running Metabase this way, you can ignore this message.)"
-msgstr "(Si ya estás ejecutando Metabase de esta manera, puedes ignorar este mensaje.)"
+msgstr "(Om du redan kör Metabase på detta sätt kan du bortse från detta meddelande.)"
 
 #: src/metabase/public_settings.clj
 msgid "Identify when new versions of Metabase are available."
-msgstr "Informar cuándo hay nuevas versiones de Metabase."
+msgstr "Uppmärksamma när nya versioner av Metabase finns tillgängliga."
 
 #: src/metabase/public_settings.clj
 msgid "Information about available versions of Metabase."
-msgstr "Información sobre las versiones disponibles de Metabase."
+msgstr "Information om tillgängliga versioner av Metabase."
 
 #: src/metabase/public_settings.clj
 msgid "The name used for this instance of Metabase."
-msgstr "El nombre usado para esta instancia de Metabase."
+msgstr "Namnet som används för denna instans av Metabase."
 
 #: src/metabase/public_settings.clj
 msgid "The base URL of this Metabase instance, e.g. \"http://metabase.my-company.com\"."
-msgstr "La URL base de esta instancia de Metabase, p.e. \"http://metabase.my-company.com\"."
+msgstr "Huvud-URL:en för denna Metabase-instans, t.ex \"http://metabase.my-company.com\"."
 
 #: src/metabase/public_settings.clj
 msgid "The default language for this Metabase instance."
-msgstr "El idioma predeterminado para esta instancia de Metabase."
+msgstr "Förvalt språk för denna Metabase-instans."
 
 #: src/metabase/public_settings.clj
 msgid "This only applies to emails, Pulses, etc. Users'' browsers will specify the language used in the user interface."
-msgstr "Esto solo se aplica a correos electrónicos, pulsos, etc. Los navegadores de los usuarios especificarán el idioma utilizado en la interfaz de usuario."
+msgstr "Detta gäller bara epost, ögonblicksbild etc. Användarnas webbläsare kommer själv att ange önskat språk i användargränssnittet."
 
 #: src/metabase/public_settings.clj
 msgid "The email address users should be referred to if they encounter a problem."
-msgstr "La dirección de correo electrónico al que se dirigirán los usuarios si encuentran un problema."
+msgstr "Epost-adressen användare ska använda om de stöter på ett problem."
 
 #: src/metabase/public_settings.clj
 msgid "Enable the collection of anonymous usage data in order to help Metabase improve."
-msgstr "Habilita la recopilación de datos de uso anónimos para ayudar a mejorar Metabase."
+msgstr "Aktivera insamling av anonym användardata för att hjälpa Metabase att förbättras."
 
 #: src/metabase/public_settings.clj
 msgid "The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox."
-msgstr "La plantilla de URL del servidor de capas de mapa utilizada en las visualizaciones de mapas, por ejemplo desde OpenStreetMaps o MapBox."
+msgstr "URL:en för kartserverns mall som används vid visning, t.ex från OpenStreetMaps eller MapBox."
 
 #: src/metabase/public_settings.clj
 msgid "Enable admins to create publicly viewable links (and embeddable iframes) for Questions and Dashboards?"
-msgstr "¿Habilita a los administradores para crear enlaces visibles públicamente (y iframes incrustados) para Preguntas y Cuadros de Mando?"
+msgstr "Tillåta administratörer att skapa offentligt tillgängliga länka (och inbäddade iframes) för Frågor och instrumentpaneler?"
 
 #: src/metabase/public_settings.clj
 msgid "Allow admins to securely embed questions and dashboards within other applications?"
-msgstr "¿Permite a los administradores insertar preguntas y cuadros de mando de forma segura dentro de otras aplicaciones?"
+msgstr "Tillåta administratörer att säkert inbädda frågor och instrumentpaneler i andra applikationer?"
 
 #: src/metabase/public_settings.clj
 msgid "Allow using a saved question as the source for other queries?"
-msgstr "¿Permitir usar una pregunta guardada como fuente para otras consultas?"
+msgstr "Tillåta användning av en sparad fråga som källa för andra frågor?"
 
 #: src/metabase/public_settings.clj
 msgid "Enabling caching will save the results of queries that take a long time to run."
-msgstr "Al habilitar el almacenamiento en caché se guardan los resultados de las consultas que tardan mucho tiempo en ejecutarse."
+msgstr "Genom att tillåta cache-teknik sparas resultaten av frågor som tar lång tid att köra."
 
 #: src/metabase/public_settings.clj
 msgid "The maximum size of the cache, per saved question, in kilobytes:"
-msgstr "El tamaño máximo de la memoria caché, por pregunta guardada, en kilobytes:"
+msgstr "Max cache-storlek per sparad fråga i kb:"
 
 #: src/metabase/public_settings.clj
 msgid "The absolute maximum time to keep any cached query results, in seconds."
-msgstr "El tiempo máximo absoluto para mantener los resultados de las consultas en caché, en segundos."
+msgstr "Den absoluta max-tiden att spara resultat i cache i sekunder."
 
 #: src/metabase/public_settings.clj
 msgid "Metabase will cache all saved questions with an average query execution time longer than this many seconds:"
-msgstr "Metabase guardará en caché todas las preguntas guardadas con un tiempo promedio de ejecución de la consulta más largo que estos segundos:"
+msgstr "Metabase kommer att spara alla frågor i cache som har genomsnittlig frågetid längre än detta antal sekunder:"
 
 #: src/metabase/public_settings.clj
 msgid "To determine how long each saved question''s cached result should stick around, we take the query''s average execution time and multiply that by whatever you input here."
-msgstr "Para determinar cuánto tiempo debe permanecer el resultado guardado en la memoria de cada pregunta guardada, tomamos el tiempo de ejecución promedio de la consulta y lo multiplicamos por lo que pones aquí."
+msgstr "För att räkna ut hur länge varje sparad frågas cache-resultat ska finnas kvar, tar vi frågans genomsnittliga tid och multiplicerar med vad du anger här."
 
 #: src/metabase/public_settings.clj
 msgid "So if a query takes on average 2 minutes to run, and you input 10 for your multiplier, its cache entry will persist for 20 minutes."
-msgstr "Así que, si una consulta tarda un promedio de 2 minutos en ejecutarse, e introduces 10 para su multiplicador, su entrada en la memoria caché se mantendrá por 20 minutos."
+msgstr "Så om en fråga tar i genomsnitt 2 minuter att köra och du anger 10 som multiplikator kommer innehållet i cache att sparas i 20 minuter."
 
 #: src/metabase/public_settings.clj
 msgid "When using the default binning strategy and a number of bins is not provided, this number will be used as the default."
-msgstr "Cuando se usa la estrategia de agrupación predeterminada y no se proporciona una cantidad de tramos, este número se usará como el predeterminado."
+msgstr "När den förvalda behållare-strategin används och ett antal behållare inte finns tillgängliga kommer denna siffra att användas som förval."
 
 #: src/metabase/public_settings.clj
 msgid "When using the default binning strategy for a field of type Coordinate (such as Latitude and Longitude), this number will be used as the default bin width (in degrees)."
-msgstr "Cuando se utiliza la estrategia de agrupación predeterminada para un campo de tipo Coordenada (como Latitud y Longitud), este número se utilizará como el ancho predeterminado del tramo (en grados)."
+msgstr "När den förvalda behållare-strategin används för ett koordinat-fält (som latitud eller longitud) kommer detta nummer att användas som förvald behållare-bredden (i grader)."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Unable to validate token."
-msgstr "No se puede validar el token."
+msgstr "Kan inte validera värdebevis."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error fetching token status:"
-msgstr "Error consultando el estado del Token:"
+msgstr "Fel vid hämtning av status för värdebevis:"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "There was an error checking whether this token was valid."
-msgstr "Hubo un error al verificar si este token es válido."
+msgstr "Ett fel uppstod vid kontroll av detta värdebevis."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token validation timed out."
-msgstr "La validación de token agotó el tiempo de espera."
+msgstr "Timeout när värdebeviset skulle valideras."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Invalid token: token isn't in the right format."
-msgstr "Token inválido: el token no está en el formato correcto."
+msgstr "Felaktigt värdebevis - fel format."
 
 #. attempt to query the metastore API about the status of this token. If the request doesn't complete in a
 #. reasonable amount of time throw a timeout exception
 #: src/metabase/public_settings/metastore.clj
 msgid "Checking with the MetaStore to see whether {0} is valid..."
-msgstr "Verificando en el MetaStore para ver si {0} es válido ..."
+msgstr "Kontrollerar med MetaStore för att se om {0} är giltigt..."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token for premium embedding. Go to the MetaStore to get yours!"
-msgstr "Token para incrustación premium. ¡Ve a MetaStore para obtener el tuyo!"
+msgstr "Värdebevis för premium-inbäddning. Gå till MetaStore för att skaffa ditt eget!"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token is valid."
-msgstr "Token válido"
+msgstr "Värdebeviset är giltigt."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error setting premium embedding token"
-msgstr "Error al configurar el Token de inserción premium"
+msgstr "Fel uppstod vid inställning av värdebevis för premium-inbäddning"
 
 #: src/metabase/pulse.clj
 msgid "Unable to compare results to goal for alert."
-msgstr "No se pueden comparar los resultados con el objetivo de alerta."
+msgstr "Kan inte jämföra resultat för mål vid signalering."
 
 #: src/metabase/pulse.clj
 msgid "Question ID is ''{0}'' with visualization settings ''{1}''"
-msgstr "El ID de la pregunta es ''{0}'' con configuración de visualización ''{1}''"
+msgstr "Frågas ID är \"{0}\" med inställning för visning \"{1}\""
 
 #: src/metabase/pulse.clj
 msgid "Unrecognized alert with condition ''{0}''"
-msgstr "Alerta desconocida con condición ''{0}''"
+msgstr "Okänd signalering med villkor \"{0}\""
 
 #: src/metabase/pulse.clj
 msgid "Unrecognized channel type {0}"
-msgstr "El tipo de canal {0} es desconocido"
+msgstr "Okänd kanal-typ {0}"
 
 #: src/metabase/pulse.clj
 msgid "Error sending notification!"
-msgstr "¡Error enviando norificación!"
+msgstr "Kund inte skicka notifiering!"
 
 #: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
-msgstr "No se ha podido encontrar selector JS en ''{0}''"
+msgstr "Kan inte hitta JS-färgväljare vid \"{0}\""
 
 #: src/metabase/pulse/render.clj
 msgid "Card has errors: {0}"
-msgstr "La tarjeta tiene errores: {0}"
+msgstr "Listan har fel: {0}"
 
 #: src/metabase/pulse/render.clj
 msgid "Pulse card render error"
-msgstr "Error al procesar Pulso"
+msgstr "Ögonblicksbild-lista kunde inte visas"
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Trimming trailing comment from card with id {0}"
-msgstr "Eliminando el comentario final de la tarjeta con id {0}"
+msgstr "Rensar avslutande text från lista med id {0}"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Can't find field with ID: {0}"
-msgstr "No se puede encontrar el campo con ID: {0}"
+msgstr "Hittar inte fältet med ID: {0}"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "''{0}'' is a required param."
-msgstr "''{0}'' es un parámetro requerido"
+msgstr "Parametern \"{0}\" krävs."
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Found ''{0}'' with no terminating ''{1}'' in query ''{2}''"
-msgstr "Encontrado ''{0}'' sin terminación ''{1}'' en la consulta ''{2}''"
+msgstr "Hittade \"{0}\" utan avslutande \"{1}\" i fråga \"{2}\""
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Unable to substitute ''{0}'': param not specified.nFound: {1}"
-msgstr "No se puede sustituir ''{0}'': parámetro no especificado.\n"
-"Encontrado: {1}"
+msgstr "Kan inte ersätta \"{0}\": Parametern ej angiven.nFound:{1}"
 
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "You do not have permissions to view Card {0}."
-msgstr "No tienes permiso para ver la Tarjeta {0}."
+msgstr "Du har inte rättighet att visa listan {0}."
 
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "You do not have permissions to run this query."
-msgstr "No tienes permiso para ejecutar esta consulta."
+msgstr "Du har inte rättighet att köra denna fråga."
 
 #: src/metabase/sync/analyze.clj
 msgid "Fingerprint updates attempted {0}, updated {1}, no data found {2}, failed {3}"
-msgstr "Actualizaciones de huellas dactilares intentadas {0}, actualizadas {1}, no se encontraron datos {2}, fallaron {3}"
+msgstr "Antal uppdaterade fingeravtryck: {0}, antal uppdaterade: {1}, inga data hittades: {2}, misslyckades: {3}"
 
 #: src/metabase/sync/analyze.clj
 msgid "Total number of fields classified {0}, {1} failed"
-msgstr "El número total de campos clasificados {0}, {1} han fallado"
+msgstr "Totalt antal klassificerade fält: {0}, misslyckade: {1}"
 
 #: src/metabase/sync/analyze.clj
 msgid "Total number of tables classified {0}, {1} updated"
-msgstr "Número total de tablas clasificadas {0}, {1} actualizadas"
+msgstr "Totalt antal tabeller klassificerade: {0}, uppdaterade: {1}"
 
 #: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
 msgid "Error generating fingerprint for {0}"
-msgstr "Error generando huella para {0}"
+msgstr "Fel när fingeravtryck skapades för {0}"
 
 #: src/metabase/sync/field_values.clj
 msgid "Updated {0} field value sets, created {1}, deleted {2} with {3} errors"
-msgstr "Conjuntos de valores de campo actualizados {0}, creados {1}, eliminados {2} con {3} errores"
+msgstr "Uppdaterade {0} uppsättningar av fältvärden, skapade {1}, tog bort {2}, och fel:{3}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of fields sync''d {0}, number of fields updated {1}"
-msgstr "Número total de campos sincronizados {0}, número de campos actualizados {1}"
+msgstr "Totalt antal fält synkade:{0}, antal fält uppdaterade: {1}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of tables sync''d {0}, number of tables updated {1}"
-msgstr "Número total de tablas sincronizados {0}, número de tablas actualizados {1}"
+msgstr "Totalt antal tabeller synkade:{0}, antal tabeller uppdaterade: {1}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Found timezone id {0}"
-msgstr "Encontrado la zona horaria {0}"
+msgstr "Hittade tidszon med id {0}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of foreign keys sync''d {0}, {1} updated and {2} tables failed to update"
-msgstr "El número total de claves externas sincronizadas {0}, {1} actualizadas y {2} tablas han fallado"
+msgstr "Totalt antal externa nycklar synkade: {0}, uppdaterade: {1} och {2} tabeller kunde inte uppdateras"
 
 #: src/metabase/sync/util.clj
 msgid "{0} Database {1} ''{2}''"
-msgstr "{0} Base de Datos {1} ''{2}''"
+msgstr "{0} Databas {1} \"{2}\""
 
 #: src/metabase/sync/util.clj
 msgid "Table {0} ''{1}''"
-msgstr "Tabla {0} ''{1}''"
+msgstr "Tabell {0} \"{1}\""
 
 #: src/metabase/sync/util.clj
 msgid "Field {0} ''{1}''"
-msgstr "Campo {0} ''{1}''"
+msgstr "Fält {0} \"{1}\""
 
 #: src/metabase/sync/util.clj
 msgid "Field ''{0}''"
-msgstr "Campo ''{0}''"
+msgstr "Fält \"{0}\""
 
 #: src/metabase/sync/util.clj
 msgid "step ''{0}'' for {1}"
-msgstr "paso ''{0}'' para {1}"
+msgstr "steg \"{0}\" för {1}"
 
 #: src/metabase/sync/util.clj
 msgid "Completed {0} on {1}"
-msgstr "Realizadas {0} de {1}"
+msgstr "Avslutade {0} på {1}"
 
 #: src/metabase/sync/util.clj
 msgid "Start: {0}"
-msgstr "Inicio: {0}"
+msgstr "Start: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "End: {0}"
-msgstr "Fin: {0}"
+msgstr "Slut: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "Duration: {0}"
-msgstr "Duración: {0}"
+msgstr "Varaktighet: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "Completed step ''{0}''"
-msgstr "Realizado el paso ''{0}''"
+msgstr "Avslutade steg \"{0}\""
 
 #: src/metabase/task.clj
 msgid "Loading tasks namespace:"
-msgstr "Cargando espacio de nombres para las tareas:"
+msgstr "Laddar uppgifternas namespace:"
 
 #: src/metabase/task.clj
 msgid "Starting Quartz Scheduler"
-msgstr "Iniciando Programador Quartz"
+msgstr "Startar schemaläggaren Quartz"
 
 #: src/metabase/task.clj
 msgid "Stopping Quartz Scheduler"
-msgstr "Parando Programador Quartz"
+msgstr "Stoppar schemaläggaren Quartz"
 
 #: src/metabase/task.clj
 msgid "Job already exists:"
-msgstr "Tarea ya existe:"
+msgstr "Jobb finns redan:"
 
 #. This is the very first log message that will get printed.  It's here because this is one of the very first
 #. namespaces that gets loaded, and the first that has access to the logger It shows up a solid 10-15 seconds before
 #. the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
 #: src/metabase/util.clj
 msgid "Loading Metabase..."
-msgstr "Cargando Metabase..."
+msgstr "Laddar Metabase..."
 
 #: src/metabase/util/date.clj
 msgid "Possible timezone conflict found on database {0}."
-msgstr "Posible conflicto de zona horaria en la base de datos {0}"
+msgstr "Potentiell konflikt mellan tidszoner hittades i databas {0}."
 
 #: src/metabase/util/date.clj
 msgid "JVM timezone is {0} and detected database timezone is {1}."
-msgstr "La zona horaria de la JVM es {0} y la zona horaria de la base de datos es {1}."
+msgstr "Tidszon för JVM är {0} och identifierad tidszon i databasen är {1}."
 
 #: src/metabase/util/date.clj
 msgid "Configure a report timezone to ensure proper date and time conversions."
-msgstr "Configura una zona horaria de los informes para realizar conversiones correctas de fecha y hora."
+msgstr "Konfigurera en tidszon i rapporten för att säkerställa korrekta datum- och tidöversättningar."
 
 #: src/metabase/util/embed.clj
 msgid "Secret key used to sign JSON Web Tokens for requests to `/api/embed` endpoints."
-msgstr "Clave secreta utilizada para firmar tokens web JSON para solicitudes al API `/api/embed`."
+msgstr "Hemlig nyckel som används för att signera JSON Web Tokens för anrop till ändpunkterna `/api/embed`."
 
 #: src/metabase/util/encryption.clj
 msgid "MB_ENCRYPTION_SECRET_KEY must be at least 16 characters."
-msgstr "MB_ENCRYPTION_SECRET_KEY debe tener al menos 16 caracteres"
+msgstr "MB_ENCRYPTION_SECRET_KEY måste vara minst 16 tecken."
 
 #: src/metabase/util/encryption.clj
 msgid "Saved credentials encryption is ENABLED for this Metabase instance."
-msgstr "Guardar credenciales encriptadas está HABILITADO para esta instancia de Metabase."
+msgstr "Kryptering av sparade säkerhetsuppgifter är AKTIVERAD i denna Metabase-instans."
 
 #: src/metabase/util/encryption.clj
 msgid "Saved credentials encryption is DISABLED for this Metabase instance."
-msgstr "Guardar credenciales encriptadas está DESHABILITADO para esta instancia de Metabase."
+msgstr "Kryptering av sparade säkerhetsuppgifter är INAKTIVERAD i denna Metabase-instans."
 
 #: src/metabase/util/encryption.clj
 msgid "nFor more information, see"
-msgstr "Para más información, ver"
+msgstr "nFör mer information, se"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer."
-msgstr "el valor debe ser un entero."
+msgstr "värdet måste vara ett heltal"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a string."
-msgstr "el valor debe ser un texto."
+msgstr "värdet måste vara en text"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a boolean."
-msgstr "el valor debe ser un booleano"
+msgstr "det måste vara ett logiskt värde"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a string that matches the regex `{0}`."
-msgstr "el valor debe ser un texto que cumpla la expresión regular `{0}`."
+msgstr "värdet måste vara en text som matchar regex-uttrycket `{0}`."
 
 #: src/metabase/util/schema.clj
 msgid "value must satisfy one of the following requirements: "
-msgstr "el valor debe satisfacer uno de los requerimientos siguientes:"
+msgstr "värdet måste uppfylla endera av följande krav: "
 
 #: src/metabase/util/schema.clj
 msgid "value may be nil, or if non-nil, {0}"
-msgstr "el valor puede ser nulo, o si no es nulo, {0}"
+msgstr "värdet kan vara tomt, eller om ej tomt, {0}"
 
 #: src/metabase/util/schema.clj
 msgid "value must be one of: {0}."
-msgstr "el valor debe ser uno de: {0}."
+msgstr "värdet måste vara en av: {0}."
 
 #: src/metabase/util/schema.clj
 msgid "value must be an array."
-msgstr "el valor debe ser un conjunto"
+msgstr "värdet måste vara en samling (array)."
 
 #: src/metabase/util/schema.clj
 msgid "Each {0}"
-msgstr "Cada {0}"
+msgstr "Varje {0}"
 
 #: src/metabase/util/schema.clj
 msgid "The array cannot be empty."
-msgstr "El conjunto no puede estar vacío."
+msgstr "Array:en kan inte vara tom."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a non-blank string."
-msgstr "el valor debe ser un texto no vacío"
+msgstr "värdet måste vara en text som inte är blank."
 
 #: src/metabase/util/schema.clj
 msgid "Integer greater than zero"
-msgstr "Entero mayor que cero"
+msgstr "Heltal större än noll"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer greater than zero."
-msgstr "el valor debe ser un entero mayor que cero."
+msgstr "värdet måste vara ett heltal större än noll."
 
 #: src/metabase/util/schema.clj
 msgid "Number greater than zero"
-msgstr "Número mayor que cero"
+msgstr "Siffra större än noll."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a number greater than zero."
-msgstr "el valor debe ser un número mayor que cero."
+msgstr "värdet måste vara en siffra större än noll."
 
 #: src/metabase/util/schema.clj
 msgid "Keyword or string"
-msgstr "Palabra clave o texto"
+msgstr "Nyckelord eller text"
 
 #: src/metabase/util/schema.clj
 msgid "Valid field type"
-msgstr "Tipo de campo válido"
+msgstr "Giltig fälttyp."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid field type."
-msgstr "el valor debe ser un tipo de campo válido"
+msgstr "värdet måste vara en giltig fälttyp."
 
 #: src/metabase/util/schema.clj
 msgid "Valid field type (keyword or string)"
-msgstr "Tipo de campo válido (palabra clave o texto)"
+msgstr "Giltig fälttyp (nyckelord eller text)"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid field type (keyword or string)."
-msgstr "el valor debe ser un tipo de campo válido (palabra clave o texto)."
+msgstr "värdet måste vara en giltig fälttyp (nyckelord eller text)."
 
 #: src/metabase/util/schema.clj
 msgid "Valid entity type (keyword or string)"
-msgstr "Tipo de campo válido (palabra clave o texto)"
+msgstr "Giltig entitet (nyckelord eller text)"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid entity type (keyword or string)."
-msgstr "el valor debe ser un tipo de campo válido (palabra clave o texto)."
+msgstr "värdet måste vara en giltig entitetstyp (nyckelord eller text)"
 
 #: src/metabase/util/schema.clj
 msgid "Valid map"
-msgstr "Mapa válido"
+msgstr "Giltig karta"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a map."
-msgstr "el valor debe ser un mapa"
+msgstr "värdet måste vara en karta."
 
 #: src/metabase/util/schema.clj
 msgid "Valid email address"
-msgstr "Dirección de Email válido"
+msgstr "Giltig epost-adress"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid email address."
-msgstr "el valor debe ser una dirección de correo electrónico válida"
+msgstr "värdet måste vara en giltig epost-adress."
 
 #: src/metabase/util/schema.clj
 msgid "Insufficient password strength"
-msgstr "Insuficiente complejidad de contraseña"
+msgstr "Lösenordet inte tillräckligt säkert"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer."
-msgstr "el valor debe ser un entero válido"
+msgstr "värdet måste vara ett giltigt heltal."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer greater than zero."
-msgstr "el valor debe ser un entero válido mayor que cero."
+msgstr "värdet måste vara ett giltigt heltal större än noll."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid boolean string (''true'' or ''false'')."
-msgstr "el valor debe ser un booleano válido (''true'' o ''false'')."
+msgstr "värdet måste vara ett giltigt logiskt värde (\"true\" eller \"false\")."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid JSON string."
-msgstr "el valor debe ser un texto JSON válido."
+msgstr "värdet måste vara en giltig JSON-sträng."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid embedding params map."
-msgstr "el valor debe ser un mapa de parámetros de integración válido."
+msgstr "värdet måste vara giltiga parametrar för karta."
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx:12
 msgid "Data permissions"
-msgstr "Permisos de acceso de datos"
+msgstr "Datarättigheter"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx:13
 msgid "Collection permissions"
-msgstr "Permisos de acceso de colecciones"
+msgstr "Samlingsrättigheter"
 
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
 msgid "See all collection permissions"
-msgstr "Ver todos los permisos de colecciones"
+msgstr "Visa alla samlingsrättigheter"
 
 #: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
 msgid "Also change sub-collections"
-msgstr "También cambiar sub-colecciones"
+msgstr "Ändra också under-samlingar"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
-msgstr "Puede editar esta colección y sus contenidos"
+msgstr "Kan redigera denna samling och dess innehåll"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
-msgstr "Puede ver artículos en esta colección"
+msgstr "Kan visa delar av denna samling"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:765
 msgid "Collection Access"
-msgstr "Acceso a Colección"
+msgstr "Tillgång till samling"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:841
 msgid "This group has permission to view at least one subcollection of this collection."
-msgstr "Este grupo tiene permiso para ver al menos una subcolección de esta colección."
+msgstr "Denna grupp har rättighet att visa minst en av delarna i denna samling."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "This group has permission to edit at least one subcollection of this collection."
-msgstr "Este grupo tiene permiso para editar al menos una subcolección de esta colección."
+msgstr "Denna grupp har rättighet att redigera minst en av delarna i denna samling."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:859
 msgid "View sub-collections"
-msgstr "Ver subcolección"
+msgstr "Visa under-samlingar"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:245
 msgid "Remember Me"
-msgstr "Recuerdame"
+msgstr "Kom ihåg mig"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:73
 msgid "X-ray this schema"
-msgstr "Aplica rayos-X a este esquema"
+msgstr "Genomlys detta schema"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:258
 msgid "Edit the permissions for this collection"
-msgstr "Editar los permisos de acceso de esta colección"
+msgstr "Redigera rättigheterna till denna samling"
 
 #: frontend/src/metabase/containers/AddToDashSelectDashModal.jsx:55
 msgid "Add this question to a dashboard"
-msgstr "Añadir esta pregunta a un cuadro de mando"
+msgstr "Lägg till en fråga till denna instrumentpanel"
 
 #: frontend/src/metabase/containers/AddToDashSelectDashModal.jsx:65
 msgid "Create a new dashboard"
-msgstr "Crea un Cuadro de Mando"
+msgstr "Skapa en ny instrumentpanel"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:47
 msgid "The page you asked for couldn't be found."
-msgstr "La página que pidió no ha sido encontrada."
+msgstr "Sidan du begärde kunde inte hittas."
 
 #: frontend/src/metabase/containers/ItemSelect.jsx:30
 msgid "Select a {0}"
-msgstr "Seleccione un(a) {0}"
+msgstr "Välj en {0}"
 
 #: frontend/src/metabase/containers/Overworld.jsx:234
 msgid "Save dashboards, questions, and collections in \"{0}\""
-msgstr "Guardar cuadros de mando, preguntas, y colecciones en \"{0}\""
+msgstr "Spara instrumentpaneler, frågor och samlingar i \"{0}\""
 
 #: frontend/src/metabase/containers/Overworld.jsx:235
 msgid "Access dashboards, questions, and collections in \"{0}\""
-msgstr "Acceder cuadros de mando, preguntas, y colecciones en \"{0}\""
+msgstr "Använda instrumentpaneler, frågor och samlingar i \"{0}\""
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
-msgstr "Compara"
+msgstr "Jämför"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
-msgstr "Alejarse"
+msgstr "Panorera ut"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
-msgstr "Relacionado"
+msgstr "Relaterade"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
-msgstr "Más Rayos-X"
+msgstr "Flera genomlysningar"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
-msgstr "No hay resultados"
+msgstr "Inga resultat"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:42
 msgid "Metabase couldn't find any results for your search."
-msgstr "Metabase no pudo encontrar ningún resultado para su busqueda."
+msgstr "Metabase kunde inte hitta något resultat till din sökning."
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
-msgstr "Métricas no encontradas"
+msgstr "Inga mått"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:41
 msgid "Aggregations"
-msgstr "Agregaciones"
+msgstr "Sammanslagningar"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:42
 msgid "Operators"
-msgstr "Operadores"
+msgstr "Operatörer"
 
 #: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:35
 msgid "Custom fields"
-msgstr "Campos personalizados"
+msgstr "Anpassade fält"
 
 #. 2. Create the new collections.
 #: src/metabase/db/migrations.clj
 msgid "Migrated Dashboards"
-msgstr "Cuadros de Mando migrados"
+msgstr "Migerade instrumentpaneler"
 
 #: src/metabase/db/migrations.clj
 msgid "Migrated Pulses"
-msgstr "Pulsos migrados"
+msgstr "Migrerade ögonblicksbilder"
 
 #: src/metabase/db/migrations.clj
 msgid "Migrated Questions"
-msgstr "Preguntas migradas"
+msgstr "Migrerade frågor"
 
 #. 4. move everything not in this Collection to a new Collection
 #: src/metabase/db/migrations.clj
 msgid "Moving instances of {0} that aren't in a Collection to {1} Collection {2}"
-msgstr "Moviendo instancias de {0} que no están en ninguna colección a {1} Colección {2}"
+msgstr "Flyttar instanser av {0} som inte ingår i en samling till {1}, samling {2}"
 
 #: src/metabase/models/permissions.clj
 msgid "Failed to grant permissions: {0}"
-msgstr "Error al conceder permisos: {0}"
+msgstr "Kunde inte tilldela rättigheter: {0}"
 
 #: src/metabase/util/encryption.clj
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
-msgstr "No se ha podido desencriptar la cadena. ¿Has configurado correctamenteMB_ENCRYPTION_SECRET_KEY?"
+msgstr "Kan inte avkryptera krypterad sträng. Har du ändrat eller glömt att sätta MB_ENCRYPTION_SECRET_KEY?"
 
 #: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
-msgstr "Todas las colecciones personales"
+msgstr "Alla personliga samlingar"
 
 #: src/metabase/driver/common.clj
 msgid "Host"
-msgstr "Servidor"
+msgstr "Värd"
 
 #: src/metabase/driver/common.clj
 msgid "Port"
-msgstr "Puerto"
+msgstr "Port"
 
 #: src/metabase/driver/common.clj
 msgid "Database username"
-msgstr "nombre de usuario de base de datos"
+msgstr "Databas-användarnamn"
 
 #: src/metabase/driver/common.clj
 msgid "What username do you use to login to the database?"
-msgstr "¿Qué nombre de usuario usas para iniciar sesión en la base de datos?"
+msgstr "Vilket användarnamn använder du för att logga in i databasen?"
 
 #: src/metabase/driver/common.clj
 msgid "Database password"
-msgstr "Contraseña de la base de datos"
+msgstr "Databas-lösenord"
 
 #: src/metabase/driver/common.clj
 msgid "Database name"
-msgstr "nombre de la base de datos"
+msgstr "Databas-namn"
 
 #: src/metabase/driver/common.clj
 msgid "birds_of_the_world"
-msgstr "aves_del_mundo"
+msgstr "alla_världens_fåglar"
 
 #: src/metabase/driver/common.clj
 msgid "Use a secure connection (SSL)?"
-msgstr "¿Utilizar una conexión segura (SSL)?"
+msgstr "Använda en säker anslutning (SSL)?"
 
 #: src/metabase/driver/common.clj
 msgid "Additional JDBC connection string options"
-msgstr "Opciones adicionales de cadena de conexión JDBC"
+msgstr "Sträng med ytterligare JDBC-anslutningsuppgifter"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Project ID"
-msgstr "ID de proyecto"
+msgstr "Projekt-id"
 
 #: src/metabase/driver/bigquery.clj
 msgid "praxis-beacon-120871"
-msgstr "praxis-beacon-120871"
+msgstr "övnings-fyr-120871"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Dataset ID"
-msgstr "Conjunto de datos ID"
+msgstr "Dataset-id"
 
 #: src/metabase/driver/bigquery.clj
 msgid "toucanSightings"
-msgstr "avistamientosDeTucanes"
+msgstr "tukanfynd"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Client ID"
-msgstr "ID de cliente"
+msgstr "Klient-id"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Client Secret"
-msgstr "Clave secreta del cliente"
+msgstr "Klient-hemlighet"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Auth Code"
-msgstr "Código de Autorización"
+msgstr "Auth-kod"
 
 #: src/metabase/driver/crate.clj
 msgid "Hosts"
-msgstr "Servidores"
+msgstr "Värdar"
 
 #: src/metabase/driver/druid.clj
 msgid "Broker node port"
-msgstr "Puerto de nodo intermediario"
+msgstr "Agentkodsport"
 
 #: src/metabase/driver/googleanalytics.clj
 msgid "Google Analytics Account ID"
-msgstr "ID de cuenta de Google Analytics"
+msgstr "Google Analytics Accound ID"
 
 #: src/metabase/driver/h2.clj
 msgid "Connection String"
-msgstr "Cadena de conexión"
+msgstr "Anslutningssträng"
 
 #: src/metabase/driver/h2.clj
 msgid "Users/camsaul/bird_sightings/toucans"
-msgstr "Users/camsaul/avistamientos_de_aves/tucanes"
+msgstr "Användare/camsaul/fågelfynd/tukaner"
 
 #: src/metabase/driver/mongo.clj
 msgid "carrierPigeonDeliveries"
-msgstr "entregasPorPalomasMensajeras"
+msgstr "brevduveleveranser"
 
 #: src/metabase/driver/mongo.clj
 msgid "Authentication Database"
-msgstr "base de datos para autenticación"
+msgstr "Databas för autentisering"
 
 #: src/metabase/driver/mongo.clj
 msgid "Optional database to use when authenticating"
-msgstr "base de datos opcional para la autenticación"
+msgstr "Valfri databas att använda för autentisering"
 
 #: src/metabase/driver/mongo.clj
 msgid "Additional Mongo connection string options"
-msgstr "Opciones adicionales de cadena de conexión Mongo"
+msgstr "Ytterligare anslutningssträng för Mongo-alternativ"
 
 #: src/metabase/driver/oracle.clj
 msgid "Oracle system ID (SID)"
-msgstr "ID del sistema Oracle (SID)"
+msgstr "Oracle system ID (SID)"
 
 #: src/metabase/driver/oracle.clj
 msgid "Usually something like ORCL or XE."
-msgstr "Generalmente algo como ORCL o XE"
+msgstr "Normalt något som t.ex ORCL eller XE."
 
 #: src/metabase/driver/oracle.clj
 msgid "Optional if using service name"
-msgstr "Opcional cuando se usa nombre del servicio"
+msgstr "Valfri om service-namn används"
 
 #: src/metabase/driver/oracle.clj
 msgid "Oracle service name"
-msgstr "Nombre del servicio Oracle"
+msgstr "Service-namn för Oracle"
 
 #: src/metabase/driver/oracle.clj
 msgid "Optional TNS alias"
-msgstr "Alias TNS (opcional)"
+msgstr "Valfri TNS-alias"
 
 #: src/metabase/driver/presto.clj
 msgid "hive"
-msgstr "hive"
+msgstr "bikupa"
 
 #: src/metabase/driver/redshift.clj
 msgid "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
-msgstr "nombre-de-mi-cluster.abcd1234.us-east-1.redshift.amazonaws.com"
+msgstr "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
 
 #: src/metabase/driver/redshift.clj
 msgid "toucan_sightings"
-msgstr "avistamientos_de_tucanes"
+msgstr "tukanfynd"
 
 #: src/metabase/models/collection.clj
 msgid "default"
-msgstr "por defecto"
+msgstr "förvald"
 
 #: src/metabase/driver/sqlite.clj
 msgid "Filename"
-msgstr "Nombre del archivo"
+msgstr "Filnamn"
 
 #: src/metabase/driver/sqlite.clj
 msgid "/home/camsaul/toucan_sightings.sqlite 😋"
-msgstr "/home/camsaul/avistamientos_de_tucanes.sqlite"
+msgstr "/home/camsaul/tukanfynd.sqlite 😋"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "BirdsOfTheWorld"
-msgstr "AvesDelMundo"
+msgstr "AllVärldensFåglar"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "Database instance name"
-msgstr "Nombre de la instancia de base de datos"
+msgstr "Databasen instans-namn"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "N/A"
-msgstr "No aplica"
+msgstr "Ej tillämpligt"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "Windows domain"
-msgstr "Dominio de Windows"
+msgstr "Windows-domän"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:528
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:534
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:543
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
-msgstr "Etiquetas"
+msgstr "Etiketter"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 msgid "Add members"
-msgstr "Añadir miembros"
+msgstr "Lägg till medlemmar"
 
 #: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
-msgstr "Colección que se guarda en"
+msgstr "Samlingen den sparats i"
 
 #: frontend/src/metabase/lib/groups.js:4
 msgid "All Users"
-msgstr "Todos los Usuarios"
+msgstr "Alla användare"
 
 #: frontend/src/metabase/lib/groups.js:5
 msgid "Administrators"
-msgstr "Administradores"
+msgstr "Administratörer"
 
 #: frontend/src/metabase/lib/groups.js:6
 msgid "MetaBot"
@@ -9297,7 +9277,7 @@ msgstr "MetaBot"
 
 #: frontend/src/metabase/public/components/widgets/EmbedModalContent.jsx:290
 msgid "Sharing"
-msgstr "Compartir"
+msgstr "Delning"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:218
@@ -9321,7 +9301,7 @@ msgstr "Compartir"
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
-msgstr "Visualización"
+msgstr "Visa"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:402
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:437
@@ -9332,611 +9312,610 @@ msgstr "Visualización"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:521
 msgid "Axes"
-msgstr "Ejes"
+msgstr "Axlar"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:219
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:62
 msgid "Formatting"
-msgstr "Formato"
+msgstr "Formattering"
 
 #: frontend/src/metabase/containers/Overworld.jsx:121
 msgid "Try these x-rays based on your data."
-msgstr "Pruebe estos rayos-X en función de tus datos."
+msgstr "Prova dessa genomlysningar på dina data"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:38
 msgid "There was a problem displaying this chart."
-msgstr "Hubo un problema al mostrar esta gráfico."
+msgstr "Ett problem uppstod när diagrammet skulle visas."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:39
 msgid "Sorry, you don't have permission to see this card."
-msgstr "Lo siento, no tienes permiso para ver etsa tarjeta."
+msgstr "Ursäkta, du har inte rättighet att visa denna lista."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:55
 msgid "Just a heads up:"
-msgstr "Solo un aviso:"
+msgstr "Bara en påminnelse:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:63
 msgid "{0} without the Sample Dataset, the Query Builder tutorial won't work. You can always restore the Sample Dataset, but any questions you've saved using this data will be lost."
-msgstr "{0} sin el conjunto de datos de muestra, el tutorial del generador de consultas no funcionará. Siempre puede restaurar el conjunto de datos de muestra, pero cualquier pregunta que haya guardado con esta información se perderá"
+msgstr "{0} utan exempeldatat kan inte frågebyggaren fungera. Du kan alltid återställa exempeldatat, men eventuella frågor du sparat mot detta data kommer att försvinna."
 
 #: frontend/src/metabase/modes/components/drill/AutomaticDashboardDrill.jsx:33
 msgid "X-ray"
-msgstr "Aplica rayos-X"
+msgstr "Genomlysning"
 
 #: frontend/src/metabase/modes/components/drill/CompareToRestDrill.js:34
 msgid "Compare to the rest"
-msgstr "Compara con el resto"
+msgstr "Jämför mot resten"
 
 #: frontend/src/metabase/entities/databases/forms.js:18
 msgid "Use the Java Virtual Machine (JVM) timezone"
-msgstr "Utiliza la zona horaria de la máquina virtual Java"
+msgstr "Använda tidszon från Java Virtual Machine (JVM)"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
-msgstr "Te sugerimos que desactives esto a menos que estés forzando manualmente la zona horaria en\n"
-"muchas o la mayoría de tus consultas con estos datos."
+msgstr "Vi föreslår att du inte aktiverar denna om du inte använder manuell hantering av tidszon i många eller de flesta av dina frågor mot denna data."
 
 #: frontend/src/metabase/containers/Overworld.jsx:395
 msgid "Your team's most important dashboards go here"
-msgstr "Los cuadros de mando más importantes van aquí"
+msgstr "Din grupps viktigaste instrumentpaneler läggs här"
 
 #: frontend/src/metabase/containers/Overworld.jsx:396
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
-msgstr "Fija los cuadros de mando en {0} para que aparezcan en este espacio para todos"
+msgstr "Fäst instrumentpaneler i {0} för att de ska synas här för alla."
 
 #: src/metabase/db/liquibase.clj
 msgid "Unable to release the Liquibase lock after a migration failure"
-msgstr "No se ha podido eliminar el bloqueo Liquibase tras un error en la migración"
+msgstr "Kunde inte släppa Liquibase-låsningen efter en misslyckad migrering"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Use JVM Time Zone"
-msgstr "Utiliza la zona horaria del JVM"
+msgstr "Använd tidszon från JVM"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:29
 msgid "We're currently analyzing the tables and fields to help you explore your data."
-msgstr "Estamos analizando las tablas y los campos para ayudarte a explorar tus datos."
+msgstr "Vi analyserar tabeller och och fält för att hjälpa dig utforska dina data."
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
 msgid "Tip: "
-msgstr "Consejo: "
+msgstr "Tips: "
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
-msgstr "Selecciona un tipo de moneda"
+msgstr "Välj en valutatyp"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
 msgid "Field Type"
-msgstr "Tipo Campo"
+msgstr "Fälttyp"
 
 #: frontend/src/metabase/admin/routes.jsx:118
 #: frontend/src/metabase/nav/containers/Navbar.jsx:267
 msgid "Troubleshooting"
-msgstr "Solución de problemas"
+msgstr "Felsökning"
 
 #: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Enable X-ray features"
-msgstr "Habilitar características de Rayos-X"
+msgstr "Aktivera genomlysningsfunktioner"
 
 #: frontend/src/metabase/admin/settings/selectors.js:220
 msgid "Formatting Options"
-msgstr "Opciones de Formato"
+msgstr "Formatteringsalternativ"
 
 #: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
-msgstr "Detalles de la tarea"
+msgstr "Jobbdetaljer"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:29
 msgid "Troubleshooting logs"
-msgstr "Registro de solución de problemas"
+msgstr "Felsökningsloggar"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:31
 msgid "Trying to get to the bottom of something? This section shows logs of Metabase's background tasks, which can help shed light on what's going on."
-msgstr "¿Tratando de llegar al fondo de algo? Esta sección muestra los registros de las tareas en segundo plano de Metabase, que pueden ayudar a aclarar lo que está pasando."
+msgstr "Försöker du gå till botten med något? Denna avdelning visar loggar över Metabases bakgrundsjobb, vilka kan belysa vad som händer."
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:56
 msgid "Task"
-msgstr "Tarea"
+msgstr "Jobb"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:57
 msgid "DB ID"
-msgstr "ID BBDD"
+msgstr "DB-id"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:58
 msgid "Started at"
-msgstr "Iniciado a las"
+msgstr "Började"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:59
 msgid "Ended at"
-msgstr "Terminado a las"
+msgstr "Slutade"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:60
 msgid "Duration (ms)"
-msgstr "Duración (ms)"
+msgstr "Varaktighet (ms)"
 
 #: frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx:34
 #: frontend/src/metabase/lib/core.js:92
 msgid "Currency"
-msgstr "Moneda"
+msgstr "Valuta"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
-msgstr "Elige un usuario o canal..."
+msgstr "Välj en användare eller kanal..."
 
 #: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:90
 msgid "No formatting settings"
-msgstr "Sin ajustes de formato"
+msgstr "Inga inställningar för formattering"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:81
 msgid "Label for this range (optional)"
-msgstr "Nombre para este rango (opcional)"
+msgstr "Namn på detta intervall (valfritt)"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:93
 msgid "Add a range"
-msgstr "Añade un rango"
+msgstr "Lägg till ett intervall"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:26
 msgid "is less than"
-msgstr "es menor que"
+msgstr "är mindre än"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:27
 msgid "is greater than"
-msgstr "es mayor que"
+msgstr "är större än"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:28
 msgid "is less than or equal to"
-msgstr "es menor o igual a"
+msgstr "är mindre än eller lika med"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:29
 msgid "is greater than or equal to"
-msgstr "es mayor o igual a"
+msgstr "är större än eller lika med"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:37
 msgid "is equal to"
-msgstr "es igual a"
+msgstr "är lika med"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:31
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:38
 msgid "is not equal to"
-msgstr "no es igual a"
+msgstr "är inte lika med"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:32
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:39
 msgid "is null"
-msgstr "es nulo"
+msgstr "är tomt"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:33
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:40
 msgid "is not null"
-msgstr "no es nulo"
+msgstr "är inte tomt"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:41
 msgid "contains"
-msgstr "contiene"
+msgstr "innehåller"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:42
 msgid "does not contain"
-msgstr "no contiene"
+msgstr "innehåller inte"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:43
 msgid "starts with"
-msgstr "empieza con"
+msgstr "börjar med"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:44
 msgid "ends with"
-msgstr "termina con"
+msgstr "slutar med"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:292
 msgid "When a cell in these columns {0} it will be tinted this color."
-msgstr "Cuando una celda de estas columnas sea {0} se pintará de este color."
+msgstr "När en cell i dessa kolumner {0} kommer den att färgas med denna färg."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:351
 msgid "When a cell in this column…"
-msgstr "Cuando una celda en esta columna..."
+msgstr "När en cell i denna kolumn..."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:42
 msgid "This visualization requires you to group by a field."
-msgstr "Esta visualización require agrupar por un campo."
+msgstr "Denna visualisering kräver att du grupperar på ett fält."
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:184
 msgid "Date style"
-msgstr "Formato de fecha"
+msgstr "Datumformat"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:207
 msgid "Date separators"
-msgstr "Separador de fecha"
+msgstr "Datum-separatorer"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:226
 msgid "Abbreviate names of days and months"
-msgstr "Abreviar nombres de días y meses."
+msgstr "Förkorta namn på dagar och månader"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:236
 msgid "Show the time"
-msgstr "Mostrar la hora"
+msgstr "Visa tiden"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:243
 msgid "HH:MM"
-msgstr "HH:MM"
+msgstr "TT:MM"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:251
 msgid "HH:MM:SS"
-msgstr "HH:MM:SS"
+msgstr "TT:MM:SS"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:254
 msgid "HH:MM:SS.MS"
-msgstr "HH:MM:SS.MS"
+msgstr "TT:MM:SS:MS"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:265
 msgid "Time style"
-msgstr "Formato de hora"
+msgstr "Datumformat"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:314
 msgid "Unit of currency"
-msgstr "Unidad de moneda"
+msgstr "Valutaenhet"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:334
 msgid "Currency label style"
-msgstr "Formato etiqueta de moneda"
+msgstr "Valutaformattering"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:361
 msgid "Where to display the unit of currency"
-msgstr "Donde mostrar la unidad de moneda"
+msgstr "Var valutaenheten ska visas"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:394
 msgid "Minimum number of decimal places"
-msgstr "Número mínimo de decimales"
+msgstr "Minsta antal decimaler"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
-msgstr "Tipo de gráfico apilado"
+msgstr "Travad tabelltyp"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
-msgstr "Etiqueta de Objetivo"
+msgstr "Mål-etikett"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
-msgstr "Mostrar línea de tendencia"
+msgstr "Visa trend-linje"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:67
 msgid "Line style"
-msgstr "Formato de línea"
+msgstr "Linjestil"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:84
 msgid "Show dots on lines"
-msgstr "Mostrar puntos en las líneas"
+msgstr "Visa punkter på linjer"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:348
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
-msgstr "Automatico"
+msgstr "Auto"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:120
 msgid "Which axis?"
-msgstr "¿En qué eje?"
+msgstr "Vilken axel?"
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
 msgid "Line + Bar"
-msgstr "Línea + Barra"
+msgstr "Linje + stapel"
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
 msgid "line and bar chart"
-msgstr "gráfico de línea y barra"
+msgstr "Linje- och stapeldiagram"
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
-msgstr "La visualización del contador requiere un número."
+msgstr "En räknare kräver en siffra."
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:60
 msgid "Gauge"
-msgstr "Contador"
+msgstr "Räknare"
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
 msgid "Gauge ranges"
-msgstr "Rangos del contador"
+msgstr "Räknaromfång"
 
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:107
 msgid "Field to show"
-msgstr "Campo a mostrar"
+msgstr "Fält att visa"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
 msgid "last {0}"
-msgstr "último {0}"
+msgstr "senaste {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
 msgid "{0} was {1} {2}"
-msgstr "{0} era {1} {2}"
+msgstr "{0} var {1} {2}"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
 msgid "Group by a time field to see how this has changed over time"
-msgstr "Agrupa por un campo temporal para ver como ha cambiado a lo largo del tiempo"
+msgstr "Grupperat på ett tidsfält för att se hur detta har ändrats över tid"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:51
 msgid "Switch positive / negative colors?"
-msgstr "¿Mostrar colores positivos/negativos?"
+msgstr "Byta posittiva / negativa färger?"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
 msgid "Pivot column"
-msgstr "Columna pivote"
+msgstr "Pivot-kolumn"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
 msgid "Cell column"
-msgstr "Columna celda"
+msgstr "Cell-kolumn"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
 msgid "Visible columns"
-msgstr "Columnas visibles"
+msgstr "Synliga kolumner"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
 msgid "Conditional Formatting"
-msgstr "Formato condicional"
+msgstr "Villkorad formattering"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
 msgid "Column title"
-msgstr "Título columna"
+msgstr "Kolumnrubrik"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:243
 msgid "Show a mini bar chart"
-msgstr "Mostrar una gráfica de barras en miniatura"
+msgstr "Visa en mini-tabell"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:254
 msgid "Link"
-msgstr "Enlace"
+msgstr "Länk"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:258
 msgid "Email link"
-msgstr "Enlace Email"
+msgstr "Epost-länk"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:262
 msgid "Image"
-msgstr "Imagen"
+msgstr "Bild"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:266
 msgid "Automatic"
-msgstr "Automático"
+msgstr "Automatisk"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:271
 msgid "View as link or image"
-msgstr "Ver como enlace o imagen"
+msgstr "Visa som länk eller bild"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:281
 msgid "Link text"
-msgstr "Texto del enlace"
+msgstr "Länk-text"
 
 #: src/metabase/api/common/internal.clj
 msgid "Not a valid integer: ''{0}''"
-msgstr "No es un entero válido: \"{0}\""
+msgstr "Inte ett giltigt heltal: \"{0}\""
 
 #: src/metabase/api/embed.clj
 msgid "Embedding is not enabled for this object."
-msgstr "No se puede incluir este tipo de objeto."
+msgstr "Inbäddning är inte aktiverat för detta objekt."
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fallback to local authentication: {0}"
-msgstr "Problema al conectarse al servidor LDAP, se recurrirá a la autenticación local: {0}"
+msgstr "Problem vid anslutning till LDAP-server, kommer att fortsätta med lokal autentisering: {0}"
 
 #: src/metabase/api/task.clj
 msgid "When including an offset, a limit must also be included."
-msgstr "Al incluir un desplazamiento, también hay que indicar un límite."
+msgstr "När startvärde anges måste en gräns också anges."
 
 #: src/metabase/api/task.clj
 msgid "When including a limit, an offset must also be included."
-msgstr "Al incluir un límite, también hay que indicar el desplazamiento."
+msgstr "När en gräns anges måste också ett startvärde anges."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Applying heuristic {0} to {1}."
-msgstr "Aplicando heurística {0} a {1}."
+msgstr "Tillämpa heuristik {0} till {1}."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Dimensions bindings:n{0}"
-msgstr "Fijaciones de dimensiones:n{0}"
+msgstr "Dimensionsgränser:n{0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Using definitions:nMetrics:n{0}nFilters:n{1}"
-msgstr "Utilizando definiciones:\\nMétricas{0}\\nFiltros:\\n{1}"
+msgstr "Med definitionerna:nMetrics:n{0}nFilters:n{1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "minute"
-msgstr "minuto"
+msgstr "minut"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "hour"
-msgstr "hora"
+msgstr "timme"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of week"
-msgstr "día de la semana"
+msgstr "veckodag"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of month"
-msgstr "día del mes"
+msgstr "dag i månaden"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of year"
-msgstr "día del año"
+msgstr "dag på året"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "week"
-msgstr "semana"
+msgstr "vecka"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "month"
-msgstr "mes"
+msgstr "månad"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "quarter"
-msgstr "trimestre"
+msgstr "kvartal"
 
 #: src/metabase/automagic_dashboards/populate.clj
 msgid "Adding {0} cards to dashboard {1}:n{2}"
-msgstr "Añadiendo {0} tarjetas al cuadro de mando {1}:n{2}"
+msgstr "Lägger till listorna {0} till instrumentpanelen {1}:n{2}"
 
 #: src/metabase/util/yaml.clj
 msgid "Error parsing {0}:n{1}"
-msgstr "Error leyendo {0}:n{1}"
+msgstr "Fel vid tolkning av {0}:n{1}"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Filtering only works on dimensions! ''{0}'' is a metric. Ignoring filter."
-msgstr "ADVERTENCIA: ¡El filtrado solo funciona sobre dimensiones! ''{0}'' es una métrica, así que será ignorado."
+msgstr "VARNING: Filtrering fungerar bara på dimensioner! \"{0}\" är ett mätetal. Ignorerar filter."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: A date can't belong to multiple discrete intervals, so ANDing them together doesn't make sense."
-msgstr "ADVERTENCIA: Una fecha no puede pertenecer a múltiples intervalos discretos, por lo que el hecho de unirlos con un Y no tiene sentido."
+msgstr "VARNING: Ett datum kan inte tillhöra flera separata intervall, så att koppla dem med AND är inte rimligt."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "Ignoring these intervals: {0}"
-msgstr "Ignorando estos intérvalos: {0}"
+msgstr "Ignorerar dessa intervall: {0}"
 
 #. We should never get to this point since the all non-string negations should get automatically rewritten
 #. by the query expander.
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Don't know how to negate: {0}"
-msgstr "ADVERTENCIA: No sé cómo negar: {0}"
+msgstr "VARNING: Kan inte göra om till negativt: {0}"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "Sorting with Druid is only allowed in queries that have one or more breakout columns. Ignoring :order-by clause."
-msgstr "Ordenando con Druid solo se permite en consultas que tienen una o más columnas de ruptura. Ignorando la cláusula de orden."
+msgstr "Sortering med Druid är bara tillåtet i frågor som har en eller flera utbrutna kolumner. Ignorerar sortera-på-satsen."
 
 #. TODO - this is not really true, is it
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: It only makes sense to specify :fields for a query with no aggregation. Ignoring the clause."
-msgstr "ADVERTENCIA: Solo tiene sentido especificar campos para una consulta sin agregación. Ignorando la cláusula."
+msgstr "VARNING: Det är bara meningsfull att ange :fields i en fråga som saknar sammanslagning. Ignorerar satsen."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Druid doenst allow limitSpec in timeseries queries. Ignoring the LIMIT clause."
-msgstr "ADVERTENCIA: Druid no permite limitSpec en consultas de series de tiempo. Ignorando la cláusula LIMIT."
+msgstr "VARNING: Druid tillåter inte limitSpec i frågor med tidsserier. Ignorerar LIMIT-satsen."
 
 #: src/metabase/driver/sql/query_processor.clj
 msgid "HoneySQL Form:"
-msgstr "Formulario HoneySQL:"
+msgstr "HoneySQL-formulär"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Unable to parse date ''{0}''"
-msgstr "No se ha podido leer la fecha \"{0}\""
+msgstr "Kan inte tolka datum \"{0}\""
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Client closed connection, cancelling query"
-msgstr "Conecxión cerrada por el cliente, cancelando consulta"
+msgstr "Klienten stängde förbindelsen, avbryter frågan"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Setting timezone with statement: {0}"
-msgstr "Establecer zona horaria con declaración: {0}"
+msgstr "Sätter tidszon med uttrycket: {0}"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid "Multiple date filters are not supported"
-msgstr "No se pueden hacer filtros con varias fechas."
+msgstr "Multipla datum-filter stöds inte"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid ":not is not yet implemented"
-msgstr ":no no se ha implementado aun"
+msgstr ":not är ännu inte implementerat"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid "Only one Google Analytics segment allowed at a time."
-msgstr "Solo se permite un segmento de Google Analytics a la vez."
+msgstr "Bara ett Google Analytics-segment tillåts samtidigt."
 
 #: src/metabase/driver/mongo/query_processor.clj
 msgid "MONGO AGGREGATION PIPELINE:"
-msgstr "PIPELINE DE AGREGACION DE MONGO:"
+msgstr "MONGO AGGREGATION PIPELINE:"
 
 #: src/metabase/driver/mongo/query_processor.clj
 msgid "Error: mismatched columns in results! Expected: {0} Got: {1}"
-msgstr "Error: ¡columnas no coincidentes en los resultados! Esperaba: {0} pero se ha obtenido: {1}"
+msgstr "Fel: Sammanblandade kolumner i resultat. Förväntade: {0} Fick: {1}"
 
 #: src/metabase/email/messages.clj
 msgid "Unable to create temp file in `{0}` for email attachments "
-msgstr "No se ha podido crear fichero temporal en `{0}` para adjuntos de correo "
+msgstr "Kan inte skapa temporär fil i `{0}` för epost-bilagor "
 
 #: src/metabase/events/activity_feed.clj
 msgid "Error preprocessing query:"
-msgstr "Error procesando consulta:"
+msgstr "Fel vid förbearbetning av fråga:"
 
 #: src/metabase/mbql/normalize.clj
 msgid "Illegal filter clause: {0}"
-msgstr "Cláusula de filtro incorrecto: {0}"
+msgstr "Felaktig filter-sats: {0}"
 
 #: src/metabase/mbql/normalize.clj
 msgid "Invalid clause:"
-msgstr "Cláusula inválida:"
+msgstr "Felaktig sats:"
 
 #: src/metabase/mbql/util.clj
 msgid "Error: query's source query has not been resolved. You probably need to `preprocess` the query first."
-msgstr "Error: la consulta fuente de la consulta no se ha resuelto. Probablemente necesite 'preprocesar' la consulta primero."
+msgstr "Fel: Frågans källfråga har inte färdigställts. Du behöver antagligen förbearbeta frågan först."
 
 #: src/metabase/mbql/util.clj
 msgid "No expression named ''{0}''"
-msgstr "No hay ninguna expresión llamada \"{0}\""
+msgstr "Inget uttryck kallat \"{0}\""
 
 #: src/metabase/mbql/util.clj
 msgid "No aggregation at index: {0}"
-msgstr "No hay agregación en el índice: {0}"
+msgstr "Ingen sammanslagning vid index: {0}"
 
 #: src/metabase/models/field_values.clj
 msgid "Field values total length is {0} (max {1})."
-msgstr "La longitud total de los valores de campo es {0} (máx {1})."
+msgstr "Fältvärdenas totala längd är {0} (max {1})"
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues are allowed for this Field."
-msgstr "Se permiten Valores de Campo para este Campo."
+msgstr "Fältvärden tillåts för detta fält."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues are NOT allowed for this Field."
-msgstr "NO se permiten Valores de Campo para este campo."
+msgstr "Fältvärden tillåts INTE för detta fält."
 
 #: src/metabase/models/field_values.clj
 msgid "Field {0} ''{1}'' should have FieldValues and belongs to a Database with On-Demand FieldValues updating."
-msgstr "El campo {0} ''{1}'' debe tener valores de campo y pertenece a una base de datos con la actualización de valores de campo bajo demanda."
+msgstr "Fält {0} \"{1}\" borde ha fältvärden och tillhöra en databas med fältvärden som uppdateras på begäran."
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot create or revoke permissions for the ''Admin'' group."
-msgstr "No puedes crear ni revocar permisos para el grupo ''Admin''."
+msgstr "Du kan inte skapa eller återkalla rättigheter för Admin-gruppen."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the ''MetaBot'' group."
-msgstr "No puedes agregar o eliminar usuarios del grupo ''MetaBot''."
+msgstr "Du kan inte lägga till eller ta bort användare från MetaBot-gruppen."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the ''All Users'' group."
-msgstr "No puedes agregar o eliminar usuarios del grupo \"Todos los usuarios\"."
+msgstr "Du kan inte lägga till eller ta bort användare från gruppen Alla användare."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot remove the last member of the ''Admin'' group!"
-msgstr "¡No puedes eliminar al último miembro del grupo ''Admin''!"
+msgstr "Du kan inte ta bort den sista medlemmen i Admin-gruppen!"
 
 #. go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
 #: src/metabase/models/setting/cache.clj
 msgid "Error inserting a new Setting: {0}"
-msgstr "Error registrando la nueva configuración: {0}"
+msgstr "Fel när en ny inställning skulle sparas: {0}"
 
 #: src/metabase/models/setting.clj
 msgid "defsetting descriptions strings must be `:internal?` or internationalized, found: `{0}`"
-msgstr "las cadenas de descripciones defsetting deben ser `:internal?` o traducidas, encontradas: `{0}`"
+msgstr "Beskrivning av förval måste vara `:internal?` eller internationalized, hittade `{0}`"
 
 #: src/metabase/plugins.clj
 msgid "Loading plugin {0}... {1}"
-msgstr "Cargando extensión {0}... {1}"
+msgstr "Laddar plugin {0}... {1}"
 
 #: src/metabase/public_settings.clj
 msgid "Object keyed by type, containing formatting settings"
-msgstr "Objeto tecleado por tipo, contiene ajustes de formato"
+msgstr "Objekt med nyckel på typ, innehållande formatteringsinställningar"
 
 #: src/metabase/public_settings.clj
 msgid "Allow users to explore data using X-rays"
-msgstr "Permitir que los usuarios hagan uso de Rayos-X"
+msgstr "Tillåt användare att utforska data med genomlysningar"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Using this URL to check token: {0}"
-msgstr "Utilizando esta URL para validar el símbolo: {0}"
+msgstr "Använder denna URL för att kontrollera accessnyckel: {0}"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Unable to validate token: 404 not found."
-msgstr "No se ha podido validar el símbolo: 404 no encontrado."
+msgstr "Kan inte validera accessnyckel: 404 saknas."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "There was an error checking whether this token was valid:"
-msgstr "Se produjo un error al verificar si este token era válido:"
+msgstr "Ett fel uppstod vid kontroll av denna accessnyckel:"
 
 #. +----------------------------------------------------------------------------------------------------------------+
 #. |                                             SETTING & RELATED FNS                                              |
@@ -9944,234 +9923,234 @@ msgstr "Se produjo un error al verificar si este token era válido:"
 #. TODO - rename this to premium-features-token?
 #: src/metabase/public_settings/metastore.clj
 msgid "Token for premium features. Go to the MetaStore to get yours!"
-msgstr "Token para características premium. ¡Ve a MetaStore para conseguir el tuyo!"
+msgstr "Accessnyckel för premium-funktioner. Gå till MetaStore för att skaffa dina!"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token format is invalid. Token should be 64 hexadecimal characters."
-msgstr "El formato del token no es válido. El token debe tener 64 caracteres hexadecimales."
+msgstr "Accessnyckelns format är felaktigt. Den ska vara 64 hexdecimala tecken."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error setting premium features token"
-msgstr "Error al configurar el token de características premium"
+msgstr "Fel när premium-funktionernas accessnyckel sparades"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error validating token:"
-msgstr "Error validando el símbolo:"
+msgstr "Fel vid validering av accessnyckel:"
 
 #: src/metabase/query_processor.clj
 msgid "Error preprocessing query"
-msgstr "Error procesando la consulta"
+msgstr "Fel vid förbearbetning av fråga"
 
 #: src/metabase/query_processor.clj
 msgid "No native form returned."
-msgstr "No se ha obtenido un formulario nativo."
+msgstr "Ingen inbyggd form returnerades."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
-msgstr "Respuesta no válida del controlador de base de datos. No se ha definido el estado."
+msgstr "Felaktigt svar från databas-drivrutinen. Ingen :status returnerades."
 
 #: src/metabase/query_processor.clj
 msgid "General error"
-msgstr "Error general"
+msgstr "Allmänt fel"
 
 #: src/metabase/query_processor.clj
 msgid "Missing query hash!"
-msgstr "¡Falta el hash de consulta!"
+msgstr "Saknad frågesammansättning"
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Table ''{0}'' has no Fields associated with it."
-msgstr "La tabla '' {0} '' no tiene campos asociados."
+msgstr "Tabellen \"{0}\" har inga associerade fält."
 
 #: src/metabase/query_processor/middleware/add_query_throttle.clj
 msgid "Max concurrent query limit reached"
-msgstr "Se ha alcanzado el máximo de consultas concurrentes"
+msgstr "Gräns för max antal samtidiga frågor nådd"
 
 #. we should never reach this if our patterns are written right so this is more to catch code mistakes than
 #. something the user should expect to see
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Don't know how to get information about Field:"
-msgstr "No se cómo obtener información del Campo:"
+msgstr "Kan inte hitta information om fältet:"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "metabase.query-processor.interface/*driver* is unbound."
-msgstr "metabase.query-processor.interface/*driver* no está definido."
+msgstr "metabase.query-processor.interface/*driver* är inte kopplad."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Query processor error: mismatched number of columns in query and results."
-msgstr "Error del procesador de consultas: número de columnas no coincidentes en la consulta y los resultados."
+msgstr "Frågemotor-fel: fel antal kolumner i fråga och resultat."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected {0} fields, got {1}"
-msgstr "Esperaba {0} campos pero hay {1}"
+msgstr "Förväntade {0} fält, fick {1}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected: {0}"
-msgstr "Esperado: {0}"
+msgstr "Förväntat: {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Actual: {0}"
-msgstr "Actual: {0}"
+msgstr "Verkligt: {0}"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Unable to bin Field without a min/max value"
-msgstr "No se puede agrupar el campo sin un valor mínimo/máximo"
+msgstr "Kan inte lägga fält i behållare utan ett min/max-värde"
 
 #: src/metabase/query_processor/middleware/check_features.clj
 msgid "{0} is not supported by this driver."
-msgstr "Este controlador no soporta {0}"
+msgstr "{0} stöds inte av denna drivrutin."
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Segment {0} does not exist, or is invalid."
-msgstr "El segmento {0} no existe o es inválido."
+msgstr "Segmentet {0} finns inte eller är felaktigt"
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Metric {0} does not exist, or is invalid."
-msgstr "La Métrica {0} no existe o es inválida."
+msgstr "Mätvärde {0} finns inte eller är felaktigt."
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Missing source query in Card {0}"
-msgstr "Falta la consulta de origen en la tarjeta {0}"
+msgstr "Saknad frågekälla för frågan i lista {0}"
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Fetched source query from Card {0}:"
-msgstr "Leído la consulta de origen de la tarjeta {0}:"
+msgstr "Hämtade frågekälla från lista {0}:"
 
 #: src/metabase/query_processor/middleware/mbql_to_native.clj
 msgid "Error transforming MBQL query to native:"
-msgstr "Error al transformar la consulta MBQL a nativo:"
+msgstr "Fel vid överföring av MBQL-fråga till intern:"
 
 #: src/metabase/query_processor/middleware/resolve_source_table.clj
 msgid "Cannot run query: could not find source table {0}."
-msgstr "No se ha podido ejecutar la consulta: no se ha encontrado la tabla origen {0}."
+msgstr "Kan inte köra fråga: kunde inte hitta käll-tabellen {0}."
 
 #: src/metabase/query_processor/middleware/results_metadata.clj
 msgid "Error recording results metadata for query:"
-msgstr "Error al registrar los metadatos de resultados para la consulta:"
+msgstr "Fel när metadata om resultat skulle sparas för frågan:"
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Query Processor store is not initialized."
-msgstr "Error: el almacén del procesador de consultas no está inicializada."
+msgstr "Fel: Frågeprocessorn är inte initierad."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Table {0} is not present in the Query Processor Store."
-msgstr "Error: la tabla {0} no está presente en el almacén del procesador de consultas."
+msgstr "Fel: Tabell {0} saknas i frågeprocessorns uppsättning."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Field {0} is not present in the Query Processor Store."
-msgstr "Error: el campo {0} no está presente en el almacén del procesador de consultas."
+msgstr "Fel: Fält {0} finns inte i frågeprocessorns uppsättning."
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, rows were {0}deleted"
-msgstr "La limpieza del historial de tareas fue exitosa, {0} se eliminaron filas"
+msgstr "Rensning av jobbhistorik genomförd, {0} rader togs bort"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "not"
-msgstr "no"
+msgstr "inte"
 
 #: src/metabase/db.clj src/metabase/util/encryption.clj
 msgid "For more information, see"
-msgstr "Para obtener más información, visita"
+msgstr "För mer info, se"
 
 #: src/metabase/util/schema.clj
 msgid "Integer greater than or equal to zero"
-msgstr "Entero mayor o igual a cero"
+msgstr "Heltal större eller lika med noll"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer greater than or equal to zero."
-msgstr "valor debe ser un entero igual o superior a cero."
+msgstr "värdet måste vara ett heltal större än eller lika med noll"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer zero or greater."
-msgstr "valor debe ser un entero igual o superior a cero."
+msgstr "värdet måste vara ett heltal som är noll eller större."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer greater than or equal to zero."
-msgstr "valor debe ser un entero igual o superior a cero."
+msgstr "värdet måste vara ett giltigt heltal större än eller lika med noll."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "New users per state in the last 30 days"
-msgstr "Nuevos usuarios por estado en los últimos 30 días"
+msgstr "Nya användare per stat de senaste 30 dagarna"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by day of the week"
-msgstr "Creado por día de la semana"
+msgstr "Skapad per veckodag"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by quarter of the year"
-msgstr "Creado por trimestre"
+msgstr "Skapad per kvartal"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per country"
-msgstr "[[this.short-name]] por país"
+msgstr "[[this.short-name]]  per land"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Users per source"
-msgstr "Usuarios por origen"
+msgstr "Användare per källa"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "The top external pages that brought users to your site"
-msgstr "Las principales páginas externas que trajeron usuarios a tu sitio."
+msgstr "De översta externa sidorna som drog användare till din sajt"
 
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
-msgstr "Cómo se distribuye [[this]] y algo más."
+msgstr "Hur [[this]] är fördelat och mer."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "The [[this]] over time"
-msgstr "El [[this]] a lo largo del tiempo"
+msgstr "[[this]] över tid"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "User growth"
-msgstr "Crecimiendo de usuarios"
+msgstr "Användartillväxt"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Whether or not there are any patterns to when they happen."
-msgstr "Si hay o no patrones para cuando suceden."
+msgstr "Huruvida det finns något mönster i när de inträffar."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Users per state"
-msgstr "Usuarios por provincia"
+msgstr "Användare per stat"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions"
-msgstr "Sesiones"
+msgstr "Sessioner"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "How some of the numbers in [[this]] relate to each other"
-msgstr "Cómo algunos de los números en [[this]] se relacionan entre sí"
+msgstr "Hur några av siffrorna i [[this]] är relaterade till varandra"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per country"
-msgstr "Ventas por país"
+msgstr "Försäljning per land"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by month of the year"
-msgstr "Unir fecha por el mes del año"
+msgstr "Slå ihop datum med månadsnummer"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by hour of the day"
-msgstr "[[Timestamp]] por hora del día"
+msgstr "[[Timestamp]] med timme"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "A look at the [[this]]"
-msgstr "Un vistazo a [[this]]"
+msgstr "En titt på [[this]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Bottom 5 per category"
-msgstr "Ultimos 5 por categoría"
+msgstr "De sista 5 per kategori"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Number of orders"
-msgstr "Número de pedidos"
+msgstr "Antal order"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Event growth"
-msgstr "Crecimiento de Eventos"
+msgstr "Händelsetillväxt"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "Total [[GenericTable]]"
@@ -10179,35 +10158,35 @@ msgstr "Total [[GenericTable]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Income growth"
-msgstr "Crecimiento de Ingresos"
+msgstr "Ökning förtjänst"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top 10 countries by sales in the last 30 days"
-msgstr "Primeros 10 paises por ventas en los últimos 30 días"
+msgstr "De 10 första länderna försäljningsmässigt de senaste 30 dagarna"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by month of the year"
-msgstr "[[this]] por mes del año"
+msgstr "[[this]] per månadsnummer"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per day of the week"
-msgstr "Transacciones por día de la semana"
+msgstr "Transaktioner per veckodag"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by device type"
-msgstr "Sesiones por dispositivo"
+msgstr "Session per enhetstyp"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Transactions per country"
-msgstr "Transacciones por país"
+msgstr "Transaktioner per land"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by quarter of the year"
-msgstr "Unir fecha por trimestre"
+msgstr "Slå ihop datum med kvartal"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per hour of the day"
-msgstr "Eventos por hora del día"
+msgstr "Händelser per timme"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Singleton]]"
@@ -10216,20 +10195,20 @@ msgstr "[[Singleton]]"
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Top 5 [[this]]"
-msgstr "Primeros 5 [[this]]"
+msgstr "De 5 högsta [[this]]"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Bottom 5 [[this]]"
-msgstr "Ultimos 5 [[this]]"
+msgstr "De 5 lägsta [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by day of the month"
-msgstr "[[Timestamp]] por día del mes"
+msgstr "[[Timestamp]] per dag i månaden"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[GenericCategoryLarge]]"
-msgstr "Por [[GenericCategoryLarge]]"
+msgstr "Per [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10237,335 +10216,335 @@ msgstr "Por [[GenericCategoryLarge]]"
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "Null values"
-msgstr "Valores nulos"
+msgstr "Tomma värden"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Total events"
-msgstr "Total eventos"
+msgstr "Totalt antal händelser"
 
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "A look at [[GenericTable]] across your [[this]], and how it changes over time."
-msgstr "Una mirada a [[GenericTable]] a través de tu [[this]], y cómo cambia con el tiempo."
+msgstr "En titt på [[GenericTable]] över din [[this]] och hur det ändras över tid."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryMedium]]"
-msgstr "[[this]] por [[GenericCategoryMedium]]"
+msgstr "[[this]] per [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] changes with time"
-msgstr "Como el [[this]] cambia con el tiempo"
+msgstr "Hur [[this]] ändras över tid"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "How they compare by seasonality"
-msgstr "Cómo se comparan por estacionalidad."
+msgstr "Hur de kan jämföras per säsong"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average income per transaction"
-msgstr "Ingreso medio por transacción"
+msgstr "Genomsnittlig förtjänst per transaktion"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per country"
-msgstr "[[this]] por país"
+msgstr "[[this]] per land"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Income per state"
-msgstr "Ingresos por provincia"
+msgstr "Förtjänst per stat"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[GenericCategoryMedium]]"
-msgstr "Por [[GenericCategoryMedium]]"
+msgstr "Per [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "A closer look at your [[this]]"
-msgstr "Una mirada detallada a tus [[this]]"
+msgstr "En närmare titt på din [[this]]"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "How [[GenericNumber]] is distributed"
-msgstr "Como se distribuye [[GenericNumber]]"
+msgstr "Hur  [[GenericNumber]] är fördelat"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by quarter of year"
-msgstr "[[Timestamp]] por trimestre"
+msgstr "[[Timestamp]] per kvartal"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per country"
-msgstr "Eventos por país"
+msgstr "Händelser per land"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Weekdays when [[this.short-name]] were added"
-msgstr "Días de la semana cuando se añadío [[this.short-name]]"
+msgstr "Veckodagar när [[this.short-name]] lades till"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Months when [[this.short-name]] were added"
-msgstr "Mes cuando se añadío [[this.short-name]]"
+msgstr "Månader när [[this.short-name]] lades till"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across different categories"
-msgstr "Cómo se comparan en diferentes categorías"
+msgstr "Jämförelse mellan olika kategorier"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "New users per source in the last 30"
-msgstr "Nuevos usuarios por origen en los últimos 30 días"
+msgstr "Nya användare per källa de senaste 30"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per quarter of the year"
-msgstr "Eventos por trimestre"
+msgstr "Händelser per kvartal"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Heres a quick look at your [[this]]"
-msgstr "Una mirada rápida a tus [[this]]"
+msgstr "Här är en snabb titt på din [[this]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryLarge]], top 5"
-msgstr "[[this]] por [[GenericCategoryLarge]], primeros 5"
+msgstr "[[this]] per [[GenericCategoryLarge]], topp-5"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Days when [[this.short-name]] were added"
-msgstr "Días en los que se añadío [[this.short-name]]"
+msgstr "Dagar när [[this.short-name]] lades till"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Total orders per source"
-msgstr "Pedidos totales por origen"
+msgstr "Totalt antal order per källa"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by quarter of the year"
-msgstr "[[this]] por trimestre"
+msgstr "[[this]] per kvartal"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per [[GenericCategoryMedium]]"
-msgstr "Eventos por [[GenericCategoryMedium]]"
+msgstr "Händelser per [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per state"
-msgstr "Eventos por provincia"
+msgstr "Händelser per stat"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top landing pages"
-msgstr "Las mejores páginas de aterrizaje"
+msgstr "Topp-slutsidor"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Heres a closer look at your [[this]] over time"
-msgstr "Una mirada detallada a tus [[this]] a lo largo del tiempo"
+msgstr "Här är en närmare titt på din [[this]] över tid"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Sum of [[this]] by [[Country]]"
-msgstr "Suma de [[this]] por [[Country]]"
+msgstr "Summan av [[this]] per [[Country]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "States that are performing best"
-msgstr "Las provincia con mejores resultados"
+msgstr "Stater som går bäst"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by month of the year"
-msgstr "Creado por mes del año"
+msgstr "Skapad per månad"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Sum of [[this]] by [[State]]"
-msgstr "Suma de [[this]] por [[State]]"
+msgstr "Summan av [[this]] per [[State]]"
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "Sum of [[GenericNumber]] per [[this]]"
-msgstr "Suma de [[GenericNumber]] por [[this]]"
+msgstr "Summan av [[GenericNumber]] per [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by coordinates"
-msgstr "Eventos por coordenadas"
+msgstr "Händelser per koordinater"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top referral pages"
-msgstr "Las mejores páginas de referencia"
+msgstr "Sidor som länkar mest"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "An exploration of your users to get you started."
-msgstr "Un exploración de tus usuarios para empezar."
+msgstr "En genomlysning av dina användare för att komma igång."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "An overview of your [[this]] and how its distributed across time, place, and categories."
-msgstr "Una visión general de tu [[this]] y cómo se distribuye en el tiempo, el lugar y las categorías."
+msgstr "En översikt över din [[this]] och hur det fördelas över tid, plats och kategorier"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Average income per state"
-msgstr "Ingresos medios por provincia"
+msgstr "Genomsnittlig förtjänst mer stat"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
-msgstr "[[this]] por [[GenericCategoryMedium]]"
+msgstr "[[this]] per [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total transactions"
-msgstr "Total transacciones"
+msgstr "Totalt antal transaktioner"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] that have joined over time"
-msgstr "[[this.short-name]] que se han unido a lo largo del tiempo"
+msgstr "[[this.short-name]] som har slagits ihop över tid"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "The [[this]] by location"
-msgstr "Los [[this]] por ubicación"
+msgstr "[[this]] per plats"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per month of the year"
-msgstr "Eventos por mes del año"
+msgstr "Händelser per månad"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] by [[GenericNumber]]"
-msgstr "[[this]] por [[GenericNumber]]"
+msgstr "[[this]] per [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Quarters when [[this.short-name]] were added"
-msgstr "Trimestres en los que se añadío [[this.short-name]]"
+msgstr "Kvartal när [[this.short-name]] lades till"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "How these [[this.short-name]] are distributed"
-msgstr "Como se distribuyen [[this.short-name]]"
+msgstr "Hur dessa [[this.short-name]] är fördelade"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by [[GenericNumber]]"
-msgstr "[[this.short-name]] por [[GenericNumber]]"
+msgstr "[[this.short-name]] per [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Where users are coming from"
-msgstr "De donde vienen los usuarios"
+msgstr "Var användare kommer ifrån"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "[[this]] comparisons and correlations"
-msgstr "comparaciones y correlaciones de [[this]]"
+msgstr "[[this]] jämförelser och korrelation"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total income"
-msgstr "Ingreso total"
+msgstr "Total förtjänst"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total income per month"
-msgstr "Inrgeso total por mes"
+msgstr "Total förtjänst per månad"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Number of users per source"
-msgstr "Número de usuarios por origen"
+msgstr "Antal användare per källa"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Transactions per state"
-msgstr "Transacciones por provincia"
+msgstr "Transaktioner per stat"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "[[this]] by [[Timestamp]]"
-msgstr "[[this]] por [[Timestamp]]"
+msgstr "[[this]] per [[Timestamp]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "New users per source in the last 30 days"
-msgstr "Nuevos usuarios por origen en los últimos 30 días"
+msgstr "Ny användare per källa de senaste 30 dagarna"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by day of the month"
-msgstr "Unir fecha por el día del mes"
+msgstr "Slå ihop datum per dag i månaden"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average discount %"
-msgstr "Descuento medio %"
+msgstr "Genomsnittlig rabattprocent"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Autogenerated metrics about [[GenericTable]]."
-msgstr "Métricas autogeneradas sobre [[GenericTable]]."
+msgstr "Automatiskt skapade mått om [[GenericTable]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per day of the month"
-msgstr "[[this]] por día del mes"
+msgstr "[[this]] per dag i månaden"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Total sessions in each country"
-msgstr "Sesiones totales en cada país"
+msgstr "Totalt antal sessioner i varje land"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per month of the year"
-msgstr "Transacciones por mes"
+msgstr "Transaktioner per månad"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per product"
-msgstr "Ventas por producto"
+msgstr "Försäljning per produkt"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Users in each country"
-msgstr "Usuarios en cada país"
+msgstr "Användare i varje land"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by hour of the day"
-msgstr "[[this]] por hora del día"
+msgstr "[[this]] per timme"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events in the last 30 days"
-msgstr "Eventos en los últimos 30 días"
+msgstr "Händelser de senaste 30 dagarna"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Transactions per source"
-msgstr "Transacciones por origen"
+msgstr "Transaktioner per källa"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Where youve acquired your users"
-msgstr "De dónde provienen tus usuarios"
+msgstr "Där du skaffade dig dina användare"
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare acrosss location"
-msgstr "Como se comparan por ubicación"
+msgstr "Hur de kan jämföras per plats"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "[[this]] per product"
-msgstr "[[this]] por producto"
+msgstr "[[this]] per produkt"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per month of the year"
-msgstr "[[this]] por mes del año"
+msgstr "[[this]] per månad"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per country"
-msgstr "Por país"
+msgstr "Per land"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "A deeper look at how different countries are performing for you."
-msgstr "Una mirada más profunda al rendimiento de los diferentes países."
+msgstr "En noggrannare titt på hur olika länder går."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per state"
-msgstr "Ventas por provincia"
+msgstr "Försäljning per stat"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by [[GenericNumber]]"
-msgstr "Eventos por [[GenericNumber]]"
+msgstr "Händelser per [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales per product [[ProductCategoryMedium]]"
-msgstr "Ventas por producto [[ProductCategoryMedium]]"
+msgstr "Försäljning per produkt [[ProductCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "User acquisition by country"
-msgstr "Adquisición de usuarios por país"
+msgstr "Användartillväxt per land"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "[[this]] per source"
-msgstr "[[this]] por origen"
+msgstr "[[this]] per källa"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by day of the week"
-msgstr "[[this]] por día de la semana"
+msgstr "[[this]] per veckodag"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Days of the month when [[this.short-name]] joined"
-msgstr "Días del mes cuando se juntan [[this.short-name]]"
+msgstr "Dagar i månaden när [[this.short-name]] lades till"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Heres an overview of the people in your [[this]]"
-msgstr "Aquí hay una visión general de las personas en tu [[this]]"
+msgstr "Här är en översikt över personer i din [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "How [[GenericTable]] are distributed across this time field, and if it has any seasonal patterns."
-msgstr "Cómo [[GenericTable]] se distribuye en este campo de tiempo, y si tiene algún patrón estacional."
+msgstr "Hur [[GenericTable]] fördelas över detta tidsfält och om det har skillnader per säsong."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10576,137 +10555,137 @@ msgstr "Cómo [[GenericTable]] se distribuye en este campo de tiempo, y si tiene
 #: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Overview"
-msgstr "Visión general"
+msgstr "Översikt"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How this metric is distributed across different categories"
-msgstr "Cómo se distribuye esta métrica en diferentes categorías."
+msgstr "Hur detta mått fördelas över olika kategorier"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per state"
-msgstr "[[this.short-name]] por provincia"
+msgstr "[[this.short-name]] per stat"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Weekdays when [[this.short-name]] joined"
-msgstr "Días de la semana cuando se une por [[this.short-name]]"
+msgstr "Veckodagar när [[this.short-name]] lades till"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Hours when [[this.short-name]] joined"
-msgstr "Horas cuando se une por [[this.short-name]]"
+msgstr "Timmar när [[this.short-name]] lades till"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Total income by month"
-msgstr "Ingreso total por mes"
+msgstr "Total förtjänst per månad"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "A breakdown of your [[this]] over time, and its min, max, average and more."
-msgstr "Un desglose de tu [[this]] a lo largo del tiempo, y su mínimo, máximo, promedio y más."
+msgstr "En nedbrytning av din [[this]] över tid, och dess min-, max- och genomsnittliga värden, och mer därtill."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Average quantity per state"
-msgstr "Cantidad media por provincia"
+msgstr "Genomsnittligt antal per stat"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare by across different numbers"
-msgstr "Cómo se comparan por diferentes números"
+msgstr "Hur de kan jämföras över olika siffror"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "New users per country in the last 30 days"
-msgstr "Nuevos usuarios por país en los últimos 30 días"
+msgstr "Nya användare per land de senaste 30 dagarna"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions over time"
-msgstr "Transacciones a lo largo del tiempo."
+msgstr "Transaktioner över tid"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategorySmall]]"
-msgstr "[[this]] por [[GenericCategorySmall]]"
+msgstr "[[this]] per [[GenericCategorySmall]]"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Some breakdown"
-msgstr "Algún desglose"
+msgstr "Lite nedbrytning"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Average of [[this]] by [[State]]"
-msgstr "Media de [[this]] por [[State]]"
+msgstr "Genomsnitt av [[this]] per [[State]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per quarter of the year"
-msgstr "Transacciones por trimestre"
+msgstr "Transaktioner per kvartal"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "By coordinates"
-msgstr "Por coordenadas"
+msgstr "Per koordinater"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Heres a closer look at your [[this]] by products"
-msgstr "Una mirada detallada de tus [[this]] por productos"
+msgstr "Här är en närmare titt på din [[this]] per produkt"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per quarter of the year"
-msgstr "[[this]] por trimestre"
+msgstr "[[this]] per kvartal"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Heres an overview of your [[this]] data from Google Analytics"
-msgstr "Aquí hay un resumen de tus datos [[this]] de Google Analytics"
+msgstr "Här är en överblick över din [[this]], data från Google Analytics"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Quarters when [[this.short-name]] joined"
-msgstr "Trimestres cuando se une por [[this.short-name]]"
+msgstr "Kvartal när [[this.short-name]] lades till"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "New [[this.short-name]] in the last 30 days"
-msgstr "Nuevo [[this.short-name]] en los últimos 30 días"
+msgstr "Nya [[this.short-name]] de senaste 30 dagarna"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Total sessions by desktop, mobile, or tablet"
-msgstr "Sesiones totales por ordenador, móvil o tablet"
+msgstr "Totalt antal sessioner per desktop, mobil eller platta"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "Indepth example"
-msgstr "Ejemplo en profundidad"
+msgstr "Detaljerat exempel"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average income per source"
-msgstr "Ingreso medio por origen"
+msgstr "Genomsnittlig förtjänst per källa"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by day of week"
-msgstr "[[Timestamp]] por día de la semana"
+msgstr "[[Timestamp]] per veckodag"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "Heres a closer look at your [[this]]"
-msgstr "Aquí hay una mirada más detallada a tus [[this]]"
+msgstr "Här är en närmare titt på din [[this]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Heres a closer look at your [[this]] field"
-msgstr "Una mirada detallada de tu campo [[this]]"
+msgstr "Här är en närmare titt på ditt fält [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Summary"
-msgstr "Resumen"
+msgstr "Summering"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] is distributed geographically"
-msgstr "Cómo se distribuye geográficamente el [[this]]"
+msgstr "Hur [[this]] är fördelat geografiskt"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "The pages with the most pageviews"
-msgstr "Las páginas con más visitas"
+msgstr "Sidorna som visats mest"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "How [[Number1]] is correlated with [[Number2]]"
-msgstr "La correlación entre [[Number1]] y [[Number2]]"
+msgstr "Hur [[Number1]] förhåller sig till [[Number2]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Top 10 states by sales in the last 30 days"
-msgstr "Primeras 10 provincias por venta en los últimos 30 días"
+msgstr "10 bästa staterna för försäljning de senaste 30 dagarna"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Top 10 states by sales"
-msgstr "Primeras 10 provincia por ventas"
+msgstr "10 bästa staterna för försäljning"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Timestamp]]"
@@ -10714,62 +10693,62 @@ msgstr "[[Timestamp]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Where these transactions happened"
-msgstr "Donde occurrieron estas transacciones"
+msgstr "När dessa transaktioner genomfördes"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top 10 countries by sales"
-msgstr "Primeros 10 paises por ventas"
+msgstr "10 bästa länderna avseende försäljning"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by state"
-msgstr "Ventas por provincia"
+msgstr "Försäljning per stat"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Where most of your sessions originate from"
-msgstr "De donde provienen la mayoría de las sesiones"
+msgstr "Varifrån de flesta av dina sessioner kommer ifrån"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top acquisition channels"
-msgstr "Los mejores canales de adquisición"
+msgstr "De bästa kanalerna för rekrytering"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "These [[this.short-name]] across time"
-msgstr "Estos [[this.short-name]] a lo largo del tiempo"
+msgstr "Dessa [[this.short-name]] över tid"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average quantity"
-msgstr "Cantidad media"
+msgstr "Genomsnittligt antal"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per source"
-msgstr "Ventas por origen"
+msgstr "Försäljning per källa"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Average income per country"
-msgstr "Ingreso medio por país"
+msgstr "Genomsnittlig förtjänst per land"
 
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
-msgstr "Como se distribuye [[this]]"
+msgstr "Hur [[this]] är fördelat"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Distinct [[FK]]"
-msgstr "[[FK]] distintos"
+msgstr "distinkt [[FK]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "How these transactions are distributed"
-msgstr "Como se distribuyen estas transacciones"
+msgstr "Hur dessa transaktioner är fördelade"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per state"
-msgstr "Por provincias"
+msgstr "Per stat"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "Count of [[GenericCategoryMedium]] by [[this]]"
-msgstr "Cuenta de [[GenericCategoryMedium]] por [[this]]"
+msgstr "Antal [[GenericCategoryMedium]] per [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10784,68 +10763,68 @@ msgstr "Cuenta de [[GenericCategoryMedium]] por [[this]]"
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "A look at your [[this]]"
-msgstr "Una mirada a tus [[this]]"
+msgstr "En titt på din [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "[[GenericNumber]] by [[this]]"
-msgstr "[[GenericNumber]] por [[this]]"
+msgstr "[[GenericNumber]] per [[this]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Sum of [[GenericNumber]] by [[this]]"
-msgstr "Suma de [[GenericNumber]] por [[this]]"
+msgstr "Summan av [[GenericNumber]] per [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A look at your [[this]] table"
-msgstr "Una mirada a tu tabla [[this]]"
+msgstr "En titt på din tabell [[this]]"
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "How many [[GenericTable]] there are per state, and how each state is represented across other categories."
-msgstr "Cuántos [[GenericTable]] hay por provincia y cómo se representa cada estado en otras categorías."
+msgstr "Hur många [[GenericTable]] det finns per stat, och varje stats fördelning över kategorier."
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Most-viewed pages"
-msgstr "Páginas más vistas"
+msgstr "Sidor med flest träffar"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Example exploration"
-msgstr "Exploración de ejemplo"
+msgstr "Exempel på analys"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales vs. rating"
-msgstr "Ventas vs. Clasificación"
+msgstr "Försäljning mot betyg"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per hour of the day"
-msgstr "[[this]] por hora del día"
+msgstr "[[this]] per timme"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Where your [[this.short-name]] are"
-msgstr "Donde están tus [[this.short-name]]"
+msgstr "Var dina [[this.short-name]] finns"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "These are the same for all your [[this.short-name]]"
-msgstr "Estos son los mismos para todos los [[this.short-name]]"
+msgstr "Detta är gemensamt för alla dina [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by different categories"
-msgstr "Eventos por diferentes categorías"
+msgstr "Händelser per olika kategorier"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Where these [[this.short-name]] are"
-msgstr "Donde están estos [[this.short-name]]"
+msgstr "Var dessa [[this.short-name]] finns"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Over time"
-msgstr "A lo largo del tiempo"
+msgstr "Över tid"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A summary of the events in your [[this]] table"
-msgstr "Un resumen de los eventos en tu tabla [[this]]"
+msgstr "En summering av händelserna i din tabell [[this]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Transactions per source over time"
-msgstr "Transacciones por origen a lo largo del tiempo."
+msgstr "Transaktioner per källa över tid"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10853,221 +10832,221 @@ msgstr "Transacciones por origen a lo largo del tiempo."
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "How the [[this]] is distributed"
-msgstr "Como se distribuye el [[this]]"
+msgstr "Hur [[this]] är fördelat"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Total income per source"
-msgstr "Ingreso total por origen"
+msgstr "Total förtjänst per källa"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Total [[this.short-name]]"
-msgstr "Total [[this.short-name]]"
+msgstr "Total [this.short-name]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Some metrics we found about your transactions."
-msgstr "Algunas métricas que encontramos sobre tus transacciones."
+msgstr "Några mått vi fann för dina transaktioner"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "How your different products are performing."
-msgstr "Rendimiento de tus productos."
+msgstr "Hur dina olika produkter går."
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Where these events are happening"
-msgstr "Donde occuren estos eventos"
+msgstr "Var dessa händelser sker"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Which US states are bringing you the most business."
-msgstr "Qué estados de los EEUU te están dando más negocio"
+msgstr "Vilka amerikanska stater som går bäst."
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
-msgstr "Como se comparan a lo largo del tiempo"
+msgstr "Hur de kan jämföras över tid"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average transaction income per month"
-msgstr "Ingreso medio de transacción por mes"
+msgstr "Genomsnittlig förtjänst per månad"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average quantity per month"
-msgstr "Cantidad media por mes"
+msgstr "Genomsnittligt antal per månad"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "Seasonal patterns in the [[this]]"
-msgstr "Patrones estacionales en [[this]]"
+msgstr "Säsongsmönster i [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events over time"
-msgstr "Eventos a lo largo del tiempo"
+msgstr "Händelser över tid"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Orders and income per source"
-msgstr "Pedidos e ingresos por origen"
+msgstr "Order och förtjänst per källa"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per hour of the day"
-msgstr "Transacciones por hora del día"
+msgstr "Transaktioner per timme"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Where most of your traffic is coming from."
-msgstr "De donde proviene la mayoría de tu tráfico"
+msgstr "Varifrån det mesta av din trafik kommer ifrån"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Heres a quick look at the [[this]]"
-msgstr "Aquí hay un vistazo rápido a [[this]]"
+msgstr "Här är en snabb titt på [[this]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "It looks like your [[this]] has transactions, so heres a look at them"
-msgstr "Parece que tu [[this]] tiene transacciones, así que aquí hay información"
+msgstr "Det ser ut som om din [[this]] har transaktioner, så här är en titt på dem"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average discount per month"
-msgstr "Descuento medio por mes"
+msgstr "Genomsnittlig rabatt per månad"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by month of the year"
-msgstr "[[Timestamp]] por mes del año"
+msgstr "[[Timestamp]] per månad"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategorySmall]] over time"
-msgstr "[[this]] por [[GenericCategorySmall]] a lo largo del tiempo"
+msgstr "[[this]] per [[GenericCategorySmall]] över tid"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Distribution by coordinates"
-msgstr "Distribución por coordenadas"
+msgstr "Fördelning över koordinater"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by source"
-msgstr "Ventas por origen"
+msgstr "Försäljning per källa"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales for each product category"
-msgstr "Ventas por cada categoría de producto"
+msgstr "Försäljning för varje produktkategori"
 
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "A closer look at the metrics and dimensions used in this saved question."
-msgstr "Una mirada detallada a las métricas y dimensiones utilizadas en esta pregunta guardada."
+msgstr "En närmare titt på mått och värden som används i denna sparade fråga."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per [[GenericCategoryMedium]]"
-msgstr "[[this.short-name]] por [[GenericCategoryMedium]]"
+msgstr "[[this.short-name]] per [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales per product [[ProductCategoryLarge]]"
-msgstr "Ventas por producto [[ProductCategoryLarge]]"
+msgstr "Försäljning per produkt [[ProductCategoryLarge]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Average quantity per country"
-msgstr "Cantidad media por país"
+msgstr "Genomsnittligt antal per land"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per [[GenericCategoryLarge]]"
-msgstr "[[this.short-name]] por [[GenericCategoryLarge]]"
+msgstr "[[this.short-name]] per [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Heres a closer look at your [[this]] per source"
-msgstr "Aquí hay una mirada detallada a tu [[this]] por origen"
+msgstr "Här är en närmare titt på din [[this]] per källa"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per day of the month"
-msgstr "Eventos por día del mes"
+msgstr "Händelser per dag i månaden"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "If youre into correlations, this is the x-ray for you."
-msgstr "Si te interesan las correlaciones, esta es la radiografía para ti."
+msgstr "Om tycker om korrelation är detta genomlysningen för dig."
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by Country"
-msgstr "Sesiones por País"
+msgstr "Sessioner per land"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Some interesting metrics about your GA stats to get you started."
-msgstr "Algunas métricas interesantes sobre tus estadísticas de GA para empezar."
+msgstr "Några intressanta mått om dina \"GA stats\" för att komma igång."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per state"
-msgstr "[[this]] por provincia"
+msgstr "[[this]] per stat"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by quarter of the year"
-msgstr "[[Timestamp]] por trimestre"
+msgstr "[[Timestamp]] per kvartal"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How its distributed across time and other categories."
-msgstr "Cómo se distribuye a través del tiempo y otras categorías."
+msgstr "Hur det är fördelat över tid och kategorier"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A look at your events over time and by several categories."
-msgstr "Una mirada a tus eventos a lo largo del tiempo y por varias categorías."
+msgstr "En titt på dina händelser över tid och flera kategorier"
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "[[GenericTable]] per [[this]]"
-msgstr "[[GenericTable]] por [[this]]"
+msgstr "[[GenericTable]] per [[this]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average quantity per source"
-msgstr "Cantidad media por origen"
+msgstr "Genomsnittligt antal per källa"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Top 5 per category"
-msgstr "Primeros 5 por categoría"
+msgstr "5 bästa per kategori"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per day of the week"
-msgstr "Eventos por día de la semana"
+msgstr "Händelser per veckodag"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "New [[this.short-name]] per month"
-msgstr "Nuevos [[this.short-name]] por mes"
+msgstr "Ny [[this.short-name]] per månad"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top performers"
-msgstr "Mejor desempeño"
+msgstr "De bästa"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Transactions in the last 30 days"
-msgstr "Transacciones en los últimos 30 días"
+msgstr "Transaktioner de senaste 30 dagarna"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[GenericTable]] by [[this]]"
-msgstr "[[GenericTable]] por [[this]]"
+msgstr "[[GenericTable]] by [[this]]"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Overview of your [[this]] data from Google Analytics"
-msgstr "Visión general de tus datos [[this]] de Google Analytics"
+msgstr "Översikt över din [[this]] -data från Google Analytics"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by hour of the day"
-msgstr "Creado por hora del día"
+msgstr "Skapad per timme"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by month"
-msgstr "Ventas por mes"
+msgstr "Försäljning per månad"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] is distributed across categories"
-msgstr "Cómo se distribuye [[this]] entre categorías"
+msgstr "Hur [[this]] fördelats över kategorier"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by month of year"
-msgstr "[[Timestamp]] por mes del año"
+msgstr "[[Timestamp]] per månad"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "How many total sessions vs. how many individual users you had each day."
-msgstr "Cuántas sesiones en total vs. cuántos usuarios individuales has tenido cada día."
+msgstr "Hur många totala sessioner jämfört med enskilda användare du hade varje dag"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How this metric is distributed across different numbers"
-msgstr "Cómo se distribuye esta métrica entre diferentes números."
+msgstr "Hur detta mått fördelas över olika siffror"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by page where the session began"
-msgstr "Sesiones por página donde comenzó la sesión."
+msgstr "Sessioner per sida där sessionen började"
 
 #: frontend/src/metabase/lib/schema_metadata.js:503
 #: resources/automagic_dashboards/field/DateTime.yaml
@@ -11076,20 +11055,20 @@ msgstr "Sesiones por página donde comenzó la sesión."
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "Distinct values"
-msgstr "Valores distintos"
+msgstr "Distinkta värden"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Hours when [[this.short-name]] were added"
-msgstr "Horas en las que se añadío [[this.short-name]]"
+msgstr "Timmar när [[this.short-name]] lades till"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by day of the week"
-msgstr "[[Timestamp]] por día de la semana"
+msgstr "[[Timestamp]] per veckodag"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[GenericNumber]] over time"
-msgstr "[[GenericNumber]] a lo largo del tiempo"
+msgstr "[[GenericNumber]] över tid"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
@@ -11098,43 +11077,43 @@ msgstr "[[GenericNumber]] a lo largo del tiempo"
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Heres an overview of your [[this]]"
-msgstr "Aquí hay una visión general de tu [[this]]"
+msgstr "Här är en översikt över din [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by coordinates"
-msgstr "[[this.short-name]] por coordenadas"
+msgstr "[[this.short-name]] per koordinater"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Heres a closer look at your [[this]] per state"
-msgstr "Una mirada detallada a los [[this]] por provincia"
+msgstr "Här är en närmare titt på din [[this]] per stat"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by day of the month"
-msgstr "Creado por día del mes"
+msgstr "Skapad per dag i månaden"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales by coordinates"
-msgstr "Ventas por coordenadas"
+msgstr "Försäljning över koordinater"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "New [[this.short-name]] over time"
-msgstr "Nuevos [[this.short-name]] a lo largo del tiempo"
+msgstr "Ny [[this.short-name]] över tid"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by hour of the day"
-msgstr "Unir fecha por hora del día"
+msgstr "Gick med per timme"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by hour of day"
-msgstr "[[Timestamp]] por hora del día"
+msgstr "[[Timestamp]] per timme"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions and unique users per day"
-msgstr "Sesiones y usuarios únicos por día."
+msgstr "Sessioner och unika användare per dag"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per [[GenericCategoryLarge]]"
-msgstr "Eventos por [[GenericCategoryLarge]]"
+msgstr "Händelser per [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -11143,413 +11122,413 @@ msgstr "Eventos por [[GenericCategoryLarge]]"
 #: resources/automagic_dashboards/field/GenericField.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
-msgstr "Cómo se comparan por distribución"
+msgstr "Hur de fördelas"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Income per country"
-msgstr "Ingreso por país"
+msgstr "Förtjänst per land"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Heres a closer look at your [[this]] per country"
-msgstr "Una mirada detallada de tus [[this]] por país"
+msgstr "Här är en närmare titt på din [[this]] per land"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by product [[ProductCategory]]"
-msgstr "Ventas por producto [[ProductCategory]]"
+msgstr "Försäljning per produkt [[ProductCategory]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryLarge]], bottom 5"
-msgstr "[[this]] por [[GenericCategoryLarge]], últimos 5"
+msgstr "[[this]] per [[GenericCategoryLarge]], sista 5"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] added in the last 30 days"
-msgstr "[[this.short-name]] añadidos en los últimos 30 días"
+msgstr "[[this.short-name]] som lagts till de senaste 30 dagarna"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[Source]]"
-msgstr "Por [[Source]]"
+msgstr "Per [[Source]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average item quantity per month"
-msgstr "Cantidad media por mes"
+msgstr "Genomsnittligt antal per månad"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "The number of [[GenericTable]] per country, and how each country is represented in different categories."
-msgstr "El número de [[GenericTable]] por país, y cómo cada país está representado en diferentes categorías."
+msgstr "Antalet [[GenericTable]] per land, och hur olika länder fördelas på olika kategorier."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per day of the week"
-msgstr "[[this]] por día de la semana"
+msgstr "[[this]] per veckodag"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average qunatity per source"
-msgstr "Cantidad media por origen"
+msgstr "Genomsnittligt antal per källa"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by [[Timestamp]]"
-msgstr "[[this.short-name]] por [[Timestamp]]"
+msgstr "[[this.short-name]] per [[Timestamp]]"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Summary statistics"
-msgstr "Resumen Estadístico"
+msgstr "Statistiksummering"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per month"
-msgstr "Ventas por mes"
+msgstr "Försäljning per månad"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[GenericNumber]] by join date"
-msgstr "[[GenericNumber]] por unión de fecha"
+msgstr "[[GenericNumber]] per datum man gick med"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Average of [[this]] by [[Country]]"
-msgstr "Media de[[this]] por [[Country]]"
+msgstr "Genomsnitt för [[this]] per [[Country]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[this]] over time"
-msgstr "[[this]] a lo largo del tiempo"
+msgstr "[[this]] över tid"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by day of the week"
-msgstr "Unir fecha por día de la semana"
+msgstr "När man gick med fördelat på veckodag"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "We crunched the numbers for your [[this]]"
-msgstr "Hemos procesado los números de tu [[this]]"
+msgstr "Vi räknade ut detta för din [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Months when [[this.short-name]] joined"
-msgstr "Meses cuando se une por [[this.short-name]]"
+msgstr "Månader när [[this.short-name]] gick med"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to parse resource `{0}` as JSON"
-msgstr "Respuesta JSON incorrecta: `{0}`"
+msgstr "Kan inte tolka resursen `{0}` som JSON"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to find JSON via relative path `{0}`"
-msgstr "No se puede encontrar JSON a través de la ruta relativa `{0}`"
+msgstr "Kan inte hitta JSON via relativ sökväg `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Connection to host timed out for URL `{0}`"
-msgstr "La conexión con el host ha caducado para la URL `{0}`"
+msgstr "Anslutning till värd fick timeout för URL:en `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to connect to unknown host at URL `{0}`"
-msgstr "No se puede conectar a un host desconocido en la URL `{0}`"
+msgstr "Kan inte ansluta till okänd värd fick timeout med URL:en `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to connect to host at URL `{0}`"
-msgstr "No se puede conectar con el host en la URL `{0}`"
+msgstr "Kan inte ansluta till värd med URL:en `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Connection refused by host at for URL `{0}`"
-msgstr "Conexión rechazada por el host en la URL `{0}`"
+msgstr "Anslutning till värd nekades för URL:en `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to retrieve resource at URL `{0}`"
-msgstr "No se puede recuperar el recurso en la URL `{0}`"
+msgstr "Kan inte hitta källan för URL:en `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to parse resource at URL `{0}` as JSON"
-msgstr "No se puede analizar el recurso en la URL `{0}` como JSON"
+msgstr "Kan inte tolka källan för URL:en `{0}` som JSON"
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fall back to local authentication: {0}"
-msgstr "Problema al conectarse al servidor LDAP, se volverá a la autenticación local: {0}"
+msgstr "Problem med att ansluta till PDAP-server - kommer att försöka med lokal autentisering: {0}"
 
 #: src/metabase/driver/bigquery.clj
 msgid "BigQuery statements can''t be parameterized!"
-msgstr "¡Las consultas BigQuery no se pueden parametrizar!"
+msgstr "BigQuery-frågor kan inte parametersättas!"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Druid does not allow limitSpec in time series queries. Ignoring the LIMIT clause."
-msgstr "ADVERTENCIA: Druid no permite limitSpec en consultas de series de tiempo. Ignorando la cláusula LIMIT."
+msgstr "VARNING: Druid tillåter inte limitSpec i frågor med tidsserier - ignorerar LIMIT-satsen."
 
 #: src/metabase/driver/snowflake.clj
 msgid "Invalid Snowflake connection details: missing DB name."
-msgstr "Valores de conexión a SnowFlake inválidas: falta el nombre de la BBDD"
+msgstr "Felaktiga anslutningsdetaljer för Snowflake: DB-namn saknas."
 
 #: src/metabase/email/messages.clj
 msgid "We’d love your feedback."
-msgstr "Nos encantaría tus comentarios."
+msgstr "Vi vill gärna veta vad du tycker."
 
 #: src/metabase/email/messages.clj
 msgid "It looks like Metabase wasn’t quite a match for you."
-msgstr "Parece que Metabase no se ha ajustado a tus expectativas."
+msgstr "Det ser ut som om Metabase inte riktigt passade dig."
 
 #: src/metabase/email/messages.clj
 msgid "Would you mind taking a fast 5 question survey to help the Metabase team understand why and make things better in the future?"
-msgstr "¿Te importaría realizar una encuesta rápida de 5 preguntas para ayudar al equipo de Metabase a comprender por qué y mejorar las cosas en el futuro?"
+msgstr "Skulle du vilja svara på en enkät med 5 frågor för att hjälpa Metabase-gänget att göra saker bättre i framtiden?"
 
 #: src/metabase/email/messages.clj
 msgid "We hope you''ve been enjoying Metabase."
-msgstr "Esperamos que hayas estado disfrutando de Metabase."
+msgstr "Vi hoppas att du har uppskattat Metabase."
 
 #: src/metabase/email/messages.clj
 msgid "Would you mind taking a fast 6 question survey to tell us how it’s going?"
-msgstr "¿Te importaría hacer una encuesta rápida de 6 preguntas para decirnos cómo va?"
+msgstr "Skulle du vilja svara på en enkät med 6 frågor för att berätta ut det går?"
 
 #: src/metabase/email/messages.clj
 msgid "{0} created a Metabase account"
-msgstr "{0} ha creado una cuenta en Metabase"
+msgstr "{0} skapade ett Metabase-konto"
 
 #: src/metabase/email/messages.clj
 msgid "{0} accepted their Metabase invite"
-msgstr "{0} ha aceptado su invitación a Metabase"
+msgstr "{0} accepterade inbjudan"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Password Reset Request"
-msgstr "[Metabase] Solicitud Reestablecer Contraseña"
+msgstr "[Metabase] - begäran om återställning av lösenord"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Notification"
-msgstr "[Metabase] Notificación"
+msgstr "[Metabase]-notifiering"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Help make Metabase better."
-msgstr "[Metabase] Ayuda a mejorar Metabase."
+msgstr "[Metabase] Hjälp till att göra Metabase bättre."
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Tell us how things are going."
-msgstr "[Metabase] Dinos como van las cosas."
+msgstr "[Metabase] Berätta hur det går."
 
 #: src/metabase/mbql/util.clj
 msgid "Error: query''s source query has not been resolved. You probably need to `preprocess` the query first."
-msgstr "Error: la consulta fuente de la consulta no se ha resuelto. Probablemente necesites 'preprocesar' la consulta primero."
+msgstr "Fel: frågans källfråga har inte körts. Du behöver antagligen preprocessa frågan först."
 
 #: src/metabase/models/params.clj
 msgid "Don't know what to do with:"
-msgstr "No se que hacer con:"
+msgstr "Vet inte vad man ska göra med:"
 
 #: src/metabase/models/params.clj
 msgid "Don't know how to wrap:"
-msgstr "No se como envolver:"
+msgstr "Vet inte hur man delar upp:"
 
 #: src/metabase/public_settings.clj
 msgid "Failed setting `query-caching-max-kb` to {0}."
-msgstr "No se ha podido establecer `query-caching-max-kb` a {0}"
+msgstr "Kunden inte sätta `query-caching-max-kb`till {0}."
 
 #: src/metabase/public_settings.clj
 msgid "Values greater than {1} are not allowed."
-msgstr "No se permiten valores superiores a {1}"
+msgstr "Värden större än {1} tillåts inte."
 
 #: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
-msgstr "La base de datos {0} no existe."
+msgstr "Databasen {0} finns inte."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Database is not present in the Query Processor Store."
-msgstr "Error: La base de datos no está presente en el procesador de consultas."
+msgstr "Fel: Databasen saknas hos frågemotorn."
 
 #: src/metabase/util/embed.clj
 msgid "Invalid embedding-secret-key! Secret key must be a hexadecimal-encoded 256-bit key (i.e., a 64-character string)."
-msgstr "¡Clave secreta no válida! La clave secreta debe ser una clave de 256 bits codificada en hexadecimal (es decir, una cadena de 64 caracteres)."
+msgstr "Felaktig inbäddad hemlig nyckel. Nyckeln måste vara en hexadecimalt kodad 256-bitars nyckel (alltså en 64-teckens sträng)"
 
 #: src/metabase/util/embed.clj
 msgid "JWT is missing `alg`."
-msgstr "Falta el JWT `alg`."
+msgstr "JWT saknar `alg`."
 
 #: src/metabase/util/embed.clj
 msgid "JWT `alg` cannot be `none`."
-msgstr "JWT `alg` no puede ser `none`."
+msgstr "JWT `alg` kan inte vara `none`"
 
 #: src/metabase/util/embed.clj
 msgid "The embedding secret key has not been set."
-msgstr "No se ha establecido la clave secreta embebida."
+msgstr "Den inbäddade nyckeln har inte satts."
 
 #: src/metabase/util/embed.clj
 msgid "Token is missing value for keypath"
-msgstr "Falta el valor de keypath en el token."
+msgstr "Biljett för \"keypath\" saknar värde"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "In-depth example"
-msgstr "Ejemplo avanzado"
+msgstr "Detaljerat exempel"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:29
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:17
 msgid "Key"
-msgstr "Clave"
+msgstr "Nyckel"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:30
 msgid "Class"
-msgstr "Clase"
+msgstr "Klass"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:32
 msgid "Triggers"
-msgstr "Disparadores"
+msgstr "Utlösare"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:48
 msgid "View triggers"
-msgstr "Ver disparadores"
+msgstr "Visa utlösare"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
-msgstr "Información del Programador"
+msgstr "Information om schemaläggare"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:20
 msgid "Priority"
-msgstr "Prioridad"
+msgstr "Prioritet"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:21
 msgid "Last Fired"
-msgstr "Última vez ejecutada"
+msgstr "Senast körd"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:22
 msgid "Next Fire Time"
-msgstr "Próxima vez que se ejecuta"
+msgstr "Nästa körning"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:23
 msgid "Start Time"
-msgstr "Hora Inicial"
+msgstr "Starttid"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:24
 msgid "End Time"
-msgstr "Hora Final"
+msgstr "Sluttid"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:25
 msgid "Final Fire Time"
-msgstr "Ultima Ejecución"
+msgstr "Slutlig körtid"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:26
 msgid "May Fire Again?"
-msgstr "¿Puede ejecutarse de nuevo?"
+msgstr "Kan köras igen?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
-msgstr "Disparadores para {0}"
+msgstr "\"Triggers\" för {0}"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:26
 msgid "Tasks"
-msgstr "Tareas"
+msgstr "Jobb"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:31
 msgid "Jobs"
-msgstr "Trabajos"
+msgstr "Jobb"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:735
 msgid "Duplicated {0}"
-msgstr "Duplicado {0}"
+msgstr "Multipel {0}"
 
 #: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
-msgstr "Duplica este ítem"
+msgstr "Duplicera denna"
 
 #: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
-msgstr "Archiva este ítem"
+msgstr "Arkivera denna"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:325
 msgid "Duplicate dashboard"
-msgstr "Duplicar Cuadro de Mando"
+msgstr "Duplicera kontrollpanel"
 
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:16
 msgid "Duplicate \"{0}\""
-msgstr "Duplicar \"{0}\""
+msgstr "Duplicera \"{0}\""
 
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
-msgstr "Duplicar"
+msgstr "Duplicera"
 
 #: frontend/src/metabase/lib/query_time.js:115
 msgid "Tomorrow"
-msgstr "Mañana"
+msgstr "Imorgon"
 
 #: frontend/src/metabase/lib/query_time.js:129
 #: frontend/src/metabase/lib/query_time.js:143
 msgid "This {0}"
-msgstr "Este {0}"
+msgstr "Denna {0}"
 
 #: frontend/src/metabase/lib/query_time.js:132
 msgid "Next {0}"
-msgstr "Siguiente {0}"
+msgstr "Nästa {0}"
 
 #: frontend/src/metabase/lib/query_time.js:135
 #: src/metabase/pulse/render/datetime.clj
 msgid "Previous {0}"
-msgstr "Anterior {0}"
+msgstr "Föregående {0}"
 
 #: frontend/src/metabase/lib/query_time.js:139
 msgid "Previous {0} {1}"
-msgstr "Anterior {0} {1}"
+msgstr "Föregående {0} {1}"
 
 #: frontend/src/metabase/lib/query_time.js:141
 msgid "Next {0} {1}"
-msgstr "Siguiente {0} {1}"
+msgstr "Nästa {0} {1}"
 
 #: frontend/src/metabase/lib/query_time.js:171
 msgid "Now"
-msgstr "Ahora"
+msgstr "Nu"
 
 #: frontend/src/metabase/lib/query_time.js:174
 msgid "{0} {1} ago"
-msgstr "hace {0} {1}"
+msgstr "{0} {1} sedan"
 
 #: frontend/src/metabase/lib/query_time.js:175
 msgid "{0} {1} from now"
-msgstr "{0} {1} desde ahora"
+msgstr "{0} {1} från nu"
 
 #: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
-msgstr[0] "Periodo por defecto"
-msgstr[1] "Periodos por defecto"
+msgstr[0] "Förvald period"
+msgstr[1] "Förvalda perioder"
 
 #: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
-msgstr[0] "Minuto de la hora"
-msgstr[1] "Minutos de la hora"
+msgstr[0] "Enskild minut"
+msgstr[1] "Enskilda minuter"
 
 #: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
-msgstr[0] "Hora del día"
-msgstr[1] "Horas del día"
+msgstr[0] "Enskild timme"
+msgstr[1] "Enskilda timmar"
 
 #: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
-msgstr[0] "Día de la semana"
-msgstr[1] "Días de la semana"
+msgstr[0] "Veckodag"
+msgstr[1] "Veckodagar"
 
 #: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
-msgstr[0] "Día del mes"
-msgstr[1] "Días del mes"
+msgstr[0] "Dag i månaden"
+msgstr[1] "Dagar i månaden"
 
 #: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
-msgstr[0] "Día del año"
-msgstr[1] "Días del año"
+msgstr[0] "Dag under året"
+msgstr[1] "Dagar under året"
 
 #: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
-msgstr[0] "Semana del año"
-msgstr[1] "Semanas del año"
+msgstr[0] "Veckonummer"
+msgstr[1] "Veckonummer"
 
 #: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
-msgstr[0] "Mes del año"
-msgstr[1] "Meses del año"
+msgstr[0] "Månad"
+msgstr[1] "Månader"
 
 #: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
-msgstr[0] "Trimestre del año"
-msgstr[1] "Trimestres del año"
+msgstr[0] "Kvartal"
+msgstr[1] "Kvartal"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
 msgid_plural "{0} selections"
-msgstr[0] "{0} seleccionado"
-msgstr[1] "{0} seleccionados"
+msgstr[0] "Selektion {0}"
+msgstr[1] "Selektionerna {0}"
 
 #: frontend/src/metabase/parameters/components/widgets/DateQuarterYearWidget.jsx:11
 msgid "[Q]Q"
@@ -11557,220 +11536,220 @@ msgstr "[Q]Q"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:28
 msgid "This"
-msgstr "Este"
+msgstr "Denna"
 
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:136
 msgid "Invalid"
-msgstr "Inválido"
+msgstr "Felaktig"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
-msgstr "Añade una hora"
+msgstr "Lägg till en tid"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
 msgid "Nothing to compare for the previous {0}."
-msgstr "Nada que comparar en el {0} anterior."
+msgstr "Inget att jämföra för den föregående {0}."
 
 #: frontend/src/metabase-lib/lib/Dimension.js:712
 msgid "by {0}"
-msgstr "por {0}."
+msgstr "per {0}"
 
 #: src/metabase/api/database.clj
 msgid "value must be a valid database engine."
-msgstr "el valor debe ser un motor de base de datos válido."
+msgstr "värdet måste vara en giltig databasmotor"
 
 #: src/metabase/api/geojson.clj
 msgid "Connection refused by host for URL `{0}`"
-msgstr "La conexión ha sido rechazada por el host a través de la URL  `{0}`"
+msgstr "Anslutningen nekades av värden för URL:en `{0}`"
 
 #: src/metabase/db.clj
 msgid "Warning: Postgres connection string with `ssl=true` detected."
-msgstr "Advertencia: Una conexión a Postgres con 'ssl=true' ha sido detectada."
+msgstr "Varning: Anslutningssträngen med `ssl=true` för Postgres hittades."
 
 #: src/metabase/db.clj
 msgid "You may need to add `?sslmode=require` to your application DB connection string."
-msgstr "Puedes requerir agregar `?sslmode=require` a la cadena de conexión a la BD."
+msgstr "Du kan behöva lägga till `?sslmode=require` till din anslutningssträng för DB."
 
 #: src/metabase/db.clj
 msgid "If Metabase fails to launch, please add it and try again."
-msgstr "Si Metabase falla al arrancar, por favor agréguelo e intente de nuevo."
+msgstr "Om Metabase inte startar, lägg till det och försök igen."
 
 #: src/metabase/db.clj
 msgid "See https://github.com/metabase/metabase/issues/8908 for more details."
-msgstr "Consultar https://github.com/metabase/metabase/issues/8908 para más detalles."
+msgstr "Se https://github.com/metabase/metabase/issues/8908 för mera detaljer"
 
 #: src/metabase/db.clj
 msgid "WARNING: Using Metabase with an H2 application database is not recomended for production deployments."
-msgstr "ADVERTENCIA: el uso de Metabase con una base de datos de aplicaciones H2 no se recomienda para implementaciones de producción."
+msgstr "VARNING: Att använda Metabase med en H2-applikationsdatabas rekommenderas inte för produktionssajter."
 
 #: src/metabase/db.clj
 msgid "For production deployments, we highly recommend using Postgres, MySQL, or MariaDB instead."
-msgstr "Para las implementaciones de producción, te recomendamos que utilices Postgres, MySQL o MariaDB."
+msgstr "För produktionssajter rekommenderar vi starkt Postgres, MySQL eller MariaDB istället."
 
 #: src/metabase/db.clj
 msgid "If you decide to continue to use H2, please be sure to back up the database file regularly."
-msgstr "Si decides continuar usando H2, asegúrate de hacer una copia de seguridad del archivo de la base de datos con regularidad."
+msgstr "Om du bestämmer att fortsätta använda H2, se till att ta backup på databasen regelbundet."
 
 #: src/metabase/db.clj
 msgid "See https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres for more information."
-msgstr "Para obtener más información, consulta https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres."
+msgstr "Se https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres för mer information."
 
 #: src/metabase/db.clj
 msgid "Unable to connect to Metabase {0} DB."
-msgstr "No se ha podido conectar a la base de datos {0} de Metabase."
+msgstr "Kan inte ansluta till DB {0} för Metabase."
 
 #: src/metabase/db/migrations.clj
 msgid "Error adding legacy SQL directive to BigQuery saved Question"
-msgstr "Error al agregar la directiva SQL a la pregunta guardada de BigQuery"
+msgstr "Fel vid tillägg av gammaldags SQL-direktiv till sparad fråga för BigQuery"
 
 #: src/metabase/driver.clj
 msgid "Failed to notify {0} Database {1} updated"
-msgstr "Error al notificar {0} Base de datos {1} actualizada"
+msgstr "Kunde inte notifera {0} Databas {1} om uppdatering"
 
 #: src/metabase/driver/impl.clj
 msgid "Loading driver {0} {1}"
-msgstr "Cargando controlador {0} {1}"
+msgstr "Laddar drivrutine {0} {1}"
 
 #: src/metabase/driver/impl.clj
 msgid "Load driver {0}"
-msgstr "Cargar controlador {0}"
+msgstr "Laddar drivrutin {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Driver not registered after loading: {0}"
-msgstr "Controlador no registrado después de la carga: {0}"
+msgstr "Drivrutin inte registrerad efter laddning: {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Error: attempting to change {0} property `:abstract?` from {1} to {2}."
-msgstr "Error: al intentar cambiar la propiedad {0} `:abstract?` de {1} a {2}."
+msgstr "Fel: försöker ändra egenskap {0} `:abstract?` från {1} till {2}."
 
 #: src/metabase/driver/impl.clj
 msgid "Registered abstract driver {0}"
-msgstr "Controlador {0} abstracto registrado"
+msgstr "Registrerad abstrakt drivrutin {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Registered driver {0}"
-msgstr "Controlador {0} registrado"
+msgstr "Registrerade drivrutin {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "(parents: {0})"
-msgstr "(superiores: {0})"
+msgstr "(föräldrar: {0})"
 
 #: src/metabase/driver/impl.clj
 msgid "Initializing driver {0}..."
-msgstr "Inicializando controlador {0}"
+msgstr "Sätter upp drivrutin {0}..."
 
 #: src/metabase/driver/impl.clj
 msgid "Reason:"
-msgstr "Razón:"
+msgstr "Anledning:"
 
 #: src/metabase/driver.clj
 msgid "Invalid driver feature: {0}"
-msgstr "Característica de controlador inválida: {0}"
+msgstr "Felaktig drivrutin-parameter: {0}"
 
 #: src/metabase/driver/sql/query_processor.clj
 msgid "Invalid HoneySQL form:"
-msgstr "Formulario HoneySQL inválido:"
+msgstr "Felaktig HoneySQL-form:"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Closing connection pool for database {0} ..."
-msgstr "Cerrando el pool de conexiones para la base de datos {0} ..."
+msgstr "Stänger anslutningspool för databas {0}..."
 
 #: src/metabase/driver/util.clj
 msgid "Error loading namespace"
-msgstr "Error cargando el espacio de nombres"
+msgstr "Fel vid laddning av \"namespace\""
 
 #: src/metabase/events.clj
 msgid "Starting events listener:"
-msgstr "Inicializando controlador de eventos:"
+msgstr "Startar lyssningstjänst:"
 
 #: src/metabase/events.clj
 msgid "Unexpected error listening on events"
-msgstr "Error no esperado escuchando eventos:"
+msgstr "Oväntat fel i lyssningstjänst"
 
 #: src/metabase/events/sync_database.clj
 msgid "Error syncing Database {0}"
-msgstr "Error sincronizando la base de datos {0}"
+msgstr "Fel vid synkning av databas {0}"
 
 #: src/metabase/events/sync_database.clj
 msgid "Failed to process sync-database event."
-msgstr "Error al procesar el evento de sincronización de la base de datos."
+msgstr "Misslyckades med att köra synkningstjänst."
 
 #: src/metabase/mbql/util.clj
 msgid "Bad nested-query-level: query does not have a source query"
-msgstr "Nivel de consulta anidado incorrecto: la consulta no tiene una consulta de origen"
+msgstr "Felaktig nästlad frågenivå: frågan har ingen källfråga"
 
 #: src/metabase/metabot/command.clj
 msgid "I don''t know how to `{0}`."
-msgstr "No se como `{0}`."
+msgstr "Jag kan inte `{0}`."
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s what I can do: "
-msgstr "Esto es lo que puedo hacer: "
+msgstr "Detta kan jag göra: "
 
 #: src/metabase/metabot/slack.clj
 msgid "Error in Metabot command"
-msgstr "Error en el comando de Metabot"
+msgstr "Fel i Metabot-kommando"
 
 #: src/metabase/metabot/websocket.clj
 msgid "Websocket associated with this Slack event is different from the websocket we're currently using."
-msgstr "El Websocket asociado con este evento Slack es diferente del websocket que estamos usando actualmente."
+msgstr "Den \"websocket\" som är kopplad till detta Slack-moment är en annan än den \"websocket\" som vi använder just nu."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues for Field {0} remain unchanged. Skipping..."
-msgstr "Los valores para el campo {0} permanecen sin cambios. Saltando..."
+msgstr "Fältvärden för fält {0} är förblev oförändrade. Hoppar över..."
 
 #: src/metabase/models/interface.clj
 msgid "Unable to normalize:"
-msgstr "No se ha podido normalizar:"
+msgstr "Kan inte normalisera:"
 
 #: src/metabase/models/params.clj
 msgid "Could not find matching Field ID for target:"
-msgstr "No se pudo encontrar el ID de campo coincidente para el destino:"
+msgstr "Hittade inte matchande fält-id för målet:"
 
 #: src/metabase/plugins.clj
 msgid "Metabase does not have permissions to write to plugins directory {0}"
-msgstr "Metabase no tiene permisos para escribir en el directorio de extensiones {0}"
+msgstr "Metabase har inte tillåtelse att skriva till plugin-katalogen {0}"
 
 #: src/metabase/plugins.clj
 msgid "Metabase cannot use the plugins directory {0}"
-msgstr "Metabase no puede utilizar el directorio de extensiones {0}"
+msgstr "Metabase kan inte använda plugin-katalogen {0}"
 
 #: src/metabase/plugins.clj
 msgid "Please make sure the directory exists and that Metabase has permission to write to it."
-msgstr "Asegúrate de que el directorio existe y que Metabase tiene permiso para escribir en él."
+msgstr "Se till att katalogen finns och att Metabase har tillåtelse att skriva till den."
 
 #: src/metabase/plugins.clj
 msgid "You can change the directory Metabase uses for modules by setting the environment variable MB_PLUGINS_DIR."
-msgstr "Puedes cambiar el directorio que utiliza Metabase para los módulos configurando la variable de entorno MB_PLUGINS_DIR."
+msgstr "Du kan ändra katalogen Metabase använder för moduler genom att sätta environment-variabeln MB_PLUGINS_DIR."
 
 #: src/metabase/plugins.clj
 msgid "Falling back to a temporary directory for now."
-msgstr "Volviendo a un directorio temporal por ahora."
+msgstr "Faller tillbaka på en tillfällig katalog tills vidare."
 
 #: src/metabase/plugins.clj
 msgid "Metabase cannot write to temporary directory. Please set MB_PLUGINS_DIR to a writable directory and restart Metabase."
-msgstr "Metabase no puede escribir en el directorio temporal. Configura MB_PLUGINS_DIR en un directorio escribible y reinicia Metabase."
+msgstr "Metabase kan inte skriva till temporär katalog. Sätt MB_PLUGINS_DIR till en skrivbar katalog och starta om Metabase."
 
 #: src/metabase/plugins.clj
 msgid "spark-deps.jar is no longer needed by Metabase 1.0+. You can delete it from the plugins directory."
-msgstr "Metabase 1.0+ ya no necesita spark-deps.jar. Puedes eliminarlo del directorio de extensiones."
+msgstr "spark-deps.jar behövs inte längre för Metbase 1.0+. Du kan ta bort den från plugin-katalogen."
 
 #: src/metabase/plugins.clj
 msgid "Failied to initialize plugin {0}"
-msgstr "No se ha podido inicializar la extensión {0}"
+msgstr "Kunde inte starta plugin {0}"
 
 #: src/metabase/plugins.clj
 msgid "Loading plugins in {0}..."
-msgstr "Cargando extensiones en {0}..."
+msgstr "Laddar plugin:er i {0}..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Using Clojure base loader as shared context classloader: {0}"
-msgstr "Uso del cargador base de Clojure como cargador de clases de contexto compartido: {0}"
+msgstr "Använder \"Clojure base loader\" som delad \"context classloader\": {0}"
 
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to shared classloader {0}..."
-msgstr "Estableciendo el contexto de subprocesos al cargador de clases compartido {0}..."
+msgstr "Sätter nuvarande \"thread context classloader\" till delar \"classloader\" {0}..."
 
 #. it's important that we deref the promise again here instead of using the one we just created because it is
 #. possible thru a race condition that somebody else delivered the promise before we did; in that case,
@@ -11778,318 +11757,318 @@ msgstr "Estableciendo el contexto de subprocesos al cargador de clases compartid
 #. value of it rather than one that ends up getting discarded
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to NEWLY CREATED classloader {0}..."
-msgstr "Configurando el contexto actual para el NUEVO cargador de clases {0} ..."
+msgstr "Sätter nuvarande \"thread context classloader\" till NYSKAPAD \"classloader\" {0}..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Added URL {0} to classpath"
-msgstr "URL {0} añadida a classpath"
+msgstr "La till URL:en {0} till \"classpath\""
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugin {0} declares a dependency that Metabase does not understand: {1}"
-msgstr "La extensión {0} declara una dependencia que Metabase no entiende: {1}"
+msgstr "Plugin {0} deklarerar en dependency som Metabase inte förstår: {1}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Refer to the plugin manifest reference for a complete list of valid plugin dependencies:"
-msgstr "Consulta la referencia del manifest de la extensión para obtener una lista completa de las dependencias válidas del mismo:"
+msgstr "Referera till \"plugin manifest reference\" för en komplett lista över giltiga \"plugin dependencies\":"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Metabase cannot initialize plugin {0} due to required dependencies."
-msgstr "Metabase no puede inicializar el complemento {0} debido a las dependencias requeridas."
+msgstr "Metabase kan inte starta upp plugin {0} på grund av \"required dependencies\"."
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Class not found: {0}"
-msgstr "Clase {0} no encontrada"
+msgstr "Klassen hittades inte: {0}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugin ''{0}'' depends on plugin ''{1}''"
-msgstr "La extensión ''{0}'' depende de la extensión ''{1}''"
+msgstr "Plugin \"{0}\" kräver plugin \"{1}\""
 
 #: src/metabase/plugins/dependencies.clj
 msgid "{0} dependency {1} satisfied? {2}"
-msgstr "{0} dependencia {1} satisfecha? {2}"
+msgstr "{0} kräver {1} fick? {2}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugins with unsatisfied deps: {0}"
-msgstr "Extensiones con dependencias no satisfechas: {0}"
+msgstr "Plugin med ej uppfyllda krav: {0}"
 
 #: src/metabase/util/files.clj
 msgid "Extract file {0} -> {1}"
-msgstr "Extraer fichero {0} -> {1}"
+msgstr "Extrahera fil {0} -> {1}"
 
 #: src/metabase/util/files.clj
 msgid "Resource does not exist."
-msgstr "Recurso no existe."
+msgstr "Resursen finns inte."
 
 #: src/metabase/plugins/init_steps.clj
 msgid "Loading plugin namespace {0}..."
-msgstr "Cargando espacio de nombres de extensiones {0}..."
+msgstr "Laddar namespace för plugin {0}..."
 
 #: src/metabase/plugins/initialize.clj
 msgid "Dependencies satisfied; these plugins will now be loaded: {0}"
-msgstr "Dependencias satisfechas; se cargarán las extensiones: {0}"
+msgstr "Kraven uppfyllda; dessa plugin:er kommer nu att laddas: {0}"
 
 #: src/metabase/plugins/jdbc_proxy.clj
 msgid "Registering JDBC proxy driver for {0}..."
-msgstr "Registrando el controlador proxy JDBC para {0} ..."
+msgstr "Registrerar JDBC-proxy-drivrutin för {0}..."
 
 #: src/metabase/plugins/jdbc_proxy.clj
 msgid "Deregistering original JDBC driver {0}..."
-msgstr "Anulación del registro del controlador JDBC original {0} ..."
+msgstr "Avregistrerar ursprunglig JDBC-drivrutin {0}..."
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Default connection property {0} does not exist."
-msgstr "La propiedad de conexión predeterminada {0} no existe."
+msgstr "Förvald anslutningsparameter {0} finns inte."
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Invalid connection property {0}: not a string or map."
-msgstr "Propiedad de conexión no válida {0}: no es una cadena o un mapa."
+msgstr "Felaktig anslutningsparameter {0}: inte en sträng eller karta."
 
 #. ok, do the init steps listed in the plugin mainfest
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Load lazy loading driver {0}"
-msgstr "Cargar el controlador de carga oportunista {0}"
+msgstr "Ladda \"lazy loading driver\" {0}"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Cannot initialize plugin: missing required property `driver-name`"
-msgstr "No se puede inicializar la extensión: falta la propiedad requerida `driver-name`"
+msgstr "Kan inte starta upp plugin: obligatorisk parameter `driver-name` saknas"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Warning: plugin manifest for {0} does not include connection properties"
-msgstr "Advertencia: el manifest de la extensión {0} no incluye las propiedades de conexión"
+msgstr "Varning: Plugin-manifest för {0} innehåller inte anslutningsparametrar"
 
 #. finally, register the Metabase driver
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Registering lazy loading driver {0}..."
-msgstr "Registrando el controlador de carga oportunista {0} ..."
+msgstr "Registrerar \"lazy loading driver\" {0}..."
 
 #: src/metabase/pulse.clj
 msgid "Error running query for Card {0}"
-msgstr "Error al ejecutar la consulta para la tarjeta {0}"
+msgstr "Fel vid körning av fråga för lista {0}"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
-msgstr "La semana pasada"
+msgstr "Förra veckan"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This week"
-msgstr "Esta semana"
+msgstr "Denna vecka"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
-msgstr "El mes pasado"
+msgstr "Förra månaden"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This month"
-msgstr "Este mes"
+msgstr "Denna månad"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
-msgstr "El trimestre pasado"
+msgstr "Förra kvartalet"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
-msgstr "Este trimestre"
+msgstr "Detta kvartalet"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
-msgstr "El año pasado"
+msgstr "Förra året"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This year"
-msgstr "Este año"
+msgstr "Innevarande år"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "*driver* is unbound."
-msgstr "*controlador* no consolidado."
+msgstr "*drivrutin* är \"unbound\"."
 
 #: src/metabase/sync/sync_metadata/fields.clj
 msgid "Error syncing Fields for Table ''{0}''"
-msgstr "Error sincronizando Campos de la Tabla \"{0}\""
+msgstr "Fel vid synkning av fält för tabell \"{0}\""
 
 #: src/metabase/sync/sync_metadata/fields.clj
 msgid "Hash of {0} matches stored hash, skipping Fields sync"
-msgstr "El hash de {0} coincide con el hash almacenado, omitiendo la sincronización de campos"
+msgstr "Samling av {0} matchar lagrad samling, hoppar över fältsynkning"
 
 #: src/metabase/sync/sync_metadata/fields/common.clj
 msgid "Field"
-msgstr "Campo"
+msgstr "Fält"
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Error checking if Fields {0} need to be created or reactivated"
-msgstr "Error al verificar si los Campos {0} necesitan ser creados o reactivados"
+msgstr "Fel när kontroll av fält {0} behöver aktiveras eller återaktiveras"
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Marking Field ''{0}'' as inactive."
-msgstr "Marcando el campo \"{0}\" como inactivo"
+msgstr "Markerar fält \"{0}\" som inaktiv."
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Error retiring {0}"
-msgstr "Error retirando {0}"
+msgstr "Fel när {0} skulle dras tillbaka"
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Database type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "El tipo de base de datos de {0} ha cambiado de ''{1}'' a ''{2}''."
+msgstr "Databastypen för {0} har ändrats från \"{1}\" till \"{2}\"."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Base type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "El tipo base de {0} ha cambiado de ''{1}'' a ''{2}''."
+msgstr "Bas-typen för {0} har ändrats från \"{1}\" till \"{2}\"."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Special type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "El tipo especial de {0} ha cambiado de ''{1}'' a ''{2}''."
+msgstr "Special-typen för {0} har ändrats från \"{1}\" till \"{2}\"."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Comment has been added for {0}."
-msgstr "Se ha añadido un comentario para {0}."
+msgstr "Kommentar har lagts till för {0}."
 
 #: src/metabase/task.clj
 msgid "Stopping Quartz Scheduler {0}"
-msgstr "Deteniendo Porgramador {0} de Quartz"
+msgstr "Stoppar schemaläggaren Quartz {0}"
 
 #: src/metabase/task.clj
 msgid "Starting Quartz Scheduler {0}"
-msgstr "Inicializando Porgramador {0} de Quartz"
+msgstr "Startar schemaläggaren Quartz {0}"
 
 #: src/metabase/task.clj
 msgid "Error loading tasks namespace {0}"
-msgstr "Error cargando el espacio de nombre de tareas {0}"
+msgstr "Fel vid laddning av \"namespace\" för jobbet {0}"
 
 #. don't bother logging namespace for now, maybe in the future if there's tasks of the same name in multiple
 #. namespaces we can log it
 #: src/metabase/task.clj
 msgid "Initializing task {0}"
-msgstr "Inicializando tarea {0}"
+msgstr "Påbörjar jobbet {0}"
 
 #: src/metabase/task.clj
 msgid "Error initializing task {0}"
-msgstr "Error inicializando tarea {0}"
+msgstr "Fel när jobbet {0} skulle påbörjas"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Problem sending abandonment email"
-msgstr "Problema enviando correo electrónico de abandono"
+msgstr "Problem med att skicka övergivelse-mejl"
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Sending anonymous usage stats."
-msgstr "Enviando estadísticas anónimas de uso."
+msgstr "Skickar anonym användarstatistik."
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Error sending anonymous usage stats"
-msgstr "Error enviando estadísticas anónimas de uso."
+msgstr "Fel vid sändning av anonym användarstatistik."
 
 #: src/metabase/task/send_pulses.clj
 msgid "Error sending Pulse {0}"
-msgstr "Error enviando pulso {0}"
+msgstr "Fel vid sändning av ögonblicksbild {0}"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Sending scheduled pulses..."
-msgstr "Enviando pulsos programados..."
+msgstr "Skickar schemalagda ögonblicksbilder..."
 
 #: src/metabase/task/send_pulses.clj
 msgid "SendPulses task failed"
-msgstr "La tarea Enviar Pulsos ha fallado"
+msgstr "Jobbet SendPulses misslyckades"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Failed to scheduler tasks for Database {0}"
-msgstr "No se ha podido programar tareas para la base de datos {0}"
+msgstr "Kunde inte schemalägga jobb för databas {0}"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Cleaning up task history"
-msgstr "Limpiando el historial de tareas"
+msgstr "Rensar jobbhistoriken"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, rows were deleted"
-msgstr "La limpieza del historial de tareas fue exitosa, las filas fueron eliminadas"
+msgstr "Jobbhistoriken är rensad, rader togs bort"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, no rows were deleted"
-msgstr "La limpieza del historial de tareas fue exitosa, no se ha eliminado ninguna fila"
+msgstr "Jobbhistoriken är rensad, inga rader togs bort"
 
 #: src/metabase/task/upgrade_checks.clj
 msgid "Checking for new Metabase version info."
-msgstr "Buscando información de la versión de Metabase."
+msgstr "Letar efter ny Metabase-versionsinfo."
 
 #: src/metabase/task/upgrade_checks.clj
 msgid "Error fetching version info"
-msgstr "Error obteniendo la información de versión"
+msgstr "Fel vid hämtning av versionsinfo"
 
 #: src/metabase/util.clj
 msgid "Maximum memory available to JVM: {0}"
-msgstr "Memoria máxima disponible para JVM: {0}"
+msgstr "Max minnesutrymme för JVM: {0}"
 
 #: src/metabase/util.clj
 msgid "Not something with an ID: {0}"
-msgstr "No es algo con un ID: {0}"
+msgstr "Inte något med id: {0}"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by month of the year"
-msgstr "[[CreateDate]] por mes del año"
+msgstr "[[CreateDate]] per månad"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Here's a quick look at your [[this]]"
-msgstr "Aquí hay un vistazo rápido a tu [[this]]"
+msgstr "Här är en snabb titt på din [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by hour of the day"
-msgstr "[[CreateTimestamp]] por hora del día"
+msgstr "[[CreateTimestamp]] per timme"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Where you've acquired your users"
-msgstr "Donde has adquirido tus usuarios"
+msgstr "Där du skaffade dina användare"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How it's distributed across time and other categories."
-msgstr "Cómo se distribuye a través del tiempo y otras categorías."
+msgstr "Hur det fördelas över tid och kategorier."
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Here's a closer look at your [[this]] per source"
-msgstr "Aquí hay una vista más detallada a tu [[this]] por origen"
+msgstr "Här är en närmare titt på din [[this]] per källa"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Here's a quick look at the [[this]]"
-msgstr "Aquí hay un vistazo rápido a [[this]]"
+msgstr "Här är en snabb titt på din [[this]] per källa"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by day of the month"
-msgstr "[[CreateTimestamp]] por día del mes"
+msgstr "[[CreateTimestamp]] per dag i månaden"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Here's an overview of the people in your [[this]]"
-msgstr "Aquí hay un resumen de las personas en tu [[this]]"
+msgstr "Här är en översikt över personerna i din [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by quarter of the year"
-msgstr "[[CreateTimestamp]] por trimestre del año"
+msgstr "[[CreateTimestamp]] per kvartal"
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
-msgstr "Cómo se comparan a través de la ubicación"
+msgstr "Hur de kan jämföras mellan platser"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Here's a closer look at your [[this]] by products"
-msgstr "Aquí hay una vista con más detalle de tu [[this]] por productos"
+msgstr "Här är en närmare titt på din [[this]] per produkt"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by month of the year"
-msgstr "[[CreateTimestamp]] por mes del año"
+msgstr "[[CreateTimestamp]] per månad"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "An overview of your [[this]] and how it's distributed across time, place, and categories."
-msgstr "Una visión general de tu [[this]] y cómo se distribuye en el tiempo, el lugar y las categorías."
+msgstr "En överblick över din [[this]] och hur det är fördelat över tid, plats och kategorier."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "Here's a closer look at your [[this]]"
-msgstr "Aquí hay una vista con más detalle de tu [[this]]"
+msgstr "Här är en närmare titt på din [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by day of the week"
-msgstr "[[CreateTimestamp]] por día de la semana"
+msgstr "[[CreateTimestamp]] per veckodag"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Here's an overview of your [[this]] data from Google Analytics"
-msgstr "Aquí hay una descripción general de tus datos [[this]] de Google Analytics"
+msgstr "Här är en översikt över din [[this]]-data från Google Analytics"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
@@ -12098,1646 +12077,1645 @@ msgstr "Aquí hay una descripción general de tus datos [[this]] de Google Analy
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
-msgstr "Aquí hay una visión general de tu [[this]]"
+msgstr "Här är en översikt över din [[this]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Here's a closer look at your [[this]] field"
-msgstr "Aquí hay una vista con más detalle de tu campo [[this]]"
+msgstr "Här är en närmare titt på ditt fält [[this]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Here's a closer look at your [[this]] per country"
-msgstr "Aquí hay una vista con más detalle de tu [[this]] por país"
+msgstr "Här är en närmare titt på din [[this]] per land"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "If you're into correlations, this is the x-ray for you."
-msgstr "Si te interesan las correlaciones, esta es la radiografía para ti."
+msgstr "Om du gillar korrelationer så är denna genomlysning något för dig."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by day of the week"
-msgstr "[[CreateDate]] por día de la semana"
+msgstr "[[CreateDate]] per veckodag"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "It looks like your [[this]] has transactions, so here's a look at them"
-msgstr "Parece que tu [[this]] tiene transacciones, así que aquí hay un vistazo a ellas"
+msgstr "Det ser ut som om din [[this]] har transaktioner, så här är en titt på dem"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Here's a closer look at your [[this]] per state"
-msgstr "Aquí hay una vista con más detalle de tu [[this]] por estado"
+msgstr "Här är en närmare titt på din [[this]] per stat"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by day of the month"
-msgstr "[[CreateDate]] por día del mes"
+msgstr "[[CreateDate]] per dag i månaden"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTime]] by hour of the day"
-msgstr "[[CreateTime]] por hora del día"
+msgstr "[[CreateTime]] per timme"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Here's a closer look at your [[this]] over time"
-msgstr "Aquí hay una mirada con más detalle de tu [[this]] a lo largo del tiempo"
+msgstr "Här är en närmare titt på din [[this]] över tid"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by quarter of the year"
-msgstr "[[CreateDate]] por trimestre del año"
+msgstr "[[CreateDate]] per kvartal"
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:202
 msgid "Edit user"
-msgstr "Editar usuario"
+msgstr "Redigera användare"
 
 #: frontend/src/metabase/admin/people/containers/NewUserModal.jsx:13
 msgid "New user"
-msgstr "Nuevo usuario"
+msgstr "Ny användare"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:206
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
-msgstr "Restablecer contraseña"
+msgstr "Återställ lösenord"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:210
 msgid "Deactivate user"
-msgstr "Desactivar usuario"
+msgstr "Inaktivera användare"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:47
 msgid "Reactivate {0}?"
-msgstr "¿Reactivar {0}?"
+msgstr "Återaktivera {0}?"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:63
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
-msgstr "No se ha podido enviar la invitación por correo electrónico, así que asegúrate de decirles que inicien sesión utilizando {0} y esta contraseña que hemos generado para ellos:"
+msgstr "Vi kunde inte skicka mejl med inbjudan, så se till att berätta för dem att de kan logga in med {0} och detta lösenord vi genererat för dem:"
 
 #: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
-msgstr "colección"
+msgstr "samling"
 
 #: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
-msgstr "colecciones"
+msgstr "samlingar"
 
 #: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
-msgstr "cuadro de mando"
+msgstr "instrumentpanel"
 
 #: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
-msgstr "cuadros de mando"
+msgstr "instrumentpaneler"
 
 #: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
-msgstr "El nombre es obligatorio"
+msgstr "Förnamn krävs"
 
 #: frontend/src/metabase/entities/users.js:38
 #: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
-msgstr "Debe ser 100 caracteres o menos"
+msgstr "Får vara 100 tecken eller färre"
 
 #: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
-msgstr "El apellido es obligatorio"
+msgstr "Efternamn krävs"
 
 #: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
-msgstr "El email es obligatorio"
+msgstr "Epost-adress krävs"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
-msgstr "Los artículos que archives aparecerán aquí."
+msgstr "Saker du arkiverar kommer att hamna här."
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:16
 msgid "No description"
-msgstr "Sin descripción"
+msgstr "Ingen beskrivning"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
-msgstr "Suma de todos los valores"
+msgstr "Summan av alla värden"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
-msgstr "Ver todos los valores distintos"
+msgstr "Visa alla distinkta värden"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:12
 msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started"
-msgstr "Examina el contenido de tus bases de datos, tablas y columnas. Elija una base de datos para empezar"
+msgstr "Visa innehållet i dina databaser, tabeller och kolumner. Välj en databas för att komma igång"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is VALID. Thanks!"
-msgstr "Los metadatos de resultados de tarjetas pasados a API son VÁLIDOS. ¡Gracias!"
+msgstr "Metadata för list-resultaten skickad till API är giltigt. Tack!"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is INVALID. Running query to fetch correct metadata."
-msgstr "Los metadatos de resultados de tarjetas pasados a API son INVÁLIDOS. Ejecutando la consulta para obtener los metadatos correctos."
+msgstr "Metadata för list-resultaten skickad till API är ogiltigt. Kör fråga för att hämta korrekta metadata."
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is  ISSING. Running query to fetch correct metadata."
-msgstr "Los metadatos de resultados de tarjetas pasados a API NO ESTÁN. Ejecutando la consulta para obtener los metadatos correctos."
+msgstr "Metadata för list-resultaten skickad till API saknas. Kör fråga för att hämta korrekta metadata."
 
 #: src/metabase/api/email.clj
 msgid "{0} was autocorrected to {1}"
-msgstr "se ha autocorregido {0} a {1}"
+msgstr "{0} rättades automatiskt till {1}"
 
 #: src/metabase/api/metric.clj
 msgid "DELETE /api/metric/:id is deprecated. Instead, change its `archived` value via PUT /api/metric/:id."
-msgstr "DELETE /api/metric/:id está obsoleta. En su lugar cambia el valor de `archivado` con PUT /api/metric/:id."
+msgstr "\"DELETE /api/metric/:id\" är föråldrat. Ändra istället dess `archived`-värde via \"PUT /api/metric/:id\"."
 
 #: src/metabase/api/segment.clj
 msgid "DELETE /api/segment/:id is deprecated. Instead, change its `archived` value via PUT /api/segment/:id."
-msgstr "DELETE /api/segment/:id está obsoleta. En su lugar cambia el valor de `archivado` con PUT /api/segment/:id."
+msgstr "\"DELETE /api/segment/:id\" är föråldrat. Ändra istället dess `archived`-värde via \"PUT /api/segment/:id\"."
 
 #: src/metabase/api/user.clj
 msgid "Value of is_superuser must correspond to presence of Admin group ID in group_ids."
-msgstr "El valor de is_superuser debe corresponder a la presencia de ID de grupo de administración en group_ids."
+msgstr "Värdet på is_superuser måste motsvara närvaron av Admin-grupp-id i group_ids."
 
 #: src/metabase/async/api_response.clj
 msgid "Unexpected error writing keepalive characters"
-msgstr "Error inesperado al escribir caracteres keepalive"
+msgstr "Oväntat fel när keepalive-tecken skulle skrivas"
 
 #: src/metabase/async/api_response.clj
 msgid "Unexpected output in async API response"
-msgstr "Salida inesperada en la respuesta de la API asíncrona"
+msgstr "Oväntat utdata i svar från \"async API\""
 
 #: src/metabase/async/api_response.clj
 msgid "starting streaming response"
-msgstr "iniciando la respuesta de streaming"
+msgstr "Startar \"streaming response\""
 
 #: src/metabase/async/api_response.clj
 msgid "Output chan closed, canceling keepalive request."
-msgstr "Salida cerrada, cancelando la solicitud de keepalive."
+msgstr "Utkanal stängd. Avbryter \"keepalive-request\"."
 
 #: src/metabase/async/api_response.clj
 msgid "Async response finished, closing channels."
-msgstr "Respuesta asincrónica finalizada, cerando canales."
+msgstr "\"Async response\" klar, stänger kanal."
 
 #: src/metabase/async/api_response.clj
 msgid "No response after waiting {0}. Canceling request."
-msgstr "No hay respuesta después de esperar {0}. Cancelando solicitud."
+msgstr "Inget svar efter att ha väntat {0}. Avbryter begäran."
 
 #: src/metabase/async/api_response.clj
 msgid "Input channel unexpectedly closed."
-msgstr "Se ha cerrado inesperadamente el canal de entrada."
+msgstr "Indatakanalen stängdes oväntat."
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "f finished, permit will be returned"
-msgstr "f ha terminado, se devolverá el permiso"
+msgstr "Om avslut kommer tillståndet att returneras"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "request canceled, permit will be returned"
-msgstr "solicitud cancelada, se devolverá el permiso"
+msgstr "begäran avbryts, tillståndet kommer att returneras"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Unexpected error attempting to run function after obtaining permit"
-msgstr "Error inesperado al intentar ejecutar la función después de obtener el permiso"
+msgstr "Oväntat fel vid försök till \"run function\" efter att ha fått tillstånd"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Not running pending function call: output channel already closed."
-msgstr "No se está ejecutando la llamada de función pendiente: el canal de salida ya está cerrado."
+msgstr "Kör inte \"pending function call\" - utdata-kanalen redan stängd."
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Current thread already has a permit for {0}, will not wait to acquire another"
-msgstr "El hilo actual ya tiene un permiso para {0}, no esperamos a adquirir otro"
+msgstr "Nuvarande tråd har redan tillstånd till {0}, kommer inte att vänta på ett nytt"
 
 #: src/metabase/async/util.clj
 msgid "Output channel closed, will skip running {0}."
-msgstr "Canal de salida cerrado, no se ejecutará {0}."
+msgstr "Utdata-kanalen stängd, hoppar över körning av {0}."
 
 #: src/metabase/async/util.clj
 msgid "Running {0} on separate thread..."
-msgstr "Ejecutando {0} en un hilo separado..."
+msgstr "Kör {0} i en separat tråd..."
 
 #: src/metabase/async/util.clj
 msgid "Caught error running {0}"
-msgstr "Error capturado ejecutando {0}"
+msgstr "Fångade ett fel vid körning av {0}"
 
 #: src/metabase/async/util.clj
 msgid "Request canceled, canceling future"
-msgstr "Solicitud cancelada, cancelando futuro"
+msgstr "Begäran avbryten, avbryter kommande"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Closing old connection pool for database {0} ..."
-msgstr "Cerrando el grupo de conexiones antiguas de la base de datos {0} ..."
+msgstr "Stänger gammal anslutningspool för databas {0}..."
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s your {0} most recent cards:"
-msgstr "Aquí están tus {0} tarjetas más recientes:"
+msgstr "Här är dina {0} nyaste listor:"
 
 #: src/metabase/metabot/command.clj
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
-msgstr "¿Podrías ser un poco más específico, o usar la identificación? He encontrado estas tarjetas con nombres que coinciden:"
+msgstr "Kan du vara lite mera specifik eller använda id:t? Jag hittade dessa listor med namn som matchar:"
 
 #: src/metabase/driver/common/parameters/values.clj
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
-msgstr "No se ha encontrado la tarjeta {0}"
+msgstr "Lista {0} kunde inte hittas"
 
 #: src/metabase/middleware/exceptions.clj
 msgid "Exception in API call"
-msgstr "Excepción en la llamada a la API"
+msgstr "Fel i \"API call\""
 
 #: src/metabase/middleware/exceptions.clj
 msgid "Request canceled before finishing."
-msgstr "Solicitud cancelada antes de terminar."
+msgstr "Begäran avbryts innan den färdigbehandlats."
 
 #: src/metabase/middleware/json.clj
 msgid "Metabase only supports JSON requests."
-msgstr "Metabase solo admite solicitudes JSON."
+msgstr "Metabase stödjer bara JSON-anrop"
 
 #: src/metabase/middleware/json.clj
 msgid "Make sure you set a 'Content-Type: application/json' header."
-msgstr "Asegúrate de establecer un encabezado 'Content-Type: application / json'."
+msgstr "Se till att du anger en \"'Content-Type: application/json' header\""
 
 #: src/metabase/middleware/misc.clj
 msgid "Setting Metabase site URL to {0}"
-msgstr "Estableciendo la URL de Metabase a {0}"
+msgstr "Sätter Metabase-sajtens URL till {0}"
 
 #: src/metabase/models/database.clj
 msgid "Error scheduling tasks for DB"
-msgstr "Error programando tareas para DB"
+msgstr "Fel vid schemaläggning av jobb för DB"
 
 #: src/metabase/models/database.clj
 msgid "Error unscheduling tasks for DB."
-msgstr "Error desprogramando tareas para DB"
+msgstr "Fel vid borttagning schemaläggning av jobb för DB."
 
 #: src/metabase/models/database.clj
 msgid "{0} Database ''{1}'' sync/analyze schedules have changed!"
-msgstr "\"{1}\" tiempos de sincronización/análisis han cambiado en {0}"
+msgstr "synk/analys-scheman för {0} Databas \"{1}\"  har ändrats!"
 
 #: src/metabase/models/database.clj
 msgid "Sync metadata was: ''{0}'' is now: ''{1}''"
-msgstr "Sincronización de metadatos: ''{0}'' es ahora: ''{1}''"
+msgstr "Synkning metadata var \"{0}\" och är nu \"{1}\""
 
 #: src/metabase/models/database.clj
 msgid "Cache FieldValues was: ''{0}'', is now: ''{1}''"
-msgstr "Valor de campo en cache era: ''{0}'', ahora es: ''{1}''"
+msgstr "Fältvärden i cache var \"{0} och är nu \"{1}\""
 
 #: src/metabase/models/metric.clj
 msgid "You cannot update the creator_id of a Metric."
-msgstr "No se puede cambiar el creado de una métrica."
+msgstr "Du kan inte uppdatera \"creator_id\" på ett mått"
 
 #: src/metabase/models/permissions.clj
 msgid "MetaBot can only have Collection permissions."
-msgstr "MetaBot solo puede tener permisos de Colección."
+msgstr "MetaBot kan bara ha rättigheter för samlingar"
 
 #: src/metabase/models/permissions.clj
 msgid "Failed to grant permissions"
-msgstr "Error al otorgar permisos"
+msgstr "Kunde inte tilldela rättigheter"
 
 #: src/metabase/models/permissions.clj
 msgid "Changing permissions"
-msgstr "Cambiando los permisos"
+msgstr "Ändrar rättigheter"
 
 #: src/metabase/models/permissions.clj
 msgid "FROM:"
-msgstr "DE:"
+msgstr "FRÅN:"
 
 #: src/metabase/models/permissions.clj
 msgid "TO:"
-msgstr "A:"
+msgstr "TILL:"
 
 #: src/metabase/models/segment.clj
 msgid "You cannot update the creator_id of a Segment."
-msgstr "No se puede cambiar el creador de un segmento."
+msgstr "Du kan inte uppdatera \"creator_id\" på ett segment."
 
 #: src/metabase/models/setting.clj
 msgid "Attempted to set Setting {0} to obfuscated value. Ignoring change."
-msgstr "Se intentó establecer la configuración {0} en un valor obfuscado. Ignorando el cambio."
+msgstr "Försökte sätta inställningen {0} till att dölja värde. Ignorerar ändringen."
 
 #: src/metabase/models/setting.clj
 msgid "Using value of env var {0}"
-msgstr "Utilizando el valor de la variable de entorno {0}"
+msgstr "Använder värde från environment-variabel {0}"
 
 #: src/metabase/models/user.clj
 msgid "Adding User {0} to All Users permissions group..."
-msgstr "Agregando el usuario {0} al grupo de todos los usuarios..."
+msgstr "Lägger till användare {0} till gruppen för Alla användare..."
 
 #: src/metabase/models/user.clj
 msgid "Adding User {0} to Admin permissions group..."
-msgstr "Agregando el usuario {0} al grupo de permisos de administrador..."
+msgstr "Lägg till användare {0} till gruppen Admin"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
-msgstr "Fallo en la consulta"
+msgstr "Fel i fråga"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
-msgstr "Número máximo de consultas simultáneas permitidas por base de datos conectada."
+msgstr "Max antal samtidiga frågor att tillåta per ansluten databas."
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
-msgstr "Tiempo agotado después de {0} milisegundos."
+msgstr "Timeout efter {0} millisekunder."
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
 msgid "Misfire Instruction"
-msgstr "Instrucciones de fallo"
+msgstr "Felaktig instruktion"
 
 #: frontend/src/metabase/components/ArchiveModal.jsx:31
 msgid "Archive this?"
-msgstr "¿Archivar esto?"
+msgstr "Arkivera detta?"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
-msgstr "Aprende cosas de nuestros datos"
+msgstr "Lär dig om våra data"
 
 #: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
-msgstr "Utiliza DNS SRV al conectar"
+msgstr "Använd \"DNS SRV\" vid anslutning"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
 msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
 "an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
 "leave this disabled."
-msgstr "Esta opción requiere que el host sea FQDN. Si se conecta a un clúster Atlas, es posible que deba habilitar esta opción. Si no sabe lo que esto significa, deje esto deshabilitado."
+msgstr "För att använda detta val krävs att angiven värd är en \"FQDN\". Om du ansluter till ett Atlas-kluster kan du behöva använda detta val. Om du inte vet vad det innebär, aktivera inte detta val."
 
 #: frontend/src/metabase/entities/databases/forms.js:273
 msgid "Automatically run queries when doing simple filtering and summarizing"
-msgstr "Ejecutar consultas automáticamente al realizar un filtrado/resumen simple"
+msgstr "Kör automatiska frågor för enkla summeringar och filter"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
 msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
-msgstr "Cuando esto está activo en Metabase, se ejecutarán consultas automáticamente cuando los usuarios realicen exploraciones simples con los botones Resumir y Filtrar al ver una tabla o gráfico. Puedes desactivar esto si las consultas de esta base de datos son lentas. Esta configuración no afecta la obtención de detalles ni a las consultas SQL."
+msgstr "När detta är aktiverat kommer Metabase att automatiskt köra frågor när användare kör enkel utforskning med Summa- och Filter-knapparna mot en tabell eller graf. Du kan slå av detta om frågorna mot databasen går långsamt. Denna inställning påverkar inte nedbrytning eller SQL-frågor."
 
 #: frontend/src/metabase/containers/Overworld.jsx:329
 msgid "Learn about this database"
-msgstr "Aprende cosas sobre esta base de datos"
+msgstr "Lär dig om denna databas"
 
 #: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
 msgid "Archive this dashboard?"
-msgstr "¿Archivar este cuadro de mando?"
+msgstr "Arkivera denna instrumentpanel?"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:112
 msgid "All results"
-msgstr "Todos los resultados"
+msgstr "Alla resultat"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:175
 msgid "Our Analytics"
-msgstr "Nuestras Analíticas"
+msgstr "Våra analyser"
 
 #: frontend/src/metabase/lib/schema_metadata.js:513
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
-msgstr "Suma aditiva de todos los valores de una columna.\\ne.g. ingresos totales a lo largo del tiempo."
+msgstr "Ökande summa av alla värden i en kolumn,\\n t.ex total intäkt över tid."
 
 #: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
-msgstr "Conteo aditivo del número de filas.\\ne.g. Número total de ventas en el tiempo."
+msgstr "Ökande summa av antal rader.\\n T.ex totalt antal försäljningar över tid."
 
 #: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:98
 msgid "Filter"
-msgstr "Filtro"
+msgstr "Filter"
 
 #: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:50
 msgid "record"
 msgid_plural "records"
-msgstr[0] "registro"
-msgstr[1] "registros"
+msgstr[0] "post"
+msgstr[1] "poster"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:369
 msgid "Browse Data"
-msgstr "Navegar "
+msgstr "Visa data"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:402
 msgid "Write SQL"
-msgstr "Escribir SQL"
+msgstr "Skriv SQL"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
-msgstr "Pregunta Simple"
+msgstr "Enkel fråga"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:87
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
-msgstr "Elige algunos datos, visualízalos y fíltralos, resúmelos y analízalos fácilmente."
+msgstr "Välj lite data, visa det och på ett enkelt sätt - filtrera, summera och visualisera det."
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:98
 msgid "Custom question"
-msgstr "Pregunta personalizada"
+msgstr "Anpassad fråga"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:99
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
-msgstr "Utiliza el editor avanzado para unir datos, crear columnas personalizadas, hacer cálculos matemáticos y más."
+msgstr "Använd den anvancerade editorn för att slå ihop data, skapa anpassade kolumner, utföra beräkningar och mycket mer."
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Basic Metrics"
-msgstr "Indicadores básicos"
+msgstr "Grundläggande mått"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
 msgid "Custom…"
-msgstr "Personalizado..."
+msgstr "Anpassad..."
 
 #: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
 msgid "Add grouping"
-msgstr "Añadir agrupación"
+msgstr "Lägg till gruppering"
 
 #: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
 msgid "Pick a limit"
-msgstr "Seleccione un límite"
+msgstr "Välj en gräns"
 
 #: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
 msgid "Show maximum"
-msgstr "Mostrar máximo"
+msgstr "Visa maxvärde"
 
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:45
 msgid "Get Preview"
-msgstr "Vista previa"
+msgstr "Förhandsgranska"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
 msgid "Back to previous results"
-msgstr "Volver a los resultados anteriores"
+msgstr "Tillbaka till föregående resultat"
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
 msgid "Sample values"
-msgstr "Valores de ejemplo"
+msgstr "Testvärden"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
 msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
-msgstr "Explora el contenido de tus bases de datos, tablas y columnas. Elige una base de datos para empezar."
+msgstr "Visa innehållet i dina databaser, tabeller och kolumner. Välj en databas för att komma igång."
 
 #: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
 msgid "Visualize"
-msgstr "Visualizar"
+msgstr "Visualisera"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
 msgid "Join data"
-msgstr "Unir datos"
+msgstr "Slå ihop data"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
 msgid "Custom column"
-msgstr "Columna personalizada"
+msgstr "Anpassad kolumn"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
 #: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:60
 msgid "Summarize"
-msgstr "Resumir"
+msgstr "Summera"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
 msgid "Aggregate"
-msgstr "Agregar"
+msgstr "Slå ihop"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
 msgid "Breakout"
-msgstr "Desglosar"
+msgstr "Bryt ut"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
 msgid "Pick the metric you want to see"
-msgstr "Elige la métrica que quieres ver"
+msgstr "Välj måttet du vill använda"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
 msgid "Pick a column to group by"
-msgstr "Elige una columna para agrupar"
+msgstr "Välj en kolumn att gruppera på"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:28
 msgid "Pick your starting data"
-msgstr "Elige tus datos iniciales"
+msgstr "Välj dina startdata"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select None"
-msgstr "Selecciona Ninguno"
+msgstr "Välj Inget"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select All"
-msgstr "Selecciona Todos"
+msgstr "Välj Alla"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:152
 msgid "Pick a table..."
-msgstr "Elige una tabla..."
+msgstr "Välj en tabell..."
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
 msgid "Enter a limit"
-msgstr "Introduce un límite"
+msgstr "Sätt en gräns"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:273
 msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
-msgstr "Los corchetes alrededor de un {0} crean una cláusula opcional en la plantilla. Si se establece \"variable\", la cláusula completa se coloca en la plantilla. Si no, se ignora toda la cláusula."
+msgstr "Hakar runt en {0} skapar en valfri del i mallen. Om \"variable\" är satt kommer hela delen att placeras i mallen. Om inte kommer hela delen att utelämnas."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:290
 msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
-msgstr "Cuando se usa un Filtro de Campo, el nombre de la columna no debe incluirse en la SQL. En su lugar, la variable debe asignarse a un campo en el panel lateral."
+msgstr "När filter på ett fält används bör inte kolumn-namnet användas i SQL. Istället bör variabeln mappas till ett fält i sido-panelen."
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
 msgid "View the native query"
-msgstr "Ver la consulta nativa"
+msgstr "Visa den interna frågan"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
 msgid "Native query for this question"
-msgstr "Consulta nativa de esta pregunta"
+msgstr "Intern fråga för detta"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
 msgid "Convert this question to a native query"
-msgstr "Convertir esta pregunta en una consulta nativa"
+msgstr "Konvertera denna fråga till intern"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
 msgid "SQL for this question"
-msgstr "SQL de esta pregunta"
+msgstr "SQL för denna fråga"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
 msgid "Convert this question to SQL"
-msgstr "Convertir esta pregunta a SQL"
+msgstr "Konvertera denna fråga till SQL"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
 msgid "Get alerts"
-msgstr "Recibir alertas"
+msgstr "Få varningar"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
 msgid "{0} breakout"
 msgid_plural "{0} breakouts"
-msgstr[0] "desglose de {0}"
-msgstr[1] "desgloses de {0}"
+msgstr[0] "{0} utbrytning"
+msgstr[1] "{0} utbrytningar"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:41
 msgid "Hide filters"
-msgstr "Esconder filtros"
+msgstr "Dölj filter"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:41
 msgid "Show filters"
-msgstr "Mostrar filtros"
+msgstr "Visa filter"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:18
 msgid "Started from"
-msgstr "Iniciado desde"
+msgstr "Startade från"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
 msgid "{0} row"
 msgid_plural "{0} rows"
-msgstr[0] "{0} fila"
-msgstr[1] "{0} filas"
+msgstr[0] "{0} rad"
+msgstr[1] "{0} rader"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
 msgid "Show all rows"
-msgstr "Mostrar todas las filas"
+msgstr "Visa alla rader"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
 msgid "Show {0}"
-msgstr "Mostrar {0}"
+msgstr "Visa {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
 msgid "Showing first {0}"
-msgstr "Mostrando los primeros {0}"
+msgstr "Visar de första {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
 msgid "Showing {0}"
-msgstr "Mostrando {0}"
+msgstr "Visar {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
 msgid "Summarized"
-msgstr "Resumido"
+msgstr "Summerat"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionNotebookButton.jsx:17
 msgid "Hide editor"
-msgstr "Esconder editor"
+msgstr "Dölj editor"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionNotebookButton.jsx:17
 msgid "Show editor"
-msgstr "Mostrar editor"
+msgstr "Visa editor"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
 msgid "Pick the metric you'd like to see"
-msgstr "Elige la métrica que quieres ver"
+msgstr "Välj måttet du vill se"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:29
 msgid "{0} options"
-msgstr "{0} opciones"
+msgstr "{0} val"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
 msgid "Choose a visualization"
-msgstr "Elige una visualización"
+msgstr "Välj en visualisering"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
 msgid "Filter by"
-msgstr "Filtrar por"
+msgstr "Filtrerat på"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
 msgid "Summarize by"
-msgstr "Resumir por"
+msgstr "Summerat på"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
 msgid "Group by"
-msgstr "Agrupar por"
+msgstr "Grupperat på"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
 msgid "Add a metric"
-msgstr "Añadir una métrica"
+msgstr "Lägg till ett mått"
 
 #: frontend/src/metabase/lib/core.js:137 frontend/src/metabase/lib/core.js:142
 #: frontend/src/metabase/lib/core.js:147 frontend/src/metabase/lib/core.js:152
 #: frontend/src/metabase/lib/core.js:157 frontend/src/metabase/lib/core.js:162
 #: frontend/src/metabase/user/components/UserSettings.jsx:64
 msgid "Profile"
-msgstr "Perfil"
+msgstr "Profil"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:567
 msgid "This is usually pretty fast but seems to be taking a while right now."
-msgstr "Esto suele ser bastante rápido, pero parece estar tardando un poco en este momento."
+msgstr "Detta är normalt ganska snabbt, men det ser ut att ta en stund just nu."
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
 msgid "Combo"
-msgstr "Combo"
+msgstr "Kombination"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
 msgid "Row"
-msgstr "Fila"
+msgstr "Rad"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
 msgid "Trend"
-msgstr "Tendencia"
+msgstr "Trend"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:129
 msgid "Boolean"
-msgstr "Booleano"
+msgstr "Boolean"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:62
 msgid "Unknown Segment"
-msgstr "Segmento Desconocido"
+msgstr "Okänt segment"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:73
 msgid "Unknown Filter"
-msgstr "Filtro Desconocido"
+msgstr "Okänt filter"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
 msgid "Left outer join"
-msgstr "Unión izquierda externa"
+msgstr "Left outer join"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:26
 msgid "Right outer join"
-msgstr "Unión derecha externa"
+msgstr "Right outer join"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:27
 msgid "Inner join"
-msgstr "Unión interna"
+msgstr "Inner join"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:28
 msgid "Full outer join"
-msgstr "Unión externa completa"
+msgstr "Full outer join"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
-msgstr "FALTAN los metadatos de resultados de la tarjeta en el API. Ejecutando la consulta para obtener los metadatos correctos."
+msgstr "Metadata för list-resultatet till \"API\" saknades. Kör fråga för att hämta korrekta metadata."
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fall back to local authentication"
-msgstr "Problema al conectarse al servidor LDAP, utilizaré la autentificación local"
+msgstr "Problem vid anslutning till LDAP-server, kommer att försöka använda lokal autentisering"
 
 #: src/metabase/api/setup.clj
 msgid "Cannot create Database: cannot find driver {0}."
-msgstr "No se puede crear la base de datos: no se puede encontrar el controlador {0}."
+msgstr "Kan inte skapa database: Kan inte hitta drivrutin {0}."
 
 #: src/metabase/api/tiles.clj
 msgid "Query failed"
-msgstr "Falló la consulta"
+msgstr "Frågan misslyckades"
 
 #: src/metabase/async/util.clj
 msgid "Warning: {0} returned `nil`"
-msgstr "Aviso: {0} devolvió `nulo`"
+msgstr "Varning: {0} returnerade `nil`"
 
 #: src/metabase/async/util.clj
 msgid "Unexpected error writing result to output channel: already closed"
-msgstr "Error inesperado al escribir el resultado en el canal de salida: ya cerrado"
+msgstr "Oväntat fel när resultatet skrevs till utdata-kanalen: redan stängd"
 
 #: src/metabase/async/util.clj
 msgid "Unexpected error writing exception to output channel: already closed"
-msgstr "Error inesperado al escribir la excepción en el canal de salida: ya cerrado"
+msgstr "Oväntat fel när avbrottet skrevs till utdata-kanalen: redan stängd"
 
 #: src/metabase/async/util.clj
 msgid "Request canceled, canceling future."
-msgstr "Solicitud cancelada, cancelando futuro."
+msgstr "Begäran avbruten, avbryter kommande."
 
 #: src/metabase/cmd/load_from_h2.clj
 msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
-msgstr "Metabase solo puede transferir datos de H2 a Postgres o MySQL/MariaDB."
+msgstr "Metabase kan bara överföra data från H2 till Postgres eller MySQL/MariaDB."
 
 #: src/metabase/db.clj
 msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
-msgstr "ADVERTENCIA: No se recomienda usar Metabase con una base de datos de aplicaciones H2 para implementaciones de producción."
+msgstr "VARNING: Att använda Metabase med en H2-applikationsdatabas rekommenderas inte för produktionssajter."
 
 #: src/metabase/db.clj
 msgid "Application database setup"
-msgstr "Configuración de la base de datos de la aplicación"
+msgstr "Inställningar för applikationsdatabasen"
 
 #: src/metabase/driver.clj
 msgid "Could not find {0} driver."
-msgstr "No se pudo encontrar el controlador {0}."
+msgstr "Kunde inte hitta drivrutin {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Abstract drivers cannot derive from concrete parent drivers."
-msgstr "Los controladores abstractos no pueden derivar de controladores padres concretos."
+msgstr "Abstrakta drivrutiner kan inte härledas från konkreta drivrutiner."
 
 #: src/metabase/driver/mysql.clj
 msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
-msgstr "Es posible que tengas que añadir 'trustServerCertificate=true' a las opciones de conexión adicionales para conectarte con SSL."
+msgstr "Du kan behöva lägga till 'trustServerCertificate=true' till de ytterligare anslutningsinställningarna för att ansluta med SSL."
 
 #: src/metabase/driver/sql/util.clj
 msgid "Don't know how to alias {0}, expected an Identifer."
-msgstr "No sé cómo hacer un alias de {0}, esperaba un identificador."
+msgstr "Vet inte hur jag ska använda alias {0}, förväntade mig en identifierare."
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Client closed connection, canceling query"
-msgstr "Conexión cerrada por el cliente, cancelando la consulta"
+msgstr "Kliente stängde anslutningen, avbryter fråga"
 
 #: src/metabase/integrations/ldap.clj
 msgid "{0} is not a valid DN."
-msgstr "{0} no es un DN válido."
+msgstr "{0} är inte en giltig DN."
 
 #: src/metabase/middleware/log.clj
 msgid "Error logging API request"
-msgstr "Error al registrar la solicitud de la API"
+msgstr "Fel vid loggning av API-begäran"
 
 #: src/metabase/middleware/misc.clj
 msgid "Failed to set site-url"
-msgstr "No he podido guardar la URL del sitio"
+msgstr "Kunde inte sätta sajt-url:en"
 
 #: src/metabase/models/database.clj
 msgid "Error destroying thread pool for DB."
-msgstr "Error al destruir el grupo de subprocesos para la BBDD."
+msgstr "Fel när trådpoolen för DB skulle tas bort."
 
 #: src/metabase/models/humanization.clj
 msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
-msgstr "Actualizando el nombre a mostrar de {0} \"{1}\": \"{2}\" -> \"{3}\""
+msgstr "Uppdaterar visningsnamn för {0} ''{1}'': ''{2}'' -> ''{3}''"
 
-#. "humanización" no tengo claro que sea la palabra correcta
 #: src/metabase/models/humanization.clj
 msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
-msgstr "Estrategia de humanización no válida \"{0}\". Las estrategias válidas son: {1}"
+msgstr "Felaktigt sätt att förmänskliga ''{0}''. Giltiga sätt är: {1}"
 
 #. now rehumanize all the Tables and Fields using the new strategy.
 #. TODO: Should we do this in a background thread because it is potentially slow?
 #: src/metabase/models/humanization.clj
 msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
-msgstr "Cambiando la estrategia de humanización de nombres de tablas y campos de \"{0}\" a \"{1}\""
+msgstr "Använder förmänskligande för tabell- och fältnamn från ''{0}'' to ''{1}''"
 
 #: src/metabase/models/task_history.clj src/metabase/sync/util.clj
 msgid "Error saving task history"
-msgstr "Error guardando el historial de tarea."
+msgstr "Fel när jobbhistoriken skulle sparas"
 
 #: src/metabase/plugins.clj
 msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
-msgstr "spark-deps.jar ya no es necesario para Metabase 0.32.0+. Puede eliminarlo del directorio de plugins."
+msgstr "spark-deps.jar behövs inte längre i Metabase 0.32.0+. Du kan ta bort den från plugin-katatlogen."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
-msgstr "Utilizando la clase NEWLY CREATED como cargador de clases de contexto compartido: {0}"
+msgstr "Använder NYLIGEN SKAPAD \"classloader\" som delad kontext för \"classloader\": {0}"
 
 #: src/metabase/util/files.clj
 msgid "Failed to copy file"
-msgstr "No se ha podido copiar el fichero"
+msgstr "Kunde inte kopiera fil"
 
 #. check that the URL is valid
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
-msgstr "URL inválida: {0}"
+msgstr "Felaktig sajt-URL: {0}"
 
 #: src/metabase/public_settings.clj
 msgid "site-url is invalid; returning nil for now. Will be reset on next request."
-msgstr "la URL del sitio no es válida; devolviendo nulo por ahora. Se restablecerá en la próxima solicitud."
+msgstr "Sajt-URL:en är inte giltig - sätter den till 'nil' tills vidare. Kommer att återställas vid nästa anrop."
 
 #: src/metabase/pulse/render/body.clj
 msgid "More results have been included as a file attachment"
-msgstr "Se han incluido más resultados como un archivo adjunto"
+msgstr "Flera resultat har sparats som bifogad fil"
 
 #: src/metabase/pulse/render/body.clj
 msgid "This question has been included as a file attachment"
-msgstr "Esta pregunta se ha incluido como un archivo adjunto"
+msgstr "Denna fråga har tagits med som en bifogad fil"
 
 #: src/metabase/pulse/render/body.clj
 msgid "We were unable to display this Pulse."
-msgstr "No he podido mostrar este Pulso."
+msgstr "Vi kunde inte visa denna ögonblicksbild."
 
 #: src/metabase/pulse/render/body.clj
 msgid "Please view this card in Metabase."
-msgstr "Por favor mostrar esta tarjeta en Metabase."
+msgstr "Visa denna lista i Metabase."
 
 #: src/metabase/pulse/render/body.clj
 msgid "An error occurred while displaying this card."
-msgstr "Se ha producido un error al mostrar esta tarjeta."
+msgstr "Ett fel uppstod när listan skulle visas."
 
 #: src/metabase/query_processor.clj
 msgid "Can only determine expected columns for MBQL queries."
-msgstr "Solo puedo determinar las columnas esperadas para las consultas MBQL."
+msgstr "Kan bara fastställa förväntade kolumner för MBQL-frågor."
 
 #: src/metabase/query_processor.clj
 msgid "No columns returned."
-msgstr "No se han obtenido columnas."
+msgstr "Inga kolumner returnerades."
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
-msgstr "Advertencia: no se pueden determinar los campos para una `consulta-fuente` explícita a menos que también incluya` metadatos-fuente`."
+msgstr "Varning: Kan inte fastställa fält för en explicit `käll-fråga` om du inte också tar med `source-metadata`."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
-msgstr "No se puede resolver {0}: el campo no existe o su tabla pertenece a una base de datos diferente."
+msgstr "Kan inte bestämma {0}: Fältet saknas eller dess tabell tillhör en annan databas."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
-msgstr "No se puede resolver :field-literal inside :fk-> a menos que se una por dentro con un alias explícito."
+msgstr "Kan inte bestämma :field-literal i en :fk-> om inte \"inside join\" med explicit :alias"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot find Table ID for {0}"
-msgstr "No he podido encontrar el ID de tabla {0}"
+msgstr "Kan inte hitta tabell-id för {0}"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "No matching info found."
-msgstr "No se encontró información coincidente."
+msgstr "Ingen matchande info hittades."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Could not resolve {0}"
-msgstr "No se pudo resolver {0}"
+msgstr "Kunde inte bestämma {0}"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Invalid fk-> clause: nowhere to add corresponding join."
-msgstr "fk-> no válida: no se puede agregar el join correspondiente."
+msgstr "Felaktig fk->sats: hittar ingenstans att lägga till motsvarande \"join\"."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "{0} driver does not support foreign keys."
-msgstr "El controlador {0} no soporta claves foráneas"
+msgstr "Drivrutinen {0} stödjer inte \"foreign keys\"."
 
 #: src/metabase/query_processor/middleware/add_source_metadata.clj
 msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
-msgstr "No se puede inferir `:source-metadata` para la consulta de origen con consulta de origen nativa sin metadatos de origen."
+msgstr "Kan inte dra slutsatser om `:source-metadata` för källfrågan med intern källa utan källans metadata."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Query processor error: number of columns returned by driver does not match results."
-msgstr "Error del procesador de consultas: número de columnas devueltas por el controlador no coincide con los resultados."
+msgstr "Frågeprocessor-fel: antal kolumner returnerat av drivrutinen matchar inte resultaten."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected {0} columns, but first row of resuls has {1} columns."
-msgstr "Se esperaban {0} columnas, pero la primera fila de resultados tiene {1} columnas."
+msgstr "Förväntade {0} kolumner, men första raden av resultat har {1} kolumner."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "No expression named {0} found. Found: {1}"
-msgstr "No he encontrado una expresión de nombre {0}. He encontrado {1}"
+msgstr "Inget uttryck {0} hittade. Hittade istället: {1}."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Distinct values of {0}"
-msgstr "Valores únicos de {0}"
+msgstr "Distinkta värden av {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Average of {0}"
-msgstr "Media de {0}"
+msgstr "Genomsnitt av {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Sum of {0}"
-msgstr "Suma de {0}"
+msgstr "Summan av {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "SD of {0}"
-msgstr "DS de {0}"
+msgstr "SD av {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Min of {0}"
-msgstr "Mínimo de {0}"
+msgstr "Min-värde av {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Max of {0}"
-msgstr "Máximo de {0}"
+msgstr "Max-värde av {0}"
 
 #. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Sum of {0} matching condition"
-msgstr "Suma de {0} con condición"
+msgstr "Summan av {0} matchande selektionen"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Share of rows matching condition"
-msgstr "Cuota de filas con condición"
+msgstr "Samling rader som matchar selektionen"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of rows matching condition"
-msgstr "Número de filas coincidentes con la condición"
+msgstr "Antal rader som matchar selektionen"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Request already canceled, will not run synchronous QP code."
-msgstr "Solicitud ya cancelada, no se ejecutará el código QP síncrono."
+msgstr "Frågan redan avbruten, kommer inte att köra synkron QP-kod."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unexpectedly got `nil` Query Processor response."
-msgstr "Inesperadamente recibí la respuesta del procesador de consultas `nil`."
+msgstr "Oväntat - fick `nil` som frågeprocessor-svar."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Got InterruptedException. Canceling query."
-msgstr "Se interrumpió la excepción. Cancelando consulta."
+msgstr "Fick \"InterruptedException\", avbryter fråga."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
-msgstr "Excepción no controlada, se espera que el middleware `catch-exceptions` lo maneje."
+msgstr "Avbrott som inte kan hanteras. Förväntade att \"`catch-exceptions` middleware\" skulle hantera det."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Query timed out after %s"
-msgstr "Se agotó el tiempo de espera de la consulta después de %s"
+msgstr "Timeout på fråga efter %s"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Creating new query thread pool for Database {0}"
-msgstr "Creando un nuevo grupo de subprocesos de consulta para la base de datos {0}"
+msgstr "Skapar ny tråd-pool för frågor mot database {0}"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Destroying query thread pool for Database {0}"
-msgstr "Destrucción del grupo de subprocesos de consulta para la base de datos {0}"
+msgstr "Tar bort tråd-pool för frågor mot databas {0}"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Request canceled, canceling pending query"
-msgstr "Solicitud cancelada, cancelando consulta pendiente"
+msgstr "Begäran avbruten, avbryter köad fråga"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: query is missing source-metadata"
-msgstr "No se puede actualizar el campo agrupado: faltan los metadatos en la consulta"
+msgstr "Kan inte uppdatera fält i behållare: frågan saknar käll-metadata"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
-msgstr "No se puede actualizar el campo agrupado: no se encontraron metadatos coincidentes para el campo \"{0}\""
+msgstr "Kan inte uppdatera fält i behållare: kunde inte hitta matchande käll-metadata för fält \"{0}\""
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Using query processor cache backend: {0}"
-msgstr "Uso el caché del procesador de consultas: {0}"
+msgstr "Använder frågeprocessorns cache \"backend\": {0}"
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Invalid metric: {0} reason: {1}"
-msgstr "Métrica inválida: {0} razón: {1}"
+msgstr "Felaktigt mått: {0} anledning {1}"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Unknown error"
-msgstr "Error desconocido"
+msgstr "Okänt fel"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Unexpected nil response from query processor."
-msgstr "Respuesta nula inesperada del procesador de consultas."
+msgstr "Oväntat tomt svar från frågeprocessorn."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query canceled"
-msgstr "Consulta cancelada"
+msgstr "Frågan avbruten"
 
 #: src/metabase/query_processor/middleware/resolve_driver.clj
 msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
-msgstr "No es posible resolver la consulta: falta o no es válida `:database` ID."
+msgstr "Kan inte hitta drivrutin för frågan: saknad eller felaktigt databas-id."
 
 #: src/metabase/query_processor/middleware/resolve_driver.clj
 msgid "Unable to resolve driver for query: Database {0} does not exist."
-msgstr "No es posible resolver la consulta: base de datos {0} no existe."
+msgstr "Kan inte hitta drivrutine för frågan: databas {0} finns inte."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
-msgstr "No se puede usar :fields :all in join contra la consulta de origen a menos que tenga :source-metadata."
+msgstr "Kan inte använda \":fields :all\" i \"join\" mot källfråga om den inte har \":source-metadata\"."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
-msgstr "Problema: join entre campos: el join con alias \"{0}\" no existe. Encontrado: {1}"
+msgstr "Felaktig \"joined-field\"-sats: join med alias \"{0}\" finns inte. Hittade {1}"
 
 #: src/metabase/query_processor/middleware/resolve_source_table.clj
 msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
-msgstr "tabla \"{0}\" inválida: ya debería haberse convertido en un ID de tabla."
+msgstr "Felaktig \":source-table\" \"{0}\": Borde ha varit omgjort till ett tabell-id vid det här laget."
 
 #: src/metabase/query_processor/store.clj
 msgid "Cannot store Tables or Fields before Database is stored."
-msgstr "No se pueden guardar tablas o campos antes de guardar la base de datos."
+msgstr "Kan inte spara tabeller eller fält innan databasen är sparad."
 
 #: src/metabase/query_processor/store.clj
 msgid "Attempting to fetch second Database. Queries can only reference one Database."
-msgstr "Intentando recuperar la segunda base de datos. Las consultas sólo pueden referenciar a una base de datos."
+msgstr "Försök till att hämta en andra databas. Frågor kan bara beröra en databas."
 
 #: src/metabase/query_processor/store.clj
 msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
-msgstr "Error al recuperar la Tabla {0}: no existe dicha tabla o pertenece a otra base de datos."
+msgstr "Kunde inte hämta tabell {0}: Tabellen saknas eller tillhör en annan databas."
 
 #: src/metabase/query_processor/store.clj
 msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
-msgstr "Error al recuperar el Campo {0}: no existe dicho campo o pertenece a otra base de datos."
+msgstr "Kunde inte hämta fält {0}: Fältet saknas eller tillhör en annan databas."
 
 #: src/metabase/routes/index.clj
 msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
-msgstr "Error al cargar la plantilla \"{0}\". ¿Te acordaste de construir la interfaz de Metabase?"
+msgstr "Kunde inte ladda mallen \"{0}\". Skapade du Metabase-framsidan?"
 
 #: src/metabase/sample_data.clj
 msgid "Sample dataset DB file ''{0}'' cannot be found."
-msgstr "No se puede encontrar el archivo de base de datos de muestra ''{0}''."
+msgstr "Testdatabas-filen \"{0}\" kan inte hittas."
 
 #: src/metabase/sample_data.clj
 msgid "Loading sample dataset..."
-msgstr "Cargando datos de muestra..."
+msgstr "Laddar testdatabas..."
 
 #: src/metabase/sample_data.clj
 msgid "Failed to load sample dataset"
-msgstr "No se ha podido cargar los datos de muestra"
+msgstr "Kunde inte ladda testdatabas"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Found new tables:"
-msgstr "Encontrado tablas nuevas:"
+msgstr "Hittade nya tabeller:"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Marking tables as inactive:"
-msgstr "Marcando tablas como inactivas:"
+msgstr "Markerar tabeller som inaktiva:"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Updating description for tables:"
-msgstr "Actualizando la descripción de las tablas:"
+msgstr "Uppdaterar beskrivning av tabeller:"
 
 #: src/metabase/task.clj
 msgid "Rescheduling job {0}"
-msgstr "Reprogramando el trabajo {0}"
+msgstr "Ändrar schemaläggning för jobbet {0}"
 
 #: src/metabase/task.clj
 msgid "Error rescheduling job"
-msgstr "Error al reprogramar trabajo"
+msgstr "Fel vid ändring av schemaläggning"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Starting Pulse Execution: {0}"
-msgstr "Iniciando la ejecución del Pulso: {0}"
+msgstr "Påbörjar ögonblicksbild: {0}"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Finished Pulse Execution: {0}"
-msgstr "Finalizado la ejecución del Pulso: {0}"
+msgstr "Avslutade ögonblicksbild: {0}"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Failed to schedule tasks for Database {0}"
-msgstr "Error al programar tareas para la base de datos {0}"
+msgstr "Kunde inte schemalägga jobb för databas {0}"
 
 #: src/metabase/util/schema.clj
 msgid "All elements must be distinct."
-msgstr "Todos los elementos deben ser distintos."
+msgstr "Alla element måste vara distinkta."
 
-#: 
+#:
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
-msgstr "Elige las columnas que quieres incluir"
+msgstr "Välj kolumnerna du vill ha med"
 
 #: frontend/src/metabase/entities/databases/forms.js:274
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
-msgstr "Al activar esto, Metabase ejecutará consultas automáticamente cuando los usuarios realicen exploraciones simples con los botones Resumir y Filtrar ea tablas o gráficos. Puedes desactivar esto si las consultas de esta base de datos son lentas. Esta configuración no afecta a los detalles ni a las consultas SQL."
+msgstr "När detta är aktiverat kommer Metabase att automatiskt köra frågor när användare utforskar med summering eller filtrering mot en tabell eller karta. Du kan inaktivera detta om frågorna tar lång tid. Denna inställning påverkar inte nedbrytning eller SQL-frågor."
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
 msgid "Change join type"
-msgstr "Cambia el tipo de unión"
+msgstr "Ändra typ av \"join\""
 
 #: src/metabase/driver/sql/util.clj
 msgid "Don't know how to alias {0}, expected an Identifier."
-msgstr "No sé cómo obtener un alias de {0}, esperaba un identificador."
+msgstr "Vet inte hur jag ska benämna {0} - förväntade mig en identifierare."
 
 #: src/metabase/integrations/common.clj
 msgid "Error adding User {0} to Group {1}"
-msgstr "Error añadiendo el Usuario {0} al Grupo {1}"
+msgstr "Fel när användare {0} skulle läggas till grupp {1}"
 
 #. now rehumanize all the Tables and Fields using the new strategy.
 #. TODO: Should we do this in a background thread because it is potentially slow?
 #: src/metabase/models/humanization.clj
 msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
-msgstr "Cambiando la estrategia de humanización de nombres de tablas y campos de \"{0}\" a \"{1}\""
+msgstr "Ändrar strategi för förmänskligande av tabell- och fältnamn från \"{0}\" till \"{1}\""
 
 #: src/metabase/query_processor.clj
 msgid "Infinite loop detected: recursively preprocessed query {0} times."
-msgstr "Bucle infinito detectado: consulta preprocesada recursivamente {0} veces."
+msgstr "Oändlig loop hittades: rekursivt preprocessad fråga {0} ggr."
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
-msgstr "Advertencia: no se pueden determinar los campos de una `consulta-fuente` explícita a menos que también incluya `metadatos`."
+msgstr "Varning: Kan inte fastställa fält för en explicit `källfråga` om du inte också tar med `source-metadata`."
 
 #: src/metabase/query_processor/middleware/add_source_metadata.clj
 msgid "Error determining expected columns for query"
-msgstr "Error al determinar las columnas esperadas de la consulta"
+msgstr "Fel vid fastställande av förväntade kolumner för frågan"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
-msgstr "Excepción no controlada, se espera que el proceso `catch-exceptions` lo manejara."
+msgstr "Fel som inte kunde hanteras, förväntade att \"`catch-exceptions` middleware\" skulle hantera det."
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
 msgid "Diagnostic Info"
-msgstr "Información de Diagnóstico"
+msgstr "Diagnostisk info"
 
 #: frontend/src/metabase/admin/tasks/containers/Logs.jsx:123
 msgid "Select Metabase process:"
-msgstr "Selecciona el proceso de Metabase:"
+msgstr "Välj Metabase-process:"
 
 #: frontend/src/metabase/admin/tasks/containers/Logs.jsx:133
 msgid "All Metabase processes"
-msgstr "Todos los procesos de Metabase"
+msgstr "Alla Metabase-processer"
 
 #: frontend/src/metabase/auth/components/GoogleButton.jsx:13
 msgid "The window was closed before completing Google Authentication."
-msgstr "Se ha cerrado la ventana sin haber completado la Autentificación con Google"
+msgstr "Fönstret stängdes innan Google Authentication gått klart."
 
 #: frontend/src/metabase/auth/components/GoogleButton.jsx:51
 msgid "There was an issue signing in with Google. Pleast contact an administrator."
-msgstr "Ha habido un problema validando con Google. Por favor, pregunta a un administrador."
+msgstr "Ett problem uppstod vid inloggning med Google. Kontakta en administratör."
 
 #: frontend/src/metabase/plugins/builtin/auth/password.js:9
 msgid "Sign in with email"
-msgstr "Entrar con email"
+msgstr "Logga in med epost"
 
 #: frontend/src/metabase/entities/databases/forms.js:23
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
-msgstr "El uso de esta opción requiere que el host proporcionado sea un FQDN. Si te conectas a un clúster de Atlas, es posible que debas habilitar esta opción. Si no sabes lo que significa esto, dejalo deshabilitado."
+msgstr "För att använda detta val krävs att angiven värd är en FQDN. Om anslutning till ett Atlas-kluster kan du behöva aktivera detta val. Om du inte vet vad detta betyder bör du inte använda detta alternativ."
 
 #: frontend/src/metabase/entities/databases/forms.js:282
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
-msgstr "De manera predeterminada, Metabase realiza una sincronización por hora y un escaneo diario intensivo de valores de campo. Si tienes una base de datos grande, recomendamos activar esto y revisar cuándo y con qué frecuencia ocurren los escaneos de valor de campo."
+msgstr "Som förval användare Metabase en snabb synkning varje timme och en mera omfattande skanning av fältvärden dagligen. Om du har en stor databas rekommenderar vi att du aktiverar detta och tittar på hur ofta skanningen av fältvärden sker."
 
 #: frontend/src/metabase/containers/Overworld.jsx:126
 msgid "Remove these suggestions"
-msgstr "Eliminar estas sugerencias"
+msgstr "Ta bort dessa förslag"
 
 #: frontend/src/metabase/containers/Overworld.jsx:135
 msgid "Remove these suggestions?"
-msgstr "Eliminar estas sugerencias?"
+msgstr "Ta bort bort dessa förslag?"
 
 #: frontend/src/metabase/containers/Overworld.jsx:151
 msgid "These won’t show up on the homepage for any of your users anymore, but you can always get to x-rays by clicking on Browse Data in the main navigation, then clicking on the lightning bolt icon on one of your tables."
-msgstr "Estos ya no aparecerán en la página de inicio de ninguno de tus usuarios, pero siempre puedes obtener radiografías haciendo clic en Examinar datos en la navegación principal y luego haciendo clic en el icono del rayo en una de las tablas."
+msgstr "Dessa kommer inte att visas på första-sidan för någon av dina användare längre, men du kan alltid komma åt genomlysningar genom att titta på data från första-sidan och sedan klicka på blixten vid en av dina tabeller."
 
 #: frontend/src/metabase/containers/Overworld.jsx:274
 msgid "Hide this section"
-msgstr "Esconder esta sección"
+msgstr "Göm denna sektion"
 
 #: frontend/src/metabase/containers/Overworld.jsx:282
 msgid "Remove this section?"
-msgstr "Eliminar esta sección"
+msgstr "Ta bort denna sektion?"
 
 #: frontend/src/metabase/containers/Overworld.jsx:298
 msgid "\"Our Data\" won’t show up on the homepage for any of your users anymore, but you can always browse through your databases and tables by clicking Browse Data in the main navigation."
-msgstr "\"Nuestros datos\" ya no aparecerá en la página de inicio de ninguno de tus usuarios, pero siempre puedes navegar por tus bases de datos y tablas haciendo clic en Examinar datos en la navegación principal."
+msgstr "\"Våra data\" kommer inte att visas på första-sidan för någon av dina användare längre, men du kan alltid titta i dina databaser och tabeller genom att klicka på Visa data på första-sidan."
 
 #: frontend/src/metabase/entities/collections.js:95
 msgid "My new fantastic collection"
-msgstr "Mi colección fantástica"
+msgstr "Min nya fantastiska samling"
 
 #: frontend/src/metabase/lib/core.js:178
 msgid "Cancelation timestamp"
-msgstr "Tiempo de cancelación"
+msgstr "Klockslag för avbrott"
 
 #: frontend/src/metabase/lib/core.js:173
 msgid "Cancelation time"
-msgstr "Tiempo de cancelación"
+msgstr "Tid för avbrott"
 
 #: frontend/src/metabase/lib/core.js:168
 msgid "Cancelation date"
-msgstr "Fecha de cancelación"
+msgstr "Datum för avbrott"
 
 #: frontend/src/metabase/lib/core.js:208
 msgid "Deletion timestamp"
-msgstr "Tiempo de eliminación"
+msgstr "Klockslag för borttagning"
 
 #: frontend/src/metabase/lib/core.js:203
 msgid "Deletion time"
-msgstr "Tiempo de eliminación"
+msgstr "Tid för borttagning"
 
 #: frontend/src/metabase/lib/core.js:198
 msgid "Deletion date"
-msgstr "Fecha de eliminación"
+msgstr "Datum för borttagning"
 
 #: frontend/src/metabase/lib/core.js:298
 msgid "Only in detail views"
-msgstr "Solo en vistas de detalle"
+msgstr "Bara i detaljbilder"
 
 #: frontend/src/metabase/lib/core.js:303
 msgid "Do not include"
-msgstr "No incluir"
+msgstr "Inkludera inte"
 
 #: frontend/src/metabase/lib/core.js:304
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
-msgstr "Este campo no será visible o seleccionable en las preguntas creadas con la aplicación. Todavía será accesible en consultas SQL/nativas."
+msgstr "Detta fält kommer inte att visas eller kunna väljas i frågor skapade i guiden. Det kommer fortfarande att vara tillgängligt via SQL- eller interna frågor."
 
 #: frontend/src/metabase/lib/schema_metadata.js:512
 msgid "Cumulative sum"
-msgstr "Suma Acumulada"
+msgstr "Ackumulerad summa"
 
 #: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Standard deviation"
-msgstr "Desviacion estandar"
+msgstr "Standardavvikelse"
 
 #: frontend/src/metabase/lib/settings.js:120
 msgid "must be at least {0} characters long"
-msgstr "debe tener al menos {0} caracteres de longitud"
+msgstr "måste vara minst {0} tecken lång"
 
 #: frontend/src/metabase/lib/settings.js:121
 msgid "Must be at least {0} characters long"
-msgstr "Debe tener al menos {0} caracteres de longitud"
+msgstr "Måste vara minst {0} tecken lång"
 
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:82
 msgid "Name (required)"
-msgstr "Nombre (requerido)"
+msgstr "Namn (obligatoriskt)"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
 msgid "Run selected text"
-msgstr "Ejecutar texto seleccionado"
+msgstr "Kör vald text"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
 msgid "Run query"
-msgstr "Ejecutar consulta"
+msgstr "Kör fråga"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(⌘ + enter)"
-msgstr "(⌘ + intro)"
+msgstr "(⌘ + enter)"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(Ctrl + enter)"
-msgstr "(Ctrl + intro)"
+msgstr "(Ctrl+enter)"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "Here's where your results will appear"
-msgstr "Aquí es donde aparecerán tus resultados"
+msgstr "Här kommer dina resultat att visas"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:16
 msgid "You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question."
-msgstr "No realizará cambios permanentes en una pregunta guardada a menos que haga clic en Guardar y elija reemplazar la pregunta original."
+msgstr "Du gör inga permanenta ändringar i en sparad fråga om du inte klickar på Spara och väljer att ersätta den ursprungliga frågan."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:200
 msgid "There aren't any filter widgets for this type of field yet."
-msgstr "Todavía no hay widgets de filtro para este tipo de campo."
+msgstr "Det finns inga filter-dialoger för denna typen av fält ännu."
 
 #: frontend/src/metabase/reference/components/FieldToGroupBy.jsx:27
 msgid "Look up this field"
-msgstr "Buscar este campo"
+msgstr "Leta upp detta fält"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:218
 msgid "Why this metric is interesting"
-msgstr "Por que esta métrica es interesante"
+msgstr "Varför detta mått är intressant"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:228
 msgid "Things to be aware of about this metric"
-msgstr "Cosas a tener en cuenta sobre esta métrica"
+msgstr "Saker att tänka på angående detta mått"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "How this metric is calculated"
-msgstr "Cómo se calcula esta métrica"
+msgstr "Hur detta mått räknas ut"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:215
 msgid "Table this is based on"
-msgstr "Tabla en la que está basada"
+msgstr "Tabelllen är baserad på"
 
 #: frontend/src/metabase/visualizations/lib/renderer_utils.js:276
 msgid "(empty)"
-msgstr "(vacío)"
+msgstr "(tom)"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Goal line"
-msgstr "Meta"
+msgstr "Mållinje"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Trend line"
-msgstr "Tendencia"
+msgstr "Trend-linje"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:317
 msgid "Show values on data points"
-msgstr "Mostrar valores en puntos de datos"
+msgstr "Visa värden på datapunkter"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:325
 msgid "Values to show"
-msgstr "Valores a mostrar"
+msgstr "Värden att visa"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:332
 msgid "As many as can fit nicely"
-msgstr "Tantos como quepan bien"
+msgstr "Så många som kan visas på ett snyggt sätt"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:333
 msgid "All"
-msgstr "Todos"
+msgstr "Alla"
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:9
 msgid "Data includes missing dimension values."
-msgstr "Los datos incluyen valores de dimensión faltantes."
+msgstr "Datat innehåller också saknade värden om dimensioner."
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:17
 msgid "We encountered an invalid date: \"{0}\""
-msgstr "Hay una fecha no válida: \"{0}\""
+msgstr "Vi stötte på ett felaktigt datum \"{0}\""
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:38
 msgid "The query for this chart was run in {0} rather than {1} due to database or driver constraints."
-msgstr "La consulta para este gráfico se ejecutó en {0} en lugar de {1} debido a restricciones de la base de datos o del controlador."
+msgstr "Frågan för denna karta kördes i {0} snarare än {1} på grund av begränsningar i databasen eller drivrutinen."
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:47
 msgid "This chart contains queries run in multiple timezones: {0}"
-msgstr "Este gráfico contiene consultas ejecutadas en varias zonas horarias: {0}"
+msgstr "Denna karta innehåller frågor som körs i multipla tidszoner: {0}"
 
 #: src/metabase/api/public.clj
 msgid "An error occurred while running the query."
-msgstr "Se produjo un error al ejecutar la consulta."
+msgstr "Ett fel uppstod när frågan kördes."
 
 #: src/metabase/cmd/dump_to_h2.clj
 msgid "Output H2 database already exists: %s, removing."
-msgstr "La base de datos H2 de salida ya existe: %s, eliminando."
+msgstr "Utdata-databasen H2 finns redan: %s, tar bort den."
 
 #: src/metabase/cmd/dump_to_h2.clj
 msgid "Don't need to migrate, just use the existing H2 file"
-msgstr "No es necesario migrar, utiliza el archivo H2 existente"
+msgstr "Ingen migrering krävs, använd bara den befintliga H2-filen"
 
 #: src/metabase/cmd/load_from_h2.clj
 msgid "Target DB is already populated!"
-msgstr "¡La base de datos de destino ya contiene datos!"
+msgstr "Mål-databasen innehåller redan data!"
 
 #: src/metabase/core.clj
 msgid "System info:n {0}"
-msgstr "Información del sistema:n {0}"
+msgstr "System-info {0}"
 
 #: src/metabase/db.clj
 msgid "Database setup"
-msgstr "Configuración de la base de datos"
+msgstr "Databasinställningar"
 
 #. 4. move everything not in this Collection to a new Collection
 #: src/metabase/db/migrations.clj
 msgid "Moving instances of {0} that aren''t in a Collection to {1} Collection {2}"
-msgstr "Moviendo instancias de {0} que no están en una Colección a {1} Colección {2}"
+msgstr "Flyttar instanser av {0} som inte tillhör en samling till {1} samling {2}"
 
 #: src/metabase/driver/common/parameters/parse.clj
 msgid "Invalid '{{...}}' clause: expected a param name"
-msgstr "Cláusula '{{...}}' no válida: se esperaba un nombre de parámetro"
+msgstr "Felaktig '{{...}}'-sats: förväntade mig ett parameternamn"
 
 #: src/metabase/driver/common/parameters/parse.clj
 msgid "'{{...}}' clauses cannot be empty."
-msgstr "las cláusulas '{{...}}' no pueden estar vacías."
+msgstr "'{{...}}'-satser kan inte vara tomma."
 
 #: src/metabase/driver/common/parameters/parse.clj
 msgid "'[[...]]' clauses must contain at least one '{{...}}' clause."
-msgstr "las cláusulas '[[...]]' deben contener al menos una cláusula '{{...}}'."
+msgstr "'[[...]]-satser måste innehålla minst en '{{...}}'-sats."
 
 #: src/metabase/driver/common/parameters/parse.clj
 msgid "Invalid query: found '[[' or '{{' with no matching ']]' or '}}'"
-msgstr "Consulta no válida: se encontró '[[' o '{{' sin coincidencias ']]' o '}}'"
+msgstr "Felaktig fråga: hittade '[[' eller '{{' utan matchande ']]' eller '}}'"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "You''ll need to pick a value for ''{0}'' before this query can run."
-msgstr "Deberá elegir un valor para \"{0}\" antes de que se pueda ejecutar esta consulta."
+msgstr "Du behöver välja ett värde för \"{0}\" innan denna fråga kan köras."
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Can''t find field with ID: {0}"
-msgstr "No se puede encontrar el campo con ID: {0}"
+msgstr "Hittar inte fältet med id: {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Error loading driver namespace"
-msgstr "Error al cargar el espacio de nombres del controlador"
+msgstr "Fel när drivrutinens \"namespace\" skulle laddas"
 
 #: src/metabase/driver/impl.clj
 msgid "Could not load {0} driver."
-msgstr "No se pudo cargar el controlador {0}."
+msgstr "Kunde inte ladda drivrutin {0}."
 
 #: src/metabase/driver/sql/parameters/substitute.clj
 msgid "Cannot run query: missing required parameters: {0}"
-msgstr "No se puede ejecutar la consulta: faltan los parámetros necesarios: {0}"
+msgstr "Kan inte köra frågan: obligatoriska parametrar saknas: {0}"
 
 #: src/metabase/driver/sql/parameters/substitution.clj
 msgid "Don''t know how to parse {0} {1}"
-msgstr "No sé cómo analizar {0} {1}"
+msgstr "Kan inte tolka {0} {1}"
 
 #: src/metabase/driver/sql/util.clj
 msgid "Don''t know how to alias {0}, expected an Identifier."
-msgstr "No sé cómo hacer un alias de {0}, esperaba un identificador."
+msgstr "Kan inte benämna {0}, förväntade mig en identifierare."
 
 #. it's better return a slightly broken SQL query with a probably incorrect string representation of the value than
 #. to have the entire QP run fail because of an unknown type.
 #: src/metabase/driver/sql/util/unprepare.clj
 msgid "Don''t know how to unprepare values of class {0}"
-msgstr "No sé cómo deshacer los valores de la clase {0}"
+msgstr "Vet inte hur jag ska köra \"unprepare values\" på klass {0}"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Creating new connection pool for {0} database {1} ..."
-msgstr "Creando un nuevo grupo de conexiones para la base de datos {0} {1} ..."
+msgstr "Skapar ny anslutningspool {0} för databas {1}..."
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Invalid timezone ''{0}''"
-msgstr "Zona horaria inválida \"{0}\""
+msgstr "Felaktig tidszon \"{0}\""
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Cannot set timezone: invalid or missing SQL format string for driver {0}."
-msgstr "No se puede establecer la zona horaria: cadena de formato SQL no válida o faltante para el controlador {0}."
+msgstr "Kan inte sätta tidszon: felaktigt eller saknat SQL-formatteringssträng för drivrutin {0}."
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Did you implement set-timezone-sql?"
-msgstr "¿Implementaste set-timezone-sql?"
+msgstr "Har du använt set-timezone-sql?"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone ''{0}''"
-msgstr "Error al establecer la zona horaria \"{0}\""
+msgstr "Kunde inte sätta tidszon \"{0}\""
 
 #: src/metabase/driver/util.clj
 msgid "Database connection error"
-msgstr "Error de conexión a la base de datos"
+msgstr "Anslutningsfel mot databas."
 
 #: src/metabase/models/interface.clj
 msgid "Error parsing JSON"
-msgstr "Error analizando JSON"
+msgstr "Fel vid tolkning av JSON"
 
 #: src/metabase/public_settings.clj
 msgid "Whether or not to display data on the homepage. Admins might turn this off in order to direct users to better content than raw data"
-msgstr "Si mostrar o no datos en la página de inicio. Los administradores pueden desactivar esto para dirigir a los usuarios a un mejor contenido que los datos sin procesar"
+msgstr "Huruvida data ska visas på första-sidan. Administratörer kan slå av detta för att visa användare till bättre innehåll än rådata."
 
 #: src/metabase/public_settings.clj
 msgid "Whether or not to display x-ray suggestions on the homepage. They will also be hidden if any dashboards are pinned. Admins might hide this to direct users to better content than raw data"
-msgstr "Si se muestran o no sugerencias de rayos X en la página de inicio. También estarán ocultos si hay paneles fijados. Los administradores pueden ocultar esto para dirigir a los usuarios a un mejor contenido que los datos sin procesar"
+msgstr "Huruvida förslag till genomlysningar ska visas på första-sidan. De kommer också att döljas om någon instrumentpanel spärrats. Administratörer kan dölja detta för att visa användare på bättre innehåll än rådata"
 
 #: src/metabase/public_settings.clj
 msgid "Identify the source of HTTP requests by this header's value, instead of its remote address."
-msgstr "Identifique el origen de las solicitudes HTTP por el valor de este encabezado, en lugar de su dirección remota."
+msgstr "Identifiera källan till HTTP-begäran via dess header-värde istället för dess remote address."
 
 #: src/metabase/public_settings.clj
 msgid "Could not resolve Setting {0}/{1}"
-msgstr "No se pudo resolver la configuración {0}/{1}"
+msgstr "Kunde inte fastställa inställningen {0}/{1}"
 
 #: src/metabase/public_settings.clj
 msgid "Invalid Setting: {0}/{1}"
-msgstr "Configuración inválida: {0}/{1}"
+msgstr "Felakti inställning: {0}/{1}"
 
 #: src/metabase/pulse.clj
 msgid "reached its goal"
-msgstr "alcanzó su objetivo"
+msgstr "nått sitt mål"
 
 #: src/metabase/pulse.clj
 msgid "gone below its goal"
-msgstr "ido por debajo de su objetivo"
+msgstr "underträffat sitt mål"
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) via email"
-msgstr "Enviando Pulso ({0}: {1}) vía email"
+msgstr "Skickar ögonblicksbild {0}: {1} via epost"
 
 #: src/metabase/pulse.clj
 msgid "Pulse: {0}"
-msgstr "Pulso: {0}"
+msgstr "Ögonblicksbild: {0}"
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) via Slack"
-msgstr "Enviando Pulso ({0}: {1}) vía Slack"
+msgstr "Skickar ögonblicksbild {0}: {1} via Slack"
 
 #: src/metabase/pulse.clj
 msgid "Sending Alert ({0}: {1}) via email"
-msgstr "Enviando Alerta ({0}: {1}) vía email"
+msgstr "Skickar notifiering ({0}: {1}) via epost"
 
 #: src/metabase/pulse.clj
 msgid "Metabase alert: {0} has {1}"
-msgstr "Alerta Metabase: {0} tiene {1}"
+msgstr "Metabase-notifiering: {0} har {1}"
 
 #: src/metabase/pulse.clj
 msgid "Sending Alert ({0}: {1}) via Slack"
-msgstr "Enviando Alerta ({0}: {1}) vía Slack"
+msgstr "Skickar notifiering ({0}: {1}) via Slack"
 
 #: src/metabase/pulse.clj
 msgid "Alert: {0}"
-msgstr "Alerta: {0}"
+msgstr "Notifiering: {0}"
 
 #: src/metabase/pulse/render/color.clj
 msgid "Can''t find JS color selector at ''{0}''"
-msgstr "No se puede encontrar el selector de color JS en \"{0}\""
+msgstr "Kan inte hitta färgväljare för JS vid \"{0}\""
 
 #. TODO  - there is code that calls this in `render.body` regardless of the types of values
 #: src/metabase/pulse/render/datetime.clj
 msgid "FIXME: These aren''t valid temporal literals: {0} {1}. Why are we attemping to format them as such?"
-msgstr "FIXME: Estos no son literales temporales válidos: {0} {1}. ¿Por qué estamos tratando de formatearlos como tales?"
+msgstr "RÄTTA: Dessa är inte giltiga tidsuttryck: {0} {1}. Varför försöker vi formattera dem som sådana?"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "No matching info found for join against Table {0} ''{1}'' on Field {2} ''{3}'' via FK {4} ''{5}''"
-msgstr "No se encontró información coincidente para unir con la tabla {0} \"{1}\" usando el campo {2} \"{3}\" a través de la clave foránea {4} \"{5}\""
+msgstr "Ingen matchande info hittades för \"join\" mot tabell {0} ''{1}'' på fält {2} ''{3}'' via FK {4} ''{5}''"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Don''t know how to get information about Field: {0}"
-msgstr "No sé cómo obtener información sobre el campo: {0}"
+msgstr "Vet inte hur jag ska få info om fält: {0}"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Query timed out after {0}"
-msgstr "La consulta expiró después de {0}"
+msgstr "Frågan fick timeout efter {0}"
 
 #: src/metabase/query_processor/middleware/format_rows.clj
 msgid "Formatting rows with results timezone ID {0}"
-msgstr "Formateando filas con resultados utilizando la zona horaria {0}"
+msgstr "Formatterar rader med resultatens tidszon-id {0}"
 
 #: src/metabase/query_processor/timezone.clj
 msgid "Invalid timezone ID ''{0}''"
-msgstr "Zona horaria inválida \"{0}\""
+msgstr "Felaktig tidszon-id \"{0}\""
 
 #: src/metabase/sync/analyze/fingerprint.clj
 msgid "Saving fingerprint for {0}"
-msgstr "Guardar huella digital para {0}"
+msgstr "Sparar fingeravtryck för {0}"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandoment email!"
-msgstr "Enviando correo electrónico de abandono!"
+msgstr "Skickar övergivelse-mejl!"
 
 #: src/metabase/transforms/core.clj
 msgid "Resulting transforms do not conform to expectations.nExpected: {0}"
-msgstr "Las transformaciones resultantes no se ajustan a las expectativas. Esperado: {0}"
+msgstr "Transformeringarna följer inte föväntad form: {0}"
 
 #: src/metabase/util.clj
 msgid "Timed out after {0}"
-msgstr "Se agotó el tiempo de espera después de {0}"
+msgstr "Timeout efter {0}"
 
 #: src/metabase/util/date_2.clj
 msgid "No temporal adjuster named {0}"
-msgstr "Ningún ajustador temporal llamado {0}"
+msgstr "Ingen justering för tid med namn {0}"
 
 #: src/metabase/util/date_2.clj
 msgid "Invalid unit: {0}"
-msgstr "Unidad inválida: {0}"
+msgstr "Felaktig enhet: {0}"
 
 #: src/metabase/util/date_2/parse.clj
 msgid "Don''t know how to parse {0} using format {1}"
-msgstr "No sé cómo analizar {0} usando el formato {1}"
+msgstr "Kan inte tolka {0} med format {1}"
 
 #: src/metabase/util/embed.clj
 msgid "Token is missing value for keypath {0}"
-msgstr "Al token le falta el valor para keypath {0}"
+msgstr "Biljett saknar värde för \"keypath\" {0}"
 
 #: src/metabase/util/stats.clj
 msgid "Sending usage stats FAILED"
-msgstr "Envío de estadísticas de uso FALLIDO"
+msgstr "Sändning av användningsstatistik MISSLYCKADES"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:69
 msgid "There was an error saving"
-msgstr "Se ha producido un error al guardar"
+msgstr "Ett fel uppstod vid sparande"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:75
 msgid "OK"
-msgstr "Vale"
+msgstr "OK"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:123
 msgid "To allow users to sign in with Google you'll need to give Metabase a Google Developers console application client ID. It only takes a few steps and instructions on how to create a key can be found {0}."
-msgstr "Para permitir a los usuarios iniciar sesión con Google, necesitas dar a Metabase un ID de cliente de aplicación de consola de Google Developers. solo unos pocos pasos y las instrucciones de cómo crear una clave están {0}"
+msgstr "För att tillåta användare logga in med Google behöver du ge Metabase ett \"Google Developers console application client ID\". Det behövs bara ett par steg och instruktioner för hur du skapar en nyckel finns på {0}."
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:134
 msgid "Be sure to include the full client ID, including the apps.googleusercontent.com suffix."
-msgstr "Asegúrate de incluir el ID de cliente completo, incluyendo el sufijo apps.googleusercontent.com"
+msgstr "Se till att du tar med hela \"client ID\" inklusive suffixet apps.googleusercontent.com"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:30
 msgid "Metabase {0} is available."
-msgstr "Está disponible Metabase {0} "
+msgstr "Metabase {0} är nu tillgänglig."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:31
 msgid "You're running {0}"
-msgstr "Tienes la versión {0}"
+msgstr "Du kör {0}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:57
 msgid "Sorry, we were unable to check for updates at this time."
-msgstr "No se pueden buscar actualizaciones en este momento."
+msgstr "Ursäkta, men vi kunde inte kontrollera uppdateringar just nu."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:96
 msgid "patch release"
-msgstr "Versión de arreglos"
+msgstr "patch-release"
 
 #: frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx:10
 msgid "Dates and Times"
-msgstr "Fechas y Horas"
+msgstr "Datum och klockslag"
 
 #: frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx:25
 msgid "Numbers"
-msgstr "Números"
+msgstr "Siffror"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
 msgid "No mappable groups"
-msgstr "No hay grupos asignables"
+msgstr "Inga grupper som går att mappa"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
-msgstr "Documentación de Metabase"
+msgstr "Metabase-dokumentation"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
-msgstr "Incluye una guía de solución de problemas."
+msgstr "Innehåller en problemlösningsguide"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
 msgid "Post on the Metabase support forum"
-msgstr "Comparte en el foro de soporte de Metabase"
+msgstr "Gör ett inlägg på Metabases supportforum"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:114
 msgid "A community forum for all things Metabase"
-msgstr "Un foro comunitario para todas las cosas Metabase"
+msgstr "Ett community-forum för allt Metabase-relaterat"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
 msgid "File a bug report"
-msgstr "Informar sobre un error"
+msgstr "Skapa en felrapport"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:119
 msgid "Create a GitHub issue (includes the diagnostic info below)"
-msgstr "Crea una incidencia en GitHub (incluye la información de diagnóstico)"
+msgstr "Skapa ett Github-ärende (med felsöknings-info enl nedan)"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:127
 msgid "Please include these details in support requests. Thank you!"
-msgstr "Incluye estos detalles en las solicitudes de soporte. ¡Gracias!"
+msgstr "Ta med dessa detaljer i support-frågor. Tack!"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:37
 msgid "youlooknicetoday@email.com"
-msgstr "tevesbienhoy@email.com"
+msgstr "youlooknicetoday@email.com"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:50
 msgid "Remember me"
-msgstr "Recuérdame"
+msgstr "Kom ihåg mig"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
-msgstr "Por razones de seguridad, los enlaces de restablecimiento de contraseña caducan después de un tiempo. Si aún necesitas restablecer tu contraseña, puedes {0}."
+msgstr "Av säkerhetsskäl upphör länkar för återställning av lösenord att gälla efter ett tag. Om du fortfarande behöver återställa ditt lösenord kan du {0}."
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
 msgid "Save new password"
-msgstr "Guardar nueva contraseña"
+msgstr "Spara nytt lösenord"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:424
 msgid "No matching result"
-msgstr "Sin resultados coincidentes"
+msgstr "Inga matchande resultat"
 
 #: frontend/src/metabase/components/form/CustomForm.jsx:178
 msgid "Submit"
-msgstr "Enviar"
+msgstr "Skicka"
 
 #: frontend/src/metabase/entities/databases/forms.js:15
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host. This option also provides an extra layer of security when a VPN is not available. Enabling this is usually slower than a direct connection."
-msgstr "Solo se puede acceder a algunas instalaciones de bases de datos conectándose a través de un host de bastión SSH. Esta opción también proporciona una capa adicional de seguridad cuando no se dispone de una VPN. Habilitar esto suele ser más lento que una conexión directa."
+msgstr "Några databas-installationer kan bara kommas åt genom att ansluta via en SSH-värd. Detta alternativ ger ett extra lager av säkerhet när VPN inte finns tillgängligt. Om detta aktiveras blir anslutningen vanligtvis långsammare än en direktuppkoppling."
 
 #: frontend/src/metabase/entities/databases/forms.js:19
 msgid "We suggest you leave this off unless you're doing manual timezone casting in many or most of your queries with this data."
-msgstr "Sugerimos que dejes esto desactivado a menos que realices una conversión manual de zona horaria en muchas o la mayoría de tus consultas con estos datos."
+msgstr "Vi föreslår att du inte aktiverar detta om du inte använder manuell tidszonshantering i de flesta av dina frågor mot detta data."
 
 #: frontend/src/metabase/entities/databases/forms.js:128
 msgid "{0} to get an auth code."
-msgstr "{0} para obtener un código de autenticación."
+msgstr "{0} för att få en behörighetskod"
 
 #: frontend/src/metabase/entities/databases/forms.js:136
 #: src/metabase/models/collection.clj
 msgid "or"
-msgstr "o"
+msgstr "eller"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
 #: frontend/src/metabase/entities/databases/forms.js:226
@@ -13745,46 +13723,46 @@ msgstr "o"
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
-msgstr "obligatorio"
+msgstr "obligatorisk"
 
 #: frontend/src/metabase/entities/databases/forms.js:257
 msgid "Database type"
-msgstr "Tipo base de datos"
+msgstr "Databastyp"
 
 #: frontend/src/metabase/entities/databases/forms.js:291
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
-msgstr "Este es un proceso ligero que busca actualizaciones para el esquema de esta base de datos. En la mayoría de los casos, debería estar bien dejarlo que sincronice cada hora."
+msgstr "Detta är en snabb process som letar efter uppdateringar till detta databasschema. För det mesta går det utmärkt att låta detta gå varje timme."
 
 #: frontend/src/metabase/entities/databases/forms.js:299
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
-msgstr "Metabase puede escanear los valores presentes en cada campo en esta base de datos para habilitar filtros de casillas de verificación en paneles y preguntas. Este puede ser un proceso de uso intensivo de recursos, especialmente si tienes una base de datos muy grande."
+msgstr "Metabase kan skanna värden i varje fält i denna databas för att aktivera val i dialogrutor. Detta kan ta en del resurser, i synnerhet om du har en väldigt stor databas."
 
 #: frontend/src/metabase/entities/questions.js:95
 msgid "Collection"
-msgstr "Colección"
+msgstr "Samling"
 
 #: frontend/src/metabase/entities/users/forms.js:55
 msgid "Confirm your password"
-msgstr "Confirma tu contraseña"
+msgstr "Bekräfta ditt lösenord"
 
 #: frontend/src/metabase/entities/users/forms.js:60
 msgid "passwords do not match"
-msgstr "las contraseñas no coinciden"
+msgstr "lösenorden matchar inte varandra"
 
 #: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
-msgstr "Departamento Impresionante"
+msgstr "Avdelningen för stordåd"
 
 #: frontend/src/metabase/lib/core.js:88 frontend/src/metabase/lib/core.js:93
 #: frontend/src/metabase/lib/core.js:98 frontend/src/metabase/lib/core.js:103
 #: frontend/src/metabase/lib/core.js:108 frontend/src/metabase/lib/core.js:113
 msgid "Financial"
-msgstr "Financiero"
+msgstr "Finansiell"
 
 #: frontend/src/metabase/lib/core.js:120 frontend/src/metabase/lib/core.js:125
 #: frontend/src/metabase/lib/core.js:130
 msgid "Numeric"
-msgstr "Numérico"
+msgstr "Numerisk"
 
 #: frontend/src/metabase/lib/core.js:169 frontend/src/metabase/lib/core.js:174
 #: frontend/src/metabase/lib/core.js:179 frontend/src/metabase/lib/core.js:184
@@ -13794,42 +13772,42 @@ msgstr "Numérico"
 #: frontend/src/metabase/lib/core.js:219 frontend/src/metabase/lib/core.js:224
 #: frontend/src/metabase/lib/core.js:229 frontend/src/metabase/lib/core.js:234
 msgid "Date and Time"
-msgstr "Fecha y Hora"
+msgstr "Datum och tid"
 
 #: frontend/src/metabase/lib/core.js:241 frontend/src/metabase/lib/core.js:246
 #: frontend/src/metabase/lib/core.js:251
 msgid "Categorical"
-msgstr "Categórico"
+msgstr "Kategorisk"
 
 #: frontend/src/metabase/lib/core.js:258 frontend/src/metabase/lib/core.js:263
 #: frontend/src/metabase/lib/core.js:268
 msgid "URLs"
-msgstr "URLs"
+msgstr "URL:er"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
 msgid "Returns the average of the values in the column."
-msgstr "Devuelve el promedio de los valores en la columna."
+msgstr "Returnerar genomsnittet av värdena i kolumnen."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
 msgid "The column whose values to average."
-msgstr "La columna cuyos valores promediar."
+msgstr "Kolumnerna att ta genomsnitt ifrån"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "start"
-msgstr "inicio"
+msgstr "start"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "end"
-msgstr "fin"
+msgstr "slut"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
 msgid "Checks a date or numeric column's values to see if they're within the specified range."
-msgstr "Comprueba los valores de una fecha o columna numérica para ver si están dentro del rango especificado."
+msgstr "Kontrollerar värdet i ett numeriskt fält eller datumfält för att se om de ligger inom ett specifikt intervall"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
-msgstr "Clasificación"
+msgstr "Betyg"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
@@ -13841,172 +13819,172 @@ msgstr "Clasificación"
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
 msgid "condition"
-msgstr "condición"
+msgstr "villkor"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
 msgid "output"
-msgstr "salida"
+msgstr "utdata"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
-msgstr "Prueba una lista de casos y devuelve el valor correspondiente del primer caso verdadero, con un valor predeterminado opcional si no se cumple ninguno."
+msgstr "Testar en lista över villkor och returnerar motsvarande värde för det första uppfyllda villkoret med ett valfritt förvalt värde om inget annat hittas."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
 msgid "Weight"
-msgstr "Peso"
+msgstr "Vikt"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
 msgid "Large"
-msgstr "Grande"
+msgstr "Stor"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
 msgid "Medium"
-msgstr "Medio"
+msgstr "Medelstor"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
 msgid "Small"
-msgstr "Pequeño"
+msgstr "Liten"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
 msgid "Something that should evaluate to true or false."
-msgstr "Algo que debería evaluar como verdadero o falso."
+msgstr "Något som ska vara sant eller falskt."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:54
 msgid "The value that will be returned if the preceeding condition is true."
-msgstr "El valor que se devolverá si la condición anterior es verdadera."
+msgstr "Värde som returneras om föregående villkor är uppfyllt."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "value1"
-msgstr "valor1"
+msgstr "värde1"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
 msgid "value2"
-msgstr "valor2"
+msgstr "värde2"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
-msgstr "Mira los valores en cada argumento en orden y devuelve el primer valor no nulo para cada fila."
+msgstr "Tittar på värdena i varje argument i tur och ordning, och returnerar det första icke-tomma värdet för varje rad."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
 msgid "Comments"
-msgstr "Comentarios"
+msgstr "Kommentarer"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
 msgid "Notes"
-msgstr "Notas"
+msgstr "Anteckningar"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
 msgid "No comments"
-msgstr "Sin comentarios"
+msgstr "Inga kommentarer"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
 msgid "A column or value."
-msgstr "Una columna o valor"
+msgstr "En kolumn eller värde"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:77
 msgid "If value1 is empty, value2 gets returned if it's not empty, and so on."
-msgstr "Si valor1 está vacío, devuelve valor2 si no está vacío, y así sucesivamente."
+msgstr "Om värde1 är tomt returneras värde2 om det inte är tomt, och så vidare."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 msgid "Combines two or more strings of text together."
-msgstr "Combina dos o más cadenas de texto."
+msgstr "Kombinerar två eller flera texter till en."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
 msgid "Last Name"
-msgstr "Apellidos"
+msgstr "Efternamn"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 msgid "First Name"
-msgstr "Nombre"
+msgstr "Förnamn"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
-msgstr "valor2 se añadirá al final de esto."
+msgstr "värde2 kommer att läggas på slutet av detta."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
-msgstr "Esto se agregará al final del valor1."
+msgstr "Detta kommer att läggas till slutet av värde1."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
 msgid "string1"
-msgstr "cadena1"
+msgstr "sträng1"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
 msgid "string2"
-msgstr "cadena2"
+msgstr "sträng2"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
 msgid "Checks to see if string1 contains string2 within it."
-msgstr "Comprueba si string1 contiene string2."
+msgstr "Kontrollerar om sträng1 innehåller sträng2."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
 msgid "Status"
-msgstr "Estado"
+msgstr "Status"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 msgid "Pass"
-msgstr "Pasar"
+msgstr "Passerat"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
-msgstr "Se verificará el contenido de esta cadena."
+msgstr "Innehållet i denna sträng kommer att kontrolleras."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
 msgid "The string of text to look for."
-msgstr "La cadena de texto a buscar."
+msgstr "Sträng eller text att söka efter."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:116
 msgid "Returns the count of rows in the source data."
-msgstr "Devuelve el número de filas en los datos de origen."
+msgstr "Returnerar antalet rader i källdatat."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Only counts rows where the condition is true."
-msgstr "Solo cuenta las filas donde la condición es verdadera."
+msgstr "Bara antal rader där villkoret uppfylls."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
 msgid "Subtotal"
-msgstr "Subtotal"
+msgstr "Delsumma"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
 msgid "The additive total of rows across a breakout."
-msgstr "El total aditivo de filas en una ruptura."
+msgstr "Ackumulerat antal rader över en utbrytning."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
 msgid "The rolling sum of a column across a breakout."
-msgstr "La suma aditiva de una columna en una ruptura."
+msgstr "Rullande summa av en kolumn över en utbrytning"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
-msgstr "La columna a sumar."
+msgstr "Kolumnen att summera"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
 msgid "The number of distinct values in this column."
-msgstr "El número de valores distintos en esta columna."
+msgstr "Antalet distinkta värden i denna kolumn."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "The column whose distinct values to count."
-msgstr "La columna en la que hay que contar los valores distintos."
+msgstr "Kolumnen var distinkta värden ska räknas"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
@@ -14029,1003 +14007,1003 @@ msgstr "La columna en la que hay que contar los valores distintos."
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
 msgid "text"
-msgstr "texto"
+msgstr "text"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
 msgid "comparison"
-msgstr "comparación"
+msgstr "jämförelse"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
 msgid "Returns true if the end of the text matches the comparison text."
-msgstr "Devuelve verdadero si el final del texto coincide con el texto de comparación."
+msgstr "Returnerar sant om slutet av texten matchar jämförelse-texten"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "Appetite"
-msgstr "Apetito"
+msgstr "Aptit"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "hungry"
-msgstr "hambriento"
+msgstr "hungrig"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 msgid "A column or string of text to check."
-msgstr "Una columna o cadena de texto para verificar."
+msgstr "En kolumn eller textsträng att kontrollera"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
 msgid "The string of text that the original text should end with."
-msgstr "La cadena de texto con la que debe terminar el texto original."
+msgstr "Textsträngen som ursprunglig text ska sluta med."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 msgid "regular_expression"
-msgstr "expresión_regular"
+msgstr "regexp"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
 msgid "Extracts matching substrings according to a regular expression."
-msgstr "Extrae subcadenas coincidentes de acuerdo con una expresión regular."
+msgstr "Plockar ut matchande del-strängar utifrån en regexp."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
 msgid "Address"
-msgstr "Dirección"
+msgstr "Adress"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 msgid "The column or string of text to search though."
-msgstr "La columna o cadena de texto en la que buscar."
+msgstr "Kolumnen eller textsträngen att genomsöka."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
 msgid "The regular expression to match."
-msgstr "La expresión regular a evaluar."
+msgstr "Matchande regexp."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the string of text in all lowercase."
-msgstr "Devuelve la cadena de texto en minúsculas."
+msgstr "Returnerar textsträngen med små bokstäver."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to lowercase."
-msgstr "La columna con valores para convertir a minúsculas."
+msgstr "Kolumnen med värden att konvertera till små bokstäver."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 msgid "Removes leading whitespace from a string of text."
-msgstr "Elimina los espacios en blanco iniciales de una cadena de texto."
+msgstr "Tar bort inledande blanktecken från en textsträng."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column with values you want to trim."
-msgstr "La columna con los valores que quieres recortar."
+msgstr "Kolumnen vars värden du vill beskära."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "Returns the largest value found in the column."
-msgstr "Devuelve el máximo valor encontrado en la columna."
+msgstr "Returnerar det största värdet från kolumnen."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
 msgid "Age"
-msgstr "Edad"
+msgstr "Ålder"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
 msgid "The numeric column whose maximum you want to find."
-msgstr "La columna numérica cuyo máximo quieres encontrar."
+msgstr "Den numeriska kolumn vars max-värde du vill hitta."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "Returns the smallest value found in the column."
-msgstr "Devuelve el valor más pequeño encontrado en la columna."
+msgstr "Returnerar det minsta värdet i kolumnen."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
 msgid "Salary"
-msgstr "Salario"
+msgstr "Lön"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
 msgid "The numeric column whose minimum you want to find."
-msgstr "La columna numérica cuyo mínimo quieres encontrar."
+msgstr "Den numeriska kolumnen vars minsta värde du vill hitta"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
 msgid "position"
-msgstr "posición"
+msgstr "position"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
 msgid "length"
-msgstr "longitud"
+msgstr "längd"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:185
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "new_text"
-msgstr "texto_nuevo"
+msgstr "ny_text"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
 msgid "Replaces a part of the input text with new text."
-msgstr "Reemplaza una parte del texto de entrada con texto nuevo."
+msgstr "Ersätter en del av indata-texten med ny text."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:189
 msgid "Order ID"
-msgstr "ID Pedido"
+msgstr "Order-id"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:189
 msgid "Updated Part of ID"
-msgstr "Parte actualizada de ID"
+msgstr "Uppdaterad del av id"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
 msgid "The text that will be modified."
-msgstr "El texto que se modificará."
+msgstr "Texten som ska ändras."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:193
 msgid "The position where the replacing will start."
-msgstr "La posición donde comenzará la sustitución."
+msgstr "Positionen där ersättning ska börja"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
 msgid "The number of characters to replace."
-msgstr "El número de caracteres a reemplazar."
+msgstr "Antalet tecken att ersätta."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:197
 msgid "The text to use in the replacement."
-msgstr "El texto a usar en el reemplazo."
+msgstr "Text att använda för ersättning."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "Removes trailing whitespace from a string of text."
-msgstr "Elimina los espacios en blanco finales de una cadena de texto."
+msgstr "Tar bort avslutande blanktecken från en textsträng."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
-msgstr "Devuelve el porcentaje de filas en los datos que coinciden con la condición, como un decimal."
+msgstr "Returnerar procenten av rader i datat som matchar villkoret som ett decimaltal."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
 msgid "Returns true if the beginning of the text matches the comparison text."
-msgstr "Devuelve verdadero si el comienzo del texto coincide con el texto de comparación."
+msgstr "Returnerar sant om början av texten matchar jämförelsetexten."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Course Name"
-msgstr "Nombre del Curso"
+msgstr "Kursnamn"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Computer Science"
-msgstr "Ciencias de la Computación"
+msgstr "Datavetenskap"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
 msgid "The string of text that the original text should start with."
-msgstr "La cadena de texto con la que debe comenzar el texto original."
+msgstr "Textsträngen som ursprunglig text ska börja med"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
 msgid "Calculates the standard deviation of the column."
-msgstr "Calcula la desviación estándar de la columna."
+msgstr "Räknar ut standardavvikelsen för kolumnen"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
 msgid "Population"
-msgstr "Población"
+msgstr "Population"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
 msgid "A numeric column."
-msgstr "Una columna numérica"
+msgstr "En numerisk kolumn."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
 msgid "Returns a portion of the supplied text."
-msgstr "Devuelve una parte del texto proporcionado."
+msgstr "Returerar en del av den angivna texten."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:313
 msgid "The text to return a portion of."
-msgstr "El texto del que hay que extraer una parte."
+msgstr "Texten att returnera en del av."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
 msgid "The position to start copying characters."
-msgstr "La posición para comenzar a copiar caracteres."
+msgstr "Positionen där tecken ska börja kopieras.."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
 msgid "The number of characters to return."
-msgstr "El número de caracteres a devolver."
+msgstr "Antalet tecken att returnera."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
 msgid "Adds up all the values of the column."
-msgstr "Suma todos los valores de la columna."
+msgstr "Adderar alla värden till kolumnen."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
 msgid "The numeric column to sum."
-msgstr "La columna numérica a sumar."
+msgstr "Den numeriska kolumnen som ska summeras."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
-msgstr "Resume valores en una columna donde las filas coinciden con la condición."
+msgstr "Summera värden i en kolumn där rader matchar villkoret."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
 msgid "Order Status"
-msgstr "Estado Pedido"
+msgstr "Orderstatus"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
 msgid "Valid"
-msgstr "Válido"
+msgstr "Giltig"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
 msgid "Removes leading and trailing whitespace from a string of text."
-msgstr "Elimina los espacios en blanco iniciales y finales de una cadena de texto."
+msgstr "Tar bort inledande och avslutande blanktecken från en textsträng."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
 msgid "Returns the string of text in all upper case."
-msgstr "Devuelve la cadena de texto en mayúsculas."
+msgstr "Returnerar en textsträng med stora bokstäver."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
 msgid "The column with values to convert to upper case."
-msgstr "La columna con valores para convertir a mayúsculas."
+msgstr "Kolumnen med värden som ska konverteras till stora bokstäver."
 
 #: frontend/src/metabase/lib/settings.js:190
 msgid "must be {0} and include {1}."
-msgstr "debe ser {0} e incluir {1}"
+msgstr "måste vara {0} och innehålla {1}."
 
 #: frontend/src/metabase/lib/settings.js:192
 msgid "must be {0}."
-msgstr "debe ser {0}"
+msgstr "måste vara {0}."
 
 #: frontend/src/metabase/lib/settings.js:194
 msgid "must include {0}."
-msgstr "debe incluir {0}."
+msgstr "måste innehålla {0}."
 
 #: frontend/src/metabase/lib/settings.js:207
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
-msgstr[0] "al menos {0} carácter"
-msgstr[1] "al menos {0} caracteres"
+msgstr[0] "minst {0} tecken lång"
+msgstr[1] "minst {0} tecken lång"
 
 #: frontend/src/metabase/lib/settings.js:216
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
-msgstr[0] "{0} letra minúscula"
-msgstr[1] "{0} letras minúsculas"
+msgstr[0] "{0} liten bokstav"
+msgstr[1] "{0} små bokstäver"
 
 #: frontend/src/metabase/lib/settings.js:225
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
-msgstr[0] "{0} letra mayúscula"
-msgstr[1] "{0} letras mayúsculas"
+msgstr[0] "{0} stor bokstav"
+msgstr[1] "{0} stora bokstäver"
 
 #: frontend/src/metabase/lib/settings.js:234
 msgid "{0} number"
 msgid_plural "{0} numbers"
-msgstr[0] "{0} número"
-msgstr[1] "{0} números"
+msgstr[0] "{0} siffra"
+msgstr[1] "{0} siffror"
 
 #: frontend/src/metabase/lib/settings.js:239
 msgid "{0} special character"
 msgid_plural "{0} special characters"
-msgstr[0] "{0} carácter especial"
-msgstr[1] "{0} caracteres especiales"
+msgstr[0] "{0} speciellt tecken"
+msgstr[1] "{0} speciella tecken"
 
 #: frontend/src/metabase/lib/validate.js:8
 msgid "must be a valid email address"
-msgstr "Debe ser una dirección de correo electrónico válida"
+msgstr "måste vara en giltig epost-adress"
 
 #: frontend/src/metabase/lib/validate.js:10
 msgid "must be {0} characters or less"
-msgstr "deben tener {0} caracteres o menos"
+msgstr "måste vara {0} tecken eller mindre"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:113
 msgid "Thanks for using Metabase!"
-msgstr "Gracias por utilizar Metabase!"
+msgstr "Tack för att du använder Metabase!"
 
 #: frontend/src/metabase/public/components/LogoBadge.jsx:20
 msgid "Powered by {0}"
-msgstr "Impulsado por {0}"
+msgstr "Byggd på {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
 msgid "To:"
-msgstr "A:"
+msgstr "Till:"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
-msgstr "Esta pregunta no se puede usar porque se basa en una base de datos diferente."
+msgstr "Denna fråga kan inte användas eftersom den är baserad på en annan databas."
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:43
 msgid "Couldn't find a saved question with that ID number."
-msgstr "No he podido encontrar una pregunta guardada con ese número de identificación."
+msgstr "Kunde inte hitta en sparad fråga med det id:t"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:54
 msgid "Pick a saved question"
-msgstr "Elige una pregunta guardada"
+msgstr "Välj en sparad fråga"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:56
 msgid "Pick a different question"
-msgstr "Elige una pregunta diferente"
+msgstr "Välj en annan fråga"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:61
 msgid "Loading…"
-msgstr "Cargando..."
+msgstr "Laddar..."
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:78
 msgid "Question #…"
-msgstr "Pregunta #..."
+msgstr "Fråga #..."
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
-msgstr "Pregunta #{0}"
+msgstr "Fråga #{0}"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
-msgstr "Última edición {0}"
+msgstr "Senast redigerad {0}"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:250
 msgid "{0} creates a variable in this query template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the query template."
-msgstr "{0} crea una variable en esta plantilla de consulta llamada \"nombre_variable\". Las variables pueden recibir tipos en el panel lateral, lo que cambia su comportamiento. Todos los tipos de variables que no sean \"Filtro de campo\" provocarán automáticamente que se coloque un widget de filtro en esta pregunta; con filtros de campo, esto es opcional. Cuando se completa este widget de filtro, ese valor reemplaza la variable en la plantilla de consulta."
+msgstr "{0} skapar en variabel i denna frågemall kallad \"variable_name\". Variabler kan ges typer i sidopaneler som ändrar deras uppförande. Alla variabeltyper med undantag för fält-filter kommer automatiskt att visa en dialogruta i denna fråga. Med fält-filter är detta valfritt. När denna dialogruta fylls i kommer värdet att ersätta variabeln i frågemallen."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:261
 msgid "Giving a variable the \"Field Filter\" type allows you to link questions to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
-msgstr "Darle a una variable el tipo de \"Filtro de campo\" te permite vincular preguntas a los widgets de filtro del tablero o usar más tipos de widgets de filtro en tu pregunta SQL. Una variable de filtro de campo inserta SQL similar al generado por el generador de consultas GUI al agregar filtros en columnas existentes."
+msgstr "Genom att tilldela en variabel typen fält-filter kan du länka frågor till filter i instrumentpanel-dialoger eller använda flera typer av dialoger i din SQL-fråga. Ett fält-filters variabel lägger in SQL motsvarande den som genereras av frågeguiden när man lägger till filter på befintliga kolumner."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
-msgstr "Nombre de variable"
+msgstr "Variabelnamn"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:218
 msgid "Filter widget label"
-msgstr "Etiqueta del widget de filtro"
+msgstr "Rubrik i dialogruta"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:64
 msgid "Select a foreign key"
-msgstr "Selecciona una clave foránea"
+msgstr "Välj en extern nyckel"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:50
 msgid "Hi, {0}. Nice to meet you!"
-msgstr "Hola, {0}. Encantada de conocerte!"
+msgstr "Hej {0}. Trevligt att träffas!"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:270
 msgid "12-hour clock"
-msgstr "Reloj de 12 horas"
+msgstr "12-timmars klocka"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:274
 msgid "24-hour clock"
-msgstr "Reloj de 24 horas"
+msgstr "24-timmars klocka"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:341
 msgid "Symbol"
-msgstr "Símbolo"
+msgstr "Symbol"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:365
 msgid "In the column heading"
-msgstr "En el encabezado de la columna"
+msgstr "i kolumnrubriken"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:366
 msgid "In every table cell"
-msgstr "en cada celda de la tabla"
+msgstr "I varje cell"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:341
 msgid "Value formatting"
-msgstr "Formato de valor"
+msgstr "Formattering av värden"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:350
 msgid "Full"
-msgstr "Lleno"
+msgstr "Hela"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
 msgid "No change from last {0}"
-msgstr "Sin cambios desde el último {0}"
+msgstr "Ingen ändring sedan {0}"
 
 #: src/metabase/api/database.clj
 msgid "Connection to ''{0}:{1}'' successful, but could not connect to DB."
-msgstr "La conexión a \"{0}:{1}\" se realizó correctamente, pero no se ha podido conectar a la base de datos."
+msgstr "Anslutning till \"{0}:{1}\" lyckades, men kunde inte ansluta till databasen."
 
 #: src/metabase/api/database.clj
 msgid "Connection to host ''{0}'' successful, but port {1} is invalid."
-msgstr "La conexión al host \"{0}\" se realizó correctamente, pero el puerto {1} no es válido."
+msgstr "Anslutning till värd \"{0}\" lyckades, men porten {1} är ogiltig."
 
 #: src/metabase/api/database.clj
 msgid "Host ''{0}'' is not reachable"
-msgstr "No se puede acceder al host \"{0}\""
+msgstr "Värden \"{0}\" kan inte nås"
 
 #: src/metabase/api/database.clj
 msgid "Unable to connect to database."
-msgstr "Incapaz de conectar a la base de datos."
+msgstr "Kan inte ansluta till databasen."
 
 #: src/metabase/api/database.clj
 msgid "Cannot connect to Database"
-msgstr "No se puede conectar a la base de datos"
+msgstr "Kan inte ansluta till databasen"
 
 #: src/metabase/api/embed.clj
 msgid "You''re not allowed to specify a value for {0}."
-msgstr "No tienes permiso para especificar un valor de {0}."
+msgstr "Du har inte tillåtelse att ange ett värde på {0}."
 
 #: src/metabase/api/embed.clj
 msgid "You can''t specify a value for {0} if it''s already set in the JWT."
-msgstr "No puedes especificar un valor para {0} si ya está configurado en el JWT."
+msgstr "Du kan inte ange ett värde på {0} om det redan är satt i JWT."
 
 #: src/metabase/api/embed.clj
 msgid "You must specify a value for {0} in the JWT."
-msgstr "Debes especificar un valor para {0} en el JWT."
+msgstr "Du måste ange ett värde på {0} i JWT."
 
 #: src/metabase/api/embed.clj
 msgid "You can only specify a value for {0} in the JWT."
-msgstr "Solo puedes especificar un valor para {0} en el JWT."
+msgstr "Du kan bara ange ett värde på {0} i JWT."
 
 #: src/metabase/api/field.clj
 msgid "Error searching field values"
-msgstr "Error al buscar valores de campo"
+msgstr "Fel vid sökning av fältvärden"
 
 #: src/metabase/api/field.clj
 msgid "Error searching for remapping"
-msgstr "Error al buscar la reasignación"
+msgstr "Fel vid ny kartläggning"
 
 #: src/metabase/api/session.clj
 msgid "Google Auth token appears to be incorrect. "
-msgstr "El token de autenticación de Google parece ser incorrecto."
+msgstr "Google Auth-biljett verkar vara felaktig"
 
 #: src/metabase/api/session.clj
 msgid "Double check that it matches in Google and Metabase."
-msgstr "Verifica que coincida en Google y Metabase."
+msgstr "Dubbelkolla att det matchar mellan Google och Metabase"
 
 #: src/metabase/api/table.clj
 msgid "Everything else"
-msgstr "Todo lo demás"
+msgstr "Allting annat"
 
 #: src/metabase/core.clj
 msgid "WARNING: You have enabled namespace tracing, which could log sensitive information like db passwords."
-msgstr "ADVERTENCIA: Has habilitado el seguimiento del espacio de nombres, que podría registrar información confidencial como contraseñas de la base de datos."
+msgstr "VARNING: Du har aktiverat spårning av \"namespace\", vilket kan logga känslig information såsom databas-lösenord."
 
 #: src/metabase/db.clj
 msgid "Database Upgrade Required"
-msgstr "Actualización de base de datos requerida"
+msgstr "Uppgradering av databasen krävs"
 
 #: src/metabase/db.clj
 msgid "NOTICE: Your database requires updates to work with this version of Metabase."
-msgstr "AVISO: tu base de datos requiere actualizaciones para funcionar con esta versión de Metabase."
+msgstr "NOTERING: Din databas behöver uppdateringar för att fungera med denna version av Metabase."
 
 #: src/metabase/db.clj
 msgid "Please execute the following sql commands on your database before proceeding."
-msgstr "Por favor, ejecuta los siguientes comandos SQL en tu base de datos antes de continuar."
+msgstr "Kör följande SQL-kommandon mot din databas innan du fortsätter."
 
 #: src/metabase/db.clj
 msgid "Once your database is updated try running the application again."
-msgstr "En cuanto hayas actualizado tu base de datos, intenta ejecutar la aplicación  de nuevo."
+msgstr "När din databas är uppdaterat, försök köra applikationen igen."
 
 #: src/metabase/db.clj
 msgid "Database requires manual upgrade."
-msgstr "La base de datos requiere actualización manual."
+msgstr "Databasen kräver manuell uppgradering."
 
 #. Tell transaction to automatically `.rollback` instead of `.commit` when the transaction finishes
 #: src/metabase/db.clj
 msgid "Set transaction to automatically roll back..."
-msgstr "Establecer la transacción para revertir automáticamente ..."
+msgstr "Ställ in transactioner att automatiskt rullas tillbaka..."
 
 #. Disable auto-commit. This should already be off but set it just to be safe
 #: src/metabase/db.clj
 msgid "Disable auto-commit..."
-msgstr "Deshabilitar confirmación automática..."
+msgstr "Inaktivera \"auto-commit\"..."
 
 #: src/metabase/db.clj
 msgid "Set default db connection with connection pool..."
-msgstr "Establecerla conexión al base de datos predeterminada con el grupo de conexiones..."
+msgstr "Sätt förvald databas-anslutning med anslutningspool..."
 
 #: src/metabase/db.clj
 msgid "Successfully verified {0} {1} application database connection."
-msgstr "Se verificó correctamente la conexión de la base de datos de la aplicación {0} {1}."
+msgstr "Lyckades verifiera anslutningen till applikationsdatabasen {0} {1}."
 
 #. if both of the decoders above fail, then the date string is invalid
 #: src/metabase/driver/common/parameters/dates.clj
 msgid "Don''t know how to parse date param ''{0}'' — invalid format"
-msgstr "No sé cómo analizar el parámetro de fecha \"{0}\" - formato no válido"
+msgstr "Vet inte hur jag ska tolka parametern \"{0}\" - felaktigt format"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "The sub-query from referenced question #{0} failed with the following error: {1}"
-msgstr "La subconsulta de la pregunta referenciada #{0} falló con el siguiente error: {1}"
+msgstr "Följande underfråga från tillhörande fråga #{0} misslyckades med följande fel: {1}"
 
 #: src/metabase/driver/mysql.clj
 msgid "WARNING: Metabase only officially supports MySQL {0}/MariaDB {1} and above."
-msgstr "ADVERTENCIA: Metabase solo admite oficialmente MySQL {0}/MariaDB {1} y superior."
+msgstr "VARNING: Metabase stödjer officiellt bara MySQL {0}/MariaDB {1} eller högre."
 
 #: src/metabase/driver/mysql.clj
 msgid "All Metabase features may not work properly when using an unsupported version."
-msgstr "Es posible que alguna funcionalidad de Metabase no funcione correctamente cuando se utiliza una versión no compatible."
+msgstr "Alla Metabase-funktioner kanske inte fungerar korrekt när en version som inte stöds används."
 
 #: src/metabase/driver/sql/parameters/substitute.clj
 msgid "Unable to substitute parameters"
-msgstr "Incapaz de sustituir parámetros"
+msgstr "Kan inte fylla i parametrarna"
 
 #: src/metabase/driver/sql/parameters/substitute.clj
 msgid "Cannot run the query: missing required parameters: {0}"
-msgstr "No se puede ejecutar la consulta: faltan los parámetros necesarios: {0}"
+msgstr "Kan inte köra frågan: obligatoriska parametrar saknas: {0}"
 
 #: src/metabase/driver/sql/parameters/substitution.clj
 msgid "Don''t know how to parse {0} {1} as a temporal literal"
-msgstr "No sé cómo analizar {0} {1} como un literal temporal"
+msgstr "Vet inte hur jag ska tolka {0} {1} som ett tidsuttryck"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Setting {0} database timezone with statement: {1}"
-msgstr "Estableciendo la zona horaria de la base de datos {0} con la declaración: {1}"
+msgstr "Sätter tidszon för databas {0} med uttrycket: {1}"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting connection to readwrite"
-msgstr "Error al establecer la conexión para escritua y lectura"
+msgstr "Fel vid ändring av anslutningen till \"readwrite\""
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone ''{0}'' for {1} database"
-msgstr "Error al establecer la zona horaria \"{0}\" para la base de datos {1}"
+msgstr "Kunde inte sätta tidszon \"{0}\" för databas {1}"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting transaction isolation level for {0} database to {1}"
-msgstr "Error al establecer el nivel de aislamiento de transacción para la base de datos {0} en {1}"
+msgstr "Fel när isolationsnivån {0} för transaktioner mot databas {1} skulle ställas in."
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting connection to read-only"
-msgstr "Error al establecer la conexión a solo lectura"
+msgstr "Fel när anslutningen skulle sättas till \"read-only\""
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting default holdability for connection"
-msgstr "Error al establecer la capacidad de retención predeterminada para la conexión"
+msgstr "Fel när förval för anslutningens värden skulle ställas in"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting result set fetch direction to FETCH_FORWARD"
-msgstr "Error al establecer la dirección de recuperación del conjunto de resultados en FETCH_FORWARD"
+msgstr "Fel när inställning för riktning med FETCH_FORWARD skulle ställas in"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Query canceled, calling PreparedStatement.cancel()"
-msgstr "Consulta cancelada, llamando a PreparedStatement.cancel()"
+msgstr "Frågan avbröts,  anropar PreparedStatement.cancel()"
 
 #: src/metabase/driver/util.clj
 msgid "Failed to connect to database"
-msgstr "Error al conectarse a la base de datos"
+msgstr "Kunde inte ansluta till databasen"
 
 #: src/metabase/driver/util.clj
 msgid "Unable to determine connection properties for driver {0}"
-msgstr "No se pueden determinar las propiedades de conexión para el controlador {0}"
+msgstr "Kan inte fastställa anslutningens parametrar för drivrutin {0}"
 
 #: src/metabase/models/field_values.clj
 msgid "Error fetching field values"
-msgstr "Error al recuperar valores de campo"
+msgstr "Fel när fältvärden skulle hämtas"
 
 #: src/metabase/models/setting.clj
 msgid "You cannot set {0}; it is a read-only setting."
-msgstr "No puedes establecer {0}; Es una configuración de solo lectura."
+msgstr "Du kan inte sätta {0} - det är inte ändringsbart."
 
 #: src/metabase/models/setting.clj
 msgid "defsetting descriptions strings must have `:visibilty` `:internal`, `:setter` `:none`, or internationalized, found: `{0}`"
-msgstr "las cadenas de descripción defsetting deben tener `:visibilty` `:internal`, `:setter` `:none`, o internazionalizado, encontrado: `{0}`"
+msgstr "\"defsetting descriptions strings\" måste ha `:visibilty` `:internal`, `:setter` `:none`, eller internationalized, hittade: `{0}`"
 
 #: src/metabase/models/setting.clj
 msgid "Setting {0} is internal"
-msgstr "La configuración {0} es interna"
+msgstr "Inställningen {0} är intern"
 
 #: src/metabase/plugins.clj
 msgid "Loading local plugin manifest at {0}"
-msgstr "Cargando el manifiesto del complemento local en {0}"
+msgstr "Ladda lokal plugin-specifikation vid {0}"
 
 #: src/metabase/public_settings.clj
 msgid "Google Analytics tracking code."
-msgstr "Código de seguimiento de Google Analytics."
+msgstr "Google Analytics tracking code."
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) with {2} Cards via email"
-msgstr "Envío de pulso ({0}: {1}) con {2} tarjetas por correo electrónico"
+msgstr "Skickar ögonblicksbild {0}: {1} med listorna {2} via epost"
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) with {2} Cards via Slack"
-msgstr "Envío de pulso ({0}: {1}) con {2} tarjetas por Slack"
+msgstr "Skickar pulse {0}: {1} med listorna {2} via Slack"
 
 #: src/metabase/pulse/render.clj
 msgid "Rendering pulse card with chart-type {0} and render-type {1}"
-msgstr "Tarjeta de pulso de representación con tipo de gráfico {0} y tipo de representación {1}"
+msgstr "Skapar ögonblicksbild-listan med tabelltyp {0} and visningstyp {1}"
 
 #. TODO  - there is code that calls this in `render.body` regardless of the types of values
 #: src/metabase/pulse/render/datetime.clj
 msgid "FIXME: These aren''t valid temporal literals: {0} {1}. Why are we attempting to format them as such?"
-msgstr "FIXME: Estos no son literales temporales válidos: {0} {1}. ¿Por qué estamos tratando de formatearlos como tales?"
+msgstr "RÄTTAS: Dessa är inte giltiga tidsuttryck: {0} {1}. Varför försöker vi formattera dem som sådana?"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Error reducing result rows"
-msgstr "Error al reducir las filas de resultados"
+msgstr "Fel när antalet rader minskades"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Unexpected nil result"
-msgstr "Resultado inesperado nulo"
+msgstr "Oväntat tomt resultat"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Query timed out after {0} ms, raising timeout exception."
-msgstr "La consulta expiró después de {0} ms, generando una excepción de tiempo de espera."
+msgstr "Frågan fick timeout efter {0} vilket leder till timeout-hantering."
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Timed out after {0}."
-msgstr "Se agotó el tiempo de espera después de {0}."
+msgstr "Timeout efter {0}."
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Query canceled before finishing."
-msgstr "Consulta cancelada antes de finalizar."
+msgstr "Frågan avbröts innan den gått klart."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Unknown query type {0}"
-msgstr "Tipo de consulta desconocido {0}"
+msgstr "Okänd frågetyp {0}"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Error purging old cache entires"
-msgstr "Error al depurar entradas de caché antiguas"
+msgstr "Fel vid rensning av gamla cache-data"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Caching results for next time for query with hash {0}."
-msgstr "Resultados de la consulta con hash {0}, almacenados en caché para la próxima vez."
+msgstr "Sparar resultat till nästa gång för fråga med lista {0}."
 
 #: src/metabase/query_processor/middleware/cache.clj
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
 msgid "Error saving query results to cache."
-msgstr "Error al guardar los resultados de la consulta en la memoria caché."
+msgstr "Fel när frågeresultat sparades till cache."
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Successfully cached results for query."
-msgstr "Resultados de la consulta almacenados en caché con éxito."
+msgstr "Lyckades spara frågans resultat i cache."
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Query took {0} to run; miminum for cache eligibility is {1}"
-msgstr "La consulta tardó {0} en ejecutarse; el mínimo para entrar en caché es {1}"
+msgstr "Frågan tog {0} att köra. Mininum för giltig cache är {1}"
 
 #: src/metabase/query_processor/middleware/cache/impl.clj
 msgid "Results are too large to cache."
-msgstr "Los resultados son demasiado grandes para almacenar en caché."
+msgstr "Resultaten är för stora för att spara i cache."
 
 #: src/metabase/query_processor/middleware/cache/impl.clj
 msgid "Serialization timed out after {0}."
-msgstr "La serialización se agotó después de {0}."
+msgstr "Serialisering fick timeout efter {0}."
 
 #: src/metabase/query_processor/middleware/cache/impl.clj
 msgid "Error parsing serialized results"
-msgstr "Error al analizar resultados serializados"
+msgstr "Fel vid tolkning av serialiserade resultat"
 
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
 msgid "Error purging old cache entries"
-msgstr "Error al eliminar entradas de caché antiguas"
+msgstr "Fel vid rensning av gammal cache"
 
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
 msgid "Caching results for query with hash {0}."
-msgstr "Resultados de almacenamiento en caché para consulta con hash {0}."
+msgstr "Sparar resultat för fråga med lista {0} i cache."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Cannot save QueryExecution, missing :context"
-msgstr "No se puede guardar QueryExecution, falta :context"
+msgstr "Kan inte spara frågekörningen, saknas :context"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Error saving query execution info"
-msgstr "Error al guardar la información de ejecución de la consulta"
+msgstr "Fel när frågans körningsinfo sparades"
 
 #: src/metabase/query_processor/middleware/resolve_database_and_driver.clj
 msgid "Unable to resolve database for query: missing or invalid `:database` ID."
-msgstr "No se puede resolver la base de datos para la consulta: falta o no es válida la identificación `:database`."
+msgstr "Kan inte härleda databasen i frågan: saknat eller felaktigt databas-id."
 
 #: src/metabase/query_processor/middleware/resolve_database_and_driver.clj
 msgid "Unable to resolve driver for query"
-msgstr "No se puede resolver el controlador para la consulta"
+msgstr "Kan inte härleda drivrutin för frågan."
 
 #: src/metabase/query_processor/middleware/resolve_referenced.clj
 msgid "Referenced question #{0} could not be found"
-msgstr "La pregunta de referencia #{0} no se ha podido encontrar"
+msgstr "Angiven fråga #{0} kunde inte hittas"
 
 #: src/metabase/query_processor/middleware/resolve_referenced.clj
 msgid "Referenced query is from a different database"
-msgstr "La consulta referenciada es de una base de datos diferente"
+msgstr "Angiven fråga kommer från en annan databas"
 
 #: src/metabase/query_processor/middleware/resolve_referenced.clj
 msgid "This query has circular referencing sub-queries. "
-msgstr "Esta consulta tiene subconsultas de referencia circular."
+msgstr "Frågan har cirkulära referenser till under-frågor. "
 
 #: src/metabase/query_processor/middleware/resolve_referenced.clj
 msgid "These questions seem to be part of the problem: \"{0}\" and \"{1}\"."
-msgstr "Estas preguntas parecen ser parte del problema: \"{0}\" y \"{1}\"."
+msgstr "Dessa frågor verkar tillhöra problemet: \"{0}\" och \"{1}\"."
 
 #: src/metabase/query_processor/middleware/results_metadata.clj
 msgid "Error recording results metadata for query"
-msgstr "Error al registrar metadatos de resultados para consulta"
+msgstr "Fel när metadata för frågans resultat skulle sparas"
 
 #: src/metabase/query_processor/streaming/xlsx.clj
 msgid "Query result"
-msgstr "Resultado consulta"
+msgstr "Fråge-resultat"
 
 #: src/metabase/sync/analyze/query_results.clj
 msgid "Error generating insights for column:"
-msgstr "Error al generar información para la columna:"
+msgstr "Fel när inblick skulle genereras för kolumnen:"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandonment email!"
-msgstr "Enviando correo electrónico de abandono!"
+msgstr "Skickar övergivelse-mejl"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
-msgstr "Puedes crear métricas guardadas para agregar una opción de métrica con nombre. Las métricas guardadas incluyen el tipo de agregación, el campo agregado y, opcionalmente, cualquier filtro que añadas. Como ejemplo, puedes usar esto para crear algo así como la forma oficial de calcular el \"Precio promedio\" para una tabla de pedidos."
+msgstr "Du kan skapa sparade mått för att lägga till ett namngivet mått-val. Sparade mått innehåller typ av sammanslagning, det sammanslagna fältet och ev. ytterligare filter du vill lägga till. Till exempel kan du använda detta för att skapa något som det officiella sättet att räkna ut snittpris för en order-tabell."
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:105
 msgid "Select and add filters to create your new segment."
-msgstr "Selecciona y añade filtros para crear tu nuevo segmento."
+msgstr "Välj och lägg till filter för att skapa ditt nya segment."
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
 msgid "Alphabetical"
-msgstr "Alfabético"
+msgstr "Alfanumerisk"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
 msgid "Smart"
-msgstr "Ingenioso"
+msgstr "Smart"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
 msgid "Column order: {0}"
-msgstr "Orden de Columna: {0}"
+msgstr "Sorteringsordning kolumner: {0}"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
 msgid "Unhide all"
-msgstr "Mostrar Todos"
+msgstr "Visa allt"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:204
 msgid "Hide all"
-msgstr "Esconder Todos"
+msgstr "Dölj allt"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:206
 msgid "Unhide"
-msgstr "Mostrar"
+msgstr "Ångra dölj"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:22
 msgid "New metric"
-msgstr "Nueva métrica"
+msgstr "Nytt mått"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:45
 msgid "Create metrics to add them to the Summarize dropdown in the query builder"
-msgstr "Crea métricas para añadirlas al desplegable Resumir en el generador de consultas"
+msgstr "Skapa mått för att lägga till dem i Summera-listan i frågeguiden"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:22
 msgid "New segment"
-msgstr "Nuevo segmento"
+msgstr "Nytt segment"
 
 #: frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx:71
 msgid "Filter by table"
-msgstr "Filtrar por tabla"
+msgstr "Filtrera per tabell"
 
 #: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:64
 msgid "Checking HTTPS..."
-msgstr "Comprobando HTTPS..."
+msgstr "Kontrollerar HTTPS..."
 
 #: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:66
 msgid "It looks like HTTPS is not properly configured"
-msgstr "Parece que HTTPS no está configurado correctamente"
+msgstr "Det ser ut som om HTTPS inte är korrekt uppsatt"
 
 #: frontend/src/metabase/admin/settings/selectors.js:57
 msgid "Redirect to HTTPS"
-msgstr "Redireccionar a HTTPS"
+msgstr "Dirigerar om till HTTPS"
 
 #: frontend/src/metabase/admin/settings/selectors.js:219
 msgid "Localization"
-msgstr "Localización"
+msgstr "lokalisering"
 
 #: frontend/src/metabase/admin/settings/selectors.js:222
 msgid "Instance language"
-msgstr "Idioma de Aplicación"
+msgstr "Språk i instansen"
 
 #: frontend/src/metabase/admin/settings/selectors.js:237
 msgid "Localization options"
-msgstr "Opciones de localización"
+msgstr "Val för lokalisering"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:51
 msgid "This database doesn't have any tables."
-msgstr "Esa base de datos no tiene ninguna tabla."
+msgstr "Denna databas har inga tabeller."
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
 msgid "This field only accepts a single value because it's used in a SQL query."
-msgstr "Este campo solo acepta un valor único porque se usa en una consulta SQL."
+msgstr "Detta fält accepterar bara ett enskilt värde eftersom det används i en SQL-fråga."
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:17
 msgid "Service Accounts"
-msgstr "Cuentas de servicio"
+msgstr "Service-konton"
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:26
 msgid "Metabase connects to Big Query via {0}."
-msgstr "Metabase conecta con Big Query a través de {0}"
+msgstr "Metabase ansluter till Big Query via {0}."
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:29
 msgid "Continue using an OAuth application to connect"
-msgstr "Continúa usando una aplicación OAuth para conectarte"
+msgstr "Fortsätt använda en OAuth-applikation för att ansluta"
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:43
 msgid "We recommend switching to use {0} instead of an OAuth application to connect to BigQuery"
-msgstr "Recomendamos cambiar y usar {0} en lugar de una aplicación OAuth para conectarse a BigQuery"
+msgstr "Vi rekommenderar att byta till {0} istället för OAuth-applikation för att ansluta till BigQuery"
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:48
 msgid "Connect to a Service Account instead"
-msgstr "O conecta"
+msgstr "Ansluta till ett service-konto istället"
 
 #: frontend/src/metabase/entities/databases/forms.js:44
 msgid "invalid JSON"
-msgstr "JSON Inválido"
+msgstr "felaktig JSON"
 
 #: frontend/src/metabase/entities/databases/forms.js:50
 msgid "SSH private key"
-msgstr "LLave privada SSH"
+msgstr "Privat SSH-nyckel"
 
 #: frontend/src/metabase/entities/databases/forms.js:51
 msgid "Paste the contents of your ssh private key here"
-msgstr "Pega el contenido de tu clave privada ssh aquí"
+msgstr "Klistra in innehållet i din provata SSH-nyckel här"
 
 #: frontend/src/metabase/entities/databases/forms.js:55
 msgid "Passphrase for the SSH private key"
-msgstr "Frase de contraseña para la clave privada SSH"
+msgstr "Lösenord för den privata SSH-nyckeln"
 
 #: frontend/src/metabase/entities/databases/forms.js:58
 msgid "SSH Authentication"
-msgstr "Autentificación SSH"
+msgstr "SSH-autentisering"
 
 #: frontend/src/metabase/entities/databases/forms.js:60
 msgid "SSH Key"
-msgstr "Llave SSH"
+msgstr "SSH-nyckel"
 
 #: frontend/src/metabase/entities/databases/forms.js:65
 msgid "Server SSL certificate chain"
-msgstr "Cadena de certificados SSL del servidor"
+msgstr "Kedja för serverns SSL-certifikat"
 
 #: frontend/src/metabase/entities/databases/forms.js:66
 msgid "Paste the contents of the server's SSL certificate chain here"
-msgstr "Pega el contenido de la cadena de certificados SSL del servidor aquí"
+msgstr "Klistra in kedjan för serverns SSL-certifikat här"
 
 #: frontend/src/metabase/entities/databases/mongo-fields.js:11
 msgid "Paste a connection string"
-msgstr "Pegar una cadena de conexión"
+msgstr "Klistra in en anslutningssträng"
 
 #: frontend/src/metabase/entities/databases/mongo-fields.js:12
 msgid "Fill out individual fields"
-msgstr "Rellena campos individuales"
+msgstr "Fyll i enskilda fält"
 
 #: frontend/src/metabase/entities/snippets.js:14
 msgid "Enter some SQL here so you can reuse it later"
-msgstr "Añade SQL aquí para que puedas reutilizarlo más tarde"
+msgstr "Ange någon SQL här så att du kan återanvända det senare."
 
 #: frontend/src/metabase/entities/snippets.js:24
 msgid "Give your snippet a name"
-msgstr "Dale un nombre a tu fragmento"
+msgstr "Ge din snutt ett namn"
 
 #: frontend/src/metabase/entities/snippets.js:25
 msgid "Current Customers"
-msgstr "Clientes Actuales"
+msgstr "Nuvarande kunder"
 
 #: frontend/src/metabase/entities/snippets.js:30
 msgid "Add a description"
-msgstr "Añadir una descripción"
+msgstr "Lägg till en beskrivning"
 
 #: frontend/src/metabase/entities/users/forms.js:37
 msgid "Use site default"
-msgstr "Utilizar el valor por defecto del sitio"
+msgstr "Använd förval från sajten"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "find"
-msgstr "encontrar"
+msgstr "hitta"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
 msgid "replace"
-msgstr "sustituir"
+msgstr "ersätt"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
 msgid "The text to find."
-msgstr "El texto a encontrar."
+msgstr "Text att hitta."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
 msgid "The text to use as the replacement."
-msgstr "El texto a utilizar para sustituir."
+msgstr "Texten som ska användas som ersättning."
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
 msgid "Editing {0}"
-msgstr "Editando {0}"
+msgstr "Redigerar {0}"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
 msgid "Create your new snippet"
-msgstr "Crea tu nuevo fragmento"
+msgstr "Skapa din egen snutt"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
 msgid "Archived snippets"
-msgstr "Fragmentos archivados"
+msgstr "Arkiverade snuttar"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
 msgid "Snippets are reusable bits of SQL"
-msgstr "Fragmentos son porciones de SQL reutilizables"
+msgstr "Snuttar är återanvändbara bitar SQL"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
 msgid "Create a snippet"
-msgstr "Crea un fragmento"
+msgstr "Skapa en snutt"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets"
-msgstr "Fragmentos"
+msgstr "Snuttar"
 
 #: frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx:15
 msgid "SQL Snippets"
-msgstr "Fragmentos SQL"
+msgstr "SQL-snuttar"
 
 #: frontend/src/metabase/setup/components/LanguageStep.jsx:38
 msgid "Your language is set to {0}"
-msgstr "Tu idioma es {0}"
+msgstr "Ditt språk är satt till {0}"
 
 #: frontend/src/metabase/setup/components/LanguageStep.jsx:50
 msgid "What's your preferred language?"
-msgstr "¿Cuál es tu idioma preferido?"
+msgstr "Vilket språk föredrar du?"
 
 #: frontend/src/metabase/setup/components/LanguageStep.jsx:54
 msgid "This language will be used throughout Metabase and will be the default for new users."
-msgstr "Este lenguaje se utilizará en Metabase y será el predeterminado para los nuevos usuarios."
+msgstr "Detta språk kommer att användas i Metabase och kommer att vara förvalt för nya användare."
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:159
 msgid "We filtered out {0} row(s) containing null values."
-msgstr "Hemos filtrado {0} filas que contienen valores nulos."
+msgstr "Vi filtrerade ut {0} rad(er) innehållande null-värden."
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:133
 msgid "Show values for this series"
-msgstr "Mostrar valores para esta serie"
+msgstr "Visa värden för denna serie"
 
 #: src/metabase/api/card.clj
 msgid "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
-msgstr "La duración promedio de ejecución de la pregunta es {0}; usando el TTL ''mágico'' de {1}"
+msgstr "Frågans genomsnittliga tid är {0}, använder \"magic\" TTL {1}"
 
 #: src/metabase/api/native_query_snippet.clj
 msgid "A snippet with that name already exists. Please pick a different name."
-msgstr "Ya existe un fragmento con ese nombre. Por favor, elige un nombre diferente."
+msgstr "En snutt med det namnet finns redan. Välj ett annat namn."
 
 #: src/metabase/api/query_description.clj
 msgid "[Unknown Metric]"
-msgstr "[Métrica Desconocida]"
+msgstr "[Okänt mått]"
 
 #: src/metabase/api/query_description.clj
 msgid "[Unknown Segment]"
-msgstr "[Segmento Desconocido]"
+msgstr "[Okänt segment]"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Error writing error to output stream"
-msgstr "Error al escribir error en la salida"
+msgstr "Fel när felmeddelande skulle skrivas till utdataströmmen"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Caught unexpected Exception in streaming response body"
-msgstr "Excepción inesperada en el cuerpo de respuesta al transmitir"
+msgstr "Fångade ett oväntat fel i dataströmmens svar"
 
 #: src/metabase/async/streaming_response.clj
 msgid "bound-fn caught unexpected Exception"
-msgstr "Excepción inesperada en bound-fn"
+msgstr "\"bound-fn caught unexpected Exception\""
 
 #: src/metabase/async/streaming_response.clj
 msgid "Error determining whether HTTP request was canceled"
-msgstr "Error al determinar si se canceló la solicitud HTTP"
+msgstr "Fel uppstod när avbrottskontroll för HTTP-anropet skulle genomföras"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Check cancelation status timed out after {0}"
-msgstr "Verificación del estado de cancelación agotado después de {0}"
+msgstr "Kontroll av avbrottsstatus fick timeout efter {0}"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Unexpected exception in do-f-async"
-msgstr "Excepción inesperada en do-f-async"
+msgstr "Oväntat fel i \"do-f-async\""
 
 #: src/metabase/async/streaming_response.clj src/metabase/server.clj
 msgid "Unexpected exception writing error response"
-msgstr "Excepción inesperada al escribir respuesta de error"
+msgstr "Oväntat fel när felmeddelande skulle skrivas"
 
 #: src/metabase/driver/common.clj
 msgid "Server certificate not trusted - did you specify the correct SSL certificate chain?"
-msgstr "Certificado de servidor no confiable: ¿especificó la cadena de certificados SSL correcta?"
+msgstr "Serverns certifikat är inte giltigt. Angav du rätt SS-certfikat-kedja?"
 
 #: src/metabase/driver/common.clj
 msgid "Server appears to require SSL - please enable SSL above"
-msgstr "Parece que el servidor requiere SSL; habilita SSL arriba"
+msgstr "Servern verkar kräva SSL - aktivera SSL ovan"
 
 #: src/metabase/driver/common.clj
 msgid "Username"
-msgstr "Nombre Usuario"
+msgstr "Användarnamn"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Don''t know how to parse parameter of type {0}"
-msgstr "No sé cómo analizar el parámetro de tipo {0}"
+msgstr "Kan inte tolka parametern med typ {0}"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Invalid :card parameter: missing `:card-id`"
-msgstr ":card parameter: inválido, falta `:card-id`"
+msgstr "Felaktig parameter \":card\", saknad `:card-id`"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Unable to resolve Snippet: missing `:snippet-id`"
-msgstr "No se puede resolver el fragmento: falta `:snippet-id`"
+msgstr "Kan inte härleda snutt, saknad `:snippet-id`"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Snippet {0} {1} not found."
-msgstr "Fragmento {0} {1} no encontrado."
+msgstr "Snutt {0} {1} kunde inte hittas."
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Error determining value for parameter"
-msgstr "Error al determinar el valor del parámetro"
+msgstr "Fel vid fastställande av parametervärde"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Error building query parameter map"
-msgstr "Error al generar el mapa de parámetros de consulta"
+msgstr "Fel när karta över frågans parametrar skulle byggas"
 
 #: src/metabase/middleware/log.clj
 msgid "ASYNC"
@@ -15033,169 +15011,168 @@ msgstr "ASYNC"
 
 #: src/metabase/middleware/log.clj
 msgid "{0} ({1} DB calls)"
-msgstr "{0} ({1} llamadas a la BBDD)"
+msgstr "{0} ({1} DB-anrop)"
 
 #: src/metabase/middleware/log.clj
 msgid "App DB connections: {0}/{1}"
-msgstr "Conexiones BBDD: {0}/{1}"
+msgstr "App DB-anslutningar: {0}/{1}"
 
 #: src/metabase/middleware/log.clj
 msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
-msgstr "Hilos Jetty: {0}/{1} ({2} esperando, {3} en cola)"
+msgstr "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
 
 #: src/metabase/middleware/log.clj
 msgid "({0} total active threads)"
-msgstr "({0} hilos totales activos)"
+msgstr "(totalt {0} aktiva trådar)"
 
 #: src/metabase/middleware/log.clj
 msgid "Queries in flight: {0}"
-msgstr "Consultas en ejecución: {0}"
+msgstr "Frågor på gång: {0}"
 
 #: src/metabase/middleware/log.clj
 msgid "({0} queued)"
-msgstr "({0} en cola)"
+msgstr "({0} köade)"
 
 #: src/metabase/models/collection.clj
 msgid "Collection must be in the same namespace as its parent"
-msgstr "Una colección debe estar en el mismo espacio de nombres que su padre"
+msgstr "Samlingen måste ha samma \"namespace\" som den överliggande"
 
 #: src/metabase/models/collection.clj
 msgid "Personal Collections must be in the default namespace"
-msgstr "Las colecciones personales deben estar en el espacio de nombres predeterminado"
+msgstr "Personliga samlingar måste ligga i förvald \"namespace\""
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection to a different namespace once it has been created."
-msgstr "No puedes mover una Colección a un espacio de nombres diferente una vez que se haya creado."
+msgstr "Du kan inte flytta en samling till en annan \"namespace\" när den väl har skapats."
 
 #: src/metabase/models/collection.clj src/metabase/models/permissions.clj
 msgid "Collection does not exist."
-msgstr "Colección no existe."
+msgstr "Samlingen finns inte."
 
 #: src/metabase/models/collection.clj
 msgid "A {0} can only go in Collections in the {1} namespace."
-msgstr "Un {0} solo puede ir en Colecciones en el espacio de nombres {1}."
+msgstr "En {0} kan bara läggas i samlingar med \"namespace\" {1}."
 
 #: src/metabase/models/database.clj
 msgid "Error sending database deletion notification"
-msgstr "Error al enviar la notificación de eliminación de la base de datos"
+msgstr "Fel vid sändning av notifikation om borttagning av databas"
 
 #: src/metabase/models/native_query_snippet.clj
 msgid "You cannot update the creator_id of a NativeQuerySnippet."
-msgstr "No puedes actualizar el creator_id de un Fragmento Nativo."
+msgstr "Du kan inte uppdatera fältet creator_id i en NativeQuerySnippet."
 
 #: src/metabase/models/setting.clj
 msgid "Error fetching value of Setting"
-msgstr "Error al recuperar el valor de la configuración"
+msgstr "Fel vid hämtning av inställningens värde"
 
 #: src/metabase/public_settings.clj
 msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
-msgstr "El idioma que se debe usar para la interfaz de usuario de Metabase, correos electrónicos del sistema, pulsos y alertas."
+msgstr "Språket som ska användas för Metabase-gränssnittet, systemets epost-meddelande, utskick och notifieringar."
 
 #: src/metabase/public_settings.clj
 msgid "This is also the default language for all users, which they can change from their own account settings."
-msgstr "Este es también el idioma predeterminado para todos los usuarios, que pueden cambiar desde la configuración de su propia cuenta."
+msgstr "Detta är också det förvalda språket för alla användare, som de sedan kan ändra i de egna konto-inställningarna."
 
 #: src/metabase/public_settings.clj
 msgid "Invalid locale {0}"
-msgstr "Configuración regional {0} no válida"
+msgstr "Felaktig lokalisering {0}"
 
 #: src/metabase/public_settings.clj
 msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
-msgstr "Forzar todo el tráfico a usar HTTPS a través de una redirección, si la URL del sitio es HTTPS"
+msgstr "Tvinga alla trafik att gå via HTTPS via en \"redirect\" om sajtens URL är HTTPS"
 
 #: src/metabase/public_settings.clj
 msgid "Cannot redirect requests to HTTPS unless `site-url` is HTTPS."
-msgstr "No se pueden redirigir solicitudes a HTTPS a menos que `site-url` sea HTTPS."
+msgstr "Kan inte tvinga anrop till HTTPS om inte sajtens URL är HTTPS."
 
 #: src/metabase/pulse/render/png.clj
 msgid "Error registering fonts: Metabase will not be able to send Pulses."
-msgstr "Error al registrar fuentes: Metabase no podrá enviar pulsos."
+msgstr "Fel vid registrering av fonter. Metabase kommer inte att kunna göra utskick."
 
 #: src/metabase/pulse/render/png.clj
 msgid "This is a known issue with certain JVMs. See {0} and for more details."
-msgstr "Este es un problema conocido con ciertas JVM. Ver {0} para más detalles."
+msgstr "Detta är ett känt problem med vissa JVM. Se {0} för mer info."
 
 #: src/metabase/pulse/render/png.clj
 msgid "Error rendering Pulse"
-msgstr "Error al procesar el pulso"
+msgstr "Fel när utskick skulle skapas"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Query timed out after {0}, raising timeout exception."
-msgstr "La consulta expiró después de {0}, generando una excepción de tiempo de espera."
+msgstr "Frågan fick timeout efter {0} och gav ett timeout-fel"
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "No fields found for table {0}."
-msgstr "No se encontraron campos para la tabla {0}."
+msgstr "Inga fält hittas i tabellen {0}."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Case"
-msgstr "Caso"
+msgstr "Stora/små"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Variance of {0}"
-msgstr "Varianza de {0}"
+msgstr "Skillnad i {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Median of {0}"
-msgstr "Mediana de {0}"
+msgstr "Median av {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "{0}th percentile of {1}"
-msgstr "percentil {0} de {1}"
+msgstr "{0}:a percentilen av {1}"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Not caching results: results are larger than {0} KB"
-msgstr "No se hará uso del almacenamiento en caché ya que los resultados son mayores de {0} KB"
+msgstr "Sparar inte resultat i cache - resultaten är större än {0} KB"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Cannot cache results: expected byte array, got {0}"
-msgstr "No se pueden almacenar los resultados en caché: esperaba una matriz de bytes, pero se obtuvo {0}"
+msgstr "Kan inte spara resultat i cache: förväntade \"byte array\" men fick {0}"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Request is closed; no one to return cached results to"
-msgstr "La solicitud está cerrada; nadie a quien devolver los resultados almacenados en caché"
+msgstr "Begäran är stängd. Ingen att returnera resultat från cache till"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Error attempting to fetch cached results for query with hash {0}"
-msgstr "Error al intentar obtener resultados en caché para la consulta con el hash {0}"
+msgstr "Fel uppstod när resultat från cache skulle hämtas till frågan med lista {0}"
 
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
 msgid "Error preparing statement to fetch cached query results"
-msgstr "Error al preparar la declaración para recuperar resultados de consultas en caché"
+msgstr "Fel vid förberedelse av uttryck för att hämta resultat från cache"
 
 #: src/metabase/query_processor/middleware/catch_exceptions.clj
 msgid "Error processing query: {0}"
-msgstr "Error procesando consulta: {0}"
+msgstr "Fel vid körning av fråga: {0}"
 
 #: src/metabase/server.clj
 msgid "Unexpected exception in endpoint"
-msgstr "Excepción inesperada en la llamada"
+msgstr "Oväntat avbrott i ändpunkten"
 
 #: src/metabase/server.clj
 msgid "Unexpected Exception in API request handler"
-msgstr "Excepción inesperada en el controlador de solicitud de API"
+msgstr "Oväntat avbrott i API-anropets hanterare"
 
 #: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
 msgid "Error reducing {0}"
-msgstr "Error reduciendo {0}"
+msgstr "Fel vid reduktion av {0}"
 
 #: src/metabase/sync/analyze/fingerprint/insights.clj
 msgid "Error generating timeseries insight keyed by: {0}"
-msgstr "Error al generar información de series de tiempo con clave: {0}"
+msgstr "Fel vid generering av tidsserie med nyckel: {0}"
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "La posición de {0} en la base de datos ha cambiado de ''{1}'' a ''{2}''."
+msgstr "Databas-positionen {0} har ändrats från \"{1}\" till \"{2}\"."
 
 #: src/metabase/task/sync_databases.clj
 msgid "Unscheduling task for Database {0}: trigger: {1}"
-msgstr "Quitando la tarea de la base de datos {0}: activador: {1}"
+msgstr "Ta bort schemaläggning för jobb i databas {0}: trigger: {1}"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a keyword or string."
-msgstr "El valor debe ser una palabra clave o una cadena."
+msgstr "värdet måste vara ett nyckelord eller sträng."
 
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
-msgstr "La cadena debe ser un idioma ISO válido de dos letras o un código de idioma-país, p.e. 'en' o 'en_US'."
-
+msgstr "Värdet måste vara ett giltigt två-tecken ISO-språk eller språk-land-kod, t.ex 'en' eller 'en_US'."

--- a/locales/tr.po
+++ b/locales/tr.po
@@ -29,13 +29,14 @@ msgid "Select a database type"
 msgstr "Veritabanı türü seçin"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:411
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:154
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -48,7 +49,7 @@ msgstr "Kaydet"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "Metabase veritabanınızı taramak zorundadır. Metadata'yı güncel tutmak için periyodik olarak yeniden taramaları sürdüreceğiz. Periyodik taramaların ne zaman gerçekleşeceğini kontrol edebilirsiniz."
 
-#: frontend/src/metabase/entities/databases/forms.js:221
+#: frontend/src/metabase/entities/databases/forms.js:290
 msgid "Database syncing"
 msgstr "Veritabanı senkronize ediliyor"
 
@@ -63,7 +64,7 @@ msgstr "Bu veritabanı şemasını güncelleyen, çok işlemci gücü istemeyen 
 msgid "Scan"
 msgstr "Tara"
 
-#: frontend/src/metabase/entities/databases/forms.js:228
+#: frontend/src/metabase/entities/databases/forms.js:297
 msgid "Scanning for Filter Values"
 msgstr "Filtre Değerleri Taranıyor"
 
@@ -75,7 +76,7 @@ msgid "Metabase can scan the values present in each\n"
 msgstr "Metabase , kontrol panelindeki onay kutu filtrelerini etkinleştirmek için veritabanındaki her alanda bulunan değerleri tarayabilir.\n"
 "Eğer büyük bir veritabanınız varsa bu süreç biraz yoğun olabilir."
 
-#: frontend/src/metabase/entities/databases/forms.js:232
+#: frontend/src/metabase/entities/databases/forms.js:301
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Metabase alan değerlerini otomatik olarak taramayı ve önbelleğe almayı ne zaman yapmalıdır?"
 
@@ -97,6 +98,7 @@ msgid "Never, I'll do this manually if I need to"
 msgstr "Asla, İhtiyacım olursa bunu manuel olarak yapacağım"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 msgid "Saving..."
@@ -133,9 +135,9 @@ msgid "in this box:"
 msgstr "Bu kutuda:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:75
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
@@ -152,18 +154,18 @@ msgstr "Bu kutuda:"
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:301
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:39
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:90
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:99
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:311
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:328
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "İptal"
@@ -180,7 +182,7 @@ msgstr "Sil"
 #: frontend/src/metabase/admin/permissions/selectors.js:323
 #: frontend/src/metabase/admin/permissions/selectors.js:330
 #: frontend/src/metabase/admin/permissions/selectors.js:441
-#: frontend/src/metabase/admin/routes.jsx:57
+#: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
@@ -200,9 +202,10 @@ msgid "Scheduling"
 msgstr "Zamanlama"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:71
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
@@ -210,8 +213,8 @@ msgid "Save changes"
 msgstr "Değişiklikleri kaydet"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:203
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:35
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
 msgstr "Eylemler"
 
@@ -223,8 +226,8 @@ msgstr "Veritabanı şemasını senkronize et"
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:90
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:98
 msgid "Starting…"
 msgstr "Başlıyor..."
 
@@ -242,13 +245,13 @@ msgstr "Alan değerlerini şimdi yeniden tarayın"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
 msgstr "Tarama başlatılamadı"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:92
 msgid "Scan triggered!"
 msgstr "Tarama tetiklendi!"
 
@@ -271,15 +274,15 @@ msgid "Add database"
 msgstr "Veritabanı ekle"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:28
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:28
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
 #: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:195
+#: frontend/src/metabase/entities/databases/forms.js:264
 #: frontend/src/metabase/entities/questions.js:86
 #: frontend/src/metabase/entities/questions.js:102
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
@@ -319,6 +322,7 @@ msgstr "Başarıyla kaydedildi!"
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Düzenle"
@@ -361,44 +365,43 @@ msgstr "Başarısız"
 msgid "Success"
 msgstr "Başarılı"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:185
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Ön izleme"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:93
 msgid "No column description yet"
 msgstr "Sütün açıklaması yok"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:127
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:126
 msgid "Select a field visibility"
 msgstr "Görünür bir alan seçiniz"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:187
 msgid "No special type"
 msgstr "Özel tip yok"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
 #: frontend/src/metabase/lib/core.js:275
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:44
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:37
 msgid "Other"
 msgstr "Diğer"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:221
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Özel bir tip seçiniz"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:255
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:262
 #: frontend/src/metabase/reference/components/Field.jsx:99
 msgid "Select a target"
 msgstr "Bir hedef seç"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
@@ -406,18 +409,18 @@ msgstr "Bir hedef seç"
 msgid "Columns"
 msgstr "Sütunlar"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Sütun"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:144
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:288
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
 msgid "Visibility"
 msgstr "Görünürlük"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
 msgid "Type"
 msgstr "Tip"
 
@@ -425,7 +428,7 @@ msgstr "Tip"
 msgid "Current database:"
 msgstr "Güncel veritabanı:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
 msgid "Show original schema"
 msgstr "Orjinal şemayı göster"
 
@@ -447,27 +450,27 @@ msgid_plural "{0} schemas"
 msgstr[0] "{0} şema"
 msgstr[1] "{0} şemalar"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:99
 msgid "Why Hide?"
 msgstr "Neden Gizledin?"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:100
 msgid "Technical Data"
 msgstr "Teknik Veri"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
 msgstr "Alakasız"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 msgid "Queryable"
 msgstr "Sorgulanabilir"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:108
 msgid "Hidden"
 msgstr "Gizli"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136
 msgid "No table description yet"
 msgstr "Henüz tablo açıklaması yok"
 
@@ -475,32 +478,33 @@ msgstr "Henüz tablo açıklaması yok"
 msgid "Metadata Strength"
 msgstr "Metadata Gücü"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0} Sorgulanabilir Tablo"
 msgstr[1] "{0} Sorgulanabilir Tablolar"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:91
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} Gizli Tablo"
 msgstr[1] "{0} Gizli Tablolar"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:115
 msgid "Find a table"
 msgstr "Tablo bul"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:128
 msgid "Schemas"
 msgstr "Şemalar"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:838
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:21
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:43
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:62
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 msgid "Metrics"
 msgstr "Metrikler"
@@ -509,8 +513,8 @@ msgstr "Metrikler"
 msgid "Add a Metric"
 msgstr "Metrik Ekle"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "Açıklamalar"
@@ -519,12 +523,12 @@ msgstr "Açıklamalar"
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "Sorgu oluşturucusundaki açılır/kapanır menüye eklemek için metrikler oluşturun"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:21
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
 #: frontend/src/metabase/home/containers/SearchApp.jsx:72
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:961
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:61
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Segmentler"
@@ -533,35 +537,35 @@ msgstr "Segmentler"
 msgid "Add a Segment"
 msgstr "Segment Ekle"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:51
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:45
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "Sorgu oluşturucusundaki açılır/kapanır filtreye eklemek için segmentler oluşturun"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:21
 msgid "created"
 msgstr "Oluşturuldu"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "reverted to a previous version"
 msgstr "Önceki versiyona geri döndü"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:30
 msgid "edited the title"
 msgstr "Başlığı düzenledi"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:32
 msgid "edited the description"
 msgstr "Açıklama düzenlendi"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:34
 msgid "edited the "
 msgstr "Düzenlenmiş"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:40
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "made some changes"
 msgstr "Bazı değişiklikler yaptı"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
 #: frontend/src/metabase/home/components/Activity.jsx:83
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
@@ -571,84 +575,84 @@ msgstr "Siz"
 msgid "Datamodel"
 msgstr "Veri Modeli"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:41
 msgid " History"
 msgstr "Tarihçe"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
 msgstr "Revizyon Geçmişi için"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:228
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
 msgid "{0} – Field Settings"
 msgstr "{0} –Alan Ayarları"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:289
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
 msgid "Where this field will appear throughout Metabase"
 msgstr "Bu alanın Metabase de nerede görüneceği"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:311
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
 msgid "Filtering on this field"
 msgstr "Bu alanda filtreleme"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:312
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Bu alan filtrede kullanıldığında, insanların filtrelemek istedikleri değeri girmek için ne kullanmaları gerekir?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:437
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
 msgid "No description for this field yet"
 msgstr "Bu alan için henüz açıklama yok"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
 msgid "Original value"
 msgstr "Orjinal değer"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:390
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
 msgid "Mapped value"
 msgstr "Eşlenen değer"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
 msgid "Enter value"
 msgstr "Değeri girin"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use original value"
 msgstr "Orjinal değeri kullan"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Use foreign key"
 msgstr "Yabancı anahtar kullan"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 msgid "Custom mapping"
 msgstr "Özel eşleşme"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
 msgid "Unrecognized mapping type"
 msgstr "Tanınmayan eşleşme türü"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Geçerli alan yabancı anahtar değil veya hedef tablosundaki yabancı anahtar verileri eksik"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
 msgid "The selected field isn't a foreign key"
 msgstr "Seçilen alan yabancı anahtar değildir"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:327
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
 msgid "Display values"
 msgstr "Ekran değerleri"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:328
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Orijinal değeri veritabanından göstermeyi seçin, veya bu alanın ilişkili veya özel bilgileri gösterilmesini sağlayın"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:278
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
 msgid "Choose a field"
 msgstr "Bir alan seç"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:299
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
 msgid "Please select a column to use for display."
 msgstr "Lütfen ekran için kullanılacak bir sütun seçin."
 
@@ -656,16 +660,16 @@ msgstr "Lütfen ekran için kullanılacak bir sütun seçin."
 msgid "Tip:"
 msgstr "Tavsiye:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:443
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Yaptığınız yeni seçimlerin mantıklı olduğundan emin olmak için alan adını güncellemek isteyebilirsiniz."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:344
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Önbelleğe alınmış alan değerleri"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:345
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase, kontrol paneli filtrelerinde ve sorgularda onay kutu filtrelerini etkinleştirmek için bu alanın değerlerini tarayabilir."
 
@@ -674,53 +678,53 @@ msgid "Re-scan this field"
 msgstr "Bu alanı yeniden tara"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
 msgstr "Önbelleğe alınmış değerleri atın"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
 msgstr "Değerler alamadı"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 msgid "Discard triggered!"
 msgstr "Tetik atın!"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Şemasını görmek ve meta verileri eklemek veya düzenlemek için herhangi bir tablo seçin."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:36
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "İsim gerekli"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:39
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "Açıklama gerekli"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:43
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Revizyon mesajı gerekli"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
 msgid "Aggregation is required"
 msgstr "Toplama gerekli"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Edit Your Metric"
 msgstr "Metriğini düzenle"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Create Your Metric"
 msgstr "Metriğini oluştur"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Metriğinizde değişiklikler yapın ve açıklayıcı bir not ekleyin."
 
@@ -728,62 +732,62 @@ msgstr "Metriğinizde değişiklikler yapın ve açıklayıcı bir not ekleyin."
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Bu tabloya adlandırılmış bir metrik seçeneği eklemek için kayıtlı metrikler oluşturabilirsiniz. Kayıtlı metrikler, toplama türünü, toplanmış alanı ve isteğe bağlı olarak eklediğiniz herhangi bir filtreyi içerir. Örnek olarak, bir Siparişler tablosu için \"Ortalama Fiyat\" hesaplamasını oluşturmak için bu oluşturduğunuz metrikleri kullanabilirsiniz."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:180
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
 msgid "Result: "
 msgstr "Sonuç:"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
 msgid "Name Your Metric"
 msgstr "Metriğini adlandır"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:190
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Give your metric a name to help others find it."
 msgstr "Başkalarına yardımcı olmak için metriğinize bir isim verin."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:194
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:152
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Açıklayıcı bir şey ama çok uzun değil"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:198
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
 msgid "Describe Your Metric"
 msgstr "Metriğini tanımla"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:199
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Metriğinize başkalarının ne ile ilgili olduğunu anlamasına yardımcı olmak için  bir açıklama verin."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:203
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Daha az belirgin metrik kuralları hakkında daha spesifik olmak için iyi bir yer"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:207
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:165
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Değişiklik Nedeni"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:209
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Yaptığınız değişiklikleri ve neden gerekli olduklarını açıklamak için bir not bırakın."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:213
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Bu, metriklerin revizyon geçmişinde herkesin neden değiştiğini hatırlamasına yardımcı olacak."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
 msgstr "En az bir filtre gerekli"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
 msgstr "Segmentinizi düzenleyin"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
 msgstr "Segmentinizi oluşturun"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Segmentinizde değişiklikler yapın ve açıklayıcı not bırakın"
 
@@ -791,33 +795,33 @@ msgstr "Segmentinizde değişiklikler yapın ve açıklayıcı not bırakın"
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "{0} tablosu için yeni segmentinizi oluşturmak üzere filtre seçip ekleyin"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
 msgstr "Segmentinizi adlandırın"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:148
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
 msgstr "Segmentinize başkalarının bulmasına yardımcı olacak bir ad verin."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:156
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
 msgstr "Segmentinizi açıklayın"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Segmentinize diğerlerinin neyle ilgili olduğunu anlamalarına yardımcı olacak bir açıklama verin."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "Bu daha az belirgin segment kuralları hakkında daha spesifik olmak için iyi bir yer"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "Neden değiştiğini hatırlamalarını yardımcı olmak için bu segment revizyon geçmişinde görünecek."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
-#: frontend/src/metabase/admin/routes.jsx:132
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:215
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
+#: frontend/src/metabase/admin/routes.jsx:137
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
@@ -825,11 +829,11 @@ msgstr "Neden değiştiğini hatırlamalarını yardımcı olmak için bu segmen
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase , gösterge tablolarında ve sorgularda onay kutusu filtrelerini etkinleştirmek için bu tablodaki değerleri tarayabilir."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
 msgstr "Bu tabloyu yeniden tara"
 
@@ -843,11 +847,11 @@ msgstr "Ekle"
 msgid "Not a valid formatted email address"
 msgstr "Geçerli bir e-posta adresi değil"
 
-#: frontend/src/metabase/entities/users/forms.js:12
+#: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
 msgstr "İsim"
 
-#: frontend/src/metabase/entities/users/forms.js:18
+#: frontend/src/metabase/entities/users/forms.js:20
 msgid "Last name"
 msgstr "Soyisim"
 
@@ -886,10 +890,10 @@ msgstr "Üyeler"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
-#: frontend/src/metabase/admin/settings/selectors.js:120
-#: frontend/src/metabase/entities/users/forms.js:24
+#: frontend/src/metabase/admin/settings/selectors.js:121
+#: frontend/src/metabase/entities/users/forms.js:26
 #: frontend/src/metabase/lib/core.js:146
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:294
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:298
 msgid "Email"
 msgstr "E-posta"
 
@@ -898,14 +902,14 @@ msgid "A group is only as good as its members."
 msgstr "Bir grup sadece üyeleri kadar iyidir."
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
-#: frontend/src/metabase/admin/routes.jsx:52
+#: frontend/src/metabase/admin/routes.jsx:55
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Admin"
 msgstr "Yönetici"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:241
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:299
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:288
 msgid "and"
 msgstr "ve"
 
@@ -957,12 +961,12 @@ msgstr "Grubu Kaldır"
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:42
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:294
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:397
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:317
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:334
 msgid "Done"
 msgstr "Tamam"
 
@@ -973,8 +977,9 @@ msgstr "Grup adı"
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
-#: frontend/src/metabase/admin/routes.jsx:92
+#: frontend/src/metabase/admin/routes.jsx:97
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Gruplar"
 
@@ -1004,7 +1009,7 @@ msgstr "Devre dışı bırakmak"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:21
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
-#: frontend/src/metabase/admin/routes.jsx:88
+#: frontend/src/metabase/admin/routes.jsx:93
 #: frontend/src/metabase/nav/containers/Navbar.jsx:235
 msgid "People"
 msgstr "Kişiler"
@@ -1318,25 +1323,25 @@ msgstr "Koleksiyonu görüntüle"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:542
+#: frontend/src/metabase/admin/permissions/selectors.js:558
 msgid "Data Access"
 msgstr "Veri Erişimi"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:667
-#: frontend/src/metabase/admin/permissions/selectors.js:672
+#: frontend/src/metabase/admin/permissions/selectors.js:665
+#: frontend/src/metabase/admin/permissions/selectors.js:670
 msgid "View tables"
 msgstr "Tabloları görüntüle"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:608
+#: frontend/src/metabase/admin/permissions/selectors.js:606
 msgid "SQL Queries"
 msgstr "SQL Sorguları"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:678
+#: frontend/src/metabase/admin/permissions/selectors.js:676
 msgid "View schemas"
 msgstr "Şemaları görüntüle"
 
-#: frontend/src/metabase/admin/routes.jsx:63
+#: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
 msgstr "Veri Seti"
@@ -1366,20 +1371,24 @@ msgid "Allows users within your LDAP directory to log in to Metabase with their 
 msgstr "LDAP dizininizdeki kullanıcıların, LDAP kimlik bilgileriyle Metabase'de oturum açmasına ve LDAP gruplarının Metabase gruplarına otomatik olarak eşlenmesini sağlar."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:19
-#: frontend/src/metabase/admin/settings/selectors.js:167
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
+#: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
 msgstr "Bu geçerli bir e-posta adresi değil"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
 msgstr "Bu geçerli bir tam sayı değil"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
 msgstr "Değişiklikler kaydedildi"
 
-#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:178
+#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
 msgid "Looks like we ran into some problems"
 msgstr "Görünüşe göre bazı problemlerle karşılaştık"
 
@@ -1401,7 +1410,7 @@ msgstr "Anlaşılır"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:195
+#: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Doğrulama"
 
@@ -1453,15 +1462,15 @@ msgstr "Google müşteri kimliğiniz"
 msgid "Allow users to sign up on their own if their Google account email address is from:"
 msgstr "Google hesabı e-posta adresleri şunlardan olursa, kullanıcıların kendi başlarına kayıt olmalarına izin ver:"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:242
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:249
 msgid "Answers sent right to your Slack #channels"
 msgstr "Yanıtlar Slack #channels 'a doğru gönderildi"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:251
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:258
 msgid "Create a Slack Bot User for MetaBot"
 msgstr "MetaBot için bir Slack Bot Kullanıcısı Oluştur"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:261
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:268
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "Orada bir isim verin ve {0} 'ı tıklayın. Ardından Bot API Tokeni aşağıdaki alana kopyalayıp yapıştırın. İşiniz bittiğinde, Slack'de bir \"metabase_files\" kanalı oluşturun. Metabase, grafikleri yüklemek için buna ihtiyaç duyar."
 
@@ -1474,8 +1483,8 @@ msgid "Metabase {0} is available.  You're running {1}"
 msgstr "{0} metatabase'i kullanılabilir. Siz {1}'i çalıştırıyorsunuz."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:41
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 msgid "Update"
 msgstr "Güncelleştirme"
 
@@ -1502,16 +1511,16 @@ msgstr "Özel haritayı sil"
 #: frontend/src/metabase/containers/Overworld.jsx:293
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:115
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Kaldır"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:165
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:141
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
 msgstr "Seç..."
 
@@ -1581,7 +1590,7 @@ msgstr "Yerleştirmeyi etkinleştirerek, yerleştirme lisansını kabul etmiş o
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
-msgstr "Sade ingilizce, Kendi uygulamanızda metatabanından grafikler veya gösterge tabloları yerleştirdiğinizde,Bu uygulama Metabase' in geri kalanını kapsayan Affero Genel Kamu Lisansına tabi değildir, eğer Metabase logosunu ve bu katıştırılanlarda \"Metabase ile Güçlendirildi\" ifadesini saklarsınız. Ancak yukarıda belirtilen lisans metnini okumalısınız. Çünkü özelliği etkinleştirerek kabul edeceğiniz asıl lisans budur."
+msgstr "Sade ingilizce, Kendi uygulamanızda Metabase grafikler veya gösterge tabloları yerleştirdiğinizde,Bu uygulama Metabase' in geri kalanını kapsayan Affero Genel Kamu Lisansına tabi değildir, eğer Metabase logosunu ve bu katıştırılanlarda \"Metabase ile Güçlendirildi\" ifadesini saklarsınız. Ancak yukarıda belirtilen lisans metnini okumalısınız. Çünkü özelliği etkinleştirerek kabul edeceğiniz asıl lisans budur."
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
@@ -1694,48 +1703,46 @@ msgid "Generate Key"
 msgstr "Anahtar Üret"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:87
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:18
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enabled"
 msgstr "Etkin"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:92
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:19
+#: frontend/src/metabase/admin/settings/selectors.js:93
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Engelli"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:112
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:113
 msgid "Unknown setting {0}"
 msgstr "Bilinmeyen ayar {0}"
 
-#: frontend/src/metabase/admin/settings/selectors.js:34
+#: frontend/src/metabase/admin/settings/selectors.js:37
 msgid "Setup"
 msgstr "Kurulum"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:207
-#: frontend/src/metabase/admin/settings/selectors.js:39
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:214
+#: frontend/src/metabase/admin/settings/selectors.js:42
 msgid "General"
 msgstr "Genel"
 
-#: frontend/src/metabase/admin/settings/selectors.js:43
+#: frontend/src/metabase/admin/settings/selectors.js:46
 msgid "Site Name"
 msgstr "Site adı"
 
-#: frontend/src/metabase/admin/settings/selectors.js:48
+#: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Site URL"
 msgstr "Site URL"
 
-#: frontend/src/metabase/admin/settings/selectors.js:53
+#: frontend/src/metabase/admin/settings/selectors.js:64
 msgid "Email Address for Help Requests"
 msgstr "Yardım İstekleri için E-posta Adresi"
 
-#: frontend/src/metabase/admin/settings/selectors.js:58
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
 msgstr "Saat Dilimini Bildir"
 
-#: frontend/src/metabase/admin/settings/selectors.js:61
+#: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
 msgstr "Varsayılan Veritabanı"
 
@@ -1743,11 +1750,11 @@ msgstr "Varsayılan Veritabanı"
 msgid "Select a timezone"
 msgstr "Bir saat dilimi seçin"
 
-#: frontend/src/metabase/admin/settings/selectors.js:64
+#: frontend/src/metabase/admin/settings/selectors.js:75
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "Tüm veritabanları saat dilimlerini desteklemez, bu durumda bu ayar geçerli olmaz."
 
-#: frontend/src/metabase/admin/settings/selectors.js:69
+#: frontend/src/metabase/entities/users/forms.js:34
 msgid "Language"
 msgstr "Dil"
 
@@ -1755,64 +1762,64 @@ msgstr "Dil"
 msgid "Select a language"
 msgstr "Bir dil seç"
 
-#: frontend/src/metabase/admin/settings/selectors.js:79
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
 msgstr "Anonim İzleme"
 
-#: frontend/src/metabase/admin/settings/selectors.js:84
+#: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
 msgstr "Benzer Tablo ve Alan İsimleri"
 
-#: frontend/src/metabase/admin/settings/selectors.js:90
+#: frontend/src/metabase/admin/settings/selectors.js:91
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Alt çizgi ve tire işaretlerini yalnızca boşluklarla değiştirin"
 
-#: frontend/src/metabase/admin/settings/selectors.js:98
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Enable Nested Queries"
 msgstr "İç İçe Sorguları Etkinleştir"
 
-#: frontend/src/metabase/admin/settings/selectors.js:109
+#: frontend/src/metabase/admin/settings/selectors.js:110
 msgid "Updates"
 msgstr "Güncellemeler"
 
-#: frontend/src/metabase/admin/settings/selectors.js:114
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
 msgstr "Güncellemeleri kontrol et"
 
-#: frontend/src/metabase/admin/settings/selectors.js:125
+#: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
 msgstr "SMTP Ana Bilgisayarı"
 
-#: frontend/src/metabase/admin/settings/selectors.js:133
+#: frontend/src/metabase/admin/settings/selectors.js:134
 msgid "SMTP Port"
 msgstr "SMTP Bağlantı Noktası"
 
-#: frontend/src/metabase/admin/settings/selectors.js:137
+#: frontend/src/metabase/admin/settings/selectors.js:138
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:47
 msgid "That's not a valid port number"
 msgstr "Bu geçerli bir bağlantı numarası değil"
 
-#: frontend/src/metabase/admin/settings/selectors.js:141
+#: frontend/src/metabase/admin/settings/selectors.js:142
 msgid "SMTP Security"
 msgstr "SMTP Güvenliği"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:150
 msgid "SMTP Username"
 msgstr "SMTP Kullanıcı Adı"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "SMTP Password"
 msgstr "SMTP Şifresi"
 
-#: frontend/src/metabase/admin/settings/selectors.js:163
+#: frontend/src/metabase/admin/settings/selectors.js:164
 msgid "From Address"
 msgstr "Kimden"
 
-#: frontend/src/metabase/admin/settings/selectors.js:176
+#: frontend/src/metabase/admin/settings/selectors.js:178
 msgid "Slack API Token"
 msgstr "Slack API Tokeni"
 
-#: frontend/src/metabase/admin/settings/selectors.js:178
+#: frontend/src/metabase/admin/settings/selectors.js:180
 msgid "Enter the token you received from Slack"
 msgstr "Slack'ten aldığınız tokeni girin"
 
@@ -1841,8 +1848,10 @@ msgid "Username or DN"
 msgstr "Kullanıcı adı veya DN"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:43
+#: frontend/src/metabase/entities/databases/forms.js:61
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:64
-#: frontend/src/metabase/user/components/UserSettings.jsx:65
+#: frontend/src/metabase/user/components/UserSettings.jsx:66
+#: src/metabase/driver/common.clj
 msgid "Password"
 msgstr "Parola"
 
@@ -1878,79 +1887,79 @@ msgstr "Grup üyeliklerini senkronize et"
 msgid "Group search base"
 msgstr "Grup arama tabanı"
 
-#: frontend/src/metabase/admin/settings/selectors.js:199
+#: frontend/src/metabase/admin/settings/selectors.js:201
 msgid "Maps"
 msgstr "Haritalar"
 
-#: frontend/src/metabase/admin/settings/selectors.js:203
+#: frontend/src/metabase/admin/settings/selectors.js:205
 msgid "Map tile server URL"
 msgstr "Harita yerleştirme URL'si"
 
-#: frontend/src/metabase/admin/settings/selectors.js:204
+#: frontend/src/metabase/admin/settings/selectors.js:206
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Metabase, varsayılan olarak OpenStreetMaps kullanır."
 
-#: frontend/src/metabase/admin/settings/selectors.js:209
+#: frontend/src/metabase/admin/settings/selectors.js:211
 msgid "Custom Maps"
 msgstr "Özel Haritalar"
 
-#: frontend/src/metabase/admin/settings/selectors.js:210
+#: frontend/src/metabase/admin/settings/selectors.js:212
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Farklı bölge haritası görselleştirmelerini etkinleştirmek için kendi GeoJSON dosyalarınızı ekleyin"
 
-#: frontend/src/metabase/admin/settings/selectors.js:228
+#: frontend/src/metabase/admin/settings/selectors.js:245
 msgid "Public Sharing"
 msgstr "Genel Paylaşım"
 
-#: frontend/src/metabase/admin/settings/selectors.js:232
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "Enable Public Sharing"
 msgstr "Genel Paylaşımı Etkinleştir"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:254
 msgid "Shared Dashboards"
 msgstr "Paylaşılan Panolar"
 
-#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Shared Questions"
 msgstr "Paylaşılan Sorular"
 
-#: frontend/src/metabase/admin/settings/selectors.js:250
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Embedding in other Applications"
 msgstr "Diğer Uygulamalarda Yerleştirme"
 
-#: frontend/src/metabase/admin/settings/selectors.js:276
+#: frontend/src/metabase/admin/settings/selectors.js:293
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Metabase'i Diğer Uygulamalara Yerleştirme özelliğini Etkinleştir"
 
-#: frontend/src/metabase/admin/settings/selectors.js:286
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Embedding secret key"
 msgstr "Gizli anahtarı yerleştirme"
 
-#: frontend/src/metabase/admin/settings/selectors.js:292
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Embedded Dashboards"
 msgstr "Yerleşmiş Panolar"
 
-#: frontend/src/metabase/admin/settings/selectors.js:298
+#: frontend/src/metabase/admin/settings/selectors.js:315
 msgid "Embedded Questions"
 msgstr "Yerleşmiş Sorular"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:322
 msgid "Caching"
 msgstr "Önbellek Ayarları"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:326
 msgid "Enable Caching"
 msgstr "Önbelleğe almayı etkinleştir"
 
-#: frontend/src/metabase/admin/settings/selectors.js:314
+#: frontend/src/metabase/admin/settings/selectors.js:331
 msgid "Minimum Query Duration"
 msgstr "Minimum Sorgu Süresi"
 
-#: frontend/src/metabase/admin/settings/selectors.js:321
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Önbellek Zaman-Canlı (TTL) çarpanı"
 
-#: frontend/src/metabase/admin/settings/selectors.js:328
+#: frontend/src/metabase/admin/settings/selectors.js:345
 msgid "Max Cache Entry Size"
 msgstr "Maksimum Önbellek Giriş Boyutu"
 
@@ -2117,7 +2126,8 @@ msgstr "Bu koleksiyondaki panolar, koleksiyonlar ve bildirimler arşivlenecektir
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/routes.jsx:205
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
+#: frontend/src/metabase/routes.jsx:196
 msgid "Archive"
 msgstr "Arşiv"
 
@@ -2133,21 +2143,21 @@ msgstr "Arşivi görüntüle"
 msgid "Unarchive this {0}"
 msgstr "Bunu arşivden kaldır {0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:39
-#: frontend/src/metabase/components/BrowseApp.jsx:102
-#: frontend/src/metabase/components/BrowseApp.jsx:194
+#: frontend/src/metabase/components/BrowseApp.jsx:46
+#: frontend/src/metabase/components/BrowseApp.jsx:112
+#: frontend/src/metabase/components/BrowseApp.jsx:204
 #: frontend/src/metabase/containers/Overworld.jsx:270
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
 msgstr "Verilerimiz"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:146
+#: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
 msgid "X-ray this table"
 msgstr "X-ışını bu tablo"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:161
+#: frontend/src/metabase/components/BrowseApp.jsx:171
 msgid "Learn about this table"
 msgstr "Bu tablo hakkında bilgi edinin"
 
@@ -2242,7 +2252,7 @@ msgstr "İğneler"
 msgid "Drag something here to pin it to the top"
 msgstr "Üstüne sabitlemek için buraya bir şey sürükleyin"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:755
+#: frontend/src/metabase/admin/permissions/selectors.js:753
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2296,7 +2306,7 @@ msgstr "Yeni koleksiyon"
 msgid "Copied!"
 msgstr "Kopyalanan!"
 
-#: frontend/src/metabase/entities/databases/forms.js:12
+#: frontend/src/metabase/entities/databases/forms.js:14
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Veritabanı bağlantıları için bir SSH tüneli kullanın"
 
@@ -2308,7 +2318,7 @@ msgstr "Bazı veritabanı kurulumlarına sadece bir SSH bastion ana bilgisayarı
 "Bu seçenek ayrıca bir VPN mevcut olmadığında ekstra bir güvenlik katmanı sağlar.\n"
 "Bunu etkinleştirmek genellikle doğrudan bir bağlantıdan daha yavaştır."
 
-#: frontend/src/metabase/entities/databases/forms.js:212
+#: frontend/src/metabase/entities/databases/forms.js:281
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Bu büyük bir veritabanıdır, bu yüzden Metabase senkronize edip tarama yaparken benim seçmeme izin ver"
 
@@ -2317,17 +2327,17 @@ msgid "By default, Metabase does a lightweight hourly sync and an intensive dail
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Varsayılan olarak, Metabase hafif bir saatlik senkronizasyon ve yoğun bir günlük alan taraması yapar. Büyük bir veritabanınız varsa bunu açmanızı ve alan değeri taramalarının ne zaman ve ne sıklıkta gerçekleştiğini gözden geçirmenizi öneririz."
 
-#: frontend/src/metabase/entities/databases/forms.js:78
+#: frontend/src/metabase/entities/databases/forms.js:113
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0} projeniz için bir Müşteri Kimliği ve Müşteri Sırrı oluşturmak "
 
-#: frontend/src/metabase/entities/databases/forms.js:80
-#: frontend/src/metabase/entities/databases/forms.js:95
-#: frontend/src/metabase/entities/databases/forms.js:131
+#: frontend/src/metabase/entities/databases/forms.js:115
+#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:166
 msgid "Click here"
 msgstr "Buraya tıklayın"
 
-#: frontend/src/metabase/entities/databases/forms.js:83
+#: frontend/src/metabase/entities/databases/forms.js:118
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Uygulama türü olarak \"Diğer\" i seçin. Ne istersen söylemen yeter."
 
@@ -2335,19 +2345,19 @@ msgstr "Uygulama türü olarak \"Diğer\" i seçin. Ne istersen söylemen yeter.
 msgid "{0} to get an auth code"
 msgstr "Bir kimlik kodu almak için {0}"
 
-#: frontend/src/metabase/entities/databases/forms.js:107
+#: frontend/src/metabase/entities/databases/forms.js:142
 msgid "with Google Drive permissions"
 msgstr "Google Drive izinleriyle"
 
-#: frontend/src/metabase/entities/databases/forms.js:129
+#: frontend/src/metabase/entities/databases/forms.js:164
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "Metabase'i  bu verilerle kullanmak için Google Developers Console'da API erişimini etkinleştirmeniz gerekir."
 
-#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:165
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "Daha önce yapmadıysanız {0} konsoluna gitmek için."
 
-#: frontend/src/metabase/entities/databases/forms.js:196
+#: frontend/src/metabase/entities/databases/forms.js:265
 msgid "How would you like to refer to this database?"
 msgstr "Bu veritabanına nasıl başvurmak istersiniz?"
 
@@ -2356,7 +2366,8 @@ msgstr "Bu veritabanına nasıl başvurmak istersiniz?"
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:143
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:70
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:123
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:96
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:126
 #: frontend/src/metabase/setup/components/UserStep.jsx:93
 msgid "Next"
 msgstr "Sonraki"
@@ -2539,7 +2550,7 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Önceki bir revizyona ve {0} ye  geri alındı"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:290
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "Revizyon Geçmişi"
@@ -2585,7 +2596,7 @@ msgid "Questions"
 msgstr "Sorular"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:320
+#: frontend/src/metabase/routes.jsx:311
 msgid "Pulses"
 msgstr "Bildirimler"
 
@@ -2630,15 +2641,16 @@ msgstr "Biraz kaybolduk..."
 msgid "Temporary Password"
 msgstr "Geçici Parola"
 
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:207
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:481
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
 msgid "Hide"
 msgstr "Gizle"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:467
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:482
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:471
 msgid "Show"
 msgstr "Göster"
 
@@ -2748,7 +2760,7 @@ msgstr "Üzgünüz, bunu görme izniniz yok."
 msgid "Unknown error encountered"
 msgstr "Hata oluştu"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/nav/containers/Navbar.jsx:373
 msgid "Create"
 msgstr "Oluştur"
@@ -2761,7 +2773,7 @@ msgstr "Dashboard oluştur"
 msgid "Table"
 msgstr "Tablo"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
 msgid "Database"
 msgstr "Veritabanı"
 
@@ -2781,7 +2793,7 @@ msgstr "Aradığınızı bulmak için filtrenizi ayarlamayı deneyin."
 msgid "View by"
 msgstr "Tarafından görüntüle"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:122
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:121
 msgid "of"
 msgstr "nın"
 
@@ -2808,33 +2820,33 @@ msgstr "Analizlerimiz"
 msgid "Browse all items"
 msgstr "Tüm öğelere göz at"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:118
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:117
 msgid "Replace or save as new?"
 msgstr "Değiştir veya yeni olarak kaydet"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:168
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace original question, \"{0}\""
 msgstr "Orijinal soruyu değiştir, \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:172
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:171
 msgid "Save as new question"
 msgstr "Yeni soru olarak kaydet"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:92
 msgid "First, save your question"
 msgstr "İlk önce, sorunuzu kaydedin"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:94
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
 msgid "Save question"
 msgstr "Soru kaydet"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:133
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
 msgid "What is the name of your card?"
 msgstr "Kartınızın adı nedir?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
 #: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/entities/questions.js:89
@@ -2850,15 +2862,16 @@ msgstr "Kartınızın adı nedir?"
 msgid "Description"
 msgstr "Açıklama"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
 #: frontend/src/metabase/entities/dashboards.js:150
 #: frontend/src/metabase/entities/questions.js:91
 #: frontend/src/metabase/entities/questions.js:107
+#: frontend/src/metabase/entities/snippets.js:31
 msgid "It's optional but oh, so helpful"
 msgstr "O isteğe bağlı ama, çok yararlı"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:148
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "Bu hangi koleksiyonda olmalı?"
@@ -2875,19 +2888,19 @@ msgstr "madde"
 msgid "Undo"
 msgstr "Geri alma"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:266
 msgid "Applying Question"
-msgstr "Soru uygulamak"
+msgstr "Soruyu Uygula"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:286
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "That question isn't compatible"
 msgstr "Bu soru uyumlu değil"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:322
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:309
 msgid "Search for a question"
 msgstr "Soru ara"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:351
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:343
 msgid "We're not sure if this question is compatible"
 msgstr "Bu sorunun uyumlu olup olmadığından emin değiliz."
 
@@ -2936,26 +2949,24 @@ msgstr "Bir soru ekle"
 msgid "Add a question to this dashboard"
 msgstr "Bu panele bir soru ekle"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
 msgid "Add a filter"
 msgstr "Filtre ekle"
 
 #. I don't speak Turkish but this doesn't look right to me.
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:256
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "Parametreler"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:276
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:280
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
 msgid "Add a text box"
 msgstr "Bir metin kutusu ekle"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:320
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:314
 msgid "Move dashboard"
 msgstr "Gösterge tablosunu taşı"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:303
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
 msgid "Edit dashboard"
 msgstr "Gösterge tablosunu düzenle"
 
@@ -2963,11 +2974,11 @@ msgstr "Gösterge tablosunu düzenle"
 msgid "Edit Dashboard Layout"
 msgstr "Gösterge Tablosu Düzen tasarımını Düzenle"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:371
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:365
 msgid "You are editing a dashboard"
 msgstr "Bir gösterge tablosunu düzenliyorsunuz"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:376
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:370
 msgid "Select the field that should be filtered for each card"
 msgstr "Her kart için filtrelenmesi gereken alanı seçin"
 
@@ -3055,7 +3066,7 @@ msgstr "Bu kartın, bu parametre türüne eşlenebilecek herhangi bir alanı vey
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Bu alandaki değerler, seçtiğiniz diğer alanların değerleriyle örtüşmez."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:162
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "Geçerli alan yok"
@@ -3123,7 +3134,7 @@ msgstr "en son veri alındı"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:329
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
 msgid "Unknown"
 msgstr "Bilinmeyen"
 
@@ -3250,6 +3261,7 @@ msgstr "{0} öğe seçildi"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 msgid "Unarchive"
 msgstr "Arşivden Çıkar"
 
@@ -3342,7 +3354,7 @@ msgid "Longitude"
 msgstr "Boylam"
 
 #: frontend/src/metabase/lib/core.js:43
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:45
 msgid "Number"
 msgstr "Numara"
@@ -3399,7 +3411,7 @@ msgid "User"
 msgstr "kullanıcı"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:211
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
 msgid "Source"
 msgstr "Kaynak"
 
@@ -3440,16 +3452,17 @@ msgid "Score"
 msgstr "Gol"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Başlık"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
 msgid "Comment"
 msgstr "Yorum "
 
@@ -3501,9 +3514,9 @@ msgstr "Dahil etmeyin"
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
 msgstr "Metabase bu alanı asla alamaz. Hassas veya alakasız bilgiler için bunu kullanın."
 
-#: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:300
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/query/description.js:77
+#: frontend/src/metabase/lib/query/description.js:262
+#: frontend/src/metabase/lib/schema_metadata.js:476
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
@@ -3518,8 +3531,7 @@ msgstr "Adet"
 msgid "CumulativeCount"
 msgstr "Kümülatif Sayım"
 
-#: frontend/src/metabase/lib/expressions/config.js:9
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:485
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3529,7 +3541,6 @@ msgstr "Toplam"
 msgid "CumulativeSum"
 msgstr "KümülatifToplam"
 
-#: frontend/src/metabase/lib/expressions/config.js:11
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Distinct"
 msgstr "Farklı"
@@ -3538,25 +3549,22 @@ msgstr "Farklı"
 msgid "StandardDeviation"
 msgstr "Standart Sapma"
 
-#: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:494
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Ortalama"
 
-#: frontend/src/metabase/lib/expressions/config.js:14
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:539
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Min"
 
-#: frontend/src/metabase/lib/expressions/config.js:15
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:548
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:503
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:492
 msgid "Max"
 msgstr "Maksimum"
 
@@ -3609,54 +3617,66 @@ msgstr "Aklından ne geçiyor?"
 msgid "What do you want to find out?"
 msgstr "Ne öğrenmek istiyorsun?"
 
-#: frontend/src/metabase/lib/query.js:298
-#: frontend/src/metabase/lib/schema_metadata.js:466
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:250
+#: frontend/src/metabase/lib/query/description.js:75
+#: frontend/src/metabase/lib/query/description.js:260
+#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "İşlenmemiş veri"
 
-#: frontend/src/metabase/lib/query.js:302
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/query/description.js:79
+#: frontend/src/metabase/lib/query/description.js:264
+#: frontend/src/metabase/lib/schema_metadata.js:521
 msgid "Cumulative count"
 msgstr "Birikimli sayım"
 
-#: frontend/src/metabase/lib/query.js:305
+#: frontend/src/metabase/lib/query/description.js:82
+#: frontend/src/metabase/lib/query/description.js:266
 msgid "Average of "
 msgstr "Ortalama ␣"
 
-#: frontend/src/metabase/lib/query.js:310
+#: frontend/src/metabase/lib/query/description.js:87
+#: frontend/src/metabase/lib/query/description.js:268
 msgid "Distinct values of "
 msgstr "Farklı değerleri "
 
-#: frontend/src/metabase/lib/query.js:315
+#: frontend/src/metabase/lib/query/description.js:92
+#: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
 msgstr "Standart sapma␣"
 
-#: frontend/src/metabase/lib/query.js:320
+#: frontend/src/metabase/lib/query/description.js:97
+#: frontend/src/metabase/lib/query/description.js:272
 msgid "Sum of "
-msgstr "Toplam"
+msgstr "Toplam "
 
-#: frontend/src/metabase/lib/query.js:325
+#: frontend/src/metabase/lib/query/description.js:102
+#: frontend/src/metabase/lib/query/description.js:274
 msgid "Cumulative sum of "
-msgstr "Kümülatif toplam"
+msgstr "Kümülatif toplam "
 
-#: frontend/src/metabase/lib/query.js:330
+#: frontend/src/metabase/lib/query/description.js:107
+#: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
 msgstr "...nın Maksimumu"
 
-#: frontend/src/metabase/lib/query.js:335
+#: frontend/src/metabase/lib/query/description.js:112
+#: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
 msgstr "...nın Minimumu"
 
-#: frontend/src/metabase/lib/query.js:349
+#: frontend/src/metabase/lib/query/description.js:126
+#: frontend/src/metabase/lib/query/description.js:286
 msgid "Grouped by "
 msgstr "Tarafından gruplandırıldı"
 
-#: frontend/src/metabase/lib/query.js:363
+#: frontend/src/metabase/lib/query/description.js:140
+#: frontend/src/metabase/lib/query/description.js:295
 msgid "Filtered by "
 msgstr "Tarafından filtrelendi"
 
-#: frontend/src/metabase/lib/query.js:392
+#: frontend/src/metabase/lib/query/description.js:169
+#: frontend/src/metabase/lib/query/description.js:320
 msgid "Sorted by "
 msgstr "Tarafından sıralandı"
 
@@ -3668,55 +3688,45 @@ msgstr "Doğru"
 msgid "False"
 msgstr "Yanlış"
 
-#: frontend/src/metabase/lib/schema_metadata.js:321
+#: frontend/src/metabase/lib/schema_metadata.js:322
 msgid "Select longitude field"
 msgstr "Boylam alanını seç"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:323
 msgid "Enter upper latitude"
 msgstr "Üstteki enlemi girin"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:324
 msgid "Enter left longitude"
 msgstr "Sol boylamı giriniz"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:325
 msgid "Enter lower latitude"
 msgstr "Daha düşük enlem girin"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:326
 msgid "Enter right longitude"
 msgstr "Doğru boylamı giriniz"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:539
 #: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:397
-#: frontend/src/metabase/lib/schema_metadata.js:405
-#: frontend/src/metabase/lib/schema_metadata.js:411
-#: frontend/src/metabase/lib/schema_metadata.js:416
-msgid "Is"
-msgstr "ise"
-
 #: frontend/src/metabase/lib/schema_metadata.js:362
 #: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:398
 #: frontend/src/metabase/lib/schema_metadata.js:406
 #: frontend/src/metabase/lib/schema_metadata.js:412
-msgid "Is not"
-msgstr "Değil"
+#: frontend/src/metabase/lib/schema_metadata.js:417
+msgid "Is"
+msgstr "ise"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:417
-msgid "Is empty"
-msgstr "boş"
+#: frontend/src/metabase/lib/schema_metadata.js:413
+msgid "Is not"
+msgstr "Değil"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:378
@@ -3725,109 +3735,119 @@ msgstr "boş"
 #: frontend/src/metabase/lib/schema_metadata.js:402
 #: frontend/src/metabase/lib/schema_metadata.js:408
 #: frontend/src/metabase/lib/schema_metadata.js:418
+msgid "Is empty"
+msgstr "boş"
+
+#: frontend/src/metabase/lib/schema_metadata.js:365
+#: frontend/src/metabase/lib/schema_metadata.js:379
+#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:395
+#: frontend/src/metabase/lib/schema_metadata.js:403
+#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:419
 msgid "Not empty"
 msgstr "boş değil"
 
-#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:371
 msgid "Equal to"
 msgstr "Eşittir"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:372
 msgid "Not equal to"
 msgstr "Eşit değil"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Greater than"
 msgstr "den daha büyük"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Less than"
 msgstr "Den daha küçük"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Arasında"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:376
 msgid "Greater than or equal to"
 msgstr "Den daha büyük veya eşit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Less than or equal to"
 msgstr "Den daha az veya eşit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
+#: frontend/src/metabase/lib/schema_metadata.js:384
 msgid "Contains"
 msgstr "İçerir"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:385
 msgid "Does not contain"
 msgstr "İçermez"
 
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:388
 msgid "Starts with"
 msgstr "İle başlar"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:389
 msgid "Ends with"
 msgstr "İle biter"
 
-#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:399
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Önce"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:400
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Sonra"
 
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:414
 msgid "Inside"
 msgstr "içeride"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Sadece cevapta satırları olan bir tablo, ek işlem yok."
 
-#: frontend/src/metabase/lib/schema_metadata.js:474
+#: frontend/src/metabase/lib/schema_metadata.js:475
 msgid "Count of rows"
 msgstr "Satır sayısı"
 
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:477
 msgid "Total number of rows in the answer."
 msgstr "Yanıttaki toplam satır sayısı."
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Sum of ..."
-msgstr "...nın Toplamı "
+msgstr "...nın Toplamı"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:486
 msgid "Sum of all the values of a column."
 msgstr "Bir sütunun tüm değerlerinin toplamı."
 
-#: frontend/src/metabase/lib/schema_metadata.js:492
+#: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Average of ..."
 msgstr "...nın Ortalaması"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:495
 msgid "Average of all the values of a column"
 msgstr "Bir sütunun tüm değerlerinin ortalaması"
 
-#: frontend/src/metabase/lib/schema_metadata.js:501
+#: frontend/src/metabase/lib/schema_metadata.js:502
 msgid "Number of distinct values of ..."
 msgstr "Farklı değerlerinin sayısı"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:504
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Yanıttaki tüm satırlar arasında bir sütunun benzersiz değerlerinin sayısı."
 
-#: frontend/src/metabase/lib/schema_metadata.js:510
+#: frontend/src/metabase/lib/schema_metadata.js:511
 msgid "Cumulative sum of ..."
 msgstr "...nın Kümülatif Toplamı"
 
@@ -3835,7 +3855,7 @@ msgstr "...nın Kümülatif Toplamı"
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Bir sütunun tüm değerlerinin toplamı. \\\\ ne.x. Zaman içinde toplam gelir."
 
-#: frontend/src/metabase/lib/schema_metadata.js:519
+#: frontend/src/metabase/lib/schema_metadata.js:520
 msgid "Cumulative count of rows"
 msgstr "Kümülatif satır sayısı"
 
@@ -3843,27 +3863,27 @@ msgstr "Kümülatif satır sayısı"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Satırların sayısının toplam sayısı. \\\\ ne.x. Zaman içinde toplam satış sayısı."
 
-#: frontend/src/metabase/lib/schema_metadata.js:528
+#: frontend/src/metabase/lib/schema_metadata.js:529
 msgid "Standard deviation of ..."
 msgstr "Standart sapma ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:531
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Bir sütunun değerlerinin ne kadarının cevabın tüm satırları arasında değiştiğini ifade eden sayı."
 
-#: frontend/src/metabase/lib/schema_metadata.js:537
+#: frontend/src/metabase/lib/schema_metadata.js:538
 msgid "Minimum of ..."
 msgstr "Minimum ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Minimum value of a column"
 msgstr "Bir sütunun minimum değeri"
 
-#: frontend/src/metabase/lib/schema_metadata.js:546
+#: frontend/src/metabase/lib/schema_metadata.js:547
 msgid "Maximum of ..."
 msgstr "Maksimum ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:549
 msgid "Maximum value of a column"
 msgstr "Bir sütunun maksimum değeri"
 
@@ -4039,7 +4059,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Kategori, Tip, Model, Değerlendirme, vb."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:43
-#: frontend/src/metabase/user/components/UserSettings.jsx:55
+#: frontend/src/metabase/user/components/UserSettings.jsx:56
 msgid "Account settings"
 msgstr "Hesap ayarları"
 
@@ -4051,7 +4071,7 @@ msgstr "Yönetim panelinden çık"
 msgid "Logs"
 msgstr "Kayıtlar"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:103
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:104
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:22
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:65
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:100
@@ -4091,9 +4111,9 @@ msgid "Metabase Admin"
 msgstr "Metabase Yöneticisi"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:36
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:36
 msgid "Ask a question"
 msgstr "Bir soru sor"
 
@@ -4114,7 +4134,7 @@ msgstr "Referans"
 msgid "Which metric?"
 msgstr "Hangi metrik?"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "Ekibiniz için ortak metrikler tanımlamak, soru sormayı daha da kolaylaştırır"
 
@@ -4126,7 +4146,7 @@ msgstr "Metrikler nasıl oluşturulur?"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Eğilimleri veya değişiklikleri anlamanıza yardımcı olacak şekilde zaman içindeki verileri bir harita olarak görüntüleyin veya döndürün."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:149
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
 msgid "Custom"
 msgstr "Özel"
 
@@ -4139,13 +4159,13 @@ msgstr "Yeni soru"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Trendleri, listelerin listesini görmek veya kendi metriklerinizi oluşturmak için basit soru oluşturucuyu kullanın."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:107
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:110
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Yerel sorgu"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:108
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:111
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Daha karmaşık sorular için, kendi SQL veya yerel sorgunuzu yazabilirsiniz."
 
@@ -4250,6 +4270,7 @@ msgid "Enter a default value..."
 msgstr "Varsayılan bir değer girin ..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
+#: frontend/src/metabase/containers/Form.jsx:307
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Bir hata oluştu"
@@ -4498,7 +4519,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "Tüm ekip için sindirilebilir ve kullanışlı olmalarını sağlamak için bildirimleri küçük ve odaklanmış tutmanızı öneririz."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:161
-#: frontend/src/metabase/query_builder/components/view/View.jsx:131
+#: frontend/src/metabase/query_builder/components/view/View.jsx:133
 msgid "Pick your data"
 msgstr "Verilerinizi seçin"
 
@@ -4514,47 +4535,47 @@ msgstr "E-postalar"
 msgid "Slack messages"
 msgstr "Slack mesajları"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:216
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Gönderilen"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:217
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
-msgstr "{0} adresine gönderilecek"
+msgstr "{0} şu saatte gönderilecek"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:219
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Mesajlar"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:235
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "Şimdi e-posta gönder"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:236
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Şimdi {0} adresine gönder"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:238
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Gönderiliyor ..."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "Gönderim başarısız"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "Gönderme yapılmadı çünkü bildirim hiçbir sonuç vermedi."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Bildirim gönderildi"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:282
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} bir yönetici tarafından kurulmalıdır."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:295
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:299
 msgid "Slack"
 msgstr "Gevşek"
 
@@ -4584,7 +4605,7 @@ msgstr "Sorularının hiçbiri herhangi bir sonuca sahip değilse, planlı bir b
 
 #: frontend/src/metabase/pulse/components/RecipientPicker.jsx:65
 msgid "Enter email addresses you'd like this data to go to"
-msgstr "Gitmek istediğiniz veriler için e-posta adreslerini girin"
+msgstr "Göndermek istediğiniz veriler için e-posta adreslerini girin"
 
 #: frontend/src/metabase/pulse/components/WhatsAPulse.jsx:16
 msgid "Help everyone on your team stay in sync with your data."
@@ -4707,7 +4728,7 @@ msgstr "Ort"
 msgid "Distincts"
 msgstr "Farklar"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:55
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "{0}'ni görüntüle "
@@ -4718,11 +4739,12 @@ msgstr[1] "{0}ları görüntüle"
 msgid "Zoom in"
 msgstr "Yakınlaştır"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Özel ifade"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Common Metrics"
 msgstr "Genel Metrikler"
 
@@ -4800,7 +4822,7 @@ msgstr "Bir satır veya çubuk {0} olduğunda"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:242
 msgid "crosses a goal line"
-msgstr "bir gol çizgisini geçiyor"
+msgstr "hedef çizgisini geçiyor"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:253
 msgid "When a progress bar {0}"
@@ -4856,7 +4878,7 @@ msgstr "İlerleme çubuğuda beni uyar."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
-msgstr "Gol çizgisinin üzerinde gider"
+msgstr "Hedef çizgisinin üzerinde gider"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
@@ -4864,7 +4886,7 @@ msgstr "Hedefe ulaşır"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
-msgstr "Gol çizgisinin altına gider"
+msgstr "Hedef çizgisinin altına gider"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
@@ -4919,34 +4941,34 @@ msgstr "genellikle"
 msgid "Pick a segment or table"
 msgstr "Bir segment veya tablo seçin"
 
-#: frontend/src/metabase/entities/databases/forms.js:191
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
+#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Bir veritabanı seç"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:94
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:85
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:31
 msgid "Select..."
 msgstr "Seç ..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:134
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
 msgid "Select a table"
 msgstr "Tablo seç"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:819
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:926
 msgid "No tables found in this database."
 msgstr "Bu veritabanında hiçbir tablo bulunamadı."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:856
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:901
 msgid "Is a question missing?"
 msgstr "Eksik bir soru mu var?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:863
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:909
 msgid "Learn more about nested queries"
 msgstr "Yuvalanmış sorgular hakkında daha fazla bilgi edinin."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:898
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:951
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:40
 msgid "Fields"
 msgstr "Alanlar"
 
@@ -4980,11 +5002,11 @@ msgstr "Sırala"
 msgid "Row limit"
 msgstr "Satır sınırı"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
 msgid "Unknown Field"
 msgstr "Bilinmeyen Alan"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:75
 msgid "field"
 msgstr "alan"
 
@@ -4992,19 +5014,20 @@ msgstr "alan"
 msgid "Matches"
 msgstr "Maçlar"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:148
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:156
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:135
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Cevabınızı daraltmak için filtreler ekleyin"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:293
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
 msgstr "Bir gruplama ekle"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:37
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:313
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
-#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:66
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:67
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:89
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:131
@@ -5020,16 +5043,16 @@ msgstr "Bir gruplama ekle"
 msgid "Data"
 msgstr "Veri"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:340
 msgid "Filtered by"
 msgstr "Tarafından filtrelenmiş"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:376
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:357
 msgid "View"
 msgstr "Görünüm"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:393
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:374
 msgid "Grouped By"
 msgstr "Tarafından gruplandırılmış"
 
@@ -5037,7 +5060,7 @@ msgstr "Tarafından gruplandırılmış"
 msgid "None"
 msgstr "Yok"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:471
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
 msgid "This question is written in {0}."
 msgstr "Bu soru {0} ile yazılmıştır."
 
@@ -5049,7 +5072,7 @@ msgstr "Düzenleyiciyi Gizle"
 msgid "Hide Query"
 msgstr "Sorguyu Gizle"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:481
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
 msgid "Open Editor"
 msgstr "Editör'ü Aç"
 
@@ -5290,7 +5313,7 @@ msgstr " {0} nın tüm farklı değerleri"
 msgid "Number of {0} grouped by {1}"
 msgstr "{1} ile gruplandırılmış {0} sayısı"
 
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:77
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5349,32 +5372,33 @@ msgstr "{0} için ham verileri görün"
 msgid "More"
 msgstr "Daha"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:194
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:216
 msgid "Invalid expression"
 msgstr "Geçersiz ifade"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:269
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:282
 msgid "unknown error"
 msgstr "bilinmeyen hata"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:47
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:53
 msgid "Field formula"
 msgstr "Alan formülü"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:60
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:64
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Bunu bir e-tablo programında formül yazmak gibi bir şey olarak düşünün: Sayıları, bu tablodaki alanları, + gibi matematiksel sembolleri ve bazı işlevleri kullanabilirsiniz. Böylece Subtotal - Cost gibi bir şey yazabilirsiniz."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:69
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:208
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
 msgid "Learn more"
 msgstr "Daha fazla bilgi edin"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:77
 msgid "Give it a name"
 msgstr "Bir isim ver"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:79
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
 msgid "Something nice and descriptive"
 msgstr "Güzel ve açıklayıcı bir şey"
 
@@ -5454,11 +5478,11 @@ msgid "Enter desired number"
 msgstr "İstenen numarayı giriniz"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:154
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:161
 msgid "Empty"
 msgstr "Boş"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:119
 msgid "Find a value"
 msgstr "Bir değer bul"
 
@@ -5526,35 +5550,35 @@ msgstr "Tüm belgeleri okuyun"
 msgid "Filter label"
 msgstr "Filtre etiketi"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:135
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:134
 msgid "Variable type"
 msgstr "Değişken tip"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:143
 msgid "Text"
 msgstr "Metin"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
 msgid "Date"
 msgstr "Tarih"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:147
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
 msgid "Field Filter"
 msgstr "Alan Filtresi"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Field to map to"
 msgstr "Eşlenecek alan"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:180
 msgid "Filter widget type"
 msgstr "Filtre aracı türünü filtrele"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:230
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
 msgid "Required?"
 msgstr "Gereklidir?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:240
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
 msgid "Default filter widget value"
 msgstr "Varsayılan filtre widget değeri"
 
@@ -5566,7 +5590,7 @@ msgstr "Bu soruyu arşivlediniz mi?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Bu soru, onu kullanan herhangi bir gösterge tablosundan veya bildirimlerden çıkarılacaktır."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:158
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
 msgid "Question"
 msgstr "Soru"
 
@@ -5736,7 +5760,7 @@ msgid "Details"
 msgstr "ayrıntılar"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
-#: frontend/src/metabase/reference/databases/TableList.jsx:116
+#: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
 msgstr "{0} alanındaki tablolar"
 
@@ -5817,24 +5841,24 @@ msgstr "Bu tablo neden ilginç?"
 msgid "Things to be aware of about this table"
 msgstr "Bu tablo hakkında bilinmesi gerekenler"
 
-#: frontend/src/metabase/reference/databases/TableList.jsx:30
+#: frontend/src/metabase/reference/databases/TableList.jsx:29
 msgid "Tables in this database will appear here as they're added"
 msgstr "Bu veritabanındaki tablolar, eklendiklerinde burada görünecek"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:34
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:33
 msgid "Questions about this table will appear here as they're added"
 msgstr "Bu tabloyla ilgili sorular, eklendiklerinde burada görünece"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:73
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:77
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:76
 msgid "Questions about {0}"
 msgstr "{0} ile ilgili sorular"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
 msgid "Created {0} by {1}"
 msgstr " {0} {1} tarafından düzenlendi"
 
@@ -6023,19 +6047,19 @@ msgstr "Bu metriği gruplayabileceğiniz diğer alanlar"
 msgid "Fields you can group this metric by"
 msgstr "Bu metriği gruplayabileceğiniz alanlar"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "Metrikler, ekibinizin umurunda olduğu resmi numaralardır."
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Metrics will appear here once your admins have created some"
 msgstr "Yöneticileriniz bir kez oluşturduğunuzda metrikler burada görünecek"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:28
 msgid "Learn how to create metrics"
 msgstr "Metrikleri nasıl oluşturacağınızı öğrenin"
 
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:34
 msgid "Questions about this metric will appear here as they're added"
 msgstr "Bu metrikle ilgili sorular, eklendiklerinde burada görünecek"
 
@@ -6061,23 +6085,23 @@ msgstr "Bu Segment neden ilginç?"
 msgid "Things to be aware of about this Segment"
 msgstr "Bu Bölüm hakkında bilinmesi gerekenler"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
 msgid "Segments are interesting subsets of tables"
 msgstr "Segmentler, tabloların ilginç alt kümeleridir"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "Ekibiniz için ortak segmentler tanımlamak, soru sormayı daha da kolaylaştırır"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Segments will appear here once your admins have created some"
 msgstr "Yöneticilerinizin bir süre önce oluşturdukları bölümler burada görünecek"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
 msgid "Learn how to create segments"
 msgstr "Segment oluşturmayı öğrenin"
 
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:35
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:34
 msgid "Questions about this segment will appear here as they're added"
 msgstr "Bu segmentle ilgili sorular, eklendiklerinde burada görünecek"
 
@@ -6097,22 +6121,22 @@ msgstr "Bu segmentle ilgili sorular"
 msgid "X-ray this segment"
 msgstr "Bu segmenti incele"
 
-#: frontend/src/metabase/routes.jsx:178 frontend/src/metabase/routes.jsx:179
+#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
 msgid "Login"
 msgstr "Oturum aç"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:303
 #: frontend/src/metabase/containers/ItemPicker.jsx:115
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:204
+#: frontend/src/metabase/routes.jsx:195
 msgid "Search"
 msgstr "Arama"
 
-#: frontend/src/metabase/routes.jsx:223
+#: frontend/src/metabase/routes.jsx:214
 msgid "Dashboard"
 msgstr "Gösterge paneli"
 
-#: frontend/src/metabase/routes.jsx:236
+#: frontend/src/metabase/routes.jsx:227
 msgid "New Question"
 msgstr "Yeni soru"
 
@@ -6156,64 +6180,64 @@ msgstr "Geliştirmemize yardımcı olduğunuz için teşekkürler"
 msgid "We won't collect any usage events"
 msgstr "Herhangi bir kullanım etkinliği toplamayacağız"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:88
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Metabase' i geliştirmemize yardımcı olmak için Google Analytics’le kullanımla ilgili belirli verileri toplamak istiyoruz."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:90
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Here's a full list of everything we track and why."
 msgstr "İşte izlediğimiz her şeyin tam listesi ve nedeni."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Metabase' in kullanım olaylarını anonim olarak toplamasına izin ver"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:113
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0}, verileriniz veya soru sonuçlarınızla ilgili bir şeyler toplar."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:114
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
 msgid "never"
 msgstr "asla"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:119
 msgid "All collection is completely anonymous."
 msgstr "Tüm koleksiyon tamamen anonimdir."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Koleksiyon, yönetici ayarlarınızdaki herhangi bir noktada kapatılabilir."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:44
+#: frontend/src/metabase/setup/components/Setup.jsx:59
 msgid "If you feel stuck"
 msgstr "Sıkışmış hissediyorsan"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:49
+#: frontend/src/metabase/setup/components/Setup.jsx:64
 msgid "our getting started guide"
 msgstr "başlangıç kılavuzumuz"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:50
+#: frontend/src/metabase/setup/components/Setup.jsx:65
 msgid "is just a click away."
 msgstr "sadece bir tık uzakta."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:92
+#: frontend/src/metabase/setup/components/Setup.jsx:111
 msgid "Welcome to Metabase"
 msgstr "Metabase' e Hoş Geldiniz"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:93
+#: frontend/src/metabase/setup/components/Setup.jsx:112
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Her şey çalışıyor gibi görünüyor. Şimdi sizi tanıyalım, verilerinize bağlanın ve size bazı cevaplar bulmaya başlayın!\n"
 "Onun şey çalışıyor gibi."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:97
+#: frontend/src/metabase/setup/components/Setup.jsx:116
 msgid "Let's get started"
 msgstr "Başlayalım"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:142
+#: frontend/src/metabase/setup/components/Setup.jsx:166
 msgid "You're all set up!"
 msgstr "Her şey hazır!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:153
+#: frontend/src/metabase/setup/components/Setup.jsx:177
 msgid "Take me to Metabase"
 msgstr "Beni Metabase' e götür"
 
@@ -6225,13 +6249,13 @@ msgstr "Sizi ne aramalıyız?"
 msgid "Hi, {0}. nice to meet you!"
 msgstr "Merhaba {0}. tanıştığıma memnun oldum!"
 
-#: frontend/src/metabase/entities/users/forms.js:33
+#: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
 msgstr "Şifre oluştur"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:44
-#: frontend/src/metabase/entities/users/forms.js:35
-#: frontend/src/metabase/entities/users/forms.js:82
+#: frontend/src/metabase/entities/users/forms.js:50
+#: frontend/src/metabase/entities/users/forms.js:97
 msgid "Shhh..."
 msgstr "Shhh ..."
 
@@ -6239,11 +6263,11 @@ msgstr "Shhh ..."
 msgid "Confirm password"
 msgstr "Şifreyi Onayla"
 
-#: frontend/src/metabase/entities/users/forms.js:42
+#: frontend/src/metabase/entities/users/forms.js:57
 msgid "Shhh... but one more time so we get it right"
 msgstr "Shhh ... ama bir kez daha doğru anlıyoruz"
 
-#: frontend/src/metabase/entities/users/forms.js:70
+#: frontend/src/metabase/entities/users/forms.js:85
 msgid "Your company or team name"
 msgstr "Şirketiniz veya takımın adı"
 
@@ -6286,7 +6310,7 @@ msgstr "Birkaç dakika içinde verilerinizin bazı ilginç keşiflerini size gö
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:72
 msgid "This seems to be taking a while. In the meantime, you can check out one of these example explorations to see what Metabase can do for you."
-msgstr "Bu biraz zaman alıyor gibi görünüyor. Bu arada, Metatabanının sizin için neler yapabileceğini görmek için bu örnek araştırmalardan birini kontrol edebilirsiniz."
+msgstr "Bu biraz zaman alıyor gibi görünüyor. Bu arada, Metabase sizin için neler yapabileceğini görmek için bu örnek araştırmalardan birini kontrol edebilirsiniz."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:86
 msgid "I took a look at the data you just connected, and I have some explorations of interesting things I found. Hope you like them!"
@@ -6412,7 +6436,7 @@ msgstr "Şifre başarıyla güncellendi!"
 msgid "Account updated successfully!"
 msgstr "Hesap başarıyla güncellendi!"
 
-#: frontend/src/metabase/entities/users/forms.js:81
+#: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
 msgstr "Şimdiki Şifre"
 
@@ -6424,7 +6448,7 @@ msgstr "Google E-posta adresiyle giriş yap"
 msgid "User Details"
 msgstr "Kullanıcı detayları"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:327
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:344
 msgid "Reset to defaults"
 msgstr "Varsayılanlara dön"
 
@@ -6449,15 +6473,15 @@ msgstr "X ve Y eksenleri için hangi alanları kullanmak istiyorsunuz?"
 msgid "Choose fields"
 msgstr "Alanları seç"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:217
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:234
 msgid "Save as default view"
 msgstr "Varsayılan görünüm olarak kaydet"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Draw box to filter"
 msgstr "Filtrelemek için çizim kutusu"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Cancel filter"
 msgstr "Filtreyi iptal et"
 
@@ -6485,19 +6509,19 @@ msgstr "Görselleştirme bulunamadı"
 msgid "Could not display this chart with this data."
 msgstr "Grafik bu verileri görüntülenemedi."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:526
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
 msgid "No results!"
 msgstr "Sonuç yok!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:547
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
 msgid "Still Waiting..."
 msgstr "Hala bekliyorum ."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:550
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
 msgid "This usually takes an average of {0}."
 msgstr "Bu genellikle ortalama {0} alır."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:556
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Bu bir gösterge paneli için biraz uzun)"
 
@@ -6656,19 +6680,19 @@ msgstr "Kural ekle"
 msgid "Update rule"
 msgstr "Güncelleme kuralı"
 
-#: frontend/src/metabase/visualizations/index.js:32
+#: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
 msgstr "Görselleştirme boş"
 
-#: frontend/src/metabase/visualizations/index.js:37
+#: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
 msgstr "Görselleştirme bir 'tanımlayıcı' statik değişkeni tanımlamalıdır: "
 
-#: frontend/src/metabase/visualizations/index.js:43
+#: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
 msgstr "Bu tanımlayıcı ile görselleştirme zaten kayıtlı: ␣"
 
-#: frontend/src/metabase/visualizations/index.js:71
+#: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
 msgstr "{0} için görselleştirme yok"
 
@@ -6694,23 +6718,23 @@ msgid "Doh! The data from your query doesn't fit the chosen display choice. This
 msgstr "Doh! Sorgunuzdaki veriler seçilen ekran seçimine uymuyor. Bu görselleştirme en az {0} {1} veri gerektirir."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:9
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:117
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:120
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:161
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:169
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:249
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:267
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "sütun"
@@ -6731,7 +6755,7 @@ msgstr "Aylak. Bu veriler için aslında bir iğne haritası oluşturamayız ç�
 
 #: frontend/src/metabase/visualizations/lib/errors.js:55
 msgid "Please configure this chart in the chart settings"
-msgstr "Lütfen bu grafiği grafik ayarlarında yapılandırın"
+msgstr "Lütfen bu tabloyu grafik ayarlarından yapılandırın"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:57
 msgid "Edit Settings"
@@ -6821,83 +6845,83 @@ msgstr "Hiçbir şey değil"
 msgid "Linear Interpolated"
 msgstr "Doğrusal İnterpolasyon"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
 msgstr "X ekseni ölçeği"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
 msgstr "Zaman serisi"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:454
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
 msgid "Linear"
 msgstr "Doğrusal"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
 msgid "Power"
 msgstr "Güç"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:428
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:445
 msgid "Log"
 msgstr "Giriş"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:441
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:430
 msgid "Histogram"
 msgstr "Histogram"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
 msgstr "Sıra"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
 msgstr "Y ekseni ölçeği"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:462
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
 msgstr "X ekseni çizgisini ve işaretlerini göster"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:360
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:468
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:349
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
 msgid "Compact"
 msgstr "Kompakt"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:469
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
 msgid "Rotate 45°"
 msgstr "45 ° döndür"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:459
 msgid "Rotate 90°"
 msgstr "90 ° döndür"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
 msgid "Show y-axis line and marks"
 msgstr "Y ekseni satırını ve işaretlerini göster"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:489
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Auto y-axis range"
 msgstr "Otomatik y ekseni aralığı"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:533
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:522
 msgid "Use a split y-axis when necessary"
 msgstr "Gerektiğinde bölünmüş bir y ekseni kullanın"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:540
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:529
 msgid "Show label on x-axis"
 msgstr "X ekseni üzerindeki etiketi göster"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:546
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:535
 msgid "X-axis label"
 msgstr "X ekseni etiketi"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:555
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:544
 msgid "Show label on y-axis"
 msgstr "Y ekseninde etiketi göster"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:561
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:550
 msgid "Y-axis label"
 msgstr "Y ekseni etiketi"
 
@@ -6912,16 +6936,16 @@ msgstr "Alan"
 
 #: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
 msgid "area chart"
-msgstr "alan şeması"
+msgstr "alan grafik"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
 #: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
 msgid "Bar"
-msgstr "Bubuk "
+msgstr "Çubuk "
 
 #: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
 msgid "bar chart"
-msgstr "çubuk grafik"
+msgstr "sütun grafik"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
@@ -6943,7 +6967,7 @@ msgstr "Huni tipi"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
-msgstr "Çubuk grafik"
+msgstr "Sütun grafik"
 
 #: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
 msgid "line chart"
@@ -7023,23 +7047,23 @@ msgstr "Min Opaklık"
 msgid "Max Zoom"
 msgstr "Maksimum Zum"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:231
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:234
 msgid "No relationships found."
 msgstr "İlişki bulunamadı."
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:269
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:272
 msgid "via {0}"
 msgstr "{0} ile"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:347
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
 msgid "This {0} is connected to:"
 msgstr "Bu {0} şuna bağlı:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "Object Detail"
 msgstr "Nesne detay"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:93
 msgid "object"
 msgstr "nesne"
 
@@ -7053,7 +7077,7 @@ msgstr "Hangi sütunları kullanmak istiyorsunuz?"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
 msgid "Pie"
-msgstr "Turta"
+msgstr "Pasta"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
 msgid "Dimension"
@@ -7099,11 +7123,11 @@ msgstr "Renk"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row Chart"
-msgstr "Satır Grafiği"
+msgstr "Çubuk Grafik"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
 msgid "row chart"
-msgstr "satır grafiği"
+msgstr "çubuk Grafik"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:381
 msgid "Separator style"
@@ -7127,7 +7151,7 @@ msgstr "Bir sayı ile çarpın"
 
 #: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
 msgid "Scatter"
-msgstr "dağatmak"
+msgstr "Dağıtma"
 
 #: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
 msgid "scatter plot"
@@ -7328,7 +7352,7 @@ msgstr "API son noktası mevcut değil."
 
 #: src/metabase/api/session.clj
 msgid "Password did not match stored password."
-msgstr "Şifre kayıdedilen şifreyle eşleşmedi."
+msgstr "Şifre kaydedilen şifreyle eşleşmedi."
 
 #: src/metabase/api/session.clj
 msgid "did not match stored password"
@@ -7360,7 +7384,7 @@ msgstr "E-posta teyit edilmedi."
 
 #: src/metabase/api/session.clj
 msgid "You''ll need an administrator to create a Metabase account before you can use Google to log in."
-msgstr "Giriş yapmak için Google'ı kullanabilmeniz için önce bir Metatabanı hesabı oluşturmak üzere bir yöneticiye ihtiyacınız olacak."
+msgstr "Giriş yapmak için Google'ı kullanabilmeniz için önce bir Metabase hesabı oluşturmak üzere bir yöneticiye ihtiyacınız olacak."
 
 #: src/metabase/api/session.clj
 msgid "Successfully authenticated Google Auth token for: {0} {1}"
@@ -7428,9 +7452,9 @@ msgstr "{0} de çok fazla kayıtlı soru var mı? Bunları yönetmek ve bağlam 
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:149 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
 msgid "Metabase"
-msgstr "Metatabanı"
+msgstr "Metabase"
 
 #: src/metabase/api/setup.clj
 msgid "Create metrics"
@@ -7511,7 +7535,7 @@ msgstr "Yılın haftası"
 
 #: src/metabase/api/table.clj
 msgid "Month of Year"
-msgstr "Yilin ayı"
+msgstr "Yılın ayı"
 
 #: src/metabase/api/table.clj
 msgid "Quarter of Year"
@@ -7787,7 +7811,7 @@ msgstr "% S ayrıştırılırken hata oluştu: n% s"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "No user found with email address ''{0}''. "
-msgstr "Hiçbir kullanıcı e-posta adresiyle bulunamadı '' {0} ''."
+msgstr "E-posta adresine ait kullanıcı bulunamadı '' {0} ''."
 
 #: src/metabase/cmd/reset_password.clj
 msgid "Please check the spelling and try again."
@@ -7807,19 +7831,19 @@ msgstr "Başarısız [[[{0}]]]"
 
 #: src/metabase/core.clj
 msgid "Please use the following URL to setup your Metabase installation:"
-msgstr "Metatabanı yüklemenizi ayarlamak için lütfen aşağıdaki URL'yi kullanın:"
+msgstr "Metabase yüklemenizi ayarlamak için lütfen aşağıdaki URL'yi kullanın:"
 
 #: src/metabase/core.clj
 msgid "Metabase Shutting Down ..."
-msgstr "Metatabanı Kapanıyor ..."
+msgstr "Metabase Kapanıyor ..."
 
 #: src/metabase/core.clj
 msgid "Metabase Shutdown COMPLETE"
-msgstr "Metatabanı Kapatma TAMAMLANDI"
+msgstr "Metabase Kapatma TAMAMLANDI"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase version {0} ..."
-msgstr "Metatabanı sürümü {0} başlatılıyor ..."
+msgstr "Metabase sürümü {0} başlatılıyor ..."
 
 #: src/metabase/core.clj
 msgid "System timezone is ''{0}'' ..."
@@ -7828,7 +7852,7 @@ msgstr "Sistem saat dilimi '' {0} '' ..."
 #. startup database.  validates connection & runs any necessary migrations
 #: src/metabase/core.clj
 msgid "Setting up and migrating Metabase DB. Please sit tight, this may take a minute..."
-msgstr "Metatabanı DB'yi kurma ve taşıma. Lütfen bekleyin, Bu bir dakika sürebilir .."
+msgstr "Metabase DB'yi kurma ve taşıma. Lütfen bekleyin, Bu bir dakika sürebilir .."
 
 #: src/metabase/core.clj
 msgid "Looks like this is a new installation ... preparing setup wizard"
@@ -7836,7 +7860,7 @@ msgstr "Görünüşe göre bu yeni bir kurulum ... kurulum sihirbazını hazırl
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization COMPLETE"
-msgstr "Metatabanı Başlatma İşlemi COMPLETE"
+msgstr "Metabase Başlatma İşlemi COMPLETE"
 
 #: src/metabase/server.clj
 msgid "Launching Embedded Jetty Webserver with config:"
@@ -7848,11 +7872,11 @@ msgstr "Gömülü Jetty Web Sunucusunu Kapatma"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase in STANDALONE mode"
-msgstr "STANDALONE modunda Metatabanını başlatma"
+msgstr "STANDALONE modunda Metabase başlatma"
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization FAILED"
-msgstr "Metatabanı Başlatma Başarısız"
+msgstr "Metabase Başlatma Başarısız"
 
 #: src/metabase/db/liquibase.clj
 msgid "Database has migration lock; cannot run migrations."
@@ -8013,7 +8037,7 @@ msgstr "Metabase.driver başarıyla kaydedildi. JDBC ile SabitHiveDriver"
 #. TODO - smtp-port should be switched to type :integer
 #: src/metabase/email.clj
 msgid "Email address you want to use as the sender of Metabase."
-msgstr "Metatabanı göndereni olarak kullanmak istediğiniz e-posta adresi."
+msgstr "Metabase göndereni olarak kullanmak istediğiniz e-posta adresi."
 
 #: src/metabase/email.clj
 msgid "The address of the SMTP server that handles your emails."
@@ -8106,7 +8130,7 @@ msgstr "Gruplar için arama tabanı, LDAP dizininiz bir '' memberOf '' yerleşim
 #. Should be in the form: {"cn=Some Group,dc=...": [1, 2, 3]} where keys are LDAP groups and values are lists of MB groups IDs
 #: src/metabase/integrations/ldap.clj
 msgid "JSON containing LDAP to Metabase group mappings."
-msgstr "Metatabanı grup eşlemelerine LDAP içeren JSON."
+msgstr "Metabase grup eşlemelerine LDAP içeren JSON."
 
 #. Define a setting which captures our Slack api token
 #: src/metabase/integrations/slack.clj
@@ -8322,7 +8346,7 @@ msgstr "{0} Alanı için FieldValues saklanıyor ..."
 
 #: src/metabase/models/humanization.clj
 msgid "Metabase can attempt to transform your table and field names into more sensible, human-readable versions, e.g. \"somehorriblename\" becomes \"Some Horrible Name\"."
-msgstr "Metatabanı, tablo ve alan adlarınızı daha duyarlı olan insan tarafından okunabilir versiyonlara getirmeye deneyecektir. \"bazıkorkunçisimler\", \"Bazı Korkunç İsimler\" olur."
+msgstr "Metabase, tablo ve alan adlarınızı daha duyarlı olan insan tarafından okunabilir versiyonlara getirmeye deneyecektir. \"bazıkorkunçisimler\", \"Bazı Korkunç İsimler\" olur."
 
 #: src/metabase/models/humanization.clj
 msgid "This doesn’t work all that well if the names are in a language other than English, however."
@@ -8468,11 +8492,11 @@ msgstr "{0} eklentisi yükleniyor ... ␣"
 
 #: src/metabase/plugins.clj
 msgid "It looks like you have some external dependencies in your Metabase plugins directory."
-msgstr "Metatabanı eklentileri dizininizde bazı dış bağımlılıklarınız var gibi görünüyor."
+msgstr "Metabase eklentileri dizininizde bazı dış bağımlılıklarınız var gibi görünüyor."
 
 #: src/metabase/plugins.clj
 msgid "With Java 9 or higher, Metabase cannot automatically add them to your classpath."
-msgstr "Java 9 veya üstü ile, Metatabanı bunları otomatik olarak sınıf yolunuza ekleyemez."
+msgstr "Java 9 veya üstü ile, Metabase bunları otomatik olarak sınıf yolunuza ekleyemez."
 
 #: src/metabase/plugins.clj
 msgid "Instead, you should include them at launch with the -cp option. For example:"
@@ -8492,19 +8516,19 @@ msgstr "Metabase'in yeni sürümlerinin ne zaman kullanılabilir olduğunu belir
 
 #: src/metabase/public_settings.clj
 msgid "Information about available versions of Metabase."
-msgstr "Metatabanı'nın kullanılabilir sürümleri hakkında bilgi."
+msgstr "Metabase kullanılabilir sürümleri hakkında bilgi."
 
 #: src/metabase/public_settings.clj
 msgid "The name used for this instance of Metabase."
-msgstr "Metatabanı'nın bu örneği için kullanılan ad."
+msgstr "Metabase bu örneği için kullanılan ad."
 
 #: src/metabase/public_settings.clj
 msgid "The base URL of this Metabase instance, e.g. \"http://metabase.my-company.com\"."
-msgstr "Bu Metatabanı örneğinin temel URL'si, ör. \"http://metabase.my-company.com\"."
+msgstr "Bu Metabase örneğinin temel URL'si, ör. \"http://metabase.my-company.com\"."
 
 #: src/metabase/public_settings.clj
 msgid "The default language for this Metabase instance."
-msgstr "Bu Metatabanı örneğinin varsayılan dili."
+msgstr "Bu Metabase örneğinin varsayılan dili."
 
 #: src/metabase/public_settings.clj
 msgid "This only applies to emails, Pulses, etc. Users'' browsers will specify the language used in the user interface."
@@ -8516,7 +8540,7 @@ msgstr "Kullanıcıların bir sorunla karşılaşmaları halinde e-posta adresin
 
 #: src/metabase/public_settings.clj
 msgid "Enable the collection of anonymous usage data in order to help Metabase improve."
-msgstr "Metatabanı geliştirmeye yardımcı olmak için anonim kullanım verilerinin toplanmasını etkinleştirin."
+msgstr "Metabase geliştirmeye yardımcı olmak için anonim kullanım verilerinin toplanmasını etkinleştirin."
 
 #: src/metabase/public_settings.clj
 msgid "The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox."
@@ -8548,7 +8572,7 @@ msgstr "Önbelleğe alınmış sorgu sonuçlarını saklamak için mutlak maksim
 
 #: src/metabase/public_settings.clj
 msgid "Metabase will cache all saved questions with an average query execution time longer than this many seconds:"
-msgstr "Metatabanı, kaydedilen tüm soruları, bu birkaç saniyeden daha uzun bir ortalama sorgu yürütme süresiyle önbelleğe alır:"
+msgstr "Metabase, kaydedilen tüm soruları, bu birkaç saniyeden daha uzun bir ortalama sorgu yürütme süresiyle önbelleğe alır:"
 
 #: src/metabase/public_settings.clj
 msgid "To determine how long each saved question''s cached result should stick around, we take the query''s average execution time and multiply that by whatever you input here."
@@ -8761,7 +8785,7 @@ msgstr "İş zaten var:"
 #. the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
 #: src/metabase/util.clj
 msgid "Loading Metabase..."
-msgstr "Metatabanı yükleniyor ..."
+msgstr "Metabase yükleniyor ..."
 
 #: src/metabase/util/date.clj
 msgid "Possible timezone conflict found on database {0}."
@@ -8785,11 +8809,11 @@ msgstr "MB_ŞİFRELEME_GİZLİ_ANAHTARI en az 16 karakter olmalıdır."
 
 #: src/metabase/util/encryption.clj
 msgid "Saved credentials encryption is ENABLED for this Metabase instance."
-msgstr "Kayıtlı kimlik bilgileri şifreleme, bu Metatabanı örneği için YETKİLİDİR."
+msgstr "Kayıtlı kimlik bilgileri şifreleme, bu Metabase örneği için YETKİLİDİR."
 
 #: src/metabase/util/encryption.clj
 msgid "Saved credentials encryption is DISABLED for this Metabase instance."
-msgstr "Kayıtlı kimlik bilgileri şifreleme, bu Metatabanı örneği için DEVRE DIŞI."
+msgstr "Kayıtlı kimlik bilgileri şifreleme, bu Metabase örneği için DEVRE DIŞI."
 
 #: src/metabase/util/encryption.clj
 msgid "nFor more information, see"
@@ -8947,19 +8971,19 @@ msgstr "Bu koleksiyonu ve içeriğini düzenleyebilir"
 msgid "Can view items in this collection"
 msgstr "Bu koleksiyondaki öğeleri görebilir"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:767
+#: frontend/src/metabase/admin/permissions/selectors.js:765
 msgid "Collection Access"
 msgstr "Koleksiyon Erişimi"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:841
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Bu grup, bu koleksiyonun en az bir alt koleksiyonunu görüntüleme iznine sahiptir."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:848
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Bu grubun bu koleksiyonun en az bir alt koleksiyonunu düzenleme izni var."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:861
+#: frontend/src/metabase/admin/permissions/selectors.js:859
 msgid "View sub-collections"
 msgstr "Alt koleksiyonları görüntüle"
 
@@ -8967,7 +8991,7 @@ msgstr "Alt koleksiyonları görüntüle"
 msgid "Remember Me"
 msgstr "Beni hatırla"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:63
+#: frontend/src/metabase/components/BrowseApp.jsx:73
 msgid "X-ray this schema"
 msgstr "Bu şema X-ışını"
 
@@ -9028,15 +9052,15 @@ msgstr "Metabase aramanız için herhangi bir sonuç bulamadı."
 msgid "No metrics"
 msgstr "Metrik yok"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:31
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:41
 msgid "Aggregations"
 msgstr "Toplamlar"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:32
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:42
 msgid "Operators"
 msgstr "Operatörler"
 
-#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:30
+#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:35
 msgid "Custom fields"
 msgstr "Özel Alanlar"
 
@@ -9202,7 +9226,7 @@ msgstr "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
 msgid "toucan_sightings"
 msgstr "toucan_sightings"
 
-#: src/metabase/driver/sparksql.clj
+#: src/metabase/models/collection.clj
 msgid "default"
 msgstr "varsayılan"
 
@@ -9230,10 +9254,10 @@ msgstr "N/A"
 msgid "Windows domain"
 msgstr "Windows alanı"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:539
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:545
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:554
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:560
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:528
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:534
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:543
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
 msgstr "Etiketler"
 
@@ -9251,7 +9275,7 @@ msgstr "Tüm Kullanıcılar"
 
 #: frontend/src/metabase/lib/groups.js:5
 msgid "Administrators"
-msgstr "Yönetici"
+msgstr "Yöneticiler"
 
 #: frontend/src/metabase/lib/groups.js:6
 msgid "MetaBot"
@@ -9268,9 +9292,9 @@ msgstr "Paylaşım"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:286
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:294
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:302
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:319
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:324
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
@@ -9285,19 +9309,18 @@ msgstr "Paylaşım"
 msgid "Display"
 msgstr "Göster"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:461
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:476
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:502
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:532
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:402
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:465
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:483
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:521
 msgid "Axes"
 msgstr "Eksen"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:212
-#: frontend/src/metabase/admin/settings/selectors.js:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:219
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:62
 msgid "Formatting"
@@ -9331,7 +9354,7 @@ msgstr "X-ışını"
 msgid "Compare to the rest"
 msgstr "Diğerleriyle karşılaştır"
 
-#: frontend/src/metabase/entities/databases/forms.js:16
+#: frontend/src/metabase/entities/databases/forms.js:18
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Java Sanal Makine (JVM) zaman dilimini kullanın"
 
@@ -9360,24 +9383,24 @@ msgstr "JVM Zaman Dilimini Kullan"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Veri içinde gezebilmeniz için tabloları ve kolonları analiz ediyoruz."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
 msgid "Tip: "
 msgstr "İpucu:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:237
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
 msgstr "Para birimi seçin"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:300
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
 msgid "Field Type"
 msgstr "Alan Tipi"
 
-#: frontend/src/metabase/admin/routes.jsx:113
+#: frontend/src/metabase/admin/routes.jsx:118
 #: frontend/src/metabase/nav/containers/Navbar.jsx:267
 msgid "Troubleshooting"
 msgstr "Sorun Giderme"
 
-#: frontend/src/metabase/admin/settings/selectors.js:103
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Enable X-ray features"
 msgstr "X-Ray özelliklerini açın"
 
@@ -9422,7 +9445,7 @@ msgstr "Süre (ms)"
 msgid "Currency"
 msgstr "Para Birimi"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
 msgstr "Kullanıcı veya kanal seçin"
 
@@ -9570,7 +9593,7 @@ msgstr "Çizgi stili"
 msgid "Show dots on lines"
 msgstr "Çizgleride nokta göster"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:348
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
@@ -9584,7 +9607,7 @@ msgstr "Hangi eksen?"
 msgid "Line + Bar"
 msgstr "Çizgi + Çubuk"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
 msgid "line and bar chart"
 msgstr "çizgi ve çubuk çzigesi"
 
@@ -11031,7 +11054,7 @@ msgstr "Bu metrik'in, farklı sayılar içinde nasıl dağıtılması"
 msgid "Sessions by page where the session began"
 msgstr "Sayfaya göre oturumun başladığı yerdeki oturumlar"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:503
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -11237,7 +11260,7 @@ msgstr "Geri bildiriminizi bekliyoruz."
 
 #: src/metabase/email/messages.clj
 msgid "It looks like Metabase wasn’t quite a match for you."
-msgstr "Metatabanı senin için tam bir eşleşme değildi."
+msgstr "Metabase senin için tam bir eşleşme değildi."
 
 #: src/metabase/email/messages.clj
 msgid "Would you mind taking a fast 5 question survey to help the Metabase team understand why and make things better in the future?"
@@ -11257,7 +11280,7 @@ msgstr "{0} bir Metabase hesabı oluşturdu"
 
 #: src/metabase/email/messages.clj
 msgid "{0} accepted their Metabase invite"
-msgstr "{0} Metatabanı davetlerini kabul etti"
+msgstr "{0} Metabase davetlerini kabul etti"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Password Reset Request"
@@ -11265,11 +11288,11 @@ msgstr "[Metabase] Şifre Sıfırlama İsteği"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Notification"
-msgstr "[Metatabanı] Bildirimi"
+msgstr "[Metabase] Bildirimi"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Help make Metabase better."
-msgstr "[Metatabanı] Metatabanını daha iyi hale getirmeye yardımcı olun."
+msgstr "[Metabase] Metabase daha iyi hale getirmeye yardımcı olun."
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Tell us how things are going."
@@ -11400,7 +11423,7 @@ msgstr "Bu ögeyi kopyala"
 msgid "Archive this item"
 msgstr "Bu ögeyi arşivle"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:331
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:325
 msgid "Duplicate dashboard"
 msgstr "Bu panoyu kopyala"
 
@@ -11505,7 +11528,7 @@ msgid_plural "Quarters of year"
 msgstr[0] "Yılın çeyreği"
 msgstr[1] "Yılın çeyrekleri"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
@@ -11521,8 +11544,8 @@ msgstr "[Q]Q"
 msgid "This"
 msgstr "Bu"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:97
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:137
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:136
 msgid "Invalid"
 msgstr "Geçersiz"
 
@@ -12285,6 +12308,7 @@ msgstr "Sizin en son {0} kartınız:"
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
 msgstr "Lütfen biraz daha kesin olabilir misiniz, ya da bir ID kullanabilir misiniz? İsimler ile eşleşen şu kartları buldum:"
 
+#: src/metabase/driver/common/parameters/values.clj
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
 msgstr "Kart {0} bulunamadı."
@@ -12393,11 +12417,11 @@ msgstr "Yanlış talimat"
 msgid "Archive this?"
 msgstr "Arşiv"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:243
+#: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
 msgstr "Veri hakkında daha fazla"
 
-#: frontend/src/metabase/entities/databases/forms.js:20
+#: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
 msgstr "Bağlanırken DNS SRV kullan"
 
@@ -12409,7 +12433,7 @@ msgstr "Bu seçeneğin kullanılması, sağlanan ana makinenin bir FQDN olmasın
 "bir Atlas kümesine bağlaniyorsa, bu seçeneği etkinleştirmeniz gerekebilir. Bunun ne anlama geldiğini bilmiyorsanız,\n"
 "bunu devre dışı bırakın."
 
-#: frontend/src/metabase/entities/databases/forms.js:204
+#: frontend/src/metabase/entities/databases/forms.js:273
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Basit filteleme işlemleri yaparken sörfü sonuçlarını hemen göster "
 
@@ -12433,11 +12457,11 @@ msgstr "Tüm sonuçlar "
 msgid "Our Analytics"
 msgstr "Analizler"
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:513
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
 msgstr "Bir kolona ait dip toplam (ör: toplam sipariş tutarı ) "
 
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
 msgstr "Toplam kayıt sayısı (ör : toplam sipariş sayısı)"
 
@@ -12447,7 +12471,7 @@ msgstr "Toplam kayıt sayısı (ör : toplam sipariş sayısı)"
 msgid "Filter"
 msgstr "Filtre"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:50
 msgid "record"
 msgid_plural "records"
 msgstr[0] "Kayıt "
@@ -12461,27 +12485,27 @@ msgstr "Verileri incele"
 msgid "Write SQL"
 msgstr "SQL yaz"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:83
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
 msgstr "Basit soru"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:84
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:87
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
 msgstr "Bir veri kümesi seçerek filtrele ya da görselleştir"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:95
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:98
 msgid "Custom question"
 msgstr "Özel soru"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:96
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:99
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Verileri birleştirmek, özel sütunlar oluşturmak, matematiksel işlemler yapmak ve daha fazlası için gelişmiş not defteri düzenleyicisini kullanın."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Basic Metrics"
 msgstr "Basit Metrikler"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:322
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
 msgid "Custom…"
 msgstr "Özel..."
 
@@ -12550,15 +12574,15 @@ msgstr "Gruplamak istediğiniz kolonu seçiniz"
 msgid "Pick your starting data"
 msgstr "başlangıç verinizi seçiniz "
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select None"
 msgstr "Seçileni temizle"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select All"
 msgstr "Hepsini seç "
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:151
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:152
 msgid "Pick a table..."
 msgstr "Bir tablo seçiniz "
 
@@ -12681,17 +12705,17 @@ msgstr "Metrik ekle"
 #: frontend/src/metabase/lib/core.js:137 frontend/src/metabase/lib/core.js:142
 #: frontend/src/metabase/lib/core.js:147 frontend/src/metabase/lib/core.js:152
 #: frontend/src/metabase/lib/core.js:157 frontend/src/metabase/lib/core.js:162
-#: frontend/src/metabase/user/components/UserSettings.jsx:63
+#: frontend/src/metabase/user/components/UserSettings.jsx:64
 msgid "Profile"
 msgstr "Profil"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:560
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "Genellikle hızlıdır ama şu an biraz sürecek gibi duruyor."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
 msgid "Combo"
-msgstr "Açılır kutu"
+msgstr "Birleşik"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
 msgid "Row"
@@ -12705,11 +12729,11 @@ msgstr "Trend"
 msgid "Boolean"
 msgstr "Doğru/Yanlış "
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:62
 msgid "Unknown Segment"
 msgstr "Bilinmeyen Segment"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:73
 msgid "Unknown Filter"
 msgstr "Bilinmeyen Filtre"
 
@@ -12839,6 +12863,7 @@ msgstr "Yeni oluşturulan sınıf yükleyiciyi paylaşılan bağlam sınıf yük
 msgid "Failed to copy file"
 msgstr "Dosya kopyalanamadı"
 
+#. check that the URL is valid
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
 msgstr "Hatalı URL: {0}"
@@ -12933,7 +12958,7 @@ msgstr "Ortalama"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Sum of {0}"
-msgstr "Toplam"
+msgstr "Toplam {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "SD of {0}"
@@ -13113,9 +13138,9 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Eklemek istediğiniz sütunları seçin"
 
-#: frontend/src/metabase/entities/databases/forms.js:205
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
-msgstr "Bu açıkken, kullanıcılar bir tabloyu veya grafiği görüntülerken Özetle ve Filtrele düğmeleriyle basit keşifler yaptığında Metatabanı otomatik olarak sorguları çalıştırır. Bu veritabanını sorgulamak yavaşsa bunu kapatabilirsiniz. Bu ayar detaylandırma veya SQL sorgularını etkilemez."
+msgstr "Bu açıkken, kullanıcılar bir tabloyu veya grafiği görüntülerken Özetle ve Filtrele düğmeleriyle basit keşifler yaptığında Metabase otomatik olarak sorguları çalıştırır. Bu veritabanını sorgulamak yavaşsa bunu kapatabilirsiniz. Bu ayar detaylandırma veya SQL sorgularını etkilemez."
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
 msgid "Change join type"
@@ -13151,7 +13176,7 @@ msgstr "Sorgu için beklenen sütunlar belirlenirken hata oluştu"
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "Beklenmeyen hata, catch-exceptions katmanlarını kullanarak çözebilirsiniz."
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:125
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
 msgid "Diagnostic Info"
 msgstr "Teşhis Bilgisi"
 
@@ -13175,11 +13200,11 @@ msgstr "Google ile oturum açılırken bir sorun oluştu. Lütfen bir yöneticiy
 msgid "Sign in with email"
 msgstr "E-posta ile oturum açın"
 
-#: frontend/src/metabase/entities/databases/forms.js:21
+#: frontend/src/metabase/entities/databases/forms.js:23
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "Bu seçeneğin kullanılması, sağlanan ana makinenin bir FQDN olmasını gerektirir. Bir Atlas kümesine bağlanıyorsanız, bu seçeneği etkinleştirmeniz gerekebilir. Bunun ne anlama geldiğini bilmiyorsanız, devre dışı bırakın."
 
-#: frontend/src/metabase/entities/databases/forms.js:213
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Varsayılan olarak, Metabase sistemi yormadan saatlik senkronizasyonlar yapar ve alan değerlerinin günlük olarak yoğun bir şekilde taranmasını sağlar. Büyük bir veritabanınız varsa, bunu açmanızı ve alan değeri taramalarının ne zaman ve ne sıklıkta gerçekleştiğini gözden geçirmenizi öneririz."
 
@@ -13247,11 +13272,11 @@ msgstr "Dahil etme"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "Bu alan, GUI arabirimleriyle oluşturulan sorularda görünmez veya seçilemez. Yine de SQL / yerel sorgularda erişilebilir."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:512
 msgid "Cumulative sum"
 msgstr "Kümülatif toplam"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Standard deviation"
 msgstr "Standart sapma"
 
@@ -13263,23 +13288,23 @@ msgstr "en az {0} karakter uzunluğunda olmalı"
 msgid "Must be at least {0} characters long"
 msgstr "En az {0} karakter uzunluğunda olmalı"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:389
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:82
 msgid "Name (required)"
 msgstr "İsim (gerekli)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:556
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
 msgid "Run selected text"
 msgstr "Seçili metni çalıştır"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:557
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
 msgid "Run query"
 msgstr "Sorguyu çalıştır"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(⌘ + enter)"
 msgstr "(⌘ + enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + enter)"
 
@@ -13291,7 +13316,7 @@ msgstr "Sonuçlarınızın nerede görüneceği burada"
 msgid "You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question."
 msgstr "Kaydet'i tıklayıp orijinal soruyu değiştirmeyi seçmedikçe kaydedilmiş bir soruda kalıcı değişiklikler yapmayacaksınız."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:199
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:200
 msgid "There aren't any filter widgets for this type of field yet."
 msgstr "Bu alan türü için henüz herhangi bir filtre aracı yok."
 
@@ -13327,19 +13352,19 @@ msgstr "Hedef çizgisi"
 msgid "Trend line"
 msgstr "Trend çizgisi"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:320
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:317
 msgid "Show values on data points"
 msgstr "Veri noktalarındaki değerleri göster"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:334
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:325
 msgid "Values to show"
 msgstr "Gösterilecek değerler"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:342
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:332
 msgid "As many as can fit nicely"
 msgstr "Güzelce sığabilecek kadar çok"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:343
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
 msgid "All"
 msgstr "Tümü"
 
@@ -13631,31 +13656,31 @@ msgstr "Sayılar"
 msgid "No mappable groups"
 msgstr "Eşlenebilir grup yok"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:107
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
 msgstr "Metabase Belgeleri"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
 msgstr "Bir sorun giderme kılavuzu içerir"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:112
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
 msgid "Post on the Metabase support forum"
 msgstr "Metabase destek forumunda yayınlayın"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:114
 msgid "A community forum for all things Metabase"
 msgstr "Metabase için her şey için bir topluluk forumu"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:117
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
 msgid "File a bug report"
 msgstr "Hata raporu gönderme"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:119
 msgid "Create a GitHub issue (includes the diagnostic info below)"
 msgstr "GitHub sorunu oluşturun (aşağıdaki teşhis bilgilerini içerir)"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:127
 msgid "Please include these details in support requests. Thank you!"
 msgstr "Lütfen bu ayrıntıları destek taleplerine ekleyin. Teşekkürler!"
 
@@ -13683,54 +13708,56 @@ msgstr "Eşleşen sonuç bulunamadı"
 msgid "Submit"
 msgstr "Gönder"
 
-#: frontend/src/metabase/entities/databases/forms.js:13
+#: frontend/src/metabase/entities/databases/forms.js:15
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host. This option also provides an extra layer of security when a VPN is not available. Enabling this is usually slower than a direct connection."
 msgstr "Bazı veritabanı kurulumlarına yalnızca bir SSH kalesi ana bilgisayarı üzerinden bağlanarak erişilebilir. Bu seçenek ayrıca bir VPN kullanılamadığında fazladan bir güvenlik katmanı sağlar. Bunun etkinleştirilmesi genellikle doğrudan bağlantıdan daha yavaştır."
 
-#: frontend/src/metabase/entities/databases/forms.js:17
+#: frontend/src/metabase/entities/databases/forms.js:19
 msgid "We suggest you leave this off unless you're doing manual timezone casting in many or most of your queries with this data."
 msgstr "Bu verilerle sorgularınızın çoğunda veya çoğunda manuel saat dilimi yayını yapmadığınız sürece bunu bırakmanızı öneririz."
 
-#: frontend/src/metabase/entities/databases/forms.js:93
+#: frontend/src/metabase/entities/databases/forms.js:128
 msgid "{0} to get an auth code."
 msgstr "{0} bir kimlik doğrulama kodu almak için."
 
-#: frontend/src/metabase/entities/databases/forms.js:101
+#: frontend/src/metabase/entities/databases/forms.js:136
+#: src/metabase/models/collection.clj
 msgid "or"
 msgstr "veya"
 
-#: frontend/src/metabase/entities/databases/forms.js:159
-#: frontend/src/metabase/entities/databases/forms.js:197
-#: frontend/src/metabase/entities/users/forms.js:44
+#: frontend/src/metabase/entities/databases/forms.js:39
+#: frontend/src/metabase/entities/databases/forms.js:226
+#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "zorunlu"
 
-#: frontend/src/metabase/entities/databases/forms.js:188
+#: frontend/src/metabase/entities/databases/forms.js:257
 msgid "Database type"
 msgstr "Veritabanı türü"
 
-#: frontend/src/metabase/entities/databases/forms.js:222
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Bu, bu veritabanının şemasındaki güncellemeleri kontrol eden hafif bir işlemdir. Çoğu durumda, bu seti saatlik olarak senkronize etmek için iyi durumda olmalısınız."
 
-#: frontend/src/metabase/entities/databases/forms.js:230
+#: frontend/src/metabase/entities/databases/forms.js:299
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
-msgstr "Metatabanı, gösterge tablolarında ve sorulardaki onay kutusu filtrelerini etkinleştirmek için bu veritabanındaki her alanda bulunan değerleri tarayabilir. Bu, özellikle çok büyük bir veritabanınız varsa, kaynak yoğun bir süreç olabilir."
+msgstr "Metabase, gösterge tablolarında ve sorulardaki onay kutusu filtrelerini etkinleştirmek için bu veritabanındaki her alanda bulunan değerleri tarayabilir. Bu, özellikle çok büyük bir veritabanınız varsa, kaynak yoğun bir süreç olabilir."
 
 #: frontend/src/metabase/entities/questions.js:95
 msgid "Collection"
 msgstr "Koleksiyon"
 
-#: frontend/src/metabase/entities/users/forms.js:40
+#: frontend/src/metabase/entities/users/forms.js:55
 msgid "Confirm your password"
 msgstr "Parolayı onayla"
 
-#: frontend/src/metabase/entities/users/forms.js:45
+#: frontend/src/metabase/entities/users/forms.js:60
 msgid "passwords do not match"
 msgstr "parolalar uyuşmuyor"
 
-#: frontend/src/metabase/entities/users/forms.js:71
+#: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
 msgstr "Mükemmelliğin Bölümü"
 
@@ -13770,328 +13797,324 @@ msgid "Returns the average of the values in the column."
 msgstr "Sütundaki değerlerin ortalamasını döndürür."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:18
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
 msgid "The column whose values to average."
 msgstr "Değerleri ortalama olan sütun."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "start"
 msgstr "Başlat"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "end"
 msgstr "Bitir"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
 msgid "Checks a date or numeric column's values to see if they're within the specified range."
 msgstr "Belirtilen aralıkta olup olmadıklarını görmek için bir tarih veya sayısal sütunun değerlerini kontrol eder."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
 msgstr "Değerlendirme"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:24
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:98
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
 msgid "condition"
 msgstr "durum"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
 msgid "output"
 msgstr "çıktı"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Bir vaka listesini test eder ve başka bir şey karşılanmazsa isteğe bağlı bir varsayılan değerle ilk gerçek vakanın karşılık gelen değerini döndürür."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
 msgid "Weight"
 msgstr "Ağırlık"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
 msgid "Large"
 msgstr "Büyük"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
 msgid "Medium"
 msgstr "Orta"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
 msgid "Small"
 msgstr "Küçük"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
 msgid "Something that should evaluate to true or false."
 msgstr "Doğru veya yanlış olarak değerlendirilmesi gereken bir şey."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:54
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "Önceki koşul doğruysa döndürülecek değer."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:62
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "value1"
 msgstr "değer1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:74
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
 msgid "value2"
 msgstr "değer2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Her bir bağımsız değişkendeki değerlere sırayla bakar ve her satır için ilk boş olmayan değeri döndürür."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:56
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
 msgid "Comments"
 msgstr "Yorumlar"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
 msgid "Notes"
 msgstr "Notlar"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
 msgid "No comments"
 msgstr "Yorum yok"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
 msgid "A column or value."
 msgstr "Bir sütun veya değer."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:65
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:77
 msgid "If value1 is empty, value2 gets returned if it's not empty, and so on."
 msgstr "Değer1 boşsa, değer2 boş değilse döndürülür ve bu böyle devam eder."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 msgid "Combines two or more strings of text together."
 msgstr "İki veya daha fazla metin dizesini bir araya getirir."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
 msgid "Last Name"
 msgstr "Soyadı"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 msgid "First Name"
 msgstr "Adı"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
 msgstr "Bunun sonuna değer2 eklenecektir."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
 msgstr "Bu değer1 sonuna eklenir."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
 msgid "string1"
 msgstr "dize1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
 msgid "string2"
 msgstr "dize2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:80
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Dize1 içinde dize2 içerip içermediğini kontrol eder."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:284
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
 msgid "Status"
 msgstr "Durum"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 msgid "Pass"
 msgstr "Geçiş"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
 msgstr "Bu dizenin içeriği kontrol edilecektir."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
 msgid "The string of text to look for."
 msgstr "Aranacak metin dizesi."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:90
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:116
 msgid "Returns the count of rows in the source data."
 msgstr "Kaynak verilerdeki satır sayısını döndürür."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Only counts rows where the condition is true."
 msgstr "Yalnızca koşulun doğru olduğu satırları sayar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:97
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:261
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
 msgid "Subtotal"
 msgstr "Ara toplam"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
 msgid "The additive total of rows across a breakout."
 msgstr "Bir aradaki satırların toplamı."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:110
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
 msgid "The rolling sum of a column across a breakout."
 msgstr "Bir koparma boyunca bir sütunun yuvarlanan toplamı."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:113
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:268
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
 msgstr "Toplanacak sütun."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
 msgid "The number of distinct values in this column."
 msgstr "Bu sütundaki farklı değerlerin sayısı."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "The column whose distinct values to count."
 msgstr "Farklı değerleri sayılacak sütun."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:128
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:145
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:153
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:201
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:274
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
 msgid "text"
 msgstr "metin"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:130
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:223
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
 msgid "comparison"
 msgstr "karşılaştırma"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Metnin sonu karşılaştırma metniyle eşleşirse true değerini döndürür."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "Appetite"
 msgstr "İştah"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "hungry"
 msgstr "Aç"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 msgid "A column or string of text to check."
 msgstr "Kontrol edilecek bir sütun veya metin dizesi."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
 msgid "The string of text that the original text should end with."
 msgstr "Orijinal metnin bitmesi gereken metin dizesi."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 msgid "regular_expression"
 msgstr "regular_expression"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:136
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Normal ifadeye göre eşleşen alt dizeleri ayıklar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:137
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
 msgid "Address"
 msgstr "Adres"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 msgid "The column or string of text to search though."
 msgstr "Yine de aranacak metin sütunu veya dizesi."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
 msgid "The regular expression to match."
 msgstr "Eşleşecek normal ifade."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the string of text in all lowercase."
 msgstr "Tüm küçük harfli metin dizesini döndürür."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:149
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to lowercase."
 msgstr "Küçük harfe dönüştürülecek değerlere sahip sütun."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:154
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 msgid "Removes leading whitespace from a string of text."
 msgstr "Bir metin dizesinden önde gelen boşlukları kaldırır."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:157
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column with values you want to trim."
 msgstr "Kırpmak istediğiniz değerlerin bulunduğu sütun."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "Returns the largest value found in the column."
 msgstr "Sütunda bulunan en büyük değeri döndürür."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
 msgid "Age"
 msgstr "Yaş"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:165
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
 msgid "The numeric column whose maximum you want to find."
 msgstr "Maksimum değerini bulmak istediğiniz sayısal sütun."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:170
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "Returns the smallest value found in the column."
 msgstr "Sütunda bulunan en küçük değeri döndürür."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
 msgid "Salary"
 msgstr "Maaş"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:173
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
 msgid "The numeric column whose minimum you want to find."
 msgstr "Minimum değerini bulmak istediğiniz sayısal sütun."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:181
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:242
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
 msgid "position"
 msgstr "durum"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:194
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
 msgid "length"
 msgstr "uzunluk"
 
@@ -14100,7 +14123,7 @@ msgstr "uzunluk"
 msgid "new_text"
 msgstr "yeni_metin"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:187
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
 msgid "Replaces a part of the input text with new text."
 msgstr "Giriş metninin bir kısmını yeni metinle değiştirir."
 
@@ -14112,7 +14135,7 @@ msgstr "Order ID"
 msgid "Updated Part of ID"
 msgstr "Güncellenmiş Kimlik Bölümü"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
 msgid "The text that will be modified."
 msgstr "Değiştirilecek metin."
 
@@ -14128,87 +14151,87 @@ msgstr "Değiştirilecek karakter sayısı."
 msgid "The text to use in the replacement."
 msgstr "Değiştirme işleminde kullanılacak metin."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Bir metin dizesinden sonraki boşlukları kaldırır."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:210
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Verideki koşulla eşleşen satırların yüzdesini ondalık sayı olarak döndürür."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:218
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Metnin başı karşılaştırma metniyle eşleşirse true değerini döndürür."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Course Name"
 msgstr "Ders Adı"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Computer Science"
 msgstr "Bilgisayar Bilimi"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
 msgid "The string of text that the original text should start with."
 msgstr "Orijinal metnin başlaması gereken metin dizesi."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:229
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
 msgid "Calculates the standard deviation of the column."
 msgstr "Sütunun standart sapmasını hesaplar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:230
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
 msgid "Population"
 msgstr "Nüfus"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
 msgid "A numeric column."
 msgstr "Sayısal bir sütun."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
 msgid "Returns a portion of the supplied text."
 msgstr "Sağlanan metnin bir bölümünü döndürür."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:241
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:313
 msgid "The text to return a portion of."
 msgstr "Bir kısmını döndürecek metin."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
 msgid "The position to start copying characters."
 msgstr "Karakterleri kopyalamaya başlama konumu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:245
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
 msgid "The number of characters to return."
 msgstr "Döndürülecek karakter sayısı."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
 msgid "Adds up all the values of the column."
 msgstr "Sütunun tüm değerlerini toplar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:253
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
 msgid "The numeric column to sum."
 msgstr "Toplanacak sayısal sütun."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Satırların koşulla eşleştiği bir sütundaki değerleri toplar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
 msgid "Order Status"
 msgstr "Sipariş durumu"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
 msgid "Valid"
 msgstr "Geçerli"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Bir metin dizesinden öndeki ve sondaki boşlukları kaldırır."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
 msgid "Returns the string of text in all upper case."
 msgstr "Tüm büyük harfli metin dizesini döndürür."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
 msgid "The column with values to convert to upper case."
 msgstr "Büyük harfe dönüştürülecek değerlere sahip sütun."
 
@@ -14270,39 +14293,39 @@ msgstr "Metabase kullandığınız için teşekkürler!"
 msgid "Powered by {0}"
 msgstr "{0} tarafından desteklenmektedir"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:191
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
 msgid "To:"
 msgstr "Kime:"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:40
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
 msgstr "Bu soru farklı bir veritabanına dayandığından kullanılamaz."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:44
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:43
 msgid "Couldn't find a saved question with that ID number."
 msgstr "Bu kimlik numarasına sahip kaydedilmiş bir soru bulunamadı."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:55
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:54
 msgid "Pick a saved question"
 msgstr "Kaydedilmiş bir soru seçin"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:57
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:56
 msgid "Pick a different question"
 msgstr "Farklı bir soru seçin"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:62
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:61
 msgid "Loading…"
 msgstr "Yükleniyor..."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:79
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:78
 msgid "Question #…"
 msgstr "Soru #…"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:81
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
 msgstr "Soru # {0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:115
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
 msgstr "Son düzenleme {0}"
 
@@ -14314,11 +14337,11 @@ msgstr "{0} bu sorgu şablonunda \"değişken_adı\" adlı bir değişken oluşt
 msgid "Giving a variable the \"Field Filter\" type allows you to link questions to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "Bir değişkene \"Alan Filtresi\" türü vermek, soruları gösterge tablosu filtre araçlarına bağlamanızı veya SQL sorunuzda daha fazla filtre araç türü kullanmanızı sağlar. Alan Filtresi değişkeni, mevcut sütunlara filtre eklerken GUI sorgu oluşturucu tarafından oluşturulana benzer SQL ekler."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:131
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
 msgstr "Değişken ismi"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:217
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:218
 msgid "Filter widget label"
 msgstr "Araç etiketini filtrele"
 
@@ -14350,11 +14373,11 @@ msgstr "Sütun başlığında"
 msgid "In every table cell"
 msgstr "Her tablo hücresinde"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:351
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:341
 msgid "Value formatting"
 msgstr "Değer biçimlendirme"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:361
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
 msgid "Full"
 msgstr "Tam"
 
@@ -14475,7 +14498,7 @@ msgstr "UYARI: Metabase, MySQL {0} / MariaDB {1} ve üzerini resmi olarak destek
 
 #: src/metabase/driver/mysql.clj
 msgid "All Metabase features may not work properly when using an unsupported version."
-msgstr "Desteklenmeyen bir sürüm kullanılırken tüm Metatabanı özellikleri düzgün çalışmayabilir."
+msgstr "Desteklenmeyen bir sürüm kullanılırken tüm Metabase özellikleri düzgün çalışmayabilir."
 
 #: src/metabase/driver/sql/parameters/substitute.clj
 msgid "Unable to substitute parameters"
@@ -14682,3 +14705,482 @@ msgstr "Sütun için içgörü oluşturulurken hata oluştu:"
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandonment email!"
 msgstr "Vazgeçme e-postası gönderme!"
+
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
+msgstr "Adlandırılmış bir metrik seçeneği eklemek için kaydedilmiş metrikler oluşturabilirsiniz. Kaydedilen metrikler, birleştirme türünü, birleştirilmiş alanı ve isteğe bağlı olarak eklediğiniz filtreleri içerir. Örnek olarak, bunu bir Siparişler tablosu için \"Ortalama Fiyat\" hesaplamanın resmi yolu gibi bir şey oluşturmak için kullanabilirsiniz."
+
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:105
+msgid "Select and add filters to create your new segment."
+msgstr "Yeni segmentinizi oluşturmak için filtreleri seçin ve ekleyin."
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+msgid "Alphabetical"
+msgstr "Alfabetik"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+msgid "Smart"
+msgstr "Akıllı"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+msgid "Column order: {0}"
+msgstr "Kolon sırası : {0}"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
+msgid "Unhide all"
+msgstr "Hepsini göster"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:204
+msgid "Hide all"
+msgstr "Hepsini gizle"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:206
+msgid "Unhide"
+msgstr "Göster"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:22
+msgid "New metric"
+msgstr "Yeni metrik"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:45
+msgid "Create metrics to add them to the Summarize dropdown in the query builder"
+msgstr "Sorgu oluşturucudaki Özetle açılır listesine eklemek için metrikler oluşturun"
+
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:22
+msgid "New segment"
+msgstr "Yeni segment"
+
+#: frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx:71
+msgid "Filter by table"
+msgstr "Tabloya göre filtrele"
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:64
+msgid "Checking HTTPS..."
+msgstr "HTTPS kontrol ediliyor..."
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:66
+msgid "It looks like HTTPS is not properly configured"
+msgstr "HTTPS düzgün konfigure edilmemiş gözüküyor"
+
+#: frontend/src/metabase/admin/settings/selectors.js:57
+msgid "Redirect to HTTPS"
+msgstr "HTTPS yönlendiriliyor"
+
+#: frontend/src/metabase/admin/settings/selectors.js:219
+msgid "Localization"
+msgstr "Yerelleştirme"
+
+#: frontend/src/metabase/admin/settings/selectors.js:222
+msgid "Instance language"
+msgstr "Örnek dil"
+
+#: frontend/src/metabase/admin/settings/selectors.js:237
+msgid "Localization options"
+msgstr "Yerelleştirme seçenekleri"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:51
+msgid "This database doesn't have any tables."
+msgstr "Veritabanı nda hiç tablo yok"
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
+msgid "This field only accepts a single value because it's used in a SQL query."
+msgstr "Bir SQL sorgusunda kullanıldığı için bu alan yalnızca tek bir değeri kabul eder"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:17
+msgid "Service Accounts"
+msgstr "Servis Hesapları"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:26
+msgid "Metabase connects to Big Query via {0}."
+msgstr "Metatabanı, {0} üzerinden Big Data 'ya bağlanır."
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:29
+msgid "Continue using an OAuth application to connect"
+msgstr "Bağlanmak için bir OAuth uygulaması kullanmaya devam et"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:43
+msgid "We recommend switching to use {0} instead of an OAuth application to connect to BigQuery"
+msgstr "BigQuery'ye bağlanmak için OAuth uygulaması yerine {0} kullanmaya geçmenizi öneririz"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:48
+msgid "Connect to a Service Account instead"
+msgstr "Bunun yerine bir Hizmet Hesabına bağlanın"
+
+#: frontend/src/metabase/entities/databases/forms.js:44
+msgid "invalid JSON"
+msgstr "geçersiz JSON"
+
+#: frontend/src/metabase/entities/databases/forms.js:50
+msgid "SSH private key"
+msgstr "SSH özel anahtarı"
+
+#: frontend/src/metabase/entities/databases/forms.js:51
+msgid "Paste the contents of your ssh private key here"
+msgstr "Ssh özel anahtarınızın içeriğini buraya yapıştırın"
+
+#: frontend/src/metabase/entities/databases/forms.js:55
+msgid "Passphrase for the SSH private key"
+msgstr "SSH özel anahtarının parolası"
+
+#: frontend/src/metabase/entities/databases/forms.js:58
+msgid "SSH Authentication"
+msgstr "SSH Kimlik Doğrulaması"
+
+#: frontend/src/metabase/entities/databases/forms.js:60
+msgid "SSH Key"
+msgstr "SSH Anahtarı"
+
+#: frontend/src/metabase/entities/databases/forms.js:65
+msgid "Server SSL certificate chain"
+msgstr "Sunucu SSL sertifika zinciri"
+
+#: frontend/src/metabase/entities/databases/forms.js:66
+msgid "Paste the contents of the server's SSL certificate chain here"
+msgstr "Sunucunun SSL sertifika zincirinin içeriğini buraya yapıştırın"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:11
+msgid "Paste a connection string"
+msgstr "Bir bağlantı dizesi yapıştırma"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:12
+msgid "Fill out individual fields"
+msgstr "Tek tek alanları doldurun"
+
+#: frontend/src/metabase/entities/snippets.js:14
+msgid "Enter some SQL here so you can reuse it later"
+msgstr "Daha sonra tekrar kullanabilmek için buraya biraz SQL girin"
+
+#: frontend/src/metabase/entities/snippets.js:24
+msgid "Give your snippet a name"
+msgstr "Snippet'inize bir ad verin"
+
+#: frontend/src/metabase/entities/snippets.js:25
+msgid "Current Customers"
+msgstr "Mevcut Müşteriler"
+
+#: frontend/src/metabase/entities/snippets.js:30
+msgid "Add a description"
+msgstr "Bir açıklama ekle"
+
+#: frontend/src/metabase/entities/users/forms.js:37
+msgid "Use site default"
+msgstr "Site varsayılanını kullan"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+msgid "find"
+msgstr "bul"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+msgid "replace"
+msgstr "değiştir"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+msgid "The text to find."
+msgstr "Bulunacak metin."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "The text to use as the replacement."
+msgstr "Değiştirme olarak kullanılacak metin."
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+msgid "Editing {0}"
+msgstr "{0} düzenleniyor"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+msgid "Create your new snippet"
+msgstr "Yeni snippet'inizi oluşturun"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+msgid "Archived snippets"
+msgstr "Arşivlenmiş snippet'ler"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+msgid "Snippets are reusable bits of SQL"
+msgstr "Parçacıklar, SQL'in yeniden kullanılabilir parçalarıdır"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+msgid "Create a snippet"
+msgstr "Parçacık oluşturma"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+msgid "Snippets"
+msgstr "Parçacıklar"
+
+#: frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx:15
+msgid "SQL Snippets"
+msgstr "SQL Parçacıkları"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:38
+msgid "Your language is set to {0}"
+msgstr "Diliniz {0} olarak ayarlandı"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:50
+msgid "What's your preferred language?"
+msgstr "Tercih ettiğiniz dil nedir?"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:54
+msgid "This language will be used throughout Metabase and will be the default for new users."
+msgstr "Bu dil Metatabanı genelinde kullanılacak ve yeni kullanıcılar için varsayılan dil olacaktır."
+
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:159
+msgid "We filtered out {0} row(s) containing null values."
+msgstr "Boş değerler içeren {0} satır filtreledik."
+
+#: frontend/src/metabase/visualizations/lib/settings/series.js:133
+msgid "Show values for this series"
+msgstr "Bu serinin değerlerini göster"
+
+#: src/metabase/api/card.clj
+msgid "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
+msgstr "Question''ın ortalama yürütme süresi {0}; {1} '' sihirli '' TTL kullanarak"
+
+#: src/metabase/api/native_query_snippet.clj
+msgid "A snippet with that name already exists. Please pick a different name."
+msgstr "Bu ada sahip bir pasaj zaten var. Lütfen farklı bir ad seçin."
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Metric]"
+msgstr "[Bilinmeyen Metrik]"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Segment]"
+msgstr "[Bilinmeyen Segment]"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error writing error to output stream"
+msgstr "Çıkış akışına yazma hatası"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Caught unexpected Exception in streaming response body"
+msgstr "Akış yanıt gövdesinde beklenmedik özel durum yakalandı"
+
+#: src/metabase/async/streaming_response.clj
+msgid "bound-fn caught unexpected Exception"
+msgstr "bound-fn beklenmedik özel durum yakaladı"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error determining whether HTTP request was canceled"
+msgstr "HTTP isteğinin iptal edilip edilmediğini belirleme hatası"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Check cancelation status timed out after {0}"
+msgstr "{0} tarihinden sonra iptal durumunu kontrol etme zaman aşımına uğradı"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Unexpected exception in do-f-async"
+msgstr "Do-f-async'de beklenmeyen istisna"
+
+#: src/metabase/async/streaming_response.clj src/metabase/server.clj
+msgid "Unexpected exception writing error response"
+msgstr "Beklenmeyen özel durum yazma hatası yanıtı"
+
+#: src/metabase/driver/common.clj
+msgid "Server certificate not trusted - did you specify the correct SSL certificate chain?"
+msgstr "Sunucu sertifikası güvenilir değil - doğru SSL sertifika zincirini belirttiniz mi?"
+
+#: src/metabase/driver/common.clj
+msgid "Server appears to require SSL - please enable SSL above"
+msgstr "Sunucu SSL gerektiriyor gibi görünüyor - lütfen yukarıdaki SSL'yi etkinleştirin"
+
+#: src/metabase/driver/common.clj
+msgid "Username"
+msgstr "Kullanıcı adı"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Don''t know how to parse parameter of type {0}"
+msgstr "{0} türünde bir parametrenin nasıl ayrıştırılacağını bilmiyorum"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Invalid :card parameter: missing `:card-id`"
+msgstr "Geçersiz: kart parametresi: eksik `: kart kimliği '"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Unable to resolve Snippet: missing `:snippet-id`"
+msgstr "Snippet çözülemedi: eksik `: snippet-id`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Snippet {0} {1} not found."
+msgstr "Snippet {0} {1} bulunamadı."
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error determining value for parameter"
+msgstr "Parametre için değer belirlenirken hata oluştu"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error building query parameter map"
+msgstr "Sorgu parametre eşlemesi oluşturulurken hata oluştu"
+
+#: src/metabase/middleware/log.clj
+msgid "ASYNC"
+msgstr "ASYNC"
+
+#: src/metabase/middleware/log.clj
+msgid "{0} ({1} DB calls)"
+msgstr "{0} ({1} DB calls)"
+
+#: src/metabase/middleware/log.clj
+msgid "App DB connections: {0}/{1}"
+msgstr "App DB connections: {0}/{1}"
+
+#: src/metabase/middleware/log.clj
+msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
+msgstr "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} total active threads)"
+msgstr "({0} toplam aktif ileti dizisi)"
+
+#: src/metabase/middleware/log.clj
+msgid "Queries in flight: {0}"
+msgstr "Uçuşta sorgular: {0}"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} queued)"
+msgstr "({0} sıraya alındı)"
+
+#: src/metabase/models/collection.clj
+msgid "Collection must be in the same namespace as its parent"
+msgstr "Koleksiyon, üst öğesiyle aynı ad alanında olmalıdır"
+
+#: src/metabase/models/collection.clj
+msgid "Personal Collections must be in the default namespace"
+msgstr "Kişisel Koleksiyonlar varsayılan ad alanında olmalıdır"
+
+#: src/metabase/models/collection.clj
+msgid "You cannot move a Collection to a different namespace once it has been created."
+msgstr "Bir Koleksiyonu oluşturulduktan sonra farklı bir ad alanına taşıyamazsınız."
+
+#: src/metabase/models/collection.clj src/metabase/models/permissions.clj
+msgid "Collection does not exist."
+msgstr "Koleksiyon mevcut değil."
+
+#: src/metabase/models/collection.clj
+msgid "A {0} can only go in Collections in the {1} namespace."
+msgstr "Bir {0} yalnızca {1} ad alanındaki Koleksiyonlara gidebilir."
+
+#: src/metabase/models/database.clj
+msgid "Error sending database deletion notification"
+msgstr "Veritabanı silme bildirimi gönderilirken hata oluştu"
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "You cannot update the creator_id of a NativeQuerySnippet."
+msgstr "Bir NativeQuerySnippet'in creator_id değerini güncelleyemezsiniz."
+
+#: src/metabase/models/setting.clj
+msgid "Error fetching value of Setting"
+msgstr "Ayar değeri getirilirken hata oluştu"
+
+#: src/metabase/public_settings.clj
+msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
+msgstr "Metatabanı kullanıcı arayüzü, sistem e-postaları, bildirimleri ve uyarıları için kullanılması gereken dil."
+
+#: src/metabase/public_settings.clj
+msgid "This is also the default language for all users, which they can change from their own account settings."
+msgstr "Bu aynı zamanda tüm kullanıcılar için kendi hesap ayarlarından değiştirebilecekleri varsayılan dildir."
+
+#: src/metabase/public_settings.clj
+msgid "Invalid locale {0}"
+msgstr "Geçersiz yerel ayar {0}"
+
+#: src/metabase/public_settings.clj
+msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
+msgstr "Site URL'si HTTPS ise, tüm trafiği bir yönlendirme yoluyla HTTPS kullanmaya zorlayın"
+
+#: src/metabase/public_settings.clj
+msgid "Cannot redirect requests to HTTPS unless `site-url` is HTTPS."
+msgstr "`Site-url` HTTPS olmadığı sürece istekler HTTPS'ye yönlendirilemez."
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error registering fonts: Metabase will not be able to send Pulses."
+msgstr "Yazı tipleri kaydedilirken hata oluştu: Metabase, bildirim gönderemez."
+
+#: src/metabase/pulse/render/png.clj
+msgid "This is a known issue with certain JVMs. See {0} and for more details."
+msgstr "Bu belirli JVM'lerde bilinen bir sorundur. Daha fazla ayrıntı için {0} bölümüne bakın."
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error rendering Pulse"
+msgstr "Bildirim oluşturulurken hata meydana geldi"
+
+#: src/metabase/query_processor/context/default.clj
+msgid "Query timed out after {0}, raising timeout exception."
+msgstr "{0} 'dan sonra sorgu zaman aşımına uğradı, zaman aşımı istisnası artırıldı."
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "No fields found for table {0}."
+msgstr "{0} tablosu için alan bulunamadı."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Case"
+msgstr "Durum"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Variance of {0}"
+msgstr "{0} sapması"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Median of {0}"
+msgstr "{0} medyanı"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "{0}th percentile of {1}"
+msgstr "{1} {0}. Persentil"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Not caching results: results are larger than {0} KB"
+msgstr "Sonuçları önbelleğe almamak: sonuçlar {0} KB'den büyük"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Cannot cache results: expected byte array, got {0}"
+msgstr "Sonuçlar önbelleğe alınamıyor: beklenen bayt dizisi, {0} aldı"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Request is closed; no one to return cached results to"
+msgstr "İstek kapalı; önbelleğe alınan sonuçları geri döndürecek kimse yok"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Error attempting to fetch cached results for query with hash {0}"
+msgstr "Hash {0} içeren sorgu için önbelleğe alınmış sonuçlar getirilmeye çalışılırken hata oluştu"
+
+#: src/metabase/query_processor/middleware/cache_backend/db.clj
+msgid "Error preparing statement to fetch cached query results"
+msgstr "Önbelleğe alınmış sorgu sonuçlarını getirmek için ifade hazırlanırken hata oluştu"
+
+#: src/metabase/query_processor/middleware/catch_exceptions.clj
+msgid "Error processing query: {0}"
+msgstr "Sorgu işlenirken hata oluştu: {0}"
+
+#: src/metabase/server.clj
+msgid "Unexpected exception in endpoint"
+msgstr "Bitiş noktasında beklenmeyen istisna"
+
+#: src/metabase/server.clj
+msgid "Unexpected Exception in API request handler"
+msgstr "API istek işleyicisinde Beklenmeyen İstisna"
+
+#: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+msgid "Error reducing {0}"
+msgstr "{0} azaltılırken hata oluştu"
+
+#: src/metabase/sync/analyze/fingerprint/insights.clj
+msgid "Error generating timeseries insight keyed by: {0}"
+msgstr "Şu anahtar tarafından zamanlama bilgileri oluşturulurken hata oluştu: {0}"
+
+#: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
+msgstr "{0} veritabanı konumu '' {1} '' iken '' {2} '' olarak değiştirildi."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Unscheduling task for Database {0}: trigger: {1}"
+msgstr "{0} Veritabanı için planlanmamış görev: tetikleyici: {1}"
+
+#: src/metabase/util/schema.clj
+msgid "value must be a keyword or string."
+msgstr "değer bir anahtar kelime veya dize olmalıdır."
+
+#: src/metabase/util/schema.clj
+msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
+msgstr "Dize, geçerli iki harfli ISO dili veya dil-ülke kodu olmalıdır; 'en' veya 'en_US'."

--- a/locales/vi.po
+++ b/locales/vi.po
@@ -5,28 +5,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 "Project-Id-Version: Metabase\n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: vi\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:24
 msgid "Your database has been added!"
-msgstr "¡Tu base de datos ha sido añadida!"
+msgstr "Cơ sở dữ liệu đã được thêm!"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:28
 msgid "We took a look at your data, and we have some automated explorations that we can show you!"
-msgstr "Echamos un vistazo a tus datos y ¡tenemos algunas exploraciones automatizadas que podemos mostrarte!"
+msgstr "Chúng tôi đã xem dữ liệu của bạn và chúng tôi có một số khám phá tự động mà có thể chỉ cho bạn!"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:35
 msgid "I'm good thanks"
-msgstr "Está bien, gracias"
+msgstr "Tôi ổn, cảm ơn"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:42
 msgid "Explore this data"
-msgstr "Explora estos datos"
+msgstr "Khám phá dữ liệu này"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:42
 msgid "Select a database type"
-msgstr "Selecciona un tipo de base de datos"
+msgstr "Chọn kiểu cơ sở dữ liệu"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
@@ -43,100 +43,96 @@ msgstr "Selecciona un tipo de base de datos"
 #: frontend/src/metabase/reference/components/EditHeader.jsx:69
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:30
 msgid "Save"
-msgstr "Guardar"
+msgstr "Lưu"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:122
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
-msgstr "Para hacer algo de magia, Metabase necesita escanear la base de datos. Lo volveremos a hacer periódicamente para mantener actualizados los metadatos. Puedes controlar cuando se realizan los repasos periódicos a continuación."
+msgstr "Để thực hiện một số magic của nó, Metabase cần quét cơ sở dữ liệu của bạn. Chúng tôi cũng sẽ quét lại định kỳ để cập nhật siêu dữ liệu. Bạn có thể kiểm soát khi việc quét lại định kỳ xảy ra dưới đây"
 
 #: frontend/src/metabase/entities/databases/forms.js:290
 msgid "Database syncing"
-msgstr "Sincronizando base de datos"
+msgstr "Đang đồng bộ cơ sở dữ liệu"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:128
 msgid "This is a lightweight process that checks for\n"
 "updates to this database’s schema. In most cases, you should be fine leaving this\n"
 "set to sync hourly."
-msgstr "Este es un proceso rápido que busca \n"
-"actualizaciones al esquema de esta base de datos. En la mayoría de los casos, estará bien dejar esto\n"
-"configurado para sincronizar cada hora."
+msgstr "thiết lập đồng bộ hóa hàng giờ"
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:42
 #: frontend/src/metabase/admin/databases/components/widgets/MetadataSyncScheduleWidget.jsx:22
 msgid "Scan"
-msgstr "Explorar"
+msgstr "Quét"
 
 #: frontend/src/metabase/entities/databases/forms.js:297
 msgid "Scanning for Filter Values"
-msgstr "Buscando valores de filtrado"
+msgstr "Quét các giá trị lọc"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:153
 msgid "Metabase can scan the values present in each\n"
 "field in this database to enable checkbox filters in dashboards and questions. This\n"
 "can be a somewhat resource-intensive process, particularly if you have a very large\n"
 "database."
-msgstr "Metabase puede escanear los valores presentes en cada \n"
-"campo en esta base de datos para habilitar filtros de casilla de verificación en cuadros de mando y preguntas. Esto \n"
-"puede ser un proceso que consume muchos recursos, particularmente si tienes una \n"
-"base de datos grande."
+msgstr "Metabase có thể quét các giá trị hiện tại trong mỗi \n"
+"\" \"có thể là một quá trình tốn nhiều tài nguyên, đặc biệt nếu bạn có \\ n rất lớn\" \"cơ sở dữ liệ"
 
 #: frontend/src/metabase/entities/databases/forms.js:301
 msgid "When should Metabase automatically scan and cache field values?"
-msgstr "¿Cuándo debería Metabase escanear y almacenar automáticamente los valores de campo?"
+msgstr "Khi nào Metabase sẽ tự động quét và lưu các giá trị trường bộ đệm "
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:25
 msgid "Regularly, on a schedule"
-msgstr "Periódicamente, siguiendo un horario"
+msgstr "Thường xuyên, theo lịch trình"
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:50
 msgid "Only when adding a new filter widget"
-msgstr "Solo cuando se añade un nuevo elemento de filtro"
+msgstr "Chỉ khi thêm tiện ích bộ lọc mới"
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:54
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
-msgstr "Cuando un usuario añade un nuevo filtro o una pregunta SQL al Dashboard Metabase escaneará los campos asignados a ese filtro para mostrar la lista de valores seleccionables."
+msgstr "Khi người dùng thêm bộ lọc mới vào bảng điều khiển hoặc câu hỏi SQL, Metabase sẽ quét (các) trường được ánh xạ tới bộ lọc đó để hiển thị danh sách các giá trị có thể chọn."
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:62
 msgid "Never, I'll do this manually if I need to"
-msgstr "Nunca, lo haré manualmente si lo necesito"
+msgstr "Không bao giờ, tôi sẽ làm thủ công nếu cần thiết"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 msgid "Saving..."
-msgstr "Guardando..."
+msgstr "Đang lưu..."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
 msgid "Server error encountered"
-msgstr "Se ha encontrado un error en el servidor"
+msgstr "Máy chủ lỗi"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 msgid "Delete this database?"
-msgstr "¿Eliminar esta base de datos?"
+msgstr "Xoá cơ sở dữ liệu này?"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
-msgstr "Todas las preguntas, métricas y segmentos guardados que dependen de esta base de datosse perderán."
+msgstr "Tất cả các câu hỏi, số liệu và phân đoạn đã lưu dựa trên cơ sở dữ liệu này sẽ bị mất."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
-msgstr "Esta acción no se puede deshacer."
+msgstr "Hành động này không thể khôi phục"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
-msgstr "Si estás seguro, por favor teclea:"
+msgstr "Nếu chắc chắn, hãy gõ vào"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
-msgstr "ELIMINAR"
+msgstr "XOÁ"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
-msgstr "en esta casilla:"
+msgstr "trong hộp thoại này:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
@@ -172,14 +168,14 @@ msgstr "en esta casilla:"
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:328
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
-msgstr "Cancelar"
+msgstr "Huỷ"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
-msgstr "Eliminar"
+msgstr "Xoá"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
@@ -191,19 +187,19 @@ msgstr "Eliminar"
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
-msgstr "Bases de datos"
+msgstr "Các cơ sở dữ liệu"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:148
 msgid "Add Database"
-msgstr "Añadir base de datos"
+msgstr "Thêm cơ sở dữ liệu"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:73
 msgid "Connection"
-msgstr "Conexión"
+msgstr "Kết nối"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:77
 msgid "Scheduling"
-msgstr "Programación"
+msgstr "Lên lịch"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
@@ -214,17 +210,17 @@ msgstr "Programación"
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
-msgstr "Guardar cambios"
+msgstr "Lưu thay đổi"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:203
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
-msgstr "Acciones"
+msgstr "Các thao tác"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 msgid "Sync database schema now"
-msgstr "Sincronizar el esquema de la base de datos ahora"
+msgstr "Đồng bộ cấu trúc cơ sở dữ liệu ngay bây giờ"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:212
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
@@ -233,49 +229,49 @@ msgstr "Sincronizar el esquema de la base de datos ahora"
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:90
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:98
 msgid "Starting…"
-msgstr "Empezando…"
+msgstr "Đang bắt đầu..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:213
 msgid "Failed to sync"
-msgstr "No se ha podido sincronizar"
+msgstr "Đồng bộ thất bại"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:214
 msgid "Sync triggered!"
-msgstr "¡Sincronización iniciada!"
+msgstr "Đã kích hoạt đồng bộ!"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:223
 msgid "Re-scan field values now"
-msgstr "Vuelva a escanear los valores de campo ahora"
+msgstr "Quét lại các trường giá trị ngay bây giờ"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
-msgstr "No se ha podido iniciar la exploración"
+msgstr "Bắt đầu quét thất bại"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:92
 msgid "Scan triggered!"
-msgstr "¡Exploración iniciada!"
+msgstr "Đã kích hoạt quét"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:233
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
-msgstr "Zona Peligrosa"
+msgstr "Khu vực nguy hiểm"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Discard saved field values"
-msgstr "Descartar valores de campos guardados"
+msgstr "Huỷ những trường giá trị đã lưu"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:257
 msgid "Remove this database"
-msgstr "Eliminar esta base de datos"
+msgstr "Xoá cơ sở dữ liệu này"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
-msgstr "Añadir base de datos"
+msgstr "Thêm cơ sở dữ liệu"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:28
@@ -292,37 +288,36 @@ msgstr "Añadir base de datos"
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
-msgstr "Nombre"
+msgstr "Tên"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
-msgstr "Motor"
+msgstr "Động c"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
-msgstr "Eliminando..."
+msgstr "Đang xoá..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
-msgstr "Cargando..."
+msgstr "Đang tải..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
-msgstr "Recuperar la base de datos de prueba"
+msgstr "Khôi phục lại dữ liệu mẫu"
 
 #: frontend/src/metabase/admin/databases/database.js:167
 msgid "Couldn't connect to the database. Please check the connection details."
-msgstr "No se ha podido conectar a la base de datos. Por favor, comprueba los detalles de la conexión."
+msgstr "Không thể kết nối tới cơ sở dữ liệu. Xin hãy kiểm tra chi tiết kết nối"
 
 #: frontend/src/metabase/admin/databases/database.js:384
 msgid "Successfully created!"
-msgstr "¡Creado con éxito!"
+msgstr "Tạo thành công!"
 
 #: frontend/src/metabase/admin/databases/database.js:394
 msgid "Successfully saved!"
-msgstr "¡Guardado con éxito!"
+msgstr "Lưu thành công!"
 
-#. Editar
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
@@ -330,64 +325,64 @@ msgstr "¡Guardado con éxito!"
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
-msgstr "Editar"
+msgstr "Sửa"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:59
 msgid "Revision History"
-msgstr "Historial de Revisiones"
+msgstr "Lịch sử sửa đổi"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
-msgstr "¿Retirar este {0}?"
+msgstr "Không sử dụng {0} nữa"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
-msgstr "Las preguntas guardadas y otras cosas que dependen de este {0} continuarán funcionando pero este {1} ya no se podrá seleccionar desde el generador de consultas."
+msgstr "Các câu hỏi đã lưu và những thứ khác phụ thuộc vào {0} này sẽ tiếp tục hoạt động, nhưng {1} này sẽ không còn có thể được chọn từ trình tạo truy vấn."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
-msgstr "Si estás seguro de querer retirar este {0} escribe una explicación de por qué está siendo retirado:"
+msgstr "Nếu bạn chắc chắn muốn rút về {0} này, vui lòng viết một lời giải thích nhanh về lý do tại sao nó được rút về:"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
-msgstr "Esto se mostrará en el resumen de actividades y en un correo electrónico que se enviará a cualquier persona de tu equipo que haya creado algo que use este {0}."
+msgstr "Điều này sẽ hiển thị trong nguồn cấp dữ liệu hoạt động và trong email sẽ được gửi cho bất kỳ ai trong nhóm của bạn, người đã tạo ra thứ gì đó sử dụng {0} này"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
-msgstr "Retirar"
+msgstr "Thu hồi"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
-msgstr "Retirando…"
+msgstr "Đang thu hồi"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 #: frontend/src/metabase/components/form/CustomForm.jsx:188
 msgid "Failed"
-msgstr "Ha fallado"
+msgstr "Thất bại"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 #: frontend/src/metabase/components/form/CustomForm.jsx:189
 msgid "Success"
-msgstr "Éxito"
+msgstr "Thành công"
 
 #: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:185
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
-msgstr "Vista preliminar"
+msgstr "Xem trước"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:93
 msgid "No column description yet"
-msgstr "No hay una descripción de la columna"
+msgstr "Chưa có cột mô tả"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:126
 msgid "Select a field visibility"
-msgstr "Selecciona una visibilidad de campo"
+msgstr "Chọn một trường hiển thị"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:187
 msgid "No special type"
-msgstr "Sin tipo especial"
+msgstr "Không có kiểu đặc biệt"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
 #: frontend/src/metabase/lib/core.js:275
@@ -395,16 +390,16 @@ msgstr "Sin tipo especial"
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:37
 msgid "Other"
-msgstr "Otro"
+msgstr "Khác"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
-msgstr "Seleccione un tipo especial"
+msgstr "Chọn một kiểu đặc biệt"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:262
 #: frontend/src/metabase/reference/components/Field.jsx:99
 msgid "Select a target"
-msgstr "Seleccione un objetivo"
+msgstr "Chọn một mục tiêu"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
@@ -412,98 +407,93 @@ msgstr "Seleccione un objetivo"
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Columns"
-msgstr "Columnas"
+msgstr "Các cột"
 
-#. Campo
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
-msgstr "Campo"
+msgstr "Cột"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
 msgid "Visibility"
-msgstr "Visibilidad"
+msgstr "Hiển thị"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
 msgid "Type"
-msgstr "Tipo"
+msgstr "Kiểu"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
-msgstr "Base de datos actual:"
+msgstr "Cơ sở dữ liệu hiện tại:"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
 msgid "Show original schema"
-msgstr "Mostrar esquema original"
+msgstr "Đưa ra schema gốc"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
-msgstr "Tipo de dato"
+msgstr "Kiểu dữ liệu"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
-msgstr "Información adicional"
+msgstr "Thông tin thêm"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
-msgstr "Encontrar un esquema"
+msgstr "Tìm một schema"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
-msgstr[0] "Ver esquema"
-msgstr[1] "Ver esquemas"
+msgstr[0] "{0} Schema"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:99
 msgid "Why Hide?"
-msgstr "¿Por qué esconderlo?"
+msgstr "Tại sao ẩn ?"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:100
 msgid "Technical Data"
-msgstr "Datos Técnicos"
+msgstr "Dữ liệu kỹ thuật"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
-msgstr "Irrelevante"
+msgstr "Không liên quan / Tuần dương"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 msgid "Queryable"
-msgstr "Consultable"
+msgstr "Có thể truy vấn"
 
-#. Oculto
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:108
 msgid "Hidden"
-msgstr "Oculto"
+msgstr "Ẩn"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136
 msgid "No table description yet"
-msgstr "No hay una descripción de la tabla"
+msgstr "Bảng chưa có mô tả"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:124
 msgid "Metadata Strength"
-msgstr "Alcance Metadatos"
+msgstr "Sức mạnh siêu dữ liệu"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
-msgstr[0] "{0] Tabla Consultable"
-msgstr[1] "{0] Tablas consultables"
+msgstr[0] "{0} Bảng có thể truy vấn"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:91
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
-msgstr[0] "{0] Tabla Escondida"
-msgstr[1] "{0] Tablas escondidas"
+msgstr[0] "{0} Bảng ẩn"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:115
 msgid "Find a table"
-msgstr "Encontrar una tabla"
+msgstr "Tìm bảng"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:128
 msgid "Schemas"
-msgstr "Esquemas"
+msgstr "Các schema"
 
 #: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
@@ -514,21 +504,21 @@ msgstr "Esquemas"
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:62
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 msgid "Metrics"
-msgstr "Métricas"
+msgstr "Số liệu"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:27
 msgid "Add a Metric"
-msgstr "Añadir una métrica"
+msgstr "Thêm một số liệu"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
-msgstr "Definición"
+msgstr "Định nghĩa"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:51
 msgid "Create metrics to add them to the View dropdown in the query builder"
-msgstr "Crea métricas para añadirlas al menú Ver en el generador de consultas"
+msgstr "Tạo số liệu để thêm chúng vào danh sách thả xuống Chế độ xem trong trình tạo truy vấn"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
@@ -538,293 +528,293 @@ msgstr "Crea métricas para añadirlas al menú Ver en el generador de consultas
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:61
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
-msgstr "Segmentos"
+msgstr "Phân khúc"
 
 #: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:27
 msgid "Add a Segment"
-msgstr "Añadir un segmento"
+msgstr "Thêm một phân khúc"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:45
 msgid "Create segments to add them to the Filter dropdown in the query builder"
-msgstr "Crea segmentos para añadirlos al menú Filtro en el generador de consultas"
+msgstr "Tạo các phân đoạn để thêm chúng vào danh sách thả xuống Bộ lọc trong trình tạo truy vấn "
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:21
 msgid "created"
-msgstr "creado"
+msgstr "đã tạo"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "reverted to a previous version"
-msgstr "revertido a una versión anterior"
+msgstr "đã khôi phục về phiên bản trước"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:30
 msgid "edited the title"
-msgstr "editado el título"
+msgstr "đã sửa tiêu đề"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:32
 msgid "edited the description"
-msgstr "editado la descripción"
+msgstr "đã sửa mô tả"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:34
 msgid "edited the "
-msgstr "editado el"
+msgstr "sửa "
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "made some changes"
-msgstr "he hecho algunos cambios"
+msgstr "tạo một vài thay đổi"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
 #: frontend/src/metabase/home/components/Activity.jsx:83
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
-msgstr "Tu"
+msgstr "Bạn"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
-msgstr "Modelo de datos"
+msgstr "Dữ liệu mẫu"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:41
 msgid " History"
-msgstr "Historia"
+msgstr " Lịch sử"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
-msgstr "Historial de Revisiones para"
+msgstr "Lịch sử thay đổi cho"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
 msgid "{0} – Field Settings"
-msgstr "{0} – Configuración de campos"
+msgstr "{0} - Cài đặt trường"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
 msgid "Where this field will appear throughout Metabase"
-msgstr "Donde aparecerá este campo en Metabase"
+msgstr "Trường này sẽ xuất hiện trên khắp Metabase"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
 msgid "Filtering on this field"
-msgstr "Filtrando sobre este campo"
+msgstr "Lọc trên trường này"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
-msgstr "Cuando este campo se usa en un filtro, ¿qué valores debería aceptar?"
+msgstr "Khi trường này được sử dụng trong bộ lọc, mọi người nên sử dụng gì để nhập giá trị họ muốn lọc?"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
 msgid "No description for this field yet"
-msgstr "No hay descripción para este campo todavía"
+msgstr "Chưa có mô tả cho trường này"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
 msgid "Original value"
-msgstr "Valor original"
+msgstr "Giá trị gốc"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
 msgid "Mapped value"
-msgstr "Valor asignado"
+msgstr "Giá trị đã được ánh xạ"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
 msgid "Enter value"
-msgstr "Introduce un valor"
+msgstr "Nhập giá trị"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use original value"
-msgstr "Utiliza valor original"
+msgstr "Sử dụng giá trị gốc"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Use foreign key"
-msgstr "Utilizar clave foránea"
+msgstr "Sử dụng khoá ngoài"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 msgid "Custom mapping"
-msgstr "Mapeo personalizado"
+msgstr "Tuỳ chỉnh ánh xạ"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
 msgid "Unrecognized mapping type"
-msgstr "Tipo de mapeo no reconocido"
+msgstr "Không nhận diện được kiểu ảnh xạ"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
-msgstr "El campo actual no es una clave foránea o faltan los metadatos de clave foránea en la tabla de destino"
+msgstr "Trường hiện tại không phải khoá ngoài hoặc thiếu bảng đích của khoá ngoài"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
 msgid "The selected field isn't a foreign key"
-msgstr "El campo seleccionado no es una clave foránea"
+msgstr "Trường đã chọn không phải khoá ngoài"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
 msgid "Display values"
-msgstr "Valores mostrados"
+msgstr "Các giá trị hiển thị"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
-msgstr "Elige si quieres mostrar el valor original de la base de datos, o mostrar información asociada o personalizada."
+msgstr "Chọn hiển thị giá trị gốc từ cơ sở dữ liệu hoặc hiển thị trường này liên quan hoặc thông tin tùy chỉnh."
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
 msgid "Choose a field"
-msgstr "Elige un campo"
+msgstr "Chọn một trường"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
 msgid "Please select a column to use for display."
-msgstr "Selecciona una columna para mostrar."
+msgstr "Vui lòng chọn một cột để hiển thị."
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:771
 msgid "Tip:"
-msgstr "Consejo:"
+msgstr "Mẹo:"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
-msgstr "Es posible que quieras actualizar el nombre del campo para asegurarte de que todavía tenga sentidoen función de las opciones de asignación."
+msgstr "Bạn có thể muốn cập nhật tên trường để đảm bảo nó vẫn có ý nghĩa dựa trên các lựa chọn ánh xạ lại của bạn."
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
-msgstr "Valores de campo en caché"
+msgstr "Giá trị trường lưu trữ"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
-msgstr "Metabase puede escanear los valores de este campo para habilitar los filtros de casilla de verificación en cuadros de mando y preguntas."
+msgstr "Metabase có thể quét các giá trị cho trường này để bật các bộ lọc hộp kiểm trong bảng điều khiển và câu hỏi."
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:14
 msgid "Re-scan this field"
-msgstr "Vuelve a escanear este campo"
+msgstr "Quét lại trường này"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
-msgstr "Descartar valores de campo en caché"
+msgstr "Hủy giá trị trường được lưu trong bộ nhớ cache"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
-msgstr "Error al descartar valores"
+msgstr "Không thể loại bỏ các giá trị"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 msgid "Discard triggered!"
-msgstr "¡Limpieza iniciada!"
+msgstr "Hủy kích hoạt!"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
-msgstr "Selecciona cualquier tabla para ver su esquema y añadir o editar metadatos."
+msgstr "Chọn bất kỳ bảng nào để xem lược đồ của nó và thêm hoặc chỉnh sửa siêu dữ liệu."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
-msgstr "Nombre es obligatorio"
+msgstr "Tên là bắt buộc"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
-msgstr "Descripción es obligatorio"
+msgstr "Mô tả là bắt buộc"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
-msgstr "Mensaje de la revisión es obligatorio"
+msgstr "Thông điệp sửa đổi là bắt buộc"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
 msgid "Aggregation is required"
-msgstr "Agregación es obligatoria"
+msgstr "Tổng hợp là cần thiết"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Edit Your Metric"
-msgstr "Edita tu Métrica"
+msgstr "Chỉnh sửa số liệu của bạn"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Create Your Metric"
-msgstr "Crea tu Métrica"
+msgstr "Tạo số liệu của bạn"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "Make changes to your metric and leave an explanatory note."
-msgstr "Haz cambios en tu métrica y deja una nota explicativa."
+msgstr "Thay đổi số liệu của bạn và để lại lời giải thích"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:145
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
-msgstr "Puedes crear métricas y guardarlas como campo calculado en esta tabla.Las métricas guardadas incluyen el tipo de agregación, el campo agregado y, opcionalmente, cualquier filtro que añadas.Por ejemplo, puedes usar esto para definir la forma oficial de calcular el \"Precio promedio\" para una tabla de Pedidos."
+msgstr "Bạn có thể tạo số liệu đã lưu để thêm tùy chọn số liệu được đặt tên vào bảng này. Số liệu đã lưu bao gồm loại tổng hợp, trường tổng hợp và tùy chọn bất kỳ bộ lọc nào bạn thêm. Ví dụ: bạn có thể sử dụng điều này để tạo một cái gì đó giống như cách tính chính thức \\ \"Giá trung bình \" cho bảng Đơn hàng."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
 msgid "Result: "
-msgstr "Resultado:"
+msgstr "Kết quả: "
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
 msgid "Name Your Metric"
-msgstr "Ponle nombre a tu Métrica"
+msgstr "Đặt tên số liệu của bạn"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Give your metric a name to help others find it."
-msgstr "Dale un nombre a tu métrica para ayudar a otros a encontrarla."
+msgstr "Đặt tên số liệu của bạn để giúp người khác tìm thấy nó"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
-msgstr "Algo descriptivo pero no demasiado largo"
+msgstr "Một vài mô tả không quá dài"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
 msgid "Describe Your Metric"
-msgstr "Describe tu Métrica"
+msgstr "Mô tả số liệu của bạn"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Give your metric a description to help others understand what it's about."
-msgstr "Dale una descripción a tu métrica para ayudar a otros a entender de qué se trata."
+msgstr "Cho số liệu của bạn một lời mô tả để giúp người khác hiểu nó là gì"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
 msgid "This is a good place to be more specific about less obvious metric rules"
-msgstr "Este es un buen lugar para ser más específico sobre las reglas métricas menos obvias"
+msgstr "Đây là một nơi tốt để cụ thể hơn về các quy tắc số liệu ít rõ ràng hơn"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
-msgstr "Motivo de los cambios"
+msgstr "Lý do thay đổi"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
-msgstr "Deja una nota para explicar qué cambios has hecho y por qué fueron necesarios."
+msgstr "Để lại một ghi chú để giải thích những thay đổi bạn đã thực hiện và tại sao chúng được yêu cầu."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
-msgstr "Esto aparecerá en el historial de revisiones de esta métrica para ayudar a todos a recordar por qué se realizó el cambio"
+msgstr "Điều này sẽ hiển thị trong lịch sử sửa đổi cho số liệu này để giúp mọi người nhớ tại sao mọi thứ thay đổi"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
-msgstr "Se requiere al menos un filtro"
+msgstr "Bắt buộc có ít nhất một giá trị lọc"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
-msgstr "Edita tu Segmento"
+msgstr "Chỉnh sửa phân khúc của bạn"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
-msgstr "Crea tu Segmento"
+msgstr "Tạo phân khúc của bạn"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
-msgstr "Haz cambios en tu segmento y deja una nota explicativa."
+msgstr "Thay đổi phân khúc của bạn và để lại một ghi chú giải thích."
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
-msgstr "Selecciona y añade filtros para crear un nuevo segmento para la tabla {0}"
+msgstr "Chọn và thêm các bộ lọc để tạo phân khúc mới của bạn cho bảng {0}"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
-msgstr "Ponle nombre a tu segmento"
+msgstr "Đặt tên phân khúc của bạn"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
-msgstr "Dale un nombre a tu segmento para ayudar a otros a encontrarla."
+msgstr "Đặt tên cho phân khúc của bạn để giúp người khác tìm thấy nó"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
-msgstr "Describe tu Segmento"
+msgstr "Mô tả phân khúc của bạn"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 msgid "Give your segment a description to help others understand what it's about."
-msgstr "Dale una descripción a tu segmento para ayudar a otros a entender de qué se trata."
+msgstr "Cho phân khúc của bạn một lời mô tả để giúp người khác hiểu nó là gì"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
-msgstr "Este es un buen lugar para ser más específico sobre las reglas de segmentación menos obvias"
+msgstr "Đây là một nơi tốt để cụ thể hơn về các quy tắc phân khúc ít rõ ràng hơn"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
-msgstr "Esto aparecerá en el historial de revisiones de este segmento para ayudar a todos a recordar por qué se realizó el cambio"
+msgstr "Điều này sẽ hiển thị trong lịch sử sửa đổi cho phân khúc này để giúp mọi người nhớ tại sao mọi thứ thay đổi"
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
 #: frontend/src/metabase/admin/routes.jsx:137
@@ -834,66 +824,66 @@ msgstr "Esto aparecerá en el historial de revisiones de este segmento para ayud
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
-msgstr "Configuración"
+msgstr "Cài đặt"
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
-msgstr "Metabase puede leer los valores en esta tabla para habilitar filtros de casillas de verificación en cuadros de mandos y preguntas."
+msgstr "Metabase có thể quét các giá trị trong bảng này để bật các bộ lọc hộp kiểm trong bảng điều khiển và câu hỏi."
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
-msgstr "Re-Leer esta tabla"
+msgstr "Quét lại bảng này"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 msgid "Add"
-msgstr "Añadir"
+msgstr "Thêm"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:103
 msgid "Not a valid formatted email address"
-msgstr "Formato de Email incorrecto"
+msgstr "Không phải là một địa chỉ email được định dạng hợp lệ"
 
 #: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
-msgstr "Nombre"
+msgstr "Tên"
 
 #: frontend/src/metabase/entities/users/forms.js:20
 msgid "Last name"
-msgstr "Apellidos"
+msgstr "Họ"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
-msgstr "Dirección de Email"
+msgstr "Địa chỉ email"
 
 #: frontend/src/metabase/admin/people/components/EditUserForm.jsx:202
 msgid "Permission Groups"
-msgstr "Grupos de Permisos"
+msgstr "Nhóm quyền"
 
 #: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
 msgid "Make this user an admin"
-msgstr "Convertir a este usuario en administrador"
+msgstr "Cho người dùng này làm quản trị viên"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
-msgstr "Todos los usuarios pertenecen al grupo {0} no se pueden eliminar. Establecer permisos para este grupo es una excelente manera de asegurarte qué podrán ver los nuevos usuarios de Metabase."
+msgstr "Tất cả người dùng thuộc nhóm {0} và không thể xóa khỏi nhóm. Đặt quyền cho nhóm này là một cách tuyệt vời để đảm bảo bạn biết những gì người dùng Metabase mới sẽ có thể nhìn thấy."
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
-msgstr "Este es un grupo especial cuyos miembros pueden ver todo en la instancia de Metabase, y quienes pueden acceder y realizar cambios en la configuración en el Panel de administración, ¡incluyendo el cambio de permisos!Así que añade personas a este grupo con cuidado."
+msgstr "Đây là một nhóm đặc biệt mà các thành viên có thể nhìn thấy mọi thứ trong ví dụ Metabase và những người có thể truy cập và thay đổi các cài đặt trong Bảng quản trị, bao gồm thay đổi quyền! Vì vậy, thêm người vào nhóm này một cách cẩn thận."
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
-msgstr "Para asegurarte de no quedar sin acceso a Metabase, siempre debe haber al menos un usuario en este grupo."
+msgstr "Để đảm bảo bạn không bị khóa khỏi Metabase, luôn phải có ít nhất một người dùng trong nhóm này."
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
-msgstr "Miembros"
+msgstr "Các thành viên"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
@@ -906,63 +896,62 @@ msgstr "Email"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
-msgstr "Un grupo solo vale lo que valen sus miembros."
+msgstr "Một nhóm chỉ tốt như các thành viên của nó."
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
 #: frontend/src/metabase/admin/routes.jsx:55
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Admin"
-msgstr "Admin"
+msgstr "Quản trị viên"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:288
 msgid "and"
-msgstr "y"
+msgstr "và"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:19
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:31
 msgid "{0} other group"
 msgid_plural "{0} other groups"
-msgstr[0] "{0} grupo más"
-msgstr[1] "{0} grupos más"
+msgstr[0] "{0} các nhóm khác"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:37
 msgid "Default"
-msgstr "Por defecto"
+msgstr "Mặc định"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:39
 msgid "Something like \"Marketing\""
-msgstr "Algo como \"Marketing\""
+msgstr "\"Tiếp thị\" chẳng hạn"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:58
 msgid "Remove this group?"
-msgstr "¿Eliminar este grupo?"
+msgstr "Xoá nhóm này?"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:60
 msgid "Are you sure? All members of this group will lose any permissions settings they have based on this group.\n"
 "This can't be undone."
-msgstr "¿Estás seguro? Todos los miembros de este grupo perderán las configuraciones de permisos que tengan basadas en este grupo.\n"
-"Esto no puede deshacerse."
+msgstr "Bạn chắc chứ? Tất cả thành viên trong nhóm sẽ mất các quyền có được nhờ nhóm này.\n"
+"Hành động này không thể khôi phục."
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
-msgstr "Sí"
+msgstr "Vâng"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
-msgstr "No"
+msgstr "Không"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:92
 msgid "Edit Name"
-msgstr "Editar Nombre"
+msgstr "Sửa tên"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:95
 msgid "Remove Group"
-msgstr "Borrar Grupo"
+msgstr "Xoá nhóm"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:46
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:138
@@ -976,11 +965,11 @@ msgstr "Borrar Grupo"
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:334
 msgid "Done"
-msgstr "Hecho"
+msgstr "Xong"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Group name"
-msgstr "Nombre Grupo"
+msgstr "Tên nhóm"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
@@ -989,383 +978,382 @@ msgstr "Nombre Grupo"
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
-msgstr "Grupos"
+msgstr "Các nhóm"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:364
 msgid "Create a group"
-msgstr "Crear un grupo"
+msgstr "Tạo một nhóm"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:370
 msgid "You can use groups to control your users' access to your data. Put users in groups and then go to the Permissions section to control each group's access. The Administrators and All Users groups are special default groups that can't be removed."
-msgstr "Puedes usar grupos para controlar el acceso de tus usuarios a los datos. Coloca a los usuarios en grupos y después, ves a la sección de Permisos para controlar el acceso de cada grupo. Los grupos Administradores y All Users son grupos predeterminados especiales que no se pueden eliminar."
+msgstr "Bạn có thể sử dụng các nhóm để kiểm soát quyền truy cập của người dùng vào dữ liệu của bạn. Đặt người dùng theo nhóm và sau đó chuyển đến phần Quyền để kiểm soát quyền truy cập của từng nhóm. Các nhóm Quản trị viên và Tất cả Người dùng là các nhóm mặc định đặc biệt không thể xóa được."
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:79
 msgid "Edit Details"
-msgstr "Editar Detalles"
+msgstr "Sửa chi tiết"
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:85
 msgid "Re-send Invite"
-msgstr "Reenviar Invitación"
+msgstr "Gửi lại thư mời"
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:90
 msgid "Reset Password"
-msgstr "Restablecer la contraseña"
+msgstr "Đặt lại mật khẩu"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:40
 msgid "Deactivate"
-msgstr "Desactivar"
+msgstr "Huỷ kích hoạt"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:21
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:93
 #: frontend/src/metabase/nav/containers/Navbar.jsx:235
 msgid "People"
-msgstr "Personas"
+msgstr "Mọi người"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:192
 msgid "Who do you want to add?"
-msgstr "¿A quien quieres añadir?"
+msgstr "Bạn muốn thêm ai?"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:207
 msgid "Edit {0}'s details"
-msgstr "Edita los detalles de {0}"
+msgstr "Sửa thông tin chi tiết của {0}"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:40
 msgid "{0} has been added"
-msgstr "Se ha añadido {0}"
+msgstr "{0} đã được thêm vào"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:224
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:262
 msgid "Add another person"
-msgstr "Añade otra persona"
+msgstr "Thêm người khác"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:231
 msgid "We couldn’t send them an email invitation,\n"
 "so make sure to tell them to log in using {0}\n"
 "and this password we’ve generated for them:"
-msgstr "No se ha podido enviarles una invitación por correo electrónico, así que asegúraste de indicarles que inicien sesión con {0} y la contraseña que les hemos generado:"
+msgstr "Không thể gửi email mời, vậy nên hãy bảo họ đăng nhập sử dụng {0} và mật khẩu chúng tôi đã sinh cho họ"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:73
 msgid "If you want to be able to send email invites, just go to the {0} page."
-msgstr "Si quieres poder enviar invitaciones por correo electrónico, simplemente ves a la página {0}."
+msgstr "Nếu bạn muốn có khả năng gửi email mời, hãy đi tới trang {0}"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:55
 msgid "We’ve sent an invite to {0} with instructions to set their password."
-msgstr "Hemos enviado una invitación a {0} con instrucciones para configurar su contraseña."
+msgstr "Chúng tôi đã gửi một thư mời tới {0} kèm hướng dẫn đặt mật khẩu."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:283
 msgid "We've re-sent {0}'s invite"
-msgstr "Hemos vuelto a enviar la invitación de {0}"
+msgstr "Chúng tôi đã gửi lại thư mời cho {0}"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:24
 msgid "Okay"
-msgstr "Vale"
+msgstr "Đồng ý"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:289
 msgid "Any previous email invites they have will no longer work."
-msgstr "Cualquier invitación de correo electrónico anterior que tengan ya no funcionará."
+msgstr "Các email mời trước đó sẽ không còn hiệu lực"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:31
 msgid "Deactivate {0}?"
-msgstr "¿Desactivar {0}?"
+msgstr "Huỷ kích hoạt {0} ?"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:34
 msgid "{0} won't be able to log in anymore."
-msgstr "{0} ya no podrá iniciar sesión."
+msgstr "{0} sẽ không thể đăng nhập được nữa."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:320
 msgid "Reactivate {0}'s account?"
-msgstr "¿Activar la cuenta de {0}?"
+msgstr "Kích hoạt lại tài khoản {0}?"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:58
 msgid "Reactivate"
-msgstr "Activar"
+msgstr "Kích hoạt lại"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:51
 msgid "They'll be able to log in again, and they'll be placed back into the groups they were in before their account was deactivated."
-msgstr "Podrán volver a iniciar sesión y se les volverá a colocar en los grupos en los que estaban antes de que se desactivara su cuenta."
+msgstr "Họ sẽ có thể đăng nhập lại được, và sẽ trở về nhóm mà họ ở trước khi tài khoản bị huỷ kích hoạt."
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:51
 msgid "Reset {0}'s password?"
-msgstr "¿Restablecer la contraseña de {0}?"
+msgstr "Đặt lại mật khẩu của {0}?"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:76
 msgid "Reset"
-msgstr "Reiniciar"
+msgstr "Đặt lại"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
 #: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
 msgid "Are you sure you want to do this?"
-msgstr "¿Seguro que quieres hacer esto?"
+msgstr "Bạn chắc chắn muốn thực hiện chứ?"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:41
 msgid "{0}'s password has been reset"
-msgstr "La contraseña de {0} ha sido restablecida"
+msgstr "Mật khẩu của {0} đã được đặt lại"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:45
 msgid "Here’s a temporary password they can use to log in and then change their password."
-msgstr "Aquí hay una contraseña temporal que pueden usar para iniciar sesión y luego cambiar su contraseña."
+msgstr "Đây là mật khẩu tạm thời họ có thể dùng để đăng nhập và đổi mật khẩu."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:388
 msgid "We've sent them an email with instructions for creating a new password."
-msgstr "Les hemos enviado un correo electrónico con instrucciones para crear una nueva contraseña."
+msgstr "Chúng tôi đã gửi cho họ một email hướng dẫn tạo mật khẩu mới."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 #: frontend/src/metabase/admin/settings/components/widgets/AuthenticationOption.jsx:15
 msgid "Active"
-msgstr "Activo"
+msgstr "Kích hoạt"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
-msgstr "Desactivado"
+msgstr "Huỷ kích hoạt"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
-msgstr "Añadir alguien"
+msgstr "Thêm ai đó"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
-msgstr "Ultimo acceso"
+msgstr "Đăng nhập cuối"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:154
 msgid "Signed up via Google"
-msgstr "Acceso via Google"
+msgstr "Đăng ký qua Google"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:159
 msgid "Signed up via LDAP"
-msgstr "Acceso via LDAP"
+msgstr "Đăng ký qua LDAP"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:171
 msgid "Reactivate this account"
-msgstr "Activar esta cuenta"
+msgstr "Kích hoạt lại tài khoản này"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:195
 msgid "Never"
-msgstr "Nunca"
+msgstr "Không bao giờ"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
-msgstr[0] "{0} tabla"
-msgstr[1] "{0} tablas"
+msgstr[0] "{0} bản"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
-msgstr "será"
+msgstr " sẽ được "
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
-msgstr "dado el acceso a"
+msgstr "cấp quyền truy cập tới"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
-msgstr " y "
+msgstr " và "
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
-msgstr "denegado el acceso a"
+msgstr "chặn truy cập tới"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
-msgstr "ya no podrá"
+msgstr " sẽ không thể"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
-msgstr "ahora será capaz de"
+msgstr " bây giờ có thể"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
-msgstr "consultas nativas para"
+msgstr "truy vấn gốc cho"
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:14
 #: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Permissions"
-msgstr "Permisos"
+msgstr "Các quyền"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:32
 msgid "Save permissions?"
-msgstr "¿Guardar permisos?"
+msgstr "Lưu các quyền?"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:38
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
 msgid "Save Changes"
-msgstr "Guardar Cambios"
+msgstr "Lưu thay đổi"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:44
 msgid "Discard changes?"
-msgstr "¿Descartar los cambios?"
+msgstr "Huỷ thay đổi?"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:46
 msgid "No changes to permissions will be made."
-msgstr "No se realizarán cambios en los permisos."
+msgstr "Không có thay đổi gì về quyền."
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:65
 msgid "You've made changes to permissions."
-msgstr "Has realizado cambios en los permisos."
+msgstr "Bạn đã tạo thay đổi về quyền."
 
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
 msgid "Permissions for this collection"
-msgstr "Permisos de esta colección"
+msgstr "Quyền hạn cho bộ sưu tập này"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:81
 msgid "You have unsaved changes"
-msgstr "Tiene cambios sin guardar"
+msgstr "Bạn có những thay đổi chưa được lưu"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:82
 msgid "Do you want to leave this page and discard your changes?"
-msgstr "¿Quieres abandonar esta página y descartar tus cambios?"
+msgstr "Bạn có muốn rời trang này và huỷ các thay đổi?"
 
 #: frontend/src/metabase/admin/permissions/permissions.js:129
 msgid "Sorry, an error occurred."
-msgstr "Lo siento, ocurrió un error."
+msgstr "Xin lỗi, đã có lỗi xảy ra."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:71
 msgid "Administrators always have the highest level of access to everything in Metabase."
-msgstr "Los administradores siempre tienen el más alto nivel de acceso a todo en Metabase."
+msgstr "Các quản trị viên luôn có quyền hạn cao nhất tới tất cả các thứ trong Metabase"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:73
 msgid "Every Metabase user belongs to the All Users group. If you want to limit or restrict a group's access to something, make sure the All Users group has an equal or lower level of access."
-msgstr "Todos los usuarios de Metabase pertenecen al grupo All Users. Si quieres limitar o restringir el acceso de un grupo a algo, asegúrate de que el grupo All Users tenga un nivel de acceso igual o inferior."
+msgstr "Tất cả người dùng Metabase nằm trong nhóm \"Tất cả người dùng\". Nếu bạn muốn giới hạn hoặc thu hẹp truy cập của một nhóm tới một thứ gì đó, hãy đảm bảo rằng nhóm \"Tất cả người dùng\" có quyền tương đương hoặc thấp hơn."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:75
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
-msgstr "MetaBot es el bot de Slack de Metabase. Puedes elegir a qué tiene acceso aquí."
+msgstr "MetaBot là một con bot của Metabase trên Slack. Bạn có thể chọn những thứ nó có thể truy cập ở đây."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:128
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
-msgstr "El grupo \"{0}\" puede tener acceso a un conjunto diferente de {1} que este grupo, lo que puede darle a este grupo acceso adicional a algún {2}."
+msgstr "Nhóm \\ \"{0} \" có thể có quyền truy cập vào một nhóm {1} khác với nhóm này, nhóm này có thể cung cấp cho nhóm này quyền truy cập bổ sung vào một số {2}."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:131
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
-msgstr "El grupo \"{0}\" tiene un mayor nivel de acceso que este, lo que anulará esta configuración. Debes limitar o revocar el acceso del grupo \"{1}\" a este elemento."
+msgstr "Nhóm \\ \"{0} \" có mức truy cập cao hơn nhóm này, sẽ ghi đè cài đặt này. Bạn nên giới hạn hoặc thu hồi quyền truy cập của nhóm \\ \"{1} \" vào mục này."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
-msgstr "¿Limitar"
+msgstr "Giới hạn"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
-msgstr "¿Revocar"
+msgstr "Thu hồi"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
-msgstr "el acceso a pesar de que el grupo \"{0}\" tiene mayor acceso?"
+msgstr "truy cập mặc dù \\ \"{0} \" có quyền truy cập lớn hơn?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
-msgstr "Limitar el acceso"
+msgstr "Giới hạn truy cập"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
 msgid "Revoke access"
-msgstr "Revocar el acceso"
+msgstr "Thu hồi quyền truy cập"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
-msgstr "¿Cambiar el acceso a esta base de datos a limitado?"
+msgstr "Thay đổi quyền truy cập tới cơ sở dữ liệu này thành giới hạn?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
-msgstr "Cambiar"
+msgstr "Thay đổi"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
-msgstr "Permitir escritura de consultas directas"
+msgstr "Cho phép viết truy vấn thuần tuý"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
-msgstr "Esto también cambiará el acceso de datos de este grupo a Sin restricciones para esta base de datos."
+msgstr "Điều này cũng sẽ thay đổi quyền truy cập dữ liệu của nhóm này thành Không giới hạn đối với cơ sở dữ liệu này."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
-msgstr "Permitir"
+msgstr "Cho phép"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
-msgstr "¿Revoca el acceso a todas las tablas?"
+msgstr "Thu hồi quyền truy cập tới tất cả cá bảng?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
-msgstr "Esto también revocará el acceso de este grupo a consultas sin formato para esta base de datos."
+msgstr "Điều này cũng sẽ thu hồi quyền truy cập của nhóm này vào các truy vấn thô cho cơ sở dữ liệu này."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
-msgstr "Conceder acceso sin restricciones"
+msgstr "Cấp quyền truy cập không hạn chế"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
-msgstr "Acceso no restingido"
+msgstr "Truy cập không hạn chế"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
-msgstr "Acceso limitado"
+msgstr "Giới hạn truy cập"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
-msgstr "Sin acceso"
+msgstr "Không truy cập"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
-msgstr "Escribir consultas directas"
+msgstr "Viết truy vấn thuần tuý"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
-msgstr "Puede escribir consultas directas"
+msgstr "Có thể viết các truy vấn thuần tuý"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
-msgstr "Mima la colección"
+msgstr "Bộ sưu tập"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
-msgstr "Ver colección"
+msgstr "Xem bộ sưu tập"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:445
 #: frontend/src/metabase/admin/permissions/selectors.js:558
 msgid "Data Access"
-msgstr "Acceso a Datos"
+msgstr "Truy cập dữ liệu"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:510
 #: frontend/src/metabase/admin/permissions/selectors.js:665
 #: frontend/src/metabase/admin/permissions/selectors.js:670
 msgid "View tables"
-msgstr "Ver tablas"
+msgstr "Xem bảng"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:606
 msgid "SQL Queries"
-msgstr "Consultas SQL"
+msgstr "Truy vấn SQL"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:676
 msgid "View schemas"
-msgstr "Ver esquemas"
+msgstr "Xem schema"
 
 #: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
-msgstr "Modelo de Datos"
+msgstr "Dữ liệu mẫu"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:118
 #: frontend/src/metabase/plugins/builtin/auth/google.js:31
 msgid "Sign in with Google"
-msgstr "Accede con Google"
+msgstr "Đăng nhập với Google"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 #: frontend/src/metabase/plugins/builtin/auth/google.js:32
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
-msgstr "Permite a los usuarios con cuentas Metabase existentes iniciar sesión con una cuenta de Google que coincida con su dirección de correo electrónico además de su nombre de usuario y contraseña de Metabase."
+msgstr "Cho phép người dùng có tài khoản Metabase hiện tại đăng nhập bằng tài khoản Google khớp với địa chỉ email của họ bên cạnh tên người dùng và mật khẩu Metabase của họ."
 
 #: frontend/src/metabase/admin/settings/components/widgets/AuthenticationOption.jsx:24
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
-msgstr "Configura"
+msgstr "Cấu hình"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:20
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:15
@@ -1374,133 +1362,133 @@ msgstr "LDAP"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:16
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
-msgstr "Permite a los usuarios de tu directorio LDAP iniciar sesión en la Metabase con sus credenciales LDAP, y permite la asignación automática de grupos LDAP a grupos de metabase."
+msgstr "Cho phép người dùng trong thư mục LDAP của bạn đăng nhập vào Metabase bằng thông tin LDAP của họ và cho phép tự động ánh xạ các nhóm LDAP sang các nhóm Metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
 #: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
-msgstr "Esa no es una dirección de correo electrónico válida"
+msgstr "Đó không phải là một địa chỉ email hợp lệ"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
-msgstr "Ese no es un entero válido"
+msgstr "Đó không phải là một số nguyên hợp lệ"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
-msgstr "¡Cambios guardados!"
+msgstr "Đã lưu thay đổi!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
 msgid "Looks like we ran into some problems"
-msgstr "Parece que nos encontramos con algunos problemas"
+msgstr "Có vẻ như chúng ta đã gặp một số vấn đề"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:19
 msgid "Send test email"
-msgstr "Enviar email de comprobación"
+msgstr "Gửi email kiểm tra"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:20
 msgid "Sending..."
-msgstr "Enviando..."
+msgstr "Đang gửi..."
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:21
 msgid "Sent!"
-msgstr "¡Enviado!"
+msgstr "Đã gửi!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:93
 msgid "Clear"
-msgstr "Limpiar"
+msgstr "Xoá"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
-msgstr "Autenticación"
+msgstr "Xác thực"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
-msgstr "Configuración Servidor"
+msgstr "Cài đặt máy chủ"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:36
 msgid "User Schema"
-msgstr "Esquema de Usuario"
+msgstr "Schema người dùng"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:40
 msgid "Attributes"
-msgstr "Atributos"
+msgstr "Các thuộc tính"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
-msgstr "Esquema de Grupo"
+msgstr "Nhóm Schema"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetting.jsx:33
 msgid "Using "
-msgstr "Utilizando"
+msgstr "Đang sử dụng "
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:105
 msgid "Getting set up"
-msgstr "Preparándote"
+msgstr "Đang thiết lập"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:106
 msgid "A few things you can do to get the most out of Metabase."
-msgstr "Algunas cosas que puedes hacer para sacar el máximo provecho de Metabase."
+msgstr "Một vài điều bạn có thể làm để tận dụng tối đa Metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:115
 msgid "Recommended next step"
-msgstr "Siguiente paso recomendado"
+msgstr "Đề xuất bước tiếp theo"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:114
 msgid "Google Sign-In"
-msgstr "Acceso Google"
+msgstr "Đăng nhập Google"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:123
 msgid "To allow users to sign in with Google you'll need to give Metabase a Google Developers console application client ID. It only takes a few steps and instructions on how to create a key can be found {0}"
-msgstr "Para permitir que los usuarios inicien sesión con Google, deberás proporcionar a Metabase un ID de cliente de aplicación de la consola de Desarrollo de Google. Solo se necesitan unos pocos pasos y se pueden encontrar instrucciones sobre cómo crear una clave {0}"
+msgstr "Để cho phép người dùng đăng nhập bằng Google, bạn cần cung cấp cho Metabase ID ứng dụng khách ứng dụng bảng điều khiển Google Developers. Chỉ mất vài bước và hướng dẫn về cách tạo khóa có thể được tìm thấy {0}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:140
 msgid "Your Google client ID"
-msgstr "Tu ID de cliente de Google"
+msgstr "Google client ID của bạn"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:145
 msgid "Allow users to sign up on their own if their Google account email address is from:"
-msgstr "Permite que los usuarios se registren solos si la dirección de correo electrónico de su cuenta de Google es de:"
+msgstr "Cho phép người dùng tự đăng ký nếu địa chỉ email tài khoản Google của họ đến từ:"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:249
 msgid "Answers sent right to your Slack #channels"
-msgstr "Respuestas enviadas directamente a tus #canales Slack"
+msgstr "Câu trả lời đã được gửi thằng tới kênh Slack của bạn"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:258
 msgid "Create a Slack Bot User for MetaBot"
-msgstr "Crear un usuario de Slack Bot para MetaBot"
+msgstr "Tạo một tài khoản Slack Bot cho MetaBot"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:268
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
-msgstr "Una vez que estés allí, asígnele un nombre y haz clic en {0}. Luego, copia y pega el API Token del Bot en el campo a continuación. En cuanto hayas terminado, crea un canal \"metabase_files\" en Slack. Metabase necesita ese para subir gráficos."
+msgstr "Khi bạn đã ở đó, hãy đặt tên cho nó và nhấp vào {0}. Sau đó sao chép và dán mã thông báo Bot API vào trường bên dưới. Khi bạn đã hoàn tất, hãy tạo kênh \\ \"metabase_files \" trong Slack. Metabase cần điều này để tải lên biểu đồ."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:17
 msgid "You're running Metabase {0} which is the latest and greatest!"
-msgstr "¡Estás ejecutando Metabase {0} que es lo último y lo mejor!"
+msgstr "Bạn đang chạy Metabase {0}, đây là phiên bản mới nhất và tốt nhất!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
-msgstr "Metabase {0} está disponible.  Estás ejecutando {1}"
+msgstr "Đã có Metabase {0}. Bạn đang sử dụng {1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:41
 #: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 msgid "Update"
-msgstr "Actualiza"
+msgstr "Cập nhật"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:46
 msgid "What's Changed:"
-msgstr "Qué ha cambiado:"
+msgstr "Những thay đổi:"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:131
 msgid "Add a map"
-msgstr "Añade un mapa"
+msgstr "Thêm một bản đồ"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
 #: frontend/src/metabase/lib/core.js:267
@@ -1509,7 +1497,7 @@ msgstr "URL"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
-msgstr "Elimina mapa personalizado"
+msgstr "Xoá bản đồ tuỳ chỉnh"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
@@ -1520,7 +1508,7 @@ msgstr "Elimina mapa personalizado"
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
-msgstr "Borrar"
+msgstr "Xoá"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
@@ -1528,298 +1516,298 @@ msgstr "Borrar"
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
-msgstr "Selecciona…"
+msgstr "Chọn..."
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
-msgstr "Valores de muestra:"
+msgstr "Các giá trị mẫu:"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
-msgstr "Añade un nuevo mapa"
+msgstr "Thêm một bản đồ mới"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
-msgstr "Editar mapa"
+msgstr "Sửa bản đồ"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
-msgstr "¿Cómo quieres llamar a este mapa?"
+msgstr "Bạn muốn gọi bản đồ này là gì?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
-msgstr "e.g. United Kingdom, Brazil, Mars"
+msgstr "ví dụ: Việt Nam, Thái lan, Mặt trăng"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
-msgstr "URL para el archivo GeoJSON que quieres usar"
+msgstr "URL đến file GeoJSON bạn muốn sử dụng"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
-msgstr "Como https://my-mb-server.com/maps/my-map.json"
+msgstr "Ví dụ như https://my-mb-server.com/maps/my-map.json"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
-msgstr "Actualizar"
+msgstr "Làm mới"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
-msgstr "Carga"
+msgstr "Tải"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
-msgstr "¿Qué propiedad especifica el identificador de la región?"
+msgstr "Thuộc tính nào xác định định danh của vùng"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
-msgstr "¿Qué propiedad especifica el nombre de la región?"
+msgstr "Thuộc tính nào xác định tên của vùng"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
-msgstr "Carga un archivo GeoJSON para ver una vista previa"
+msgstr "Tải file GeoJSON để xem trước"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
-msgstr "Guardar mapa"
+msgstr "Lưu bản đồ"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
-msgstr "Añadir mapa"
+msgstr "Thêm bản đồ"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:7
 msgid "Using embedding"
-msgstr "Utilizando embebido"
+msgstr "Sử dụng nhúng"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:9
 msgid "By enabling embedding you're agreeing to the embedding license located at"
-msgstr "Al habilitar el embebido, aceptas la licencia de incorporación ubicada en"
+msgstr "Bằng cách cho phép nhúng, bạn đồng ý với giấy phép nhúng nằm ở"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
-msgstr "En lenguaje sencillo, cuando insertas tablas o cuadros de mando de Metabase en tu propia aplicación, esa aplicación no está sujeta a la Licencia AGPL que cubre el resto de Metabase, siempre que mantengas el logotipo de Metabase y el \"Powered by Metabase\" visible en esas incrustaciones. Sin embargo, debes leer el texto de licencia, ya que esa es la licencia real que aceptas al habilitar esta función."
+msgstr "Nói một cách dễ hiểu, khi bạn nhúng biểu đồ hoặc bảng điều khiển từ Metabase vào ứng dụng của riêng bạn, ứng dụng đó không phải tuân theo Giấy phép Công cộng Chung bao gồm phần còn lại của Metabase, miễn là bạn giữ logo Metabase và \\ \"Được cung cấp bởi Metabase \\ \"Hiển thị trên các nhúng. Tuy nhiên, bạn nên đọc văn bản giấy phép được liên kết ở trên vì đó là giấy phép thực tế mà bạn sẽ đồng ý bằng cách bật tính năng này."
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
-msgstr "Habilitar"
+msgstr "Bật"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:24
 msgid "Premium embedding enabled"
-msgstr "Embebido Premium habilitado"
+msgstr "Đã bật nhúng cao cấp"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:26
 msgid "Enter the token you bought from the Metabase Store"
-msgstr "Introduce el token que compraste en la Tienda Metabase"
+msgstr "Nhập vào mã bạn đã mua từ Metabase Store"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:53
 msgid "Premium embedding lets you disable \"Powered by Metabase\" on your embedded dashboards and questions."
-msgstr "La incrustación Premium te permite desactivar \"Powered by Metabase\" en tus cuadros de mandos y preguntas embebidas."
+msgstr "Nhúng cao cấp cho phép bạn tắt thông báo \"Powered by Metabase\" trên các trang nhúng tổng quan và các câu hỏi"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:60
 msgid "Buy a token"
-msgstr "Comprar un token"
+msgstr "Mua một mã"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:63
 msgid "Enter a token"
-msgstr "Introducir un token"
+msgstr "Nhập một mã"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
 msgid "Edit Mappings"
-msgstr "Editar Asignaciones"
+msgstr "Sửa các ánh xạ"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
 msgid "Group Mappings"
-msgstr "Asignaciones de Grupo"
+msgstr "Nhóm các ánh xạ"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
 msgid "Create a mapping"
-msgstr "Crear una asignación"
+msgstr "Tạo một ánh xạ"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
-msgstr "Las asignaciones permiten que Metabase agregue y elimine automáticamente usuarios de grupos según la información de membresía proporcionada por el servidor de directorios. La membresía al grupo de administración se puede otorgar a través de asignaciones, pero no se eliminará automáticamente como una medida a prueba de fallas."
+msgstr "Ánh xạ cho phép Metabase tự động thêm và xóa người dùng khỏi các nhóm dựa trên thông tin thành viên được cung cấp bởi máy chủ thư mục. Tư cách thành viên của nhóm Quản trị viên có thể được cấp thông qua ánh xạ, nhưng sẽ không tự động bị xóa như một biện pháp không an toàn."
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:107
 msgid "Distinguished Name"
-msgstr "Nombre Distinguido"
+msgstr "Tên phân biệt"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:92
 msgid "Public Link"
-msgstr "Enlace Público"
+msgstr "Liên kết công khai"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:93
 msgid "Revoke Link"
-msgstr "Eliminar Enlace"
+msgstr "Thu hồi liên kết"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
-msgstr "¿Deshabilitar este enlace?"
+msgstr "Vô hiệu hoá liên kết này?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
-msgstr "Ya no funcionarán y no se pueden restaurar, pero puedes crear nuevos enlaces."
+msgstr "Nó sẽ không hoạt động nữa, và cũng không thể khôi phục, tuy nhiên bạn có thể tạo các liên kết mới."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 msgid "Public Dashboard Listing"
-msgstr "Listado de Cuadros de Mando Públicos"
+msgstr "Danh sách trang tổng quan công khai"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
-msgstr "Aún no se ha compartido públicamente ningún cuadro de mando."
+msgstr "Chưa có trang tổng quan nào được chia sẻ công khai."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
-msgstr "Listado de tarjetas públicas"
+msgstr "Danh sách thẻ công khai"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
-msgstr "Aún no se ha compartido públicamente ninguna pregunta."
+msgstr "Chưa có câu hỏi nào được chia sẻ không khai."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
-msgstr "Listado de cuadros de mando embebidos"
+msgstr "Danh sách trang nhúng tổng quan"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
-msgstr "No se han incrustado cuadros de mando todavía."
+msgstr "Chưa có trang tổng quan nào được nhúng."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
-msgstr "Listado de tarjetas embebidas"
+msgstr "Danh sách thẻ nhúng"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
-msgstr "No se han incrustado preguntas todavía."
+msgstr "Chưa có câu hỏi nào được nhúng."
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:35
 msgid "Regenerate embedding key?"
-msgstr "¿Regenerar la clave de inserción?"
+msgstr "Sinh lại mã khoá nhúng"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:36
 msgid "This will cause existing embeds to stop working until they are updated with the new key."
-msgstr "Esto hará que las inserciones existentes dejen de funcionar hasta que se actualicen con la nueva clave."
+msgstr "Điều này sẽ khiến các nhúng đang có không hoạt động cho tới khi bạn cập nhật mã khoá mới cho chúng."
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:39
 msgid "Regenerate key"
-msgstr "Regenerar clave"
+msgstr "Sinh lại mã khoá"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:47
 msgid "Generate Key"
-msgstr "Generar clave"
+msgstr "Sinh mã khoá"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
 #: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enabled"
-msgstr "Habilitado"
+msgstr "Bật"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
 #: frontend/src/metabase/admin/settings/selectors.js:93
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
-msgstr "Deshabilitado"
+msgstr "Tắt"
 
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:113
 msgid "Unknown setting {0}"
-msgstr "La directiva de configuración {0} es desconocida"
+msgstr "Cài đặt {0} không xác định"
 
 #: frontend/src/metabase/admin/settings/selectors.js:37
 msgid "Setup"
-msgstr "Configura"
+msgstr "Thiết lập"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:214
 #: frontend/src/metabase/admin/settings/selectors.js:42
 msgid "General"
-msgstr "General"
+msgstr "Tổng quan"
 
 #: frontend/src/metabase/admin/settings/selectors.js:46
 msgid "Site Name"
-msgstr "Nombre Sitio"
+msgstr "Tên trang"
 
 #: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Site URL"
-msgstr "URL Sitio"
+msgstr "Đường dẫn trang"
 
 #: frontend/src/metabase/admin/settings/selectors.js:64
 msgid "Email Address for Help Requests"
-msgstr "Dirección de correo electrónico para solicitudes de ayuda"
+msgstr "Địa chỉ email yêu cầu giúp đỡ"
 
 #: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
-msgstr "Zona horaria de los Informes"
+msgstr "Múi giờ báo cáo"
 
 #: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
-msgstr "La de la base de datos"
+msgstr "Cơ sở dữ liệu mặc định"
 
 #: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Select a timezone"
-msgstr "Selecciona una zona horaria"
+msgstr "Chọn múi giờ"
 
 #: frontend/src/metabase/admin/settings/selectors.js:75
 msgid "Not all databases support timezones, in which case this setting won't take effect."
-msgstr "No todas las bases de datos admiten zonas horarias, en cuyo caso esta configuración no tendrá efecto."
+msgstr "Không phải tất cả cơ sở dữ liệu đều hõ trợ múi giờ, trong trường hợp đó cài đặt này sẽ không có tác dụng."
 
 #: frontend/src/metabase/entities/users/forms.js:34
 msgid "Language"
-msgstr "Idioma"
+msgstr "Ngôn ngữ"
 
 #: frontend/src/metabase/admin/settings/selectors.js:65
 msgid "Select a language"
-msgstr "Selecciona un idioma"
+msgstr "Chọn một ngôn ngữ"
 
 #: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
-msgstr "Seguimiento anónimo"
+msgstr "Theo dõi nặc danh"
 
 #: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
-msgstr "Nombres de tablas y campos amistosos"
+msgstr "Bảng và trường dữ liệu thân thiện"
 
 #: frontend/src/metabase/admin/settings/selectors.js:91
 msgid "Only replace underscores and dashes with spaces"
-msgstr "Solo reemplaza los guiones bajos y guiones por espacios"
+msgstr "Chỉ thay thế các dấu gạch dưới và các dấu gạch ngang bằng các dấu cách"
 
 #: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Enable Nested Queries"
-msgstr "Habilitar consultas anidadas"
+msgstr "Cho phép các truy vấn lồng nhau"
 
 #: frontend/src/metabase/admin/settings/selectors.js:110
 msgid "Updates"
-msgstr "Actualizaciones"
+msgstr "Các cập nhật"
 
 #: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
-msgstr "Buscar actualizaciones"
+msgstr "Kiểm tra các cập nhật"
 
 #: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
-msgstr "Servidor SMTP"
+msgstr "Máy chủ SMTP"
 
 #: frontend/src/metabase/admin/settings/selectors.js:134
 msgid "SMTP Port"
-msgstr "Puerto SMTP"
+msgstr "Cổng SMTP"
 
 #: frontend/src/metabase/admin/settings/selectors.js:138
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:47
 msgid "That's not a valid port number"
-msgstr "Ese no es un número de puerto válido"
+msgstr "Đó không phải là một giá trị cổng hợp lệ"
 
 #: frontend/src/metabase/admin/settings/selectors.js:142
 msgid "SMTP Security"
-msgstr "Seguridad SMTP"
+msgstr "Bảo mật SMTP"
 
 #: frontend/src/metabase/admin/settings/selectors.js:150
 msgid "SMTP Username"
-msgstr "Usuario SMTP"
+msgstr "Tên tài khoản SMTP"
 
 #: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "SMTP Password"
-msgstr "Contraseña SMTP"
+msgstr "Mật khẩu SMTP"
 
 #: frontend/src/metabase/admin/settings/selectors.js:164
 msgid "From Address"
-msgstr "Email De"
+msgstr "Địa chỉ gửi"
 
 #: frontend/src/metabase/admin/settings/selectors.js:178
 msgid "Slack API Token"
@@ -1827,31 +1815,31 @@ msgstr "Slack API Token"
 
 #: frontend/src/metabase/admin/settings/selectors.js:180
 msgid "Enter the token you received from Slack"
-msgstr "Introduce el token que has recibido de Slack"
+msgstr "Nhập token bạn lấy từ Slack"
 
 #: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
-msgstr "Inicio de sesión único"
+msgstr "Đăng nhập một lần"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:30
 msgid "LDAP Authentication"
-msgstr "Autentificación LDAP"
+msgstr "Xác thực LDAP"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:36
 msgid "LDAP Host"
-msgstr "Servidor LDAP"
+msgstr "Máy chủ LDAP"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:44
 msgid "LDAP Port"
-msgstr "Puerto LDAP"
+msgstr "Cổng LDAP"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:51
 msgid "LDAP Security"
-msgstr "Seguridad LDAP"
+msgstr "Bảo mật LDAP"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:59
 msgid "Username or DN"
-msgstr "Nombre de Usuario o DN"
+msgstr "Tên tài khoản hoặc tên miền"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:43
 #: frontend/src/metabase/entities/databases/forms.js:61
@@ -1859,250 +1847,249 @@ msgstr "Nombre de Usuario o DN"
 #: frontend/src/metabase/user/components/UserSettings.jsx:66
 #: src/metabase/driver/common.clj
 msgid "Password"
-msgstr "Contraseña"
+msgstr "Mật khẩu"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:69
 msgid "User search base"
-msgstr "Base de búsqueda de usuario"
+msgstr "Cơ sở tìm kiếm người dùng"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:75
 msgid "User filter"
-msgstr "Filtro de usuario"
+msgstr "Lọc người dùng"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:81
 msgid "Check your parentheses"
-msgstr "Verifica los paréntesis"
+msgstr "Kiểm tra dấu ngoặc đơn"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
-msgstr "Atributo de Email"
+msgstr "Thuộc tính email"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
-msgstr "Atributo de Nombre"
+msgstr "Thuộc tính tên"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
-msgstr "Atributo de Apellidos"
+msgstr "Thuộc tính họ"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
-msgstr "Sincronizar membresías de grupo"
+msgstr "Đồng bộ thành viên nhóm"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:113
 msgid "Group search base"
-msgstr "Base de búsqueda para Grupo"
+msgstr "Cơ sở tìm kiếm nhóm"
 
 #: frontend/src/metabase/admin/settings/selectors.js:201
 msgid "Maps"
-msgstr "Mapas"
+msgstr "Các bản đồ"
 
 #: frontend/src/metabase/admin/settings/selectors.js:205
 msgid "Map tile server URL"
-msgstr "URL del servidor de capas de mapa"
+msgstr "Đường dẫn đến máy chủ mảnh bản đồ"
 
 #: frontend/src/metabase/admin/settings/selectors.js:206
 msgid "Metabase uses OpenStreetMaps by default."
-msgstr "Metabase usa OpenStreetMaps por defecto."
+msgstr "Metabase mặc định sử dụngOpenStreetMaps"
 
 #: frontend/src/metabase/admin/settings/selectors.js:211
 msgid "Custom Maps"
-msgstr "Mapas Personalizados"
+msgstr "Tuỳ chỉnh các bản đồ"
 
 #: frontend/src/metabase/admin/settings/selectors.js:212
 msgid "Add your own GeoJSON files to enable different region map visualizations"
-msgstr "Añade tus propios archivos GeoJSON para habilitar diferentes visualizaciones de mapas de región"
+msgstr "Thêm các file GeoJSON của bạn để có thể hiển thị các khu vực bản đồ khác nhau"
 
 #: frontend/src/metabase/admin/settings/selectors.js:245
 msgid "Public Sharing"
-msgstr "Uso compartido público"
+msgstr "Chia sẻ công khai"
 
 #: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "Enable Public Sharing"
-msgstr "Habilitar el intercambio público"
+msgstr "Bật chia sẻ công khai"
 
 #: frontend/src/metabase/admin/settings/selectors.js:254
 msgid "Shared Dashboards"
-msgstr "Cuadros de Mando compartidos"
+msgstr "Các trang tổng quan được chi sẻ"
 
 #: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Shared Questions"
-msgstr "Preguntas compartidas"
+msgstr "Các câu hỏi được chia sẻ"
 
 #: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Embedding in other Applications"
-msgstr "Incrustar en otras aplicaciones"
+msgstr "Nhung vào các ứng dụng khác"
 
 #: frontend/src/metabase/admin/settings/selectors.js:293
 msgid "Enable Embedding Metabase in other Applications"
-msgstr "Habilitar incrustación de Metabase en otras aplicaciones"
+msgstr "Cho phép nhúng Metabase vào các ứng dụng khác"
 
 #: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Embedding secret key"
-msgstr "Clave secreta de incrustación"
+msgstr "Mã nhúng khoá bí mật"
 
 #: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Embedded Dashboards"
-msgstr "Cuadros de Mando embebidos"
+msgstr "Các trang tổng quan được nhúng"
 
 #: frontend/src/metabase/admin/settings/selectors.js:315
 msgid "Embedded Questions"
-msgstr "Preguntas embebidas"
+msgstr "Các câu hỏi được nhúng"
 
 #: frontend/src/metabase/admin/settings/selectors.js:322
 msgid "Caching"
-msgstr "Almacenamiento en caché"
+msgstr "Bộ nhớ đệm"
 
 #: frontend/src/metabase/admin/settings/selectors.js:326
 msgid "Enable Caching"
-msgstr "Habilitar caché"
+msgstr "Kích hoạt bộ nhớ đệm"
 
 #: frontend/src/metabase/admin/settings/selectors.js:331
 msgid "Minimum Query Duration"
-msgstr "Duración mínima de la consulta"
+msgstr "Thời gian truy vấn tối thiểu"
 
 #: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Cache Time-To-Live (TTL) multiplier"
-msgstr "Multiplicador Time-to-Live (TTL) de caché"
+msgstr "Bộ nhớ đệm hệ số nhân thời gian sống (TTL)"
 
 #: frontend/src/metabase/admin/settings/selectors.js:345
 msgid "Max Cache Entry Size"
-msgstr "Tamaño máximo de entrada de caché"
+msgstr "Kích thước mục nhập bộ nhớ cache tối đa"
 
 #: frontend/src/metabase/alert/alert.js:60
 msgid "Your alert is all set up."
-msgstr "Tu alerta está configurada."
+msgstr "Cảnh báo của bạn đã được thiết lập."
 
 #: frontend/src/metabase/alert/alert.js:101
 msgid "Your alert was updated."
-msgstr "Tu alerta fue actualizada."
+msgstr "Cảnh báo của bạn đã được cập nhật."
 
 #: frontend/src/metabase/alert/alert.js:149
 msgid "The alert was successfully deleted."
-msgstr "La alerta fue eliminada correctamente."
+msgstr "Đã xoá cảnh báo thành công."
 
 #: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
-msgstr "Por favor introduce una dirección de correo electrónico con formato válido."
+msgstr "Vui lòng nhập một email hợp lệ"
 
 #: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
-msgstr "Las contraseñas no coinciden"
+msgstr "Mật khẩu không khớp"
 
 #: frontend/src/metabase/auth/components/BackToLogin.jsx:6
 msgid "Back to login"
-msgstr "Volver al inicio de sesión"
+msgstr "Trở về đăng nhập"
 
 #: frontend/src/metabase/auth/components/GoogleNoAccount.jsx:15
 msgid "No Metabase account exists for this Google account."
-msgstr "No existe una cuenta de Metabase para esta cuenta de Google."
+msgstr "Không có tài khoản Metabase nào tương ứng với tài khoản Google này."
 
 #: frontend/src/metabase/auth/components/GoogleNoAccount.jsx:17
 msgid "You'll need an administrator to create a Metabase account before you can use Google to log in."
-msgstr "Necesitará un administrador para crear una cuenta Metabase antes de poder usar Google para iniciar sesión."
+msgstr "Bạn sẽ cần quản trị viên tạo một tài khoản Metabase trước khi bạn có thể dùng Google để đăng nhập."
 
 #: frontend/src/metabase/auth/components/AuthProviderButton.jsx:23
 msgid "Sign in with {0}"
-msgstr "Inicia sesión con {0}"
+msgstr "Đăng nhập với {0}"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
 msgid "Please contact an administrator to have them reset your password"
-msgstr "Por favor, ponte en contacto con un administrador para que restablezca tu contraseña"
+msgstr "Xin hãy liên hệ với quản trị viên để đặt lại mật khẩu cho bạn"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "Forgot password"
-msgstr "Olvidé mi contraseña"
+msgstr "Quên mật khẩu"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "The email you use for your Metabase account"
-msgstr "El correo electrónico que utilizas para tu cuenta Metabase"
+msgstr "Địa chỉ email sử dụng cho tài khoản Metabase"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
 msgid "Send password reset email"
-msgstr "Enviar correo electrónico de restablecimiento de contraseña"
+msgstr "Gửi email khôi phục mật khẩu"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
 msgid "Check your email for instructions on how to reset your password."
-msgstr "Consulta tu correo electrónico para obtener instrucciones sobre cómo restablecer tu contraseña."
+msgstr "Hãy kiểm tra email hướng dẫn cách đặt lại mật khẩu."
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:44
 msgid "Sign in to Metabase"
-msgstr "Iniciar sesión en Metabase"
+msgstr "Đăng nhập vào Metabase"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:165
 msgid "OR"
-msgstr "O"
+msgstr "HOẶC"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
 msgid "Username or email address"
-msgstr "Nombre de usuario o dirección de correo electrónico"
+msgstr "Tên tài khoản hoặc địa chỉ email"
 
 #: frontend/src/metabase/auth/components/AuthProviderButton.jsx:23
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:56
 msgid "Sign in"
-msgstr "Acceder"
+msgstr "Đăng nhập"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:79
 msgid "I seem to have forgotten my password"
-msgstr "Parece que olvidé mi contraseña"
+msgstr "Có vẻ như tôi đã quên mật khẩu của mình"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
 msgid "request a new reset email"
-msgstr "solicitar un nuevo correo electrónico de reinicio"
+msgstr "yêu cầu một email đặt lại mật khẩu"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
 msgid "Whoops, that's an expired link"
-msgstr "Vaya, ese es un enlace caducado"
+msgstr "Ôi, liên kết đó đã hết hạn"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
-msgstr "Por razones de seguridad, los enlaces de restablecimiento de contraseña caducan después de un tiempo.\n"
-"Si aún necesita restablecer tu contraseña, puedes {0}"
+msgstr "Vì lý do bảo mật, liên kết đặt lại mật khẩu sẽ hết hạn trong một khoảng thời gian. Nếu bạn vẫn cần đặt lại mật khẩu, bạn có thể {0}"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
 msgid "New password"
-msgstr "Nueva contraseña"
+msgstr "Mật khẩu mới"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
 msgid "To keep your data secure, passwords {0}"
-msgstr "Para mantener tus datos seguros, las contraseñas {0}"
+msgstr "Để giữ cho dữ liệu của bạn được bảo mật, mật khẩu {0}"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
-msgstr "Crear una nueva contraseña"
+msgstr "Tạo mật khẩu mới"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:135
 msgid "Make sure its secure like the instructions above"
-msgstr "Ha de cumplir las instrucciones anteriores"
+msgstr "Hãy chắc rằng nó bảo mật như hướng dẫn bên trên"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:186
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:143
 msgid "Confirm new password"
-msgstr "Confirmar nueva contraseña"
+msgstr "Xác nhận mật khẩu mới"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:193
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:152
 msgid "Make sure it matches the one you just entered"
-msgstr "Tiene que coincidir con la que acabas de poner"
+msgstr "Hãy đảm bảo rằng nó khớp với giá trị bạn vừa nhập"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
 msgid "Your password has been reset."
-msgstr "Tu contraseña ha sido restablecida."
+msgstr "Mật khẩu của bạn đã được đặt lại."
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
 msgid "Sign in with your new password"
-msgstr "Inicia sesión con tu nueva contraseña"
+msgstr "Đăng nhập với mật khẩu mới"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
-msgstr "Ha fallado"
+msgstr "Lưu thất bại"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
@@ -2110,19 +2097,19 @@ msgstr "Ha fallado"
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
-msgstr "Guardado"
+msgstr "Đã lưu"
 
 #: frontend/src/metabase/components/Alert.jsx:12
 msgid "Ok"
-msgstr "Vale"
+msgstr "Được"
 
 #: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
 msgid "Archive this collection?"
-msgstr "¿Archivar esta colección?"
+msgstr "Lưu trữ bộ sưu tập này?"
 
 #: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
-msgstr "Los cuadros de mando, colecciones y pulsos guardados en esta colección también se archivarán."
+msgstr "Bảng điều khiển, bộ sưu tập và xung trong bộ sưu tập này cũng sẽ được lưu trữ."
 
 #: frontend/src/metabase/components/ArchiveModal.jsx:38
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
@@ -2136,19 +2123,19 @@ msgstr "Los cuadros de mando, colecciones y pulsos guardados en esta colección 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
 #: frontend/src/metabase/routes.jsx:196
 msgid "Archive"
-msgstr "Archivar"
+msgstr "Lưu trữ"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:65
 msgid "This {0} has been archived"
-msgstr "Este {0} ha sido archivado"
+msgstr "{0} này đã được lưu trữ"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:710
 msgid "View the archive"
-msgstr "Ver el archivo"
+msgstr "Xem lưu trữ"
 
 #: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
-msgstr "Desarchive este {0}"
+msgstr "Bỏ lưu trữ {0} này"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:46
 #: frontend/src/metabase/components/BrowseApp.jsx:112
@@ -2157,132 +2144,131 @@ msgstr "Desarchive este {0}"
 #: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
-msgstr "Nuestros datos"
+msgstr "Dữ liệu của chúng ta"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
 msgid "X-ray this table"
-msgstr "Aplica rayos-X a esta tabla"
+msgstr "X-ray bảng này"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:171
 msgid "Learn about this table"
-msgstr "Aprende sobre esta tabla"
+msgstr "Học hỏi về bảng này"
 
 #: frontend/src/metabase/components/Button.info.js:11
 #: frontend/src/metabase/components/Button.info.js:12
 #: frontend/src/metabase/components/Button.info.js:13
 msgid "Clickity click"
-msgstr "Clic"
+msgstr "Nhấp chuột"
 
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:9
 msgid "Saved!"
-msgstr "¡Guardado!"
+msgstr "Đã lưu!"
 
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:10
 msgid "Saving failed."
-msgstr "No se ha podido guardar."
+msgstr "Lưu thất bại."
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Su"
-msgstr "D"
+msgstr "CN"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Mo"
-msgstr "L"
+msgstr "T2"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Tu"
-msgstr "M"
+msgstr "T3"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "We"
-msgstr "X"
+msgstr "T4"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Th"
-msgstr "J"
+msgstr "T5"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Fr"
-msgstr "V"
+msgstr "T6"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Sa"
-msgstr "S"
+msgstr "T7"
 
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:41
 msgid "Your admin's email address"
-msgstr "La dirección de correo electrónico de tu administrador"
+msgstr "Địa chỉ email quản trị"
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:37
 msgid "To send {0}, you'll need to set up {1} integration."
-msgstr "Para enviar {0}, tendrás que configurar la integración con {1}."
+msgstr "Để gửi {0}, bạn sẽ cần thiết lập tích hợp {1}."
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:38
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:41
 msgid " or "
-msgstr " o "
+msgstr " hoặc "
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:40
 msgid "To send {0}, an admin needs to set up {1} integration."
-msgstr "Para enviar {0}, un administrador necesita configurar la integración con {1}."
+msgstr "Để gửi {0}, quản trị viên cần thiết lập tích hợp {1}."
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:15
 msgid "This collection is empty, like a blank canvas"
-msgstr "Esta colección está vacía, como una hoja en blanco"
+msgstr "Bộ sưu tập này trống rỗng, giống như một khung vẽ trống"
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:16
 msgid "You can use collections to organize and group dashboards, questions and pulses for your team or yourself"
-msgstr "Puedes usar colecciones para organizar y agrupar cuadros de mando, preguntas y pulsos para tu equipo o para ti"
+msgstr "Bạn có thể sử dụng các bộ sưu tập để sắp xếp và nhóm bảng điều khiển, câu hỏi và xung cho nhóm của bạn hoặc chính bạn"
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:28
 msgid "Create another collection"
-msgstr "Crea otra colección"
+msgstr "Tạo bộ sưu tập khác"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:68
 msgid "Dashboards let you collect and share data in one place."
-msgstr "Los cuadros de mando te permiten recopilar y compartir datos en un solo lugar."
+msgstr "Trang tổng quan cho phép bạn tổng hợp và chia sẻ dữ liệu vào một nơi."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:77
 msgid "Pulses let you send out the latest data to your team on a schedule via email or slack."
-msgstr "Los pulsos te permiten enviar datos de Metabase a correo electrónico o Slack en el horario que deseas."
+msgstr "Các xung cho phép bạn gửi dữ liệu mới nhất đến nhóm của mình theo lịch trình qua email hoặc chùng."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:86
 msgid "Questions are a saved look at your data."
-msgstr "Las preguntas son vistas guardadas de tus datos."
+msgstr "Các câu hỏi là một cái nhìn lưu vào dữ liệu của bạn."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
-msgstr "Pins"
+msgstr "Các ghim"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
-msgstr "Arrastra algo aquí para pegarlo arriba"
+msgstr "Kéo thứ gì đó vào đây để ghim nó lên đầu"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:753
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
-msgstr "Colecciones"
+msgstr "Các bộ sưu tập"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:431
 #: frontend/src/metabase/components/CollectionLanding.jsx:452
 msgid "Drag here to un-pin"
-msgstr "Arrastra aquí para despegarlo"
+msgstr "Kéo vào đây để bỏ ghim"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:487
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
-msgstr[0] "{0} elemento seleccionado"
-msgstr[1] "{0} elementos seleccionados"
+msgstr[0] "{0} mục đã chọn"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:517
 msgid "Move {0} items?"
-msgstr "¿Mover {1} elemento(s)?"
+msgstr "Di chuyển {0} mục"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:518
 msgid "Move \"{0}\"?"
-msgstr "¿Mover \"{0}\"?"
+msgstr "Di chuyển \"{0}\"?"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:623
 #: frontend/src/metabase/components/EntityMenu.info.js:29
@@ -2290,84 +2276,83 @@ msgstr "¿Mover \"{0}\"?"
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
-msgstr "Mover"
+msgstr "Di chuyển"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:687
 msgid "Edit this collection"
-msgstr "Edita esta colección"
+msgstr "Chỉnh sửa bộ sưu tập này"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:695
 msgid "Archive this collection"
-msgstr "Archivar esta colección"
+msgstr "Lưu trữ bộ sưu tập này"
 
 #: frontend/src/metabase/components/CollectionList.jsx:67
 #: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
-msgstr "Mi colección personal"
+msgstr "Bộ sưu tập cá nhân của tôi"
 
 #: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
-msgstr "Nueva colección"
+msgstr "Bộ sưu tập mới"
 
 #: frontend/src/metabase/components/CopyButton.jsx:36
 msgid "Copied!"
-msgstr "¡Copiado!"
+msgstr "Đã sao chép!"
 
 #: frontend/src/metabase/entities/databases/forms.js:14
 msgid "Use an SSH-tunnel for database connections"
-msgstr "Utiliza un túnel SSH para las conexiones a la base de datos"
+msgstr "Sử dụng một SSH-tunnel cho các kết nối tới cơ sở dữ liệu này"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
-msgstr "Algunas instalaciones de bases de datos solo se pueden acceder conectándose a través de un túnel SSH.\n"
-"Esta opción también proporciona una capa adicional de seguridad cuando no dispones de una VPN.\n"
-"Esto suele ser más lento que una conexión directa."
+msgstr "Một vài cài đặt cơ sở dữ liệu chỉ có thể truy cập bằng kết nối qua một máy chủ SSH.\n"
+"Lựa chọn này cung cấp một tầng bảo mật khi VPN không khả dụng.\n"
+"Bật tính năng này sẽ làm chậm hết nối hơn là kết nối trực tiếp."
 
 #: frontend/src/metabase/entities/databases/forms.js:281
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
-msgstr "Esta es una base de datos grande, así que déjame elegir cuándo Metabase sincroniza y escanea"
+msgstr "Đây là một cơ sở dữ liệu lớn, vậy nên hãy để tôi chọn khi nào thì Metabase đồng bộ và quét"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
-msgstr "De forma predeterminada, Metabase realiza una sincronización ligera cada hora y un análisis diario intensivo de los valores de campo.\n"
-"Si tienes una base de datos grande, te recomendamos activarla y revisar cuándo y con qué frecuencia ocurren los escaneos de valores de campo."
+msgstr "Nếu bạn có cơ sở dữ liệu lớn, chúng tôi khuyên bạn nên bật tính năng này và xem xét thời điểm và tần suất quét giá trị trường xảy ra."
 
 #: frontend/src/metabase/entities/databases/forms.js:113
 msgid "{0} to generate a Client ID and Client Secret for your project."
-msgstr "{0} para generar un ID y clave secreta de cliente para tu proyecto."
+msgstr "{0} để sinh Client ID và Client Secret cho dự án của bạn."
 
 #: frontend/src/metabase/entities/databases/forms.js:115
 #: frontend/src/metabase/entities/databases/forms.js:130
 #: frontend/src/metabase/entities/databases/forms.js:166
 msgid "Click here"
-msgstr "Haz clic aquí"
+msgstr "Nhấn vào đây"
 
 #: frontend/src/metabase/entities/databases/forms.js:118
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
-msgstr "Elige \"Otro\" como tipo de aplicación. Llámalo como quieras"
+msgstr "Chọn \"Khác\" cho kiểu ứng dụng. Đặt tên tuỳ ý bạn thích"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:357
 msgid "{0} to get an auth code"
-msgstr "{0} para obtener un código de autenticación"
+msgstr "{0} để lấy mã xác thực"
 
 #: frontend/src/metabase/entities/databases/forms.js:142
 msgid "with Google Drive permissions"
-msgstr "con permisos de Google Drive"
+msgstr "với quyền của Google Drive"
 
 #: frontend/src/metabase/entities/databases/forms.js:164
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
-msgstr "Para usar Metabase con estos datos, debes habilitar el acceso a la API en Google Developers Console."
+msgstr "Để sử dụng Metabase với dữ liệu này bạn phải bật tính năng API access trên giao diện Google Developers Console."
 
 #: frontend/src/metabase/entities/databases/forms.js:165
 msgid "{0} to go to the console if you haven't already done so."
-msgstr "{0} para ir a la consola si aún no lo has hecho."
+msgstr "{0} để đi tới bảng điều khiển nếu bạn chưa làm thế."
 
 #: frontend/src/metabase/entities/databases/forms.js:265
 msgid "How would you like to refer to this database?"
-msgstr "¿Cómo te gustaría llamar esta base de datos?"
+msgstr "Bạn muốn tham khảo cơ sở dữ liệu này như thế nào?"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:187
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
@@ -2378,148 +2363,148 @@ msgstr "¿Cómo te gustaría llamar esta base de datos?"
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:126
 #: frontend/src/metabase/setup/components/UserStep.jsx:93
 msgid "Next"
-msgstr "Siguiente"
+msgstr "Tiếp theo"
 
 #: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
-msgstr "Elimina este {0}"
+msgstr "Xoá {0} này"
 
 #: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
-msgstr "Fija este elemento"
+msgstr "Ghim cái này"
 
 #: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
-msgstr "Mueve este elemento"
+msgstr "Di chuyển cái này"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:21
 msgid "Edit this question"
-msgstr "Editar esta pregunta"
+msgstr "Sửa câu hỏi này"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:26
 #: frontend/src/metabase/components/EntityMenu.info.js:47
 #: frontend/src/metabase/components/EntityMenu.info.js:82
 #: frontend/src/metabase/components/EntityMenu.info.js:99
 msgid "Action type"
-msgstr "Tipo acción"
+msgstr "Kiểu hành động"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:26
 msgid "View revision history"
-msgstr "Ver el historial de revisiones"
+msgstr "Xem lịch sử thay đổi"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 msgid "Move action"
-msgstr "Acción de mover"
+msgstr "Hành động di chuyển"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:33
 #: frontend/src/metabase/components/EntityMenu.info.js:89
 msgid "Archive action"
-msgstr "Acción de archivar"
+msgstr "Hành động lưu trữ"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:31
 msgid "Add to dashboard"
-msgstr "Añadir a Cuadro de Mando"
+msgstr "Thêm vào bảng tổng quan"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:49
 #: frontend/src/metabase/components/EntityMenu.info.js:101
 msgid "Download results"
-msgstr "Descarga los resultados"
+msgstr "Tải xuống kết quả"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:51
 #: frontend/src/metabase/components/EntityMenu.info.js:103
 #: frontend/src/metabase/dashboard/containers/DashboardEmbedWidget.jsx:53
 msgid "Sharing and embedding"
-msgstr "Compartiendo y Incrustando"
+msgstr "Chia sẻ và nhúng"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:53
 #: frontend/src/metabase/components/EntityMenu.info.js:105
 msgid "Another action type"
-msgstr "Otro tipo de acción"
+msgstr "Kiểu hành đông khác"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:65
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
 msgid "Get alerts about this"
-msgstr "Recibe alertas sobre esto"
+msgstr "Nhận cảnh báo về cái này"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
-msgstr "Ver el SQL"
+msgstr "Xem câu truy vấn SQL"
 
 #: frontend/src/metabase/components/EntitySegments.jsx:18
 msgid "Segments for this"
-msgstr "Segmentos para este"
+msgstr "Phân khúc cho việc này"
 
 #: frontend/src/metabase/components/ErrorDetails.jsx:20
 msgid "Show error details"
-msgstr "Mostrar detalles del error"
+msgstr "Hiển thị chi tiết lỗi"
 
 #: frontend/src/metabase/components/ErrorDetails.jsx:26
 msgid "Here's the full error message"
-msgstr "Este es el mensaje de error completo"
+msgstr "Đây là chi tiết thông báo lỗi"
 
 #: frontend/src/metabase/components/ExplorePane.jsx:19
 msgid "Hi, Metabot here."
-msgstr "Hola, soy Metabot"
+msgstr "Xin chào, Metabot đây."
 
 #: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
-msgstr "Basado en el esquema"
+msgstr "Dựa vào schema"
 
 #: frontend/src/metabase/components/ExplorePane.jsx:173
 msgid "A look at your"
-msgstr "Una vista a tus"
+msgstr "Nhìn vào cái của bạn"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:296
 msgid "Search the list"
-msgstr "Busca la lista"
+msgstr "Tìm kiếm trong danh sách"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:307
 msgid "Search by {0}"
-msgstr "Buscar por {0}"
+msgstr "Tìm kiếm theo {0}"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:309
 msgid " or enter an ID"
-msgstr "o introduce un ID"
+msgstr " hoặc nhập vào một ID"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:314
 msgid "Enter an ID"
-msgstr "Introduce un ID"
+msgstr "Nhập vào một ID"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:316
 msgid "Enter a number"
-msgstr "Introduce un número"
+msgstr "Nhập vào một số"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:318
 msgid "Enter some text"
-msgstr "Introduce un texto"
+msgstr "Nhập vào vài dòng chữ"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:429
 msgid "No matching {0} found."
-msgstr "No se encontraron {0} coincidentes."
+msgstr "Không có {0} nào khớp."
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:438
 msgid "Including every option in your filter probably won’t do much…"
-msgstr "Incluir cada opción en tu filtro probablemente no hará mucho…"
+msgstr "Bao gồm mọi tùy chọn trong bộ lọc của bạn có thể sẽ không làm được nhiều"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:26
 msgid "Something's gone wrong"
-msgstr "Lo siento. Algo salió mal."
+msgstr "Có gì đó sai"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:27
 msgid "We've run into an error. You can try refreshing the page, or just go back."
-msgstr "Nos encontramos con un error. Puedes intentar refrescar la página, o simplemente volver atrás"
+msgstr "Đã gặp lỗi. Bạn có  thể thử làm mới lại trang, hoặc trở về trang trước."
 
 #: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
@@ -2530,327 +2515,327 @@ msgstr "Nos encontramos con un error. Puedes intentar refrescar la página, o si
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:238
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:213
 msgid "No description yet"
-msgstr "Sin descripción todavía"
+msgstr "Chưa có mô tả"
 
 #: frontend/src/metabase/components/Header.jsx:119
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
-msgstr "Nuevo {0}"
+msgstr "{0} mới"
 
 #: frontend/src/metabase/components/Header.jsx:130
 msgid "Asked by {0}"
-msgstr "Preguntado por {0}"
+msgstr "Được hỏi bởi {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
-msgstr "Hoy."
+msgstr "Hôm nay "
 
 #: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
-msgstr "Ayer."
+msgstr "Hôm qua "
 
 #: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
-msgstr "Primera revisión."
+msgstr "Phiên bản đầu tiên."
 
 #: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
-msgstr "Revertido a una revisión anterior y {0}"
+msgstr "Khôi phục về phiên bản trước đó và {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
-msgstr "Historial de Revisiones"
+msgstr "Lịch sử thay đổi"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
-msgstr "Cuando"
+msgstr "Khi"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
-msgstr "Quien"
+msgstr "Ai"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
-msgstr "Que"
+msgstr "Cái gì"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
-msgstr "Revertir"
+msgstr "Khôi phục"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
-msgstr "Revertiendo…"
+msgstr "Đang khôi phục..."
 
 #: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
-msgstr "Falló la reversión"
+msgstr "Không phục thất lại"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
-msgstr "Revertido"
+msgstr "Đã khôi phục"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:13
 msgid "Everything"
-msgstr "Todo"
+msgstr "Tất cả mọi thứ"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
 msgid "Dashboards"
-msgstr "Cuadros de Mando"
+msgstr "Các trang tổng quan"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
 msgid "Questions"
-msgstr "Preguntas"
+msgstr "Các câu hỏi"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
 #: frontend/src/metabase/routes.jsx:311
 msgid "Pulses"
-msgstr "Pulsos"
+msgstr "Xung"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
 #: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
-msgstr "Atrás"
+msgstr "Trở lại"
 
 #: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
-msgstr "Encontrar..."
+msgstr "Tìm..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 msgid "An error occured"
-msgstr "Ha ocurrido un error"
+msgstr "Lỗi đã xảy ra"
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:35
 msgid "Loading..."
-msgstr "Cargando..."
+msgstr "Đang tải..."
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:71
 msgid "Metabase Newsletter"
-msgstr "Boletín Metabase"
+msgstr "Bản tin Metabase"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:81
 msgid "Get infrequent emails about new releases and feature updates."
-msgstr "Recibe correos electrónicos infrecuentes sobre nuevos lanzamientos y actualizaciones de funciones."
+msgstr "Nhận email không thường xuyên về các bản phát hành hoặc tính năng cập nhật."
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:99
 msgid "Subscribe"
-msgstr "Suscribir"
+msgstr "Đăng ký"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:106
 msgid "You're subscribed. Thanks for using Metabase!"
-msgstr "Estás suscrito. ¡Gracias por usar Metabase!"
+msgstr "Bạn đã đăng ký. Cảm ơn đã sử dụng Metabase!"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:46
 msgid "We're a little lost..."
-msgstr "Estamos un poco perdidos..."
+msgstr "Chúng ta hơi lạc lối..."
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:27
 msgid "Temporary Password"
-msgstr "Contraseña Temporal"
+msgstr "Mật khẩu tạm thời"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:207
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:455
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:470
 msgid "Hide"
-msgstr "Esconder"
+msgstr "Ẩn"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:456
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:471
 msgid "Show"
-msgstr "Mostrar"
+msgstr "Hiện"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:17
 msgid "Saved! Add this to a dashboard?"
-msgstr "¡Guardado! ¿Añadir esto a un cuadro de mando?"
+msgstr "Đã lưu! Thêm vào trang tổng quan?"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:25
 msgid "Yes please!"
-msgstr "¡Sí, por favor!"
+msgstr "Vâng!"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:29
 msgid "Not now"
-msgstr "Ahora no"
+msgstr "Không phải bây giờ"
 
 #: frontend/src/metabase/components/SaveStatus.jsx:53
 msgid "Error:"
-msgstr "Error:"
+msgstr "Lỗi:"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:23
 msgid "Sunday"
-msgstr "Domingo"
+msgstr "Chủ nhật"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:24
 msgid "Monday"
-msgstr "Lunes"
+msgstr "Thứ hai"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:25
 msgid "Tuesday"
-msgstr "Martes"
+msgstr "Thứ ba"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:26
 msgid "Wednesday"
-msgstr "Miércoles"
+msgstr "Thứ tư"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:27
 msgid "Thursday"
-msgstr "Jueves"
+msgstr "Thứ năm"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:28
 msgid "Friday"
-msgstr "Viernes"
+msgstr "Thứ sáu"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:29
 msgid "Saturday"
-msgstr "Sábado"
+msgstr "Thứ bảy"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:33
 msgid "First"
-msgstr "Primero"
+msgstr "Đầu tiên"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:34
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
 msgid "Last"
-msgstr "Ultimo"
+msgstr "Cuối cùng"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:35
 msgid "15th (Midpoint)"
-msgstr "15to (punto medio)"
+msgstr "15 (điểm giữa)"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:125
 msgid "Calendar Day"
-msgstr "Día Calendario"
+msgstr "Lịch ngày"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:205
 msgid "your Metabase timezone"
-msgstr "tu zona horaria en Metabase"
+msgstr "Múi giờ Metabase của bạn"
 
 #: frontend/src/metabase/components/SearchHeader.jsx:21
 msgid "Filter this list..."
-msgstr "Filtra esta lista..."
+msgstr "Lọc danh sách này..."
 
 #: frontend/src/metabase/components/Select.info.js:8
 msgid "Blue"
-msgstr "Azul"
+msgstr "Xanh dương"
 
 #: frontend/src/metabase/components/Select.info.js:9
 msgid "Green"
-msgstr "Verde"
+msgstr "Xanh lá cây"
 
 #: frontend/src/metabase/components/Select.info.js:10
 msgid "Red"
-msgstr "Rojo"
+msgstr "Đỏ"
 
 #: frontend/src/metabase/components/Select.info.js:11
 msgid "Yellow"
-msgstr "Amarillo"
+msgstr "Vàng"
 
 #: frontend/src/metabase/components/Select.info.js:7
 msgid "A component used to make a selection"
-msgstr "Un componente utilizado para hacer una selección"
+msgstr "Một yếu tố được sử dụng để tạo lựa chọ"
 
 #: frontend/src/metabase/components/Select.info.js:20
 #: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
-msgstr "Seleccionado"
+msgstr "Đã chọn"
 
 #: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
-msgstr "Nada para seleccionar"
+msgstr "Không có gì để chọn"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:56
 msgid "Sorry, you don’t have permission to see that."
-msgstr "Lo siento, no tienes permiso para ver eso."
+msgstr "Xin lỗi, bạn không có quyền xem."
 
 #: frontend/src/metabase/components/form/FormMessage.jsx:5
 msgid "Unknown error encountered"
-msgstr "Error desconocido encontrado"
+msgstr "Lỗi không xác định"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/nav/containers/Navbar.jsx:373
 msgid "Create"
-msgstr "Crea"
+msgstr "Tạo"
 
 #: frontend/src/metabase/containers/DashboardForm.jsx:9
 msgid "Create dashboard"
-msgstr "Crea un Cuadro de Mando"
+msgstr "Tạo trang tổng quan"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
 msgid "Table"
-msgstr "Tabla"
+msgstr "Bảng"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
 msgid "Database"
-msgstr "Base de Datos"
+msgstr "Cơ sở dữ liệu"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:49
 msgid "Creator"
-msgstr "Creador"
+msgstr "Người tạo"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
-msgstr "No se han encontrado resultados"
+msgstr "Không có kết quả"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
-msgstr "Intenta ajustar tu filtro para encontrar lo que estás buscando."
+msgstr "Thử chỉnh sửa lọc để tìm những gì bạn đang tìm kiếm."
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
-msgstr "Ver por"
+msgstr "Xem bởi"
 
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:121
 msgid "of"
-msgstr "de"
+msgstr "của"
 
 #: frontend/src/metabase/containers/Overworld.jsx:91
 msgid "Don't tell anyone, but you're my favorite."
-msgstr "No se lo digas a nadie, pero eres mi favorito."
+msgstr "Đừng nói với ai, nhưng mà bạn mà người tôi yêu thích."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:85
 msgid "Once you connect your own data, I can show you some automatic explorations called x-rays. Here are some examples with sample data."
-msgstr "En cuanto conectas tus propios datos, puedo mostrarte algunas exploraciones automáticas llamadas rayos-X. Aquí hay algunos ejemplos con datos de muestra."
+msgstr "Một khi bạn kết nối dữ liệu của mình, Tôi có thể cho bạn một vài khám phá tự động gọi là x-rays. Đây là một vài ví dụ với mẫu dữ liệu."
 
 #: frontend/src/metabase/containers/Overworld.jsx:180
 #: frontend/src/metabase/containers/Overworld.jsx:384
 msgid "Start here"
-msgstr "Empieza aquí"
+msgstr "Bắt đầu ở đây"
 
 #: frontend/src/metabase/containers/Overworld.jsx:379
 #: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
-msgstr "Nuestra Analítica"
+msgstr "Các phân tích của chúng ta"
 
 #: frontend/src/metabase/containers/Overworld.jsx:248
 msgid "Browse all items"
-msgstr "Ver todos los elementos"
+msgstr "Duyệt tất cả"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:117
 msgid "Replace or save as new?"
-msgstr "¿Reemplazar o guardar como nuevo?"
+msgstr "Thay thế hoặc lưu mới?"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace original question, \"{0}\""
-msgstr "Reemplazar la pregunta original, \"{0}\""
+msgstr "Thay thế câu hỏi gốc, \"{0}\""
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:171
 msgid "Save as new question"
-msgstr "Guardar como nueva pregunta"
+msgstr "Lưu ra câu hỏi mới"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:92
 msgid "First, save your question"
-msgstr "Primero, guarda tu pregunta"
+msgstr "Đầu tiên, hãy lưu câu hỏi của bạn"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
 msgid "Save question"
-msgstr "Guardar pregunta"
+msgstr "Lưu câu hỏi"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
 msgid "What is the name of your card?"
-msgstr "¿Cuál es el nombre de tu tarjeta?"
+msgstr "Tên thẻ của bạn là gì?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
@@ -2868,7 +2853,7 @@ msgstr "¿Cuál es el nombre de tu tarjeta?"
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:211
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:26
 msgid "Description"
-msgstr "Descripción"
+msgstr "Mô tả"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
@@ -2877,468 +2862,468 @@ msgstr "Descripción"
 #: frontend/src/metabase/entities/questions.js:107
 #: frontend/src/metabase/entities/snippets.js:31
 msgid "It's optional but oh, so helpful"
-msgstr "Es opcional pero, tan útil"
+msgstr "Nó không bắt buộc, nhưng có ích đó"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
-msgstr "¿En qué colección debería ir esto?"
+msgstr "Cái này nên đi vào bộ sưu tập nào?"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:34
 msgid "modified"
-msgstr "modificado"
+msgstr "Đã điều chỉnh"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:34
 msgid "item"
-msgstr "elemento"
+msgstr "mục"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
-msgstr "Deshacer"
+msgstr "Làm lại"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:266
 msgid "Applying Question"
-msgstr "Aplicando Pregunta"
+msgstr "Áp dụng câu hỏi"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "That question isn't compatible"
-msgstr "Esa pregunta no es compatible"
+msgstr "Câu hỏi này không phù hợp"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:309
 msgid "Search for a question"
-msgstr "Busca una pregunta"
+msgstr "Tìm một câu hỏi"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:343
 msgid "We're not sure if this question is compatible"
-msgstr "No estamos seguros si esta pregunta es compatible"
+msgstr "Chúng tôi không chắc câu hỏi này là phù hợp"
 
 #: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:43
 msgid "Archive Dashboard"
-msgstr "Archivar Cuadro de Mando"
+msgstr "Lưu trữ bảng điều khiển"
 
 #: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
-msgstr "Asegúrate de hacer una selección para cada serie, o el filtro no funcionará en esta tarjeta."
+msgstr "Đảm bảo thực hiện lựa chọn cho từng chuỗi hoặc bộ lọc sẽ không hoạt động trên thẻ này."
 
 #: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
 msgid "This dashboard is looking empty."
-msgstr "Este cuadro de mando parece estar vacío."
+msgstr "Bảng điều khiển này trống"
 
 #: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
 msgid "Add a question to start making it useful!"
-msgstr "¡Añade una pregunta para hacerlo útil!"
+msgstr "Thêm một câu hỏi để bắt đầu khiến nó hữu ích"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:38
 msgid "Daytime mode"
-msgstr "Modo Diurno"
+msgstr "Chế độ ban ngày"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:38
 msgid "Nighttime mode"
-msgstr "Modo Nocturno"
+msgstr "Chế độ ban đêm"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:56
 msgid "Exit fullscreen"
-msgstr "Desactivar Pantalla Completa"
+msgstr "Thoát toàn màn hình"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:56
 msgid "Enter fullscreen"
-msgstr "Activar Pantalla Completa"
+msgstr "Vào toàn màn hình"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
-msgstr "Guardando…"
+msgstr "Đang lưu..."
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:220
 msgid "Add a question"
-msgstr "Añade una pregunta"
+msgstr "Thêm một câu hỏi"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:223
 msgid "Add a question to this dashboard"
-msgstr "Añade una pregunta a este cuadro de mando"
+msgstr "Thêm một câu hỏi vào bảng điều khiển này"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
 msgid "Add a filter"
-msgstr "Añadir filtro"
+msgstr "Thêm một bộ lọc"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
-msgstr "Parámetros"
+msgstr "Thông số"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
 msgid "Add a text box"
-msgstr "Añade una caja de texto"
+msgstr "Thêm một hộp văn bản"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:314
 msgid "Move dashboard"
-msgstr "Mover cuadro de mando"
+msgstr "Di chuyển bảng điều khiển"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
 msgid "Edit dashboard"
-msgstr "Editar Cuadro de Mando"
+msgstr "Chỉnh sửa bảng điều khiển"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:307
 msgid "Edit Dashboard Layout"
-msgstr "Editar Disposición del Cuadro de Mando"
+msgstr "Chỉnh sửa bố cục bảng điều khiển"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:365
 msgid "You are editing a dashboard"
-msgstr "Estás editando un cuadro de mando"
+msgstr "Bạn đang chỉnh sửa bảng điều khiển"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:370
 msgid "Select the field that should be filtered for each card"
-msgstr "Selecciona el campo que debe filtrarse para cada tarjeta"
+msgstr "Chọn trường được lọc cho mỗi thẻ"
 
 #: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
-msgstr "Mover cuadro de mando a..."
+msgstr "Di chuyển bảng điều khiển đến..."
 
 #: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
-msgstr "Cuadro de Mando movido a {0}"
+msgstr "Bảng điều khiển đã di chuyển tới {0}"
 
 #: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
 msgid "What do you want to filter?"
-msgstr "¿Qué quieres filtrar?"
+msgstr "Bạn muốn lọc cái gì?"
 
 #: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
 msgid "What kind of filter?"
-msgstr "¿Qué tipo de filtro?"
+msgstr "Kiểu của bộ lọc là gì?"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:242
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:250
 msgid "Off"
-msgstr "Apagado"
+msgstr "Tắt"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:14
 msgid "1 minute"
-msgstr "1 minuto"
+msgstr "1 phút"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:15
 msgid "5 minutes"
-msgstr "5 minutos"
+msgstr "5 phút"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:16
 msgid "10 minutes"
-msgstr "10 minutos"
+msgstr "10 phút"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:17
 msgid "15 minutes"
-msgstr "15 minutos"
+msgstr "15 phút"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:18
 msgid "30 minutes"
-msgstr "30 minutos"
+msgstr "30 phút"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:19
 msgid "60 minutes"
-msgstr "60 minutos"
+msgstr "60 phút"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:51
 msgid "Auto-refresh"
-msgstr "Auto-Refresco"
+msgstr "Tự động làm mới"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:57
 msgid "Refreshing in"
-msgstr "Actualizando en"
+msgstr "Làm mới trong"
 
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:30
 msgid "Remove this question?"
-msgstr "¿Eliminar esta pregunta?"
+msgstr "Bỏ câu hỏi này?"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
-msgstr "Se ha guardado tu cuadro de mando."
+msgstr "Bảng điều khiển của bạn đã được lưu"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:740
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
-msgstr "Verlo"
+msgstr "Xem nó"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
-msgstr "Guardalo"
+msgstr "Lưu"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
-msgstr "Mostrar más sobre este/a"
+msgstr "Hiển thị thêm về điều nàys"
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
-msgstr "Esta tarjeta no tiene campos ni parámetros que coincidan con este tipo de parámetro."
+msgstr "Thẻ này không có bất kỳ trường hoặc tham số nào có thể được ánh xạ tới loại tham số này."
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
-msgstr "Los valores en este campo no coinciden con los valores de ningún otro campo que hayas elegido."
+msgstr "Các giá trị trong trường này không trùng với giá trị của bất kỳ trường nào khác bạn đã chọn."
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
-msgstr "No hay campos válidos"
+msgstr "Trường không khả dụng"
 
 #: frontend/src/metabase/entities/collections.js:98
 msgid "Name must be 100 characters or less"
-msgstr "El nombre debe tener 100 caracteres o menos"
+msgstr "Tên phải chứa ít hơn 100 kí tự"
 
 #: frontend/src/metabase/entities/collections.js:112
 msgid "Color is required"
-msgstr "Color es obligatorio"
+msgstr "Màu sắc là bắt buộc"
 
 #: frontend/src/metabase/entities/dashboards.js:143
 msgid "What is the name of your dashboard?"
-msgstr "¿Cuál es el nombre de tu cuadro de mando?"
+msgstr "Tên của bảng điều khiển của bạn là gì?"
 
 #: frontend/src/metabase/home/components/Activity.jsx:95
 msgid "did some super awesome stuff that's hard to describe"
-msgstr "he hecho algunas cosas geniales que son difíciles de describir"
+msgstr "Những thứ tuyệt vời này có khó để mô tả không?"
 
 #: frontend/src/metabase/home/components/Activity.jsx:104
 #: frontend/src/metabase/home/components/Activity.jsx:119
 msgid "created an alert about - "
-msgstr "creado una alerta sobre - "
+msgstr "Đã tạo một cảnh báo về - "
 
 #: frontend/src/metabase/home/components/Activity.jsx:129
 #: frontend/src/metabase/home/components/Activity.jsx:144
 msgid "deleted an alert about - "
-msgstr "eliminado una alerta sobre - "
+msgstr "Đã xóa một cảnh báo về - "
 
 #: frontend/src/metabase/home/components/Activity.jsx:155
 msgid "saved a question about "
-msgstr "guardado una pregunta sobre"
+msgstr "Đã lưu một câu hỏi về"
 
 #: frontend/src/metabase/home/components/Activity.jsx:168
 msgid "saved a question"
-msgstr "guardado una pregunta"
+msgstr "Đã lưu một câu hỏi"
 
 #: frontend/src/metabase/home/components/Activity.jsx:172
 msgid "deleted a question"
-msgstr "eliminado una pregunta"
+msgstr "Đã xóa một câu hỏi"
 
 #: frontend/src/metabase/home/components/Activity.jsx:175
 msgid "created a dashboard"
-msgstr "creado un cuadro de mando"
+msgstr "Đã tạo một bảng điều khiển"
 
 #: frontend/src/metabase/home/components/Activity.jsx:178
 msgid "deleted a dashboard"
-msgstr "eliminado un cuadro de mando"
+msgstr "Đã xóa một bảng điều khiển"
 
 #: frontend/src/metabase/home/components/Activity.jsx:184
 #: frontend/src/metabase/home/components/Activity.jsx:199
 msgid "added a question to the dashboard - "
-msgstr "añadido una pregunta al cuadro de mando - "
+msgstr "Đã thêm một câu hỏi vào bảng điều khiển - "
 
 #: frontend/src/metabase/home/components/Activity.jsx:209
 #: frontend/src/metabase/home/components/Activity.jsx:224
 msgid "removed a question from the dashboard - "
-msgstr "eliminado una pregunta del cuadro de mando - "
+msgstr "Đã loại bỏ một câu hỏi từ bảng điều khiển - "
 
 #: frontend/src/metabase/home/components/Activity.jsx:234
 #: frontend/src/metabase/home/components/Activity.jsx:241
 msgid "received the latest data from"
-msgstr "recibido los últimos datos de"
+msgstr "Đã nhận dữ liệu mới nhất từ"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
 msgid "Unknown"
-msgstr "Desconocido"
+msgstr "Không biết"
 
 #: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Hello World!"
-msgstr "¡Hola Mundo!"
+msgstr "Xin chào thế giới!"
 
 #: frontend/src/metabase/home/components/Activity.jsx:255
 msgid "Metabase is up and running."
-msgstr "Metabase está funcionando."
+msgstr "Metabase đang hoạt động"
 
 #: frontend/src/metabase/home/components/Activity.jsx:261
 #: frontend/src/metabase/home/components/Activity.jsx:291
 msgid "added the metric "
-msgstr "añadido la métrica"
+msgstr "Đã thêm số liệu"
 
 #: frontend/src/metabase/home/components/Activity.jsx:275
 #: frontend/src/metabase/home/components/Activity.jsx:365
 msgid " to the "
-msgstr "a la"
+msgstr "Đến"
 
 #: frontend/src/metabase/home/components/Activity.jsx:285
 #: frontend/src/metabase/home/components/Activity.jsx:325
 #: frontend/src/metabase/home/components/Activity.jsx:375
 #: frontend/src/metabase/home/components/Activity.jsx:416
 msgid " table"
-msgstr "tabla"
+msgstr "Bảng"
 
 #: frontend/src/metabase/home/components/Activity.jsx:301
 #: frontend/src/metabase/home/components/Activity.jsx:331
 msgid "made changes to the metric "
-msgstr "ha hecho cambios a la métrica"
+msgstr "Đã thay đổi số liệu"
 
 #: frontend/src/metabase/home/components/Activity.jsx:315
 #: frontend/src/metabase/home/components/Activity.jsx:406
 msgid " in the "
-msgstr "en el"
+msgstr "trong"
 
 #: frontend/src/metabase/home/components/Activity.jsx:338
 msgid "removed the metric "
-msgstr "eliminado la métrica"
+msgstr "Đã loại bỏ số liệu"
 
 #: frontend/src/metabase/home/components/Activity.jsx:341
 msgid "created a pulse"
-msgstr "pulso creado"
+msgstr "Tạo một xung"
 
 #: frontend/src/metabase/home/components/Activity.jsx:344
 msgid "deleted a pulse"
-msgstr "pulso eliminado"
+msgstr "Đã xóa một xung"
 
 #: frontend/src/metabase/home/components/Activity.jsx:350
 #: frontend/src/metabase/home/components/Activity.jsx:381
 msgid "added the filter"
-msgstr "filtro añadido"
+msgstr "Đã thêm bộ lọc"
 
 #: frontend/src/metabase/home/components/Activity.jsx:391
 #: frontend/src/metabase/home/components/Activity.jsx:422
 msgid "made changes to the filter"
-msgstr "ha hecho cambios al filtro"
+msgstr "Đã thay đổi bộ lọc"
 
 #: frontend/src/metabase/home/components/Activity.jsx:429
 msgid "removed the filter {0}"
-msgstr "eliminado el filtro {0}"
+msgstr "Bỏ bộ lọc {0}"
 
 #: frontend/src/metabase/home/components/Activity.jsx:432
 msgid "joined!"
-msgstr "¡se ha unido!"
+msgstr "Đã tham gia"
 
 #: frontend/src/metabase/home/components/Activity.jsx:532
 msgid "Hmmm, looks like nothing has happened yet."
-msgstr "Hmmm, parece que nada ha pasado aún."
+msgstr "Hmmm, trông như chưa có gì xảy ra"
 
 #: frontend/src/metabase/home/components/Activity.jsx:535
 msgid "Save a question and get this baby going!"
-msgstr "¡Guarda una pregunta y haz que esto funcione!"
+msgstr "Lưu một câu hỏi và khiến "
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:19
 msgid "Ask questions and explore"
-msgstr "Haz preguntas y explora"
+msgstr "Hỏi các câu hỏi và khám phá"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:20
 msgid "Click on charts or tables to explore, or ask a new question using the easy interface or the powerful SQL editor."
-msgstr "Haz clic en cuadros o tablas para explorar, o haz una nueva pregunta usando el interfaz sencillo o el potente editor SQL."
+msgstr "Nhấp chuột vào biểu đồ hoặc bảng để khám phá, hoặc hỏi một câu hỏi mới sử dụng giao diện dễ dàng hoặc biên tập SQL mạnh."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:30
 msgid "Make your own charts"
-msgstr "Crea tus propios gráficos"
+msgstr "Tạo biểu đồ của bạn"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:31
 msgid "Create line charts, scatter plots, maps, and more."
-msgstr "Crea gráficos de líneas, gráficos de dispersión, mapas y más."
+msgstr "Tạo biểu đồ đường, sơ đồ phân tán, bản đồ, v.v."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:41
 msgid "Share what you find"
-msgstr "Comparte lo que encuentres"
+msgstr "Chia sẻ cái bạn tìm được"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:42
 msgid "Create powerful and flexible dashboards, and send regular updates via email or Slack."
-msgstr "Crea cuadros de mando potentes y flexibles, y envía actualizaciones periódicas por correo electrónico o Slack."
+msgstr "Tạo bảng điều khiển mạnh mẽ và linh hoạt và gửi cập nhật thường xuyên qua email hoặc Slack."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
 msgid "Let's go"
-msgstr "Vamos allá"
+msgstr "Đi thôi"
 
 #: frontend/src/metabase/home/components/NextStep.jsx:34
 msgid "Setup Tip"
-msgstr "Consejo de configuración"
+msgstr "Mẹo thiết lập"
 
 #: frontend/src/metabase/home/components/NextStep.jsx:40
 msgid "View all"
-msgstr "Ver todos"
+msgstr "Xem tất cả"
 
 #: frontend/src/metabase/home/components/RecentViews.jsx:40
 msgid "Recently Viewed"
-msgstr "Visto Recientemente"
+msgstr "Xem gần đây"
 
 #: frontend/src/metabase/home/components/RecentViews.jsx:77
 msgid "You haven't looked at any dashboards or questions recently"
-msgstr "No has consultado ningún cuadro de mando o pregunta recientemente"
+msgstr "Bạn không xem bảng điều khiển hay câu hỏi nào gần đây"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
-msgstr "{0} elemento(s) seleccionado(s)"
+msgstr "{0} mục được chọn"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 msgid "Unarchive"
-msgstr "Desarchivar"
+msgstr "Bỏ lưu trữ"
 
 #: frontend/src/metabase/home/containers/HomepageApp.jsx:77
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:59
 msgid "Activity"
-msgstr "Actividad"
+msgstr "Hoạt động"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:31
 msgid "Results for \"{0}\""
-msgstr "Resultados de \"{0}\""
+msgstr "Kết quả cho \"{0}\""
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:138
 msgid "Pulse"
-msgstr "Pulso"
+msgstr "Xung"
 
 #: frontend/src/metabase/lib/core.js:8
 msgid "Entity Key"
-msgstr "Clave Entidad"
+msgstr "Chìa khóa thực thể"
 
 #: frontend/src/metabase/lib/core.js:9 frontend/src/metabase/lib/core.js:15
 #: frontend/src/metabase/lib/core.js:21
 msgid "Overall Row"
-msgstr "Fila General"
+msgstr "Hàng tổng quan"
 
 #: frontend/src/metabase/lib/core.js:10
 msgid "The primary key for this table."
-msgstr "La clave principal para esta tabla."
+msgstr "Chìa khóa chính cho bảng này"
 
 #: frontend/src/metabase/lib/core.js:14
 msgid "Entity Name"
-msgstr "Nombre Entidad"
+msgstr "Tên thực thể"
 
 #: frontend/src/metabase/lib/core.js:16
 msgid "The \"name\" of each record. Usually a column called \"name\", \"title\", etc."
-msgstr "El \"nombre\" de cada registro. Por lo general, una columna llamada \"nombre\", \"título\", etc."
+msgstr "\\ \"Tên \" của mỗi bản ghi. Thông thường một cột có tên \\ \"name \", \\ \"title \", v.v."
 
 #: frontend/src/metabase/lib/core.js:20
 msgid "Foreign Key"
-msgstr "Clave Foránea"
+msgstr "Chìa khóa ngoại"
 
 #: frontend/src/metabase/lib/core.js:22
 msgid "Points to another table to make a connection."
-msgstr "Referencia otra tabla para establecer una conexión."
+msgstr "Chỉ vào một bảng khác để tạo kết nối."
 
 #: frontend/src/metabase/lib/core.js:257
 msgid "Avatar Image URL"
-msgstr "URL Avatar"
+msgstr "URL ảnh đại diện"
 
 #: frontend/src/metabase/lib/core.js:29 frontend/src/metabase/lib/core.js:34
 #: frontend/src/metabase/lib/core.js:39 frontend/src/metabase/lib/core.js:44
 #: frontend/src/metabase/lib/core.js:49
 msgid "Common"
-msgstr "Común"
+msgstr "Chung"
 
 #: frontend/src/metabase/lib/core.js:28
 #: frontend/src/metabase/meta/Dashboard.js:86
 #: frontend/src/metabase/modes/components/drill/PivotByCategoryDrill.jsx:10
 msgid "Category"
-msgstr "Categoría"
+msgstr "Ngành"
 
 #: frontend/src/metabase/lib/core.js:55
 #: frontend/src/metabase/meta/Dashboard.js:66
 msgid "City"
-msgstr "Ciudad"
+msgstr "Thành phố"
 
 #: frontend/src/metabase/lib/core.js:60
 #: frontend/src/metabase/meta/Dashboard.js:78
 msgid "Country"
-msgstr "País"
+msgstr "Quốc gia"
 
 #: frontend/src/metabase/lib/core.js:240
 msgid "Enum"
@@ -3346,118 +3331,117 @@ msgstr "Enum"
 
 #: frontend/src/metabase/lib/core.js:262
 msgid "Image URL"
-msgstr "URL Imagen"
+msgstr "URL hình ảnh"
 
 #: frontend/src/metabase/lib/core.js:274
 msgid "Field containing JSON"
-msgstr "Campo que contiene JSON"
+msgstr "Trường chứa JSON"
 
 #: frontend/src/metabase/lib/core.js:65
 msgid "Latitude"
-msgstr "Latitud"
+msgstr "Vĩ độ"
 
 #: frontend/src/metabase/lib/core.js:70
 msgid "Longitude"
-msgstr "Longitud"
+msgstr "Kinh độ"
 
 #: frontend/src/metabase/lib/core.js:43
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:45
 msgid "Number"
-msgstr "Número"
+msgstr "Số"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:19
 #: frontend/src/metabase/lib/core.js:75
 #: frontend/src/metabase/meta/Dashboard.js:70
 msgid "State"
-msgstr "Provincia"
+msgstr "Bang"
 
 #: frontend/src/metabase/lib/core.js:233
 msgid "UNIX Timestamp (Seconds)"
-msgstr "Marca de tiempo UNIX (Segundos)"
+msgstr "Dấu thời gian UNIX (Giây)"
 
 #: frontend/src/metabase/lib/core.js:228
 msgid "UNIX Timestamp (Milliseconds)"
-msgstr "Marca de tiempo UNIX (Milisegundos)"
+msgstr "Dấu thời gian UNIX (Mili giây)"
 
 #: frontend/src/metabase/lib/core.js:80
 msgid "Zip Code"
-msgstr "Código Postal"
+msgstr "Mã bưu chính"
 
 #: frontend/src/metabase/lib/core.js:119
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
 msgid "Quantity"
-msgstr "Cantidad"
+msgstr "Số lượng"
 
 #: frontend/src/metabase/lib/core.js:107
 msgid "Income"
-msgstr "Ingreso"
+msgstr "Lợi tức"
 
 #: frontend/src/metabase/lib/core.js:97
 msgid "Discount"
-msgstr "Descuento"
+msgstr "Giảm giá"
 
-#. Sé que parece una traducción muy literal, pero no sería una traducción más acertada "Sello de tiempo de creación"?
 #: frontend/src/metabase/lib/core.js:193
 msgid "Creation timestamp"
-msgstr "Fecha y Hora de Creación"
+msgstr "Dấu thời gian tạo"
 
 #: frontend/src/metabase/lib/core.js:188
 msgid "Creation time"
-msgstr "Hora de Creación"
+msgstr "Thời gian tạo"
 
 #: frontend/src/metabase/lib/core.js:183
 msgid "Creation date"
-msgstr "Fecha de Creación"
+msgstr "Ngày tạo"
 
 #: frontend/src/metabase/lib/core.js:245
 msgid "Product"
-msgstr "Producto"
+msgstr "Sản phẩm"
 
 #: frontend/src/metabase/lib/core.js:161
 msgid "User"
-msgstr "Usuario"
+msgstr "Người dùng"
 
 #: frontend/src/metabase/lib/core.js:250
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
 msgid "Source"
-msgstr "Fuente"
+msgstr "Nguồn"
 
 #: frontend/src/metabase/lib/core.js:112
 msgid "Price"
-msgstr "Precio"
+msgstr "Giá"
 
 #: frontend/src/metabase/lib/core.js:223
 msgid "Join timestamp"
-msgstr "Unir por Tiempo"
+msgstr "Dấu thời gian tham gia"
 
 #: frontend/src/metabase/lib/core.js:218
 msgid "Join time"
-msgstr "Unir por Tiempo"
+msgstr "Thời gian tham gia"
 
 #: frontend/src/metabase/lib/core.js:213
 msgid "Join date"
-msgstr "Unir por Fecha"
+msgstr "Ngày tham gia"
 
 #: frontend/src/metabase/lib/core.js:129
 msgid "Share"
-msgstr "Compartir"
+msgstr "Chia sẻ"
 
 #: frontend/src/metabase/lib/core.js:151
 msgid "Owner"
-msgstr "Propietario"
+msgstr "Chủ sở hữu"
 
 #: frontend/src/metabase/lib/core.js:141
 msgid "Company"
-msgstr "Empresa"
+msgstr "Công ty"
 
 #: frontend/src/metabase/lib/core.js:156
 msgid "Subscription"
-msgstr "Suscripción"
+msgstr "Theo dõi"
 
 #: frontend/src/metabase/lib/core.js:124
 msgid "Score"
-msgstr "Puntuación"
+msgstr "Điểm"
 
 #: frontend/src/metabase/lib/core.js:48
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
@@ -3465,62 +3449,62 @@ msgstr "Puntuación"
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
-msgstr "Título"
+msgstr "Tiêu đề"
 
 #: frontend/src/metabase/lib/core.js:33
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
 msgid "Comment"
-msgstr "Comentario"
+msgstr "Bình luận"
 
 #: frontend/src/metabase/lib/core.js:87
 msgid "Cost"
-msgstr "Coste"
+msgstr "Chi phí"
 
 #: frontend/src/metabase/lib/core.js:102
 msgid "Gross margin"
-msgstr "Margen Bruto"
+msgstr "Biên lãi gộp"
 
 #: frontend/src/metabase/lib/core.js:136
 msgid "Birthday"
-msgstr "Cumpleaños"
+msgstr "Sinh nhật"
 
 #: frontend/src/metabase/lib/core.js:285
 msgid "Search box"
-msgstr "Caja de Búsqueda"
+msgstr "Hộp tìm kiếm"
 
 #: frontend/src/metabase/lib/core.js:286
 msgid "A list of all values"
-msgstr "Una lista con todos los valores"
+msgstr "Danh sách tất cả các giá trị"
 
 #: frontend/src/metabase/lib/core.js:287
 msgid "Plain input box"
-msgstr "Caja de Texto"
+msgstr "Hộp đầu vào trơn"
 
 #: frontend/src/metabase/lib/core.js:293
 msgid "Everywhere"
-msgstr "En todas partes"
+msgstr "Mọi nơi"
 
 #: frontend/src/metabase/lib/core.js:294
 msgid "The default setting. This field will be displayed normally in tables and charts."
-msgstr "La configuración predeterminada. Este campo se mostrará normalmente en tablas y gráficos."
+msgstr "Cài đặt mặc định. Trường này sẽ được hiển thị bình thường trong bảng và biểu đồ."
 
 #: frontend/src/metabase/lib/core.js:254
 msgid "Only in Detail Views"
-msgstr "Solo en vistas detalladas"
+msgstr "Chỉ trong chế độ xem chi tiết"
 
 #: frontend/src/metabase/lib/core.js:299
 msgid "This field will only be displayed when viewing the details of a single record. Use this for information that's lengthy or that isn't useful in a table or chart."
-msgstr "Este campo solo se mostrará cuando veas los detalles de un solo registro. Úsalo para obtener información larga o que no sea útil en una tabla o gráfico."
+msgstr "Trường này sẽ chỉ được hiển thị khi xem chi tiết của một bản ghi. Sử dụng thông tin này cho thông tin dài hoặc không hữu ích trong bảng hoặc biểu đồ."
 
 #: frontend/src/metabase/lib/core.js:259
 msgid "Do Not Include"
-msgstr "No Incluir"
+msgstr "Không bao gồm"
 
 #: frontend/src/metabase/lib/core.js:260
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
-msgstr "Metabase nunca recuperará este campo. Úsalo para información sensible o irrelevante."
+msgstr "Cơ sở dữ liệu tích lũy sẽ không bao giờ lấy lại trường này. Sử dụng điều này cho thông tin nhạy cảm hoặc không liên quan."
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
@@ -3533,189 +3517,186 @@ msgstr "Metabase nunca recuperará este campo. Úsalo para información sensible
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "Count"
-msgstr "Contar"
+msgstr "Số đếm"
 
 #: frontend/src/metabase/lib/expressions/config.js:8
 msgid "CumulativeCount"
-msgstr "RecuentoAcumulativo"
+msgstr "Số tích lũy"
 
 #: frontend/src/metabase/lib/schema_metadata.js:485
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
-msgstr "Suma"
+msgstr "Tổng"
 
 #: frontend/src/metabase/lib/expressions/config.js:10
 msgid "CumulativeSum"
-msgstr "SumaAcumulativa"
+msgstr "Tổng tích lũy"
 
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Distinct"
-msgstr "Distinto"
+msgstr "Phân biệt"
 
-#. With accents a problem occured, I removed the accents (temporarily ?)
 #: frontend/src/metabase/lib/expressions/config.js:12
 msgid "StandardDeviation"
-msgstr "DesviacionEstandar"
+msgstr "Độ lệch chuẩn"
 
 #: frontend/src/metabase/lib/schema_metadata.js:494
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
-msgstr "Media"
+msgstr "Trung bình"
 
 #: frontend/src/metabase/lib/schema_metadata.js:539
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
-msgstr "Mín"
+msgstr "Nhỏ nhất"
 
 #: frontend/src/metabase/lib/schema_metadata.js:548
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
 msgid "Max"
-msgstr "Máx"
+msgstr "Lớn nhất"
 
 #: frontend/src/metabase/lib/expressions/parser.js:373
 msgid "sad sad panda, lexing errors detected"
-msgstr "triste panda triste, errores léxicos detectados"
+msgstr "Lỗi lexing được phát hiệ"
 
 #: frontend/src/metabase/lib/formatting.js:832
 msgid "{0} second"
 msgid_plural "{0} seconds"
-msgstr[0] "{0} segundo"
-msgstr[1] "{0} segundos"
+msgstr[0] "{0} giây"
 
 #: frontend/src/metabase/lib/formatting.js:835
 msgid "{0} minute"
 msgid_plural "{0} minutes"
-msgstr[0] "{0} minuto"
-msgstr[1] "{0} minutos"
+msgstr[0] "{0} phút"
 
 #: frontend/src/metabase/lib/greeting.js:4
 msgid "Hey there"
-msgstr "Hola"
+msgstr "Xin chào"
 
 #: frontend/src/metabase/lib/greeting.js:5
 #: frontend/src/metabase/lib/greeting.js:29
 msgid "How's it going"
-msgstr "¿Cómo te va"
+msgstr "Bạn thế nào?"
 
 #: frontend/src/metabase/lib/greeting.js:6
 msgid "Howdy"
-msgstr "Hola"
+msgstr "Xin chào"
 
 #: frontend/src/metabase/lib/greeting.js:7
 msgid "Greetings"
-msgstr "Saludos"
+msgstr "Xin chào"
 
 #: frontend/src/metabase/lib/greeting.js:8
 msgid "Good to see you"
-msgstr "Que bueno verte"
+msgstr "Rất vui được gặp bạn"
 
 #: frontend/src/metabase/lib/greeting.js:12
 msgid "What do you want to know?"
-msgstr "¿Que quieres saber?"
+msgstr "Bạn muốn biết cái gì?"
 
 #: frontend/src/metabase/lib/greeting.js:13
 msgid "What's on your mind?"
-msgstr "¿Qué tienes en mente?"
+msgstr "Bạn đang nghĩ gì?"
 
 #: frontend/src/metabase/lib/greeting.js:14
 msgid "What do you want to find out?"
-msgstr "¿Qué quieres saber?"
+msgstr "Bạn muốn tìm cái gì?"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
 #: frontend/src/metabase/lib/schema_metadata.js:467
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
-msgstr "Datos brutos"
+msgstr "Dữ liệu gốc"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
 #: frontend/src/metabase/lib/schema_metadata.js:521
 msgid "Cumulative count"
-msgstr "Recuento acumulativo"
+msgstr "Số tích lũy"
 
 #: frontend/src/metabase/lib/query/description.js:82
 #: frontend/src/metabase/lib/query/description.js:266
 msgid "Average of "
-msgstr "Media de"
+msgstr "Trung bình của"
 
 #: frontend/src/metabase/lib/query/description.js:87
 #: frontend/src/metabase/lib/query/description.js:268
 msgid "Distinct values of "
-msgstr "Valores distintos de"
+msgstr "Giá trị riêng biệt của"
 
 #: frontend/src/metabase/lib/query/description.js:92
 #: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
-msgstr "Desviación estándar de"
+msgstr "Độ lệch chuẩn của"
 
 #: frontend/src/metabase/lib/query/description.js:97
 #: frontend/src/metabase/lib/query/description.js:272
 msgid "Sum of "
-msgstr "Suma de"
+msgstr "Tổng của"
 
 #: frontend/src/metabase/lib/query/description.js:102
 #: frontend/src/metabase/lib/query/description.js:274
 msgid "Cumulative sum of "
-msgstr "Suma acumulativa de"
+msgstr "Tổng cộng của"
 
 #: frontend/src/metabase/lib/query/description.js:107
 #: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
-msgstr "Máximo de"
+msgstr "Lớn nhất của"
 
 #: frontend/src/metabase/lib/query/description.js:112
 #: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
-msgstr "Mínimo de"
+msgstr "Nhỏ nhất của"
 
 #: frontend/src/metabase/lib/query/description.js:126
 #: frontend/src/metabase/lib/query/description.js:286
 msgid "Grouped by "
-msgstr "Agrupado por"
+msgstr "Được nhóm bởi"
 
 #: frontend/src/metabase/lib/query/description.js:140
 #: frontend/src/metabase/lib/query/description.js:295
 msgid "Filtered by "
-msgstr "Filtrado por"
+msgstr "Được lọc bởi"
 
 #: frontend/src/metabase/lib/query/description.js:169
 #: frontend/src/metabase/lib/query/description.js:320
 msgid "Sorted by "
-msgstr "Ordenado por"
+msgstr "Được sắp xếp bởi"
 
 #: frontend/src/metabase/lib/schema_metadata.js:237
 msgid "True"
-msgstr "Verdadero"
+msgstr "Đúng"
 
 #: frontend/src/metabase/lib/schema_metadata.js:237
 msgid "False"
-msgstr "Falso"
+msgstr "Sai"
 
 #: frontend/src/metabase/lib/schema_metadata.js:322
 msgid "Select longitude field"
-msgstr "Selecciona el campo de longitud"
+msgstr "Chọn trường kinh độ"
 
 #: frontend/src/metabase/lib/schema_metadata.js:323
 msgid "Enter upper latitude"
-msgstr "Latitud Superior"
+msgstr "Nhập vĩ độ cao hơn"
 
 #: frontend/src/metabase/lib/schema_metadata.js:324
 msgid "Enter left longitude"
-msgstr "Longitud Izquierda"
+msgstr "Nhập kinh độ trái"
 
 #: frontend/src/metabase/lib/schema_metadata.js:325
 msgid "Enter lower latitude"
-msgstr "Latitud Inferior"
+msgstr "Nhập vĩ độ thấp hơn"
 
 #: frontend/src/metabase/lib/schema_metadata.js:326
 msgid "Enter right longitude"
-msgstr "Longitud Derecha"
+msgstr "Nhập kinh độ phải"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:539
 #: frontend/src/metabase-lib/lib/Dimension.js:541
@@ -3727,7 +3708,7 @@ msgstr "Longitud Derecha"
 #: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:417
 msgid "Is"
-msgstr "Es"
+msgstr "Là"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
 #: frontend/src/metabase/lib/schema_metadata.js:383
@@ -3735,7 +3716,7 @@ msgstr "Es"
 #: frontend/src/metabase/lib/schema_metadata.js:407
 #: frontend/src/metabase/lib/schema_metadata.js:413
 msgid "Is not"
-msgstr "No es"
+msgstr "Không là"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:378
@@ -3745,7 +3726,7 @@ msgstr "No es"
 #: frontend/src/metabase/lib/schema_metadata.js:408
 #: frontend/src/metabase/lib/schema_metadata.js:418
 msgid "Is empty"
-msgstr "Vacío"
+msgstr "Trống"
 
 #: frontend/src/metabase/lib/schema_metadata.js:365
 #: frontend/src/metabase/lib/schema_metadata.js:379
@@ -3755,281 +3736,279 @@ msgstr "Vacío"
 #: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/lib/schema_metadata.js:419
 msgid "Not empty"
-msgstr "No Vacío"
+msgstr "Không trống"
 
 #: frontend/src/metabase/lib/schema_metadata.js:371
 msgid "Equal to"
-msgstr "Igual a"
+msgstr "Bằng"
 
 #: frontend/src/metabase/lib/schema_metadata.js:372
 msgid "Not equal to"
-msgstr "Distinto a"
+msgstr "Không bằng"
 
 #: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Greater than"
-msgstr "Mayor que"
+msgstr "Lớn hơn"
 
 #: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Less than"
-msgstr "Menor que"
+msgstr "Ít hơn"
 
 #: frontend/src/metabase/lib/schema_metadata.js:375
 #: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
-msgstr "Entre"
+msgstr "Giữa"
 
 #: frontend/src/metabase/lib/schema_metadata.js:376
 msgid "Greater than or equal to"
-msgstr "Mayor o igual a"
+msgstr "Lớn hơn hoặc bằng"
 
 #: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Less than or equal to"
-msgstr "Menos o igual a"
+msgstr "Ít hơn hoặc bằng"
 
 #: frontend/src/metabase/lib/schema_metadata.js:384
 msgid "Contains"
-msgstr "Contiene"
+msgstr "Bao gồm"
 
 #: frontend/src/metabase/lib/schema_metadata.js:385
 msgid "Does not contain"
-msgstr "No contiene"
+msgstr "Không bao gồm"
 
 #: frontend/src/metabase/lib/schema_metadata.js:388
 msgid "Starts with"
-msgstr "Empieza con"
+msgstr "Bắt đầu với"
 
 #: frontend/src/metabase/lib/schema_metadata.js:389
 msgid "Ends with"
-msgstr "Termina en"
+msgstr "Kết thúc với"
 
 #: frontend/src/metabase/lib/schema_metadata.js:399
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
-msgstr "Antes"
+msgstr "Trước"
 
 #: frontend/src/metabase/lib/schema_metadata.js:400
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
-msgstr "Después"
+msgstr "Sau"
 
 #: frontend/src/metabase/lib/schema_metadata.js:414
 msgid "Inside"
-msgstr "Dentro"
+msgstr "Bên trong"
 
 #: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Just a table with the rows in the answer, no additional operations."
-msgstr "Solo una tabla con las filas en la respuesta, sin operaciones adicionales."
+msgstr "Chỉ cần một bảng với các hàng trong câu trả lời, không có thao tác bổ sung."
 
 #: frontend/src/metabase/lib/schema_metadata.js:475
 msgid "Count of rows"
-msgstr "Número de filas"
+msgstr "Đếm số hàng"
 
 #: frontend/src/metabase/lib/schema_metadata.js:477
 msgid "Total number of rows in the answer."
-msgstr "Número total de filas en la respuesta."
+msgstr "Tổng số dòng trong câu trả lời"
 
 #: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Sum of ..."
-msgstr "Suma de ..."
+msgstr "Tổng của ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:486
 msgid "Sum of all the values of a column."
-msgstr "Suma de todos los valores de una columna."
+msgstr "Tổng tất cả giá trị của một cột"
 
 #: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Average of ..."
-msgstr "Media de ..."
+msgstr "Trung bình của..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:495
 msgid "Average of all the values of a column"
-msgstr "Promedio de todos los valores de una columna"
+msgstr "Trung bình tất cả giá trị của một cột"
 
 #: frontend/src/metabase/lib/schema_metadata.js:502
 msgid "Number of distinct values of ..."
-msgstr "Número de valores distintos de ..."
+msgstr "Số lượng giá trị riêng biệt của ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:504
 msgid "Number of unique values of a column among all the rows in the answer."
-msgstr "Número de valores únicos de una columna entre todas las filas en la respuesta."
+msgstr "Số giá trị duy nhất của một cột trong số tất cả các hàng trong câu trả lời."
 
 #: frontend/src/metabase/lib/schema_metadata.js:511
 msgid "Cumulative sum of ..."
-msgstr "Suma acumulada de ..."
+msgstr "Tổng cộng của"
 
 #: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
-msgstr "Suma aditiva de todos los valores de una columna.\n"
-" e.g. los ingresos totales a lo largo del tiempo"
+msgstr "Tổng cộng của tất cả các giá trị của một cột. \\\\ ne.x. tổng doanh thu theo thời gian."
 
 #: frontend/src/metabase/lib/schema_metadata.js:520
 msgid "Cumulative count of rows"
-msgstr "Recuento acumulado de filas"
+msgstr "Số hàng tích lũy"
 
 #: frontend/src/metabase/lib/schema_metadata.js:501
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
-msgstr "Recuento aditiva del número de filas.\n"
-" e.g. número total de ventas en el tiempo"
+msgstr "Tổng số phụ của số lượng hàng. \\\\ ne.x. tổng số lượng bán hàng theo thời gian."
 
 #: frontend/src/metabase/lib/schema_metadata.js:529
 msgid "Standard deviation of ..."
-msgstr "Desviación estándar de ..."
+msgstr "Độ lệch chuẩn của ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:531
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
-msgstr "Número que expresa cuánto varían los valores de una columna entre todas las filas en la respuesta."
+msgstr "Số biểu thị số lượng giá trị của một cột khác nhau giữa tất cả các hàng trong câu trả lời."
 
 #: frontend/src/metabase/lib/schema_metadata.js:538
 msgid "Minimum of ..."
-msgstr "Mínimo de ..."
+msgstr "Nhỏ nhất của..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Minimum value of a column"
-msgstr "Valor mínimo de una columna"
+msgstr "Giá trị nhỏ nhất của cột"
 
 #: frontend/src/metabase/lib/schema_metadata.js:547
 msgid "Maximum of ..."
-msgstr "Máximo de ..."
+msgstr "Lớn nhất của ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:549
 msgid "Maximum value of a column"
-msgstr "Valor máximo de una columna"
+msgstr "Giá trị cao nhất của cột"
 
 #: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
-msgstr "Desglosar por dimensión"
+msgstr "Thoát ra theo chiều"
 
 #: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
-msgstr "letra en minúsculas"
+msgstr "chữ thường"
 
 #: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
-msgstr "letra en mayúsculas"
+msgstr "chữ hoa"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
-msgstr "número"
+msgstr "số"
 
 #: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
-msgstr "carácter especial"
+msgstr "Kí tự đặc biệt"
 
 #: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
-msgstr "debe ser"
+msgstr "Phải là"
 
 #: frontend/src/metabase/lib/settings.js:120
 #: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
-msgstr "caracteres"
+msgstr "Độ dài kí tự"
 
 #: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
-msgstr "Debe ser"
+msgstr "Phải là"
 
 #: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
-msgstr "e incluir"
+msgstr "và bao gồm"
 
 #: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
-msgstr "cero"
+msgstr "không"
 
 #: frontend/src/metabase/lib/utils.js:86
 msgid "one"
-msgstr "uno"
+msgstr "một"
 
 #: frontend/src/metabase/lib/utils.js:87
 msgid "two"
-msgstr "dos"
+msgstr "hai"
 
 #: frontend/src/metabase/lib/utils.js:88
 msgid "three"
-msgstr "tres"
+msgstr "ba"
 
 #: frontend/src/metabase/lib/utils.js:89
 msgid "four"
-msgstr "cuatro"
+msgstr "bốn"
 
 #: frontend/src/metabase/lib/utils.js:90
 msgid "five"
-msgstr "cinco"
+msgstr "năm"
 
 #: frontend/src/metabase/lib/utils.js:91
 msgid "six"
-msgstr "seis"
+msgstr "sáu"
 
 #: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
-msgstr "siete"
+msgstr "bảy"
 
 #: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
-msgstr "ocho"
+msgstr "tám"
 
 #: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
-msgstr "nueve"
+msgstr "chín"
 
 #: frontend/src/metabase/meta/Dashboard.js:35
 msgid "Month and Year"
-msgstr "Mes y Año"
+msgstr "Tháng và Năm"
 
 #: frontend/src/metabase/meta/Dashboard.js:36
 msgid "Like January, 2016"
-msgstr "Como Enero 2016"
+msgstr "Như tháng Một, 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:40
 msgid "Quarter and Year"
-msgstr "Trimestre y Año"
+msgstr "Quý và Năm"
 
 #: frontend/src/metabase/meta/Dashboard.js:41
 msgid "Like Q1, 2016"
-msgstr "Como T1, 2016"
+msgstr "Như Q1, 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:45
 msgid "Single Date"
-msgstr "Fecha Unica"
+msgstr "Ngày cụ thể"
 
 #: frontend/src/metabase/meta/Dashboard.js:46
 msgid "Like January 31, 2016"
-msgstr "Como 31 de Enero, 2016"
+msgstr "Như 31 tháng Một, 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:50
 msgid "Date Range"
-msgstr "Rango de Fechas"
+msgstr "Khoảng thời gian"
 
 #: frontend/src/metabase/meta/Dashboard.js:51
 msgid "Like December 25, 2015 - February 14, 2016"
-msgstr "Como 25 de Diciembre, 2015 - 14 de Febrero, 2016"
+msgstr "Như 25 tháng 12,2015 - 14 tháng 2,2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:55
 msgid "Relative Date"
-msgstr "Fecha Relativa"
+msgstr "Ngày tương đối"
 
 #: frontend/src/metabase/meta/Dashboard.js:56
 msgid "Like \"the last 7 days\" or \"this month\""
-msgstr "Como \"los últimos 7 días\" o \"este mes\""
+msgstr "Như \"7 ngày gần nhất\" hoặc \"tháng này\""
 
 #: frontend/src/metabase/meta/Dashboard.js:60
 msgid "Date Filter"
-msgstr "Filtro de Fecha"
+msgstr "Bộ lọc ngày"
 
 #: frontend/src/metabase/meta/Dashboard.js:61
 msgid "All Options"
-msgstr "Todas las Opciones"
+msgstr "Tất cả các lựa chọn"
 
 #: frontend/src/metabase/meta/Dashboard.js:62
 msgid "Contains all of the above"
-msgstr "Contiene todo lo anterior"
+msgstr "Bao gồm tất cả cái phía trên"
 
 #: frontend/src/metabase/meta/Dashboard.js:74
 msgid "ZIP or Postal Code"
-msgstr "Código Postal"
+msgstr "ZIP hoặc mã bưu chính"
 
 #: frontend/src/metabase/meta/Dashboard.js:82
 #: frontend/src/metabase/meta/Dashboard.js:112
@@ -4039,11 +4018,11 @@ msgstr "ID"
 #: frontend/src/metabase/meta/Dashboard.js:100
 #: frontend/src/metabase/modes/components/drill/PivotByTimeDrill.jsx:9
 msgid "Time"
-msgstr "Tiempo"
+msgstr "Thời gian"
 
 #: frontend/src/metabase/meta/Dashboard.js:101
 msgid "Date range, relative date, time of day, etc."
-msgstr "Rango de fechas, fecha relativa, hora del día, etc."
+msgstr "Khoảng thời gian, ngày tương đối, thời gian trong ngày, ..."
 
 #: frontend/src/metabase/lib/core.js:56 frontend/src/metabase/lib/core.js:61
 #: frontend/src/metabase/lib/core.js:66 frontend/src/metabase/lib/core.js:71
@@ -4051,143 +4030,143 @@ msgstr "Rango de fechas, fecha relativa, hora del día, etc."
 #: frontend/src/metabase/meta/Dashboard.js:106
 #: frontend/src/metabase/modes/components/drill/PivotByLocationDrill.jsx:9
 msgid "Location"
-msgstr "Ubicación"
+msgstr "Địa điểm"
 
 #: frontend/src/metabase/meta/Dashboard.js:107
 msgid "City, State, Country, ZIP code."
-msgstr "Ciudad, Provincia, País, Código Postal."
+msgstr "Thành phố, Bang, Quốc gia, mã ZIP"
 
 #: frontend/src/metabase/meta/Dashboard.js:113
 msgid "User ID, product ID, event ID, etc."
-msgstr "ID Usuario, ID Productio, ID Evento, etc."
+msgstr "ID người dùng, ID sản phẩn, ID sự kiện,..."
 
 #: frontend/src/metabase/meta/Dashboard.js:118
 msgid "Other Categories"
-msgstr "Otras Categorías"
+msgstr "Ngành khác"
 
 #: frontend/src/metabase/meta/Dashboard.js:119
 msgid "Category, Type, Model, Rating, etc."
-msgstr "Categoría, Tipo, Modelo, Clasificación, etc."
+msgstr "Ngành, loại, mẫu, đánh giá,..."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:43
 #: frontend/src/metabase/user/components/UserSettings.jsx:56
 msgid "Account settings"
-msgstr "Configuración de la cuenta"
+msgstr "Cài đặt tài khoản"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Exit admin"
-msgstr "Salir de Configuración"
+msgstr "Thoát người quản lý"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:35
 msgid "Logs"
-msgstr "Logs"
+msgstr "Nhật kí"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:104
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:22
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:65
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:100
 msgid "Help"
-msgstr "Ayuda"
+msgstr "Trợ giúp"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:72
 msgid "About Metabase"
-msgstr "Sobre Metabase"
+msgstr "Về Metabase"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:78
 msgid "Sign out"
-msgstr "Salir"
+msgstr "Thoát ra"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Thanks for using"
-msgstr "Gracias por utilizar"
+msgstr "Cảm ơn vì đã sử dụng"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:116
 msgid "You're on version"
-msgstr "Estás en la versión"
+msgstr "Bạn đang ở phiên bản"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:119
 msgid "Built on"
-msgstr "Construida el"
+msgstr "đã xây dựng trên"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:139
 msgid "is a Trademark of"
-msgstr "es una marca registrada de"
+msgstr "là nhãn hiệu của"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:141
 msgid "and is built with care in San Francisco, CA"
-msgstr "y está construido con cariño en San Francisco, CA"
+msgstr "và được xây dựng cẩn thận ở San Francisco, CA"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:224
 msgid "Metabase Admin"
-msgstr "Configuración Metabase"
+msgstr "Quản trị viên Metabase"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:36
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:36
 msgid "Ask a question"
-msgstr "Haz una pregunta"
+msgstr "Hỏi một câu hỏi"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:379
 msgid "New dashboard"
-msgstr "Añadir nuevo Cuadro de Mando"
+msgstr "Bảng điều khiển mới"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:385
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
-msgstr "Nuevo pulso"
+msgstr "Xung mới"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:323
 msgid "Reference"
-msgstr "Referencia"
+msgstr "Tham khảo"
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
-msgstr "¿Qué Métrica?"
+msgstr "Số liệu nào?"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Defining common metrics for your team makes it even easier to ask questions"
-msgstr "La definición de métricas comunes para tu equipo hace que sea aún más fácil hacer preguntas"
+msgstr "Xác định các số liệu phổ biến cho nhóm của bạn giúp đặt câu hỏi dễ dàng hơn"
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
-msgstr "Cómo crear métricas"
+msgstr "Cách tạo số liệu"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:138
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
-msgstr "Consulta los datos a lo largo del tiempo, como un mapa, o gírelos para ayudarte a comprender las tendencias o los cambios."
+msgstr "Xem dữ liệu theo thời gian, dưới dạng bản đồ hoặc xoay vòng để giúp bạn hiểu xu hướng hoặc thay đổi."
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
 msgid "Custom"
-msgstr "Personalizado"
+msgstr "Tập quán"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:157
 msgid "New question"
-msgstr "Nueva pregunta"
+msgstr "Câu hỏi mới"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:152
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
-msgstr "Utiliza el generador de preguntas para ver tendencias, listas de cosas o para crear tus propias métricas."
+msgstr "Sử dụng trình tạo câu hỏi đơn giản để xem xu hướng, danh sách các thứ hoặc để tạo số liệu của riêng bạn."
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:110
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
-msgstr "Consulta nativa"
+msgstr "Truy vấn gốc"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:111
 msgid "For more complicated questions, you can write your own SQL or native query."
-msgstr "Para preguntas más complicadas puedes escribir tu propia consulta SQL o nativa."
+msgstr "Với nhiều câu hỏi phức tạp hơn, bạn có thể viết SQL hoặc truy vấn gốc của bạn."
 
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
 msgid "Select a default value…"
-msgstr "Selecciona un valor por defecto…"
+msgstr "Chọn một giá trị mặc định..."
 
 #: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
 #: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
-msgstr "Actualizar filtro"
+msgstr "Cập nhật bộ lọc"
 
 #: frontend/src/metabase/lib/query_time.js:112
 #: frontend/src/metabase/lib/query_time.js:123
@@ -4195,22 +4174,22 @@ msgstr "Actualizar filtro"
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
 #: src/metabase/pulse/render/datetime.clj
 msgid "Today"
-msgstr "Hoy"
+msgstr "Hôm nay"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
 #: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
-msgstr "Ayer"
+msgstr "Hôm qua"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:18
 msgid "Past 7 days"
-msgstr "Ultimos 7 días"
+msgstr "7 ngày vừa qua"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:19
 msgid "Past 30 days"
-msgstr "Ultimos 30 días"
+msgstr "30 ngày vừa qua"
 
 #: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
@@ -4218,8 +4197,7 @@ msgstr "Ultimos 30 días"
 #: src/metabase/api/table.clj
 msgid "Week"
 msgid_plural "Weeks"
-msgstr[0] "Semana"
-msgstr[1] "Semanas"
+msgstr[0] "tuần"
 
 #: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
@@ -4227,8 +4205,7 @@ msgstr[1] "Semanas"
 #: src/metabase/api/table.clj
 msgid "Month"
 msgid_plural "Months"
-msgstr[0] "Mes"
-msgstr[1] "Meses"
+msgstr[0] "tháng"
 
 #: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
@@ -4236,355 +4213,353 @@ msgstr[1] "Meses"
 #: src/metabase/api/table.clj
 msgid "Year"
 msgid_plural "Years"
-msgstr[0] "Año"
-msgstr[1] "Años"
+msgstr[0] "Năm"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:152
 msgid "Past 7 Days"
-msgstr "Ultimos 7 Días"
+msgstr "7 ngày vừa qua"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:156
 msgid "Past 30 Days"
-msgstr "Ultimos 30 Días"
+msgstr "30 ngày vừa qua"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:160
 msgid "Last Week"
-msgstr "Semana Pasada"
+msgstr "Tuần trước"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:164
 msgid "Last Month"
-msgstr "El mes pasado"
+msgstr "Tháng trước"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:168
 msgid "Last Year"
-msgstr "El año pasado"
+msgstr "Năm trước"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:172
 msgid "This Week"
-msgstr "Esta Semana"
+msgstr "Tuần này"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:176
 msgid "This Month"
-msgstr "Este Mes"
+msgstr "Tháng này"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:180
 msgid "This Year"
-msgstr "Este Año"
+msgstr "Năm nay"
 
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
-msgstr "Introduce un valor..."
+msgstr "Nhập một giá trị..."
 
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:90
 msgid "Enter a default value..."
-msgstr "Introduce un valor predeterminado..."
+msgstr "Nhập một giá trị mặc định..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
 #: frontend/src/metabase/containers/Form.jsx:307
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
-msgstr "Ha ocurrido un error"
+msgstr "Có lỗi xảy ra"
 
 #: frontend/src/metabase/public/components/PublicNotFound.jsx:11
 msgid "Not found"
-msgstr "No encontrado"
+msgstr "Không tìm thấy"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:82
 msgid "You’ve made changes that need to be published before they will be reflected in your application embed."
-msgstr "Ha realizado cambios que deben publicarse antes de que se vean reflejados en la inserción de la aplicación."
+msgstr "Bạn đã thực hiện các thay đổi cần được công bố trước khi chúng được phản ánh trong ứng dụng của bạn được nhúng."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:83
 msgid "You will need to publish this {0} before you can embed it in another application."
-msgstr "Tendrás que publicar este {0} antes de poder incrustarlo en otra aplicación."
+msgstr "You will need to publish this {0} before you can embed it in another application."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:92
 msgid "Discard Changes"
-msgstr "Descartar Cambios"
+msgstr "Bỏ thay đổi"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:99
 msgid "Updating..."
-msgstr "Actualizando..."
+msgstr "Đang cập nhật..."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:100
 msgid "Updated"
-msgstr "Actualizado"
+msgstr "Đã cập nhật"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:101
 msgid "Failed!"
-msgstr "¡Ha fallado!"
+msgstr "Thất bại!"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:102
 msgid "Publish"
-msgstr "Publicar"
+msgstr "Xuất bản"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:111
 #: frontend/src/metabase/visualizations/lib/settings/column.js:345
 msgid "Code"
-msgstr "Código"
+msgstr "Mã"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:296
 msgid "Style"
-msgstr "Estilo"
+msgstr "Phong cách"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
-msgstr "¿Qué parámetros pueden usar los usuarios de este embebido?"
+msgstr "Những thông số nào người dùng có thể sử dụng nhúng này"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
-msgstr "Este {0} aún no tiene parámetros para configurar."
+msgstr "{0} này chưa có bất kì thông số nào để định cấu hình."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
-msgstr "Editable"
+msgstr "Có thể chỉnh sửa"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
-msgstr "Bloqueado"
+msgstr "Đã khóa"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:113
 msgid "Preview Locked Parameters"
-msgstr "Vista previa de los parámetros bloqueados"
+msgstr "Xem trước thông số đã khóa"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
-msgstr "Intenta pasar algunos valores a tus parámetros bloqueados aquí. Tu servidor tendrá que proporcionar los valores reales en el token firmado al usar esto de manera real."
+msgstr "Hãy thử chuyển một số giá trị cho các tham số bị khóa của bạn ở đây. Máy chủ của bạn sẽ phải cung cấp các giá trị thực tế trong mã thông báo đã ký khi sử dụng giá trị thực này."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
-msgstr "Zona peligrosa"
+msgstr "Khu vực nguy hiểm"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
-msgstr "Esto deshabilitará la incrustación para este {0}."
+msgstr "Điều này sẽ vô hiệu nhúng cho {0}"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
-msgstr "No publicar"
+msgstr "Hủy xuất bản"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:17
 msgid "Light"
-msgstr "Claro"
+msgstr "Sáng"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:18
 msgid "Dark"
-msgstr "Oscuro"
+msgstr "Tối"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:37
 msgid "Border"
-msgstr "Borde"
+msgstr "Biên"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:62
 msgid "To embed this {0} in your application:"
-msgstr "Para insertar este {0} en tu aplicación"
+msgstr "Nhúng {0} trong ứng dụng của bạn"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:64
 msgid "Insert this code snippet in your server code to generate the signed embedding URL "
-msgstr "Inserta este fragmento de código en tu código de servidor para generar la URL de inserción firmada"
+msgstr "Chèn đoạn mã này vào mã máy chủ của bạn để tạo URL nhúng đã ký "
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:87
 msgid "Then insert this code snippet in your HTML template or single page app."
-msgstr "A continuación, inserta este fragmento de código en tu plantilla HTML o aplicación de una sola página."
+msgstr "Sau đó chèn đoạn mã này vào mẫu HTML hoặc ứng dụng trang đơn."
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:94
 msgid "Embed code snippet for your HTML or Frontend Application"
-msgstr "Incrusta este fragmento de código en tu aplicación"
+msgstr "Đoạn mã nhúng cho ứng dụng HTML hoặc Frontend của bạn"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:101
 msgid "More {0}"
-msgstr "Más {0}"
+msgstr "Nhiều {0} hơn"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:103
 msgid "examples on GitHub"
-msgstr "ejemplos en GitHub"
+msgstr "Ví dụ trên GitHub"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
-msgstr "Habilitar compartir"
+msgstr "Cho phép chia sẻ"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
-msgstr "¿Deshabilitar este enlace público?"
+msgstr "Vô hiệu hóa đường dẫn công khai này?"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
-msgstr "Esto hará que el enlace existente deje de funcionar. Puedes volver a habilitarlo, pero cuando lo hagas será un enlace diferente."
+msgstr "Điều này sẽ khiến liên kết hiện tại ngừng hoạt động. Bạn có thể kích hoạt lại nó, nhưng khi bạn làm điều đó sẽ là một liên kết khác."
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
-msgstr "Enlace público"
+msgstr "Đường dẫn công khai"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
-msgstr "Comparte este {0} con personas que no tienen una cuenta de Metabase usando la siguiente URL:"
+msgstr "Chia sẻ {0} này với người không có tài khoản Metabase sử dụng URL phía dưới:"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
-msgstr "Incrustación pública"
+msgstr "Nhúng công khai"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
-msgstr "Incrusta este {0} en publicaciones de blogs o páginas web al copiar y pegar este fragmento:"
+msgstr "Nhúng {0} này vào các bài đăng trên blog hoặc trang web bằng cách sao chép và dán đoạn mã này:"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
-msgstr "Incrustar este {0} en una aplicación"
+msgstr "Nhúng {0} này trong ứng dụng"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
-msgstr "Al integrar con tu servidor de aplicaciones, puedes proporcionar un/a {0} segura limitada a un usuario específico, cliente, organización, etc."
+msgstr "Bằng cách tích hợp với mã máy chủ ứng dụng của bạn, bạn có thể cung cấp số liệu thống kê an toàn {0} giới hạn cho một người dùng, khách hàng, tổ chức cụ thể, v.v."
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
-msgstr "Eliminar adjunto"
+msgstr "Loại bỏ đính kèm"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
-msgstr "Adjuntar archivo con resultados"
+msgstr "Đính kèm tệp với các kết quả"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
-msgstr "Esta pregunta se añadirá como un archivo adjunto"
+msgstr "Câu hỏi này sẽ được thêm vào như một tệp đính kèm"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
-msgstr "Esta pregunta no estará incluida en tu Pulso"
+msgstr "Câu hỏi này sẽ không được bao gồm trong Xung của bạn"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
-msgstr "Este pulso ya no se enviará por correo electrónico a la dirección {1}"
+msgstr "Xung này sẽ không còn được gửi qua email tới {0} {1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
-msgstr[0] "{0} dirección"
-msgstr[1] "{0} direcciones"
+msgstr[0] "Địa chỉ {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:102
 msgid "Slack channel {0} will no longer get this pulse {1}"
-msgstr "El canal Slack {0} ya no recibirá este pulso {1}"
+msgstr "Kênh Slack {0} sẽ không còn nhận được xung này {1} "
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
-msgstr "El canal {0} ya no recibirá este pulso {1}"
+msgstr "Kênh {0} sẽ không còn nhận được xung này {1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
-msgstr "Edita un pulso"
+msgstr "Chỉnh sửa xung"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
-msgstr "¿Qué es un Pulso?"
+msgstr "Xung là gì?"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
-msgstr "Lo tengo"
+msgstr "Đã hiểu"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
-msgstr "¿A dónde deberían ir estos datos?"
+msgstr "Dữ liệu này nên đến đâu?"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
-msgstr "Desarchivando…"
+msgstr "Đang bỏ lưu trữ..."
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
-msgstr "Ha fallado la recuperación"
+msgstr "Bỏ lưu trữ thất bại"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
-msgstr "Desarchivado"
+msgstr "Đã bỏ lưu trữ"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
-msgstr "Crea un pulso"
+msgstr "Tạo xung"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:91
 msgid "Attachment"
-msgstr "Adjunto"
+msgstr "Đính kèm"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:105
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:112
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
-msgstr "Aviso"
+msgstr "Đứng lên"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:106
 msgid "We'll show the first 10 columns and 20 rows of this table in your Pulse. If you email this, we'll add a file attachment with all columns and up to 2,000 rows."
-msgstr "Mostraremos las primeras 10 columnas y 20 filas de esta tabla en tu Pulso. Si lo envías por correo electrónico, añadiremos un archivo adjunto con todas las columnas y hasta 2.000 filas."
+msgstr "Chúng tôi sẽ hiển thị 10 cột đầu tiên và 20 hàng của bảng này trong Xung của bạn. Nếu bạn gửi email này, chúng tôi sẽ thêm tệp đính kèm với tất cả các cột và tối đa 2.000 hàng."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:113
 msgid "Raw data questions can only be included as email attachments"
-msgstr "Las preguntas de datos brutos solo se pueden incluir como archivos adjuntos de correo electrónico"
+msgstr "Câu hỏi dữ liệu thô chỉ có thể được bao gồm dưới dạng tệp đính kèm email"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:120
 msgid "Looks like this pulse is getting big"
-msgstr "Parece que este pulso está creciendo mucho"
+msgstr "Có vẻ như xung này đang trở nên lớn"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:121
 msgid "We recommend keeping pulses small and focused to help keep them digestible and useful to the whole team."
-msgstr "Recomendamos mantener los pulsos pequeños y enfocados para ayudar a mantenerlos digeribles y útiles para todo el equipo."
+msgstr "Chúng tôi khuyên bạn nên giữ xung nhỏ và tập trung để giúp giữ cho chúng dễ tiêu hóa và hữu ích cho cả nhóm."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:161
 #: frontend/src/metabase/query_builder/components/view/View.jsx:133
 msgid "Pick your data"
-msgstr "Elige tus datos"
+msgstr "Chọn dữ liệu của bạn"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:163
 msgid "Choose questions you'd like to send in this pulse"
-msgstr "Elige las preguntas que te gustaría enviar en este pulso"
+msgstr "Chọn câu hỏi bạn muốn gửi trong xung này"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
 msgid "Emails"
-msgstr "Emails"
+msgstr "Email"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
 msgid "Slack messages"
-msgstr "Mensajes Slack"
+msgstr "Tin nhắn Slack"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
-msgstr "Enviado"
+msgstr "Đã gửi"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
-msgstr "{0} se enviará a las"
+msgstr "{0} sẽ được gửi tại"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
-msgstr "Mensajes"
+msgstr "Tin nhắn"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
-msgstr "Enviar email ahora"
+msgstr "Gửi email bây giờ"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
-msgstr "Enviar a {0} ahora"
+msgstr "Gửi đến {0} bây giờ"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
-msgstr "Enviando…"
+msgstr "Đang gửi"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
-msgstr "Ha fallado el envío"
+msgstr "Gửi thất bại"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
-msgstr "No se envió porque el pulso no tiene resultados."
+msgstr "Không gửi vì xung không có kết quả"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
-msgstr "Pulso enviado"
+msgstr "Đã gửi xung"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
-msgstr "{0} debe ser configurado por un administrador."
+msgstr "{0} cần được cài đặt bởi quản trị viên"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:299
 msgid "Slack"
@@ -4592,172 +4567,171 @@ msgstr "Slack"
 
 #: frontend/src/metabase/pulse/components/PulseEditCollection.jsx:12
 msgid "Which collection should this pulse live in?"
-msgstr "¿En qué colección debería estar este pulso?"
+msgstr "Xung này nên ở trong bộ sưu tập nào? "
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:35
 msgid "Name your pulse"
-msgstr "Nombra tu pulso"
+msgstr "Đặt tên cho xung của bạn"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:37
 msgid "Give your pulse a name to help others understand what it's about"
-msgstr "Dale un nombre a tu pulso para ayudar a otros a entender de qué se trata"
+msgstr "Đặt tên cho xung của bạn để giúp người khác hiểu nó là cái gì"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:49
 msgid "Important metrics"
-msgstr "Métricas importantes"
+msgstr "Số đo quan trọng"
 
 #: frontend/src/metabase/pulse/components/PulseEditSkip.jsx:22
 msgid "Skip if no results"
-msgstr "Omitir si no hay resultados"
+msgstr "Bỏ qua nếu không có kết quả"
 
 #: frontend/src/metabase/pulse/components/PulseEditSkip.jsx:24
 msgid "Skip a scheduled Pulse if none of its questions have any results"
-msgstr "Omitir un pulso programado si ninguna de sus preguntas tiene resultado"
+msgstr "Bỏ qua xung đã lên lịch nếu không có câu hỏi nào có kết quả"
 
 #: frontend/src/metabase/pulse/components/RecipientPicker.jsx:65
 msgid "Enter email addresses you'd like this data to go to"
-msgstr "Introduce las direcciones de correo electrónico a las que quieres que vayan estos datos"
+msgstr "Nhập địa chỉ email bạn muốn dữ liệu này tới"
 
 #: frontend/src/metabase/pulse/components/WhatsAPulse.jsx:16
 msgid "Help everyone on your team stay in sync with your data."
-msgstr "Ayuda a todos los de tu equipo a mantenerse sincronizados con tus datos."
+msgstr "Giúp mọi người trong nhóm của bạn tiếp tục đồng bộ với dữ liệu của bạn."
 
 #: frontend/src/metabase/pulse/components/WhatsAPulse.jsx:31
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
-msgstr "Los pulsos te permiten enviar datos de Metabase a correo electrónico o Slack en el horario que desees."
+msgstr "Các xung cho phép bạn gửi dữ liệu từ Metabase đến email hoặc Slack theo lịch bạn chọn"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "After {0}"
-msgstr "Después de {0}"
+msgstr "Sau {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 msgid "Before {0}"
-msgstr "Antes de {0}"
+msgstr "Trước {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
-msgstr "Vacío"
+msgstr "Trống rỗng"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
-msgstr "No Vacío"
+msgstr "Không trống rỗng"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
-msgstr "Todo el Tiempo"
+msgstr "Tất cả thời gian"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
 msgid "Apply"
-msgstr "Aplicar"
+msgstr "Áp dụng"
 
 #: frontend/src/metabase/modes/components/actions/CommonMetricsAction.jsx:21
 msgid "View {0}"
-msgstr "Ver {0}"
+msgstr "Xem {0}"
 
 #: frontend/src/metabase/modes/components/actions/CompareWithTable.jsx:29
 msgid "Compare this with all rows in the table"
-msgstr "Compara esto con todas las filas en la tabla"
+msgstr "So sánh cái này với tất cả các hàng trong bảng"
 
 #: frontend/src/metabase/modes/components/actions/CompoundQueryAction.jsx:14
 msgid "Analyze the results of this Query"
-msgstr "Analiza los resultados de esta consulta"
+msgstr "Phân tích kết quả của truy vấn này"
 
 #: frontend/src/metabase/modes/components/actions/CountByTimeAction.jsx:29
 msgid "Count of rows by time"
-msgstr "Número de filas por tiempo"
+msgstr "Số dòng theo thời gian"
 
 #: frontend/src/metabase/modes/components/drill/PivotByDrill.jsx:52
 msgid "Break out by {0}"
-msgstr "Distribuir por {0}"
+msgstr "Thoát ra bằng {0}"
 
 #: frontend/src/metabase/modes/components/actions/SummarizeBySegmentMetricAction.jsx:36
 msgid "Summarize this segment"
-msgstr "Resume este segmento"
+msgstr "Tổng hợp phân đoạn này"
 
 #: frontend/src/metabase/modes/components/actions/UnderlyingDataAction.jsx:14
 msgid "View this as a table"
-msgstr "Ver esto como una tabla"
+msgstr "Xem như một bảng"
 
 #: frontend/src/metabase/modes/components/actions/UnderlyingRecordsAction.jsx:22
 msgid "View the underlying {0} records"
-msgstr "Ver los registros subyacentes de {0}"
+msgstr "Xem các bản ghi {0} bên dưới"
 
 #: frontend/src/metabase/modes/components/actions/XRayCard.jsx:20
 msgid "X-Ray this question"
-msgstr "Aplica rayos-X a esta pregunta"
+msgstr "X-Ray câu hỏi này"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 msgid "X-ray {0} {1}"
-msgstr "Rayos-X {0} {1}"
+msgstr "X-ray {0} {1}"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "these"
-msgstr "estos"
+msgstr "Những cái nà"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "this"
-msgstr "este"
+msgstr "này"
 
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "Compare {0} {1} to the rest"
-msgstr "Compara {0} {1} con el resto"
+msgstr "So sánh {0} {1} tới hết"
 
 #: frontend/src/metabase/modes/components/drill/DistributionDrill.jsx:35
 msgid "Distribution"
-msgstr "Distribución"
+msgstr "Phân phối"
 
 #: frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx:38
 msgid "View details"
-msgstr "Ver detalles"
+msgstr "Xem chi tiết"
 
 #: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
-msgstr "Ver los {1} de {0}"
+msgstr "Xem {0} của {1}"
 
 #: frontend/src/metabase/modes/components/drill/SortAction.jsx:42
 msgid "Ascending"
-msgstr "Ascendente"
+msgstr "Tăng dần"
 
 #: frontend/src/metabase/modes/components/drill/SortAction.jsx:50
 msgid "Descending"
-msgstr "Descendente"
+msgstr "Giảm dần"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js:43
 msgid "over time"
-msgstr "a través del tiempo."
+msgstr "Thêm giờ"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:22
 msgid "Avg"
-msgstr "Media"
+msgstr "Trung bình"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:34
 msgid "Distincts"
-msgstr "Distintos"
+msgstr "Khác biệt"
 
 #: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:55
 msgid "View this {0}"
 msgid_plural "View these {0}"
-msgstr[0] "Ver el {0}"
-msgstr[1] "Ver estos {0}"
+msgstr[0] "Xem {0}"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
-msgstr "Ampliar"
+msgstr "Phóng to"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
-msgstr "Expresión Personalizada"
+msgstr "Biểu hiện tùy chỉnh"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Common Metrics"
-msgstr "Métricas Comunes"
+msgstr "Số liệu chung"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:209
 msgid "Metabasics"
@@ -4765,275 +4739,275 @@ msgstr "Metabasics"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
-msgstr "Nombre (opcional)"
+msgstr "Tên (tùy chọn)"
 
 #: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:156
 msgid "Choose an aggregation"
-msgstr "Elige una agregación"
+msgstr "Chọn một tập hợp"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:100
 msgid "Set up your own alert"
-msgstr "Configura tu propia alerta"
+msgstr "Thiết lập cảnh báo của riêng bạn"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
-msgstr "Dando de baja..."
+msgstr "Đang bỏ theo dõi..."
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
-msgstr "Error al darse de baja"
+msgstr "Thất bại bỏ theo dõi"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
-msgstr "Darse de baja"
+msgstr "Bỏ theo dõi"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
-msgstr "Sin canal"
+msgstr "Không có kênh nào"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
-msgstr "De acuerdo, has sido dado de baja"
+msgstr "Được rồi, bạn đã hủy đăng ký "
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
-msgstr "Estás recibiendo las alertas de {0}"
+msgstr "Bạn đang nhận cảnh báo của {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
-msgstr "{0} has configurado una alerta"
+msgstr "{0} thiết lập một cảnh bảo"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:160
 msgid "alerts"
-msgstr "alertas"
+msgstr "cảnh báo"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:183
 msgid "Let's set up your alert"
-msgstr "Vamos a configurar tu alerta"
+msgstr "Hãy thiết lập cảnh báo của bạn"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:214
 msgid "The wide world of alerts"
-msgstr "El amplio mundo de las alertas"
+msgstr "Thế giới cảnh báo rộng lớn"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:215
 msgid "There are a few different kinds of alerts you can get"
-msgstr "Hay algunos tipos diferentes de alertas que puedes obtener"
+msgstr "Có một vài loại cảnh báo khác nhau mà bạn có thể nhận được"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:229
 msgid "When a raw data question {0}"
-msgstr "Cuando una pregunta de datos {0}"
+msgstr "Khi một câu hỏi dữ liệu thô {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:230
 msgid "returns any results"
-msgstr "arroja resultados"
+msgstr "trả về bất kỳ kết quả nào"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:241
 msgid "When a line or bar {0}"
-msgstr "Cuando una línea o barra {0}"
+msgstr "Khi một dòng hoặc thanh {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:242
 msgid "crosses a goal line"
-msgstr "supera un objetivo"
+msgstr "vượt qua một mục tiêu"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:253
 msgid "When a progress bar {0}"
-msgstr "Cuando una barra de progreso {0}"
+msgstr "Khi một thanh tiến trình {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:254
 msgid "reaches its goal"
-msgstr "alcanza su objetivo"
+msgstr "đạt được mục tiêu của nó"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:262
 msgid "Set up an alert"
-msgstr "Crea una alerta"
+msgstr "Thiết lập cảnh báo"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:331
 msgid "Edit your alert"
-msgstr "Edita tu alerta"
+msgstr "Chỉnh sửa cảnh báo của bạn"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:331
 msgid "Edit alert"
-msgstr "Editar alerta"
+msgstr "Chỉnh sửa cảnh báo"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
-msgstr "Esta alerta ya no se enviará por correo electrónico a {0}."
+msgstr "Thông báo này sẽ không còn được gửi qua email tới {0}."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
-msgstr "El canal Slack {0} ya no recibirá esta alerta."
+msgstr "Kênh Slack {0} sẽ không còn nhận được cảnh báo này nữa"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
-msgstr "El canal {0} ya no recibirá esta alerta."
+msgstr "Kênh {0} sẽ không còn nhận được cảnh báo này nữa"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
-msgstr "Elimina esta alerta"
+msgstr "Xóa thông báo này"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
-msgstr "Detener el envío y elimina esta alerta. No se puede deshacer, así que ten cuidado."
+msgstr "Dừng giao hàng và xóa thông báo này. Không có hoàn tác, vì vậy hãy cẩn thận."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
-msgstr "¿Eliminar esta alerta?"
+msgstr "Xóa cảnh báo này?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
-msgstr "Avísame cuando la línea…"
+msgstr "Thông báo cho tôi khi đường..."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
-msgstr "Avísame cuando la barra de progreso…"
+msgstr "Thông báo cho tôi khi thanh tiến trình"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
-msgstr "Va por encima de la línea de objetivo"
+msgstr "Đi trên vạch đích"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
-msgstr "Llega al objetivo"
+msgstr "Đạt được mục tiêu"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
-msgstr "Va por debajo de la línea de objetivo"
+msgstr "Đi dưới vạch đích"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
-msgstr "Va por debajo del objetivo"
+msgstr "Đi dưới mục tiêu"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
-msgstr "¿La primera vez que cruza, o cada vez?"
+msgstr "Lần đầu tiên nó đi qua, hay mỗi lần?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
-msgstr "¿La primera vez que alcanza el objetivo, o cada vez?"
+msgstr "Lần đầu tiên nó đạt được mục tiêu, hay mọi lần?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
-msgstr "La primera vez"
+msgstr "Lần đầu tiên"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
-msgstr "Cada vez"
+msgstr "Mỗi lần"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
-msgstr "¿A dónde quieres enviar estas alertas?"
+msgstr "Bạn muốn gửi những thông báo này tới đâu"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
-msgstr "Envía emails de alerta a:"
+msgstr "Thông báo email tới:"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
-msgstr "{0} Las alertas basadas en objetivos aún no son compatibles para gráficos con más de una línea, por lo que esta alerta se enviará siempre que el gráfico tenga {1}."
+msgstr "{0} Cảnh báo dựa trên mục tiêu chưa được hỗ trợ cho các biểu đồ có nhiều hơn một dòng, vì vậy cảnh báo này sẽ được gửi bất cứ khi nào biểu đồ có {1}."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 #: src/metabase/pulse.clj
 msgid "results"
-msgstr "resultados"
+msgstr "kết quả"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
-msgstr "{0} Este tipo de alerta es más útil cuando tu pregunta {1} no arroja ningún resultado, pero quieres saber cuándo lo hace."
+msgstr "{0} Loại cảnh báo này hữu ích nhất khi câu hỏi đã lưu của bạn không {1} trả về bất kỳ kết quả nào, nhưng bạn muốn biết khi nào nó xảy ra."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
-msgstr "Consejo:"
+msgstr "Tip"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
-msgstr "generalmente"
+msgstr "thường"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:61
 msgid "Pick a segment or table"
-msgstr "Elige un segmento o tabla"
+msgstr "Chọn một phân đoạn hoặc bảng"
 
 #: frontend/src/metabase/entities/databases/forms.js:260
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
-msgstr "Selecciona una base de datos"
+msgstr "Chọn một cơ sở dữ liệu"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:85
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:31
 msgid "Select..."
-msgstr "Seleccionar..."
+msgstr "Lựa chọn..."
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
 msgid "Select a table"
-msgstr "Selecciona una tabla"
+msgstr "Chọn một bảng"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:926
 msgid "No tables found in this database."
-msgstr "No se encontraron tablas en esta base de datos."
+msgstr "Không có bảng nào được tìm thấy trong cơ sở dữ liệu này"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:901
 msgid "Is a question missing?"
-msgstr "¿Falta una pregunta?"
+msgstr "Có phải một câu hỏi đang thiếu?"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:909
 msgid "Learn more about nested queries"
-msgstr "Obtén más información sobre consultas anidadas"
+msgstr "Tìm hiểu thêm về các truy vấn lồng nhau"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:951
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:40
 msgid "Fields"
-msgstr "Campos"
+msgstr "Các trường"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:977
 msgid "No segments were found."
-msgstr "No se encontraron segmentos"
+msgstr "Không có phân đoạn nào được tìm thấy"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:1000
 msgid "Find a segment"
-msgstr "Encuentra un segmento"
+msgstr "Tìm một phân đoạn"
 
 #: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
-msgstr "Ver menos"
+msgstr "Xem ít hơn"
 
 #: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
-msgstr "Ver más"
+msgstr "Xem nhiều hơn"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:112
 msgid "Pick a field to sort by"
-msgstr "Elige un campo para ordenar por"
+msgstr "Chọn một trường để phân loại"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
-msgstr "Ordenar"
+msgstr "Phân loại"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
-msgstr "Límite de filas"
+msgstr "Giới hạn dòng"
 
 #: frontend/src/metabase/query_builder/components/FieldName.jsx:72
 msgid "Unknown Field"
-msgstr "Campo Desconocido"
+msgstr "Trường không xác định"
 
 #: frontend/src/metabase/query_builder/components/FieldName.jsx:75
 msgid "field"
-msgstr "campo"
+msgstr "trường"
 
 #: frontend/src/metabase/query_builder/components/Filter.jsx:117
 msgid "Matches"
-msgstr "Conincidencias"
+msgstr "Những sự kết hợp"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:135
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
-msgstr "Añade filtros para limitar tu respuesta"
+msgstr "Thêm bộ lọc để thu hẹp câu trả lời của bạn"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
-msgstr "Añadir una agrupación"
+msgstr "Thêm một nhóm"
 
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:37
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:313
@@ -5052,107 +5026,107 @@ msgstr "Añadir una agrupación"
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Data"
-msgstr "Datos"
+msgstr "Dữ liệu"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:340
 msgid "Filtered by"
-msgstr "Filtrado por"
+msgstr "Lọc bởi"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:357
 msgid "View"
-msgstr "Ver"
+msgstr "Xem"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:374
 msgid "Grouped By"
-msgstr "Agrupado por"
+msgstr "Được nhóm bởi"
 
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
-msgstr "Ninguno"
+msgstr "Không"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
 msgid "This question is written in {0}."
-msgstr "Esta pregunta está escrita en {0}"
+msgstr "Câu hỏi này được viết bằng {0}"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
-msgstr "Esconder Editor"
+msgstr "Ẩn biên tập"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
-msgstr "Esconder Consulta"
+msgstr "Ẩn truy vấn"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
 msgid "Open Editor"
-msgstr "Abrir Editor"
+msgstr "Mở trình chỉnh sửa"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:482
 msgid "Show Query"
-msgstr "Mostrar Consulta"
+msgstr "Hiển thị truy vấn"
 
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "This metric has been retired.  It's no longer available for use."
-msgstr "Esta métrica ha sido retirada. Ya no está disponible para su uso."
+msgstr "Số liệu này đã được bỏ. Nó không còn có sẵn để sử dụng."
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:34
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:46
 msgid "Download full results"
-msgstr "Descarga los resultados completos"
+msgstr "Tải xuống kết quả đầy đủ"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:35
 msgid "Download this data"
-msgstr "Descargar esta información"
+msgstr "Tải xuống dữ liệu này"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:46
 msgid "Warning"
-msgstr "Aviso"
+msgstr "Cảnh báo"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
-msgstr "Tu respuesta tiene una gran cantidad de filas, por lo que podría tardar un tiempo en descargarse."
+msgstr "Câu trả lời của bạn có số lượng lớn các hàng để có thể mất một lúc để tải xuống."
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
-msgstr "El tamaño máximo de descarga es de 1 millón de filas."
+msgstr "Kích thước tải xuống tối đa là 1 triệu hàng."
 
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:11
 msgid "Edit question"
-msgstr "Editar pregunta"
+msgstr "Chỉnh sửa câu hỏi"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:249
 msgid "SAVE CHANGES"
-msgstr "GUARDAR CAMBIOS"
+msgstr "LƯU THAY ĐỔI"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:263
 msgid "CANCEL"
-msgstr "CANCELAR"
+msgstr "HỦY BỎ"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:276
 msgid "Move question"
-msgstr "Mover pregunta"
+msgstr "Di chuyển câu hỏi"
 
 #: frontend/src/metabase/query_builder/components/QueryModals.jsx:155
 msgid "Which collection should this be in?"
-msgstr "¿En qué colección debería estar esto?"
+msgstr "Cái này nên ở trong bộ sưu tập nào?"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:85
 #: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
-msgstr "Variables"
+msgstr "Các biến"
 
 #: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
-msgstr "Conoce tus datos"
+msgstr "Tìm hiểu về dữ liệu của bạn"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:460
 msgid "Alerts are on"
-msgstr "Las alertas están activadas"
+msgstr "Thông báo đang bật"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:522
 msgid "started from"
-msgstr "iniciado desde"
+msgstr "được bắt đầu từ"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:48
 msgid "SQL"
@@ -5160,169 +5134,168 @@ msgstr "SQL"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:48
 msgid "native query"
-msgstr "consulta nativa"
+msgstr "truy vấn gốc"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:52
 msgid "Not Supported"
-msgstr "No Soportado"
+msgstr "Không hỗ trợ"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:58
 msgid "View the {0}"
-msgstr "Ver el {0}"
+msgstr "Xem {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:59
 msgid "Switch to {0}"
-msgstr "Cambiar a {0}"
+msgstr "Chuyển sang {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:62
 msgid "Switch to Builder"
-msgstr "Cambiar al Editor"
+msgstr "Chuyển sang Builder"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:87
 msgid "{0} for this question"
-msgstr "{0} de esta pregunta"
+msgstr "{0} cho câu hỏi này"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:111
 msgid "Convert this question to {0}"
-msgstr "Convertir esta pregunta en {0}"
+msgstr "Chuyển đổi câu hỏi này thành {0}"
 
 #: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:16
 msgid "This question will take approximately {0} to refresh"
-msgstr "Esta pregunta se actualizará en aproximadamente {0}"
+msgstr "Câu hỏi này sẽ mất khoảng {0} để làm mới"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
-msgstr "Actualizado hace {0}"
+msgstr "Đã cập nhật {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:141
 msgid "row"
 msgid_plural "rows"
-msgstr[0] "fila"
-msgstr[1] "filas"
+msgstr[0] "hàng"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:148
 msgid "Showing first {0} {1}"
-msgstr "Mostrando primeras {0} {1}"
+msgstr "Hiển thị đầu tiên {0} {1}"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:151
 msgid "Showing {0} {1}"
-msgstr "Mostrando {0} {1}"
+msgstr "Hiển thị {0} {1}"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
-msgstr "Haciendo ciencia"
+msgstr "Làm khoa học"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
-msgstr "Si me das algunos datos puedo mostrarte algo genial. ¡Ejecuta una consulta!"
+msgstr "Nếu bạn cho tôi một số dữ liệu tôi có thể cho bạn thấy một cái gì đó tuyệt vời. Chạy một truy vấn!"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:299
 msgid "How do I use this thing?"
-msgstr "¿Cómo uso esta cosa?"
+msgstr "Làm thế nào để tôi sử dụng điều này?"
 
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:45
 msgid "Get Answer"
-msgstr "Obtener Respuesta"
+msgstr "Nhận câu trả lời"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:12
 msgid "It's okay to play around with saved questions"
-msgstr "Puedes jugar con preguntas guardadas"
+msgstr "Bạn có thể chơi xung quanh với những câu hỏi đã lưu"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:14
 msgid "You won't make any permanent changes to a saved question unless you click the edit icon in the top-right."
-msgstr "No harás ningún cambio permanente en una pregunta guardada a menos que hagas clic en el icono de edición en la esquina superior derecha."
+msgstr "Bạn sẽ không thực hiện bất kỳ thay đổi vĩnh viễn nào cho câu hỏi đã lưu trừ khi bạn nhấp vào biểu tượng chỉnh sửa ở góc trên bên phải."
 
 #: frontend/src/metabase/query_builder/components/SearchBar.jsx:28
 msgid "Search for"
-msgstr "Buscar"
+msgstr "Tìm kiếm"
 
 #: frontend/src/metabase/query_builder/components/SelectionModule.jsx:158
 msgid "Advanced..."
-msgstr "Avanzado..."
+msgstr "Nâng cao..."
 
 #: frontend/src/metabase/query_builder/components/SelectionModule.jsx:167
 msgid "Sorry. Something went wrong."
-msgstr "Lo siento. Algo salió mal."
+msgstr "Lấy làm tiếc. Đã xảy ra lỗi."
 
 #: frontend/src/metabase/query_builder/components/TimeGroupingPopover.jsx:40
 msgid "Group time by"
-msgstr "Agrupar tiempo por"
+msgstr "Nhóm thời gian bằng"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
-msgstr "Tu pregunta tardó demasiado tiempo"
+msgstr "Câu hỏi của bạn mất quá nhiều thời gian"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
-msgstr "No obtuvimos una respuesta de tu base de datos a tiempo, así que tuvimos que parar.Puedes volver a intentarlo en un minuto, o si el problema persiste, puedes enviar un correo electrónico a un administrador para avisarle."
+msgstr "Chúng tôi đã không nhận được câu trả lời từ cơ sở dữ liệu của bạn kịp thời, vì vậy chúng tôi đã phải dừng lại. Bạn có thể thử lại sau một phút hoặc nếu sự cố vẫn còn, bạn có thể gửi email cho quản trị viên để thông báo cho họ biết."
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
-msgstr "Estamos experimentando problemas con el servidor"
+msgstr "Chúng tôi đang gặp sự cố máy chủ"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
-msgstr "Intenta actualizar la página después de esperar uno o dos minutos. Si el problema persiste, te recomendamos que te pongas en contacto con un administrador."
+msgstr "Hãy thử làm mới trang sau khi đợi một hoặc hai phút. Nếu vấn đề vẫn còn, chúng tôi khuyên bạn nên liên hệ với quản trị viên."
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
-msgstr "Hubo un problema con tu pregunta"
+msgstr "Có một vấn đề với câu hỏi của bạn"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
-msgstr "La mayoría de las veces esto es causado por una selección no válida o un valor de entrada incorrecto.Revisa tus entradas y vuelva a intentar la consulta."
+msgstr "Hầu hết thời gian này là do lựa chọn không hợp lệ hoặc giá trị đầu vào xấu. Kiểm tra lại đầu vào của bạn và thử lại truy vấn của bạn."
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
-msgstr "Esta puede ser la respuesta que estás buscando. De lo contrario, intenta eliminar o cambiar tus filtros para que sean menos específicos."
+msgstr "Đây có thể là câu trả lời mà bạn đang tìm kiếm. Nếu không, hãy thử loại bỏ hoặc thay đổi các bộ lọc của bạn để làm cho chúng ít cụ thể hơn."
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
-msgstr "También puedes {0} cuando hay algunos resultados."
+msgstr "Bạn cũng có thể {0} khi có một số kết quả."
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
-msgstr "recibir una alerta"
+msgstr "nhận một thông báo"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:77
 msgid "Back to last run"
-msgstr "Volver a la última ejecución"
+msgstr "Quay lại lần chạy trước"
 
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:194
 msgid "Visualization"
-msgstr "Visualización"
+msgstr "Hình ảnh hóa"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
 msgid "No description set."
-msgstr "Sin descripción"
+msgstr "Không có bộ mô tả."
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
 msgid "Use for current question"
-msgstr "Usar para la pregunta actual"
+msgstr "Sử dụng cho câu hỏi hiện tại"
 
 #: frontend/src/metabase/reference/components/UsefulQuestions.jsx:14
 msgid "Potentially useful questions"
-msgstr "Preguntas potencialmente útiles"
+msgstr "Câu hỏi tiềm năng hữu ích"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
-msgstr "Agrupar por {0}"
+msgstr "Nhóm theo {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:165
 msgid "Sum of all values of {0}"
-msgstr "Suma de todos los valores de {0}"
+msgstr "Tổng tất cả các giá trị của {0}"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:63
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:51
 msgid "All distinct values of {0}"
-msgstr "Todos los valores distintos de {0}"
+msgstr "Tất cả các giá trị riêng biệt của {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
-msgstr "Número de {0} agrupadas por {1}"
+msgstr "Số {0} được nhóm theo {1}"
 
 #: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
@@ -5334,335 +5307,335 @@ msgstr "Número de {0} agrupadas por {1}"
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:24
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:23
 msgid "Data Reference"
-msgstr "Referencia de Datos"
+msgstr "Dữ liệu tham khảo"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:13
 msgid "Learn more about your data structure to ask more useful questions"
-msgstr "Aprende más sobre tu estructura de datos para hacer preguntas más útiles"
+msgstr "Tìm hiểu thêm về cấu trúc dữ liệu của bạn để hỏi những câu hỏi hữu ích hơn"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
-msgstr "No se pudieron encontrar los metadatos de la tabla antes de crear una nueva pregunta"
+msgstr "Không thể tìm thấy siêu dữ liệu bảng trước khi tạo câu hỏi mới"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
-msgstr "Ver {0}"
+msgstr "Xem {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
 msgid "Metric Definition"
-msgstr "Definición de Métrica"
+msgstr "Định nghĩa số liệu"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
-msgstr "Filtrar por {0}"
+msgstr "Lọc bởi {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:38
 msgid "Number of {0}"
-msgstr "Número de {0}"
+msgstr "Số của {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:48
 msgid "See all {0}"
-msgstr "Ver todos los {0}"
+msgstr "Xem tất cả {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
 msgid "Segment Definition"
-msgstr "Definición de Segmento"
+msgstr "Định nghĩa phân đoạn"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
 msgid "An error occurred loading the table"
-msgstr "Se produjo un error al cargar la tabla"
+msgstr "Lỗi xảy ra khi tải bảng"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:74
 msgid "See the raw data for {0}"
-msgstr "Ver los datos de {0}"
+msgstr "Xem dữ liệu thô cho {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
 msgid "More"
-msgstr "Más"
+msgstr "Nhiều hơn"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:216
 msgid "Invalid expression"
-msgstr "Expresión inválida"
+msgstr "Biểu hiện không hợp lệ"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:282
 msgid "unknown error"
-msgstr "error no controlado"
+msgstr "lỗi không xác định"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:53
 msgid "Field formula"
-msgstr "Fórmula de campo"
+msgstr "Công thức trường"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:64
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
-msgstr "Piensa en esto como algo parecido a escribir una fórmula en un programa de hoja de cálculo: puedes usar números, campos de esta tabla, símbolos matemáticos como + y algunas funciones. Así puedes escribir algo como Subtotal - Cost."
+msgstr "Hãy nghĩ về điều này giống như viết một công thức trong chương trình bảng tính: bạn có thể sử dụng các số, các trường trong bảng này, các ký hiệu toán học như + và một số hàm. Vì vậy, bạn có thể gõ một cái gì đó như tổng phụ - Chi phí."
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
 msgid "Learn more"
-msgstr "Aprende más"
+msgstr "Tìm hiểu thêm"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:77
 msgid "Give it a name"
-msgstr "Dale un nombre"
+msgstr "Đặt tên cho nó"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
 msgid "Something nice and descriptive"
-msgstr "Algo agradable y descriptivo"
+msgstr "Một cái gì đó tốt đẹp và mô tả"
 
 #: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:60
 msgid "Add a custom field"
-msgstr "Añadir un campo personalizado"
+msgstr "Thêm một trường tùy chỉnh"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:17
 msgid "Include {0}"
-msgstr "Incluir {0}"
+msgstr "Bao gồm {0}"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:19
 msgid "Case sensitive"
-msgstr "Distingue mayúsculas y minúsculas"
+msgstr "Trường hợp nhạy cảm"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:23
 msgid "today"
-msgstr "hoy"
+msgstr "hôm nay"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:24
 msgid "this week"
-msgstr "esta semana"
+msgstr "tuần này"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:25
 msgid "this month"
-msgstr "este mes"
+msgstr "tháng này"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:26
 msgid "this year"
-msgstr "este año"
+msgstr "năm nay"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:27
 msgid "this minute"
-msgstr "este minuto"
+msgstr "phút này"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:28
 msgid "this hour"
-msgstr "esta hora"
+msgstr "giờ này"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:290
 msgid "not implemented {0}"
-msgstr "{0} no está implementado"
+msgstr "không thực hiện {0}"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:291
 msgid "true"
-msgstr "verdadero"
+msgstr "đúng"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:291
 msgid "false"
-msgstr "falso"
+msgstr "sai"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
-msgstr "Añadir filtro"
+msgstr "Thêm bộ lọc"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
 msgid "Item"
-msgstr "Elemento"
+msgstr "mục"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
-msgstr "Anterior"
+msgstr "Trước"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
-msgstr "Actual"
+msgstr "Hiện tại"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:257
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
-msgstr "Activado"
+msgstr "trên"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx:47
 msgid "Enter desired number"
-msgstr "Introduce el número deseado"
+msgstr "Nhập số mong muốn"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:161
 msgid "Empty"
-msgstr "Vacío"
+msgstr "Rỗng"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:119
 msgid "Find a value"
-msgstr "Encuentra un valor"
+msgstr "Tìm một giá trị"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:113
 msgid "Hide calendar"
-msgstr "Esconder calendario"
+msgstr "Ẩn lịch"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:113
 msgid "Show calendar"
-msgstr "Mostrar calendario"
+msgstr "Hiển thị lịch"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx:97
 msgid "You can enter multiple values separated by commas"
-msgstr "Puedes introducir varios valores separados por comas"
+msgstr "Bạn có thể nhập nhiều giá trị được ngăn cách bởi dấu phẩy"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx:38
 msgid "Enter desired text"
-msgstr "Introduce el texto deseado"
+msgstr "Nhập văn bản mong muốn"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:210
 msgid "Try it"
-msgstr "Pruébalo"
+msgstr "Thử"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:243
 msgid "What's this for?"
-msgstr "¿Para qué sirve esto?"
+msgstr "Cái này để làm gì?"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:245
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
-msgstr "Las variables en las consultas nativas te permiten reemplazar dinámicamente los valores en tus consultas utilizando elementos de filtro o a través de la URL."
+msgstr "Các biến trong các truy vấn gốc cho phép bạn thay thế linh hoạt các giá trị trong các truy vấn của mình bằng các tiện ích bộ lọc hoặc thông qua URL."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
-msgstr "{0} crea una variable en esta plantilla SQL llamada \"nombre_variable\". Puedes asignar tipos a las variables en el panel lateral, lo que cambia su comportamiento. Todos los tipos de variables que no sean \"Filtro de Campo\" provocarán automáticamente que se coloque un elemento de filtro en esta pregunta; con Filtros de Campo, esto es opcional. Cuando se rellena este elemento de filtro, ese valor reemplaza a la variable en la plantilla SQL."
+msgstr "{0} tạo một biến trong mẫu SQL này được gọi là \\ \"biến_name \". Các biến có thể được đưa ra các loại trong bảng điều khiển bên, làm thay đổi hành vi của chúng. Tất cả các loại biến khác ngoài \\ \"Bộ lọc trường \" sẽ tự động khiến tiện ích bộ lọc được đặt vào câu hỏi này; với Bộ lọc trường, đây là tùy chọn. Khi tiện ích bộ lọc này được điền vào, giá trị đó sẽ thay thế biến trong mẫu SQL."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:259
 msgid "Field Filters"
-msgstr "Filtros de Campo"
+msgstr "Bộ lọc trường"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
-msgstr "Darle a una variable el tipo \"Filtro de campo\" te permite vincular las tarjetas SQL con los elementos de filtro en los cuadros de mando o usar más tipos de elementos de filtro en tu pregunta de SQL. Una variable de filtro de campo inserta SQL similar a la generada por el generador de consultas GUI cuando se añaden filtros en columnas existentes."
+msgstr "Đưa ra một biến loại \\ \"Bộ lọc trường \" cho phép bạn liên kết thẻ SQL với các tiện ích bộ lọc bảng điều khiển hoặc sử dụng nhiều loại tiện ích bộ lọc hơn cho câu hỏi SQL của bạn. Biến Bộ lọc trường chèn SQL tương tự như được tạo bởi trình tạo truy vấn GUI khi thêm bộ lọc vào các cột hiện có."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:264
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
-msgstr "Al añadir una variable de Filtro de campo, deberás asignarla a un campo específico. A continuación, puedes optar por mostrar un elemento de filtro en tu pregunta, pero incluso si no lo haces, ahora puedes asignar tu variable de Filtro de campo a un filtro de cuadro de mando al agregar esta pregunta al mismo. Los filtros de campo deben usarse dentro de una cláusula \"WHERE\"."
+msgstr "Khi thêm biến Bộ lọc trường, bạn sẽ cần ánh xạ nó tới một trường cụ thể. Sau đó, bạn có thể chọn hiển thị tiện ích bộ lọc cho câu hỏi của mình, nhưng ngay cả khi bạn không, giờ đây bạn có thể ánh xạ biến Bộ lọc trường vào bộ lọc bảng điều khiển khi thêm câu hỏi này vào bảng điều khiển. Bộ lọc trường nên được sử dụng bên trong mệnh đề \\ \"WHERE \"."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:271
 msgid "Optional Clauses"
-msgstr "Cláusulas opcionales"
+msgstr "Điều khoản tùy chọn"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:132
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
-msgstr "los corchetes alrededor de un {0} crean una cláusula opcional en la plantilla. Si se establece la \"variable\", entonces la cláusula completa se coloca en la plantilla. Si no, entonces se ignora toda la cláusula."
+msgstr "dấu ngoặc quanh {0} tạo mệnh đề tùy chọn trong mẫu. Nếu \\ \"biến \" được đặt, thì toàn bộ mệnh đề được đặt vào mẫu. Nếu không, thì toàn bộ mệnh đề được bỏ qua."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:283
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
-msgstr "Para utilizar varias cláusulas opcionales, puedes incluir al menos una cláusula WHERE no opcional seguida de cláusulas opcionales que comiencen con \"AND\"."
+msgstr "Để sử dụng nhiều mệnh đề tùy chọn, bạn có thể bao gồm ít nhất một mệnh đề WHERE không tùy chọn, theo sau là các mệnh đề tùy chọn bắt đầu bằng \\ \"AND \"."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:301
 msgid "Read the full documentation"
-msgstr "Lee la documentación completa"
+msgstr "Đọc tài liệu đầy đủ"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:133
 msgid "Filter label"
-msgstr "Filtro de Etiqueta"
+msgstr "Nhãn bộ lọc"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:134
 msgid "Variable type"
-msgstr "Tipo de Variable"
+msgstr "Loại biến"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:143
 msgid "Text"
-msgstr "Texto"
+msgstr "Bản văn"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
 msgid "Date"
-msgstr "Fecha"
+msgstr "Ngày"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
 msgid "Field Filter"
-msgstr "Filtro de Campo"
+msgstr "Bộ lọc trường"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Field to map to"
-msgstr "Campo para mapear a"
+msgstr "Trường để ánh xạ tới"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:180
 msgid "Filter widget type"
-msgstr "Tipo de filtro"
+msgstr "Loại bộ lọc"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
 msgid "Required?"
-msgstr "¿Obligatorio?"
+msgstr "Cần thiết?"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
 msgid "Default filter widget value"
-msgstr "Valor por defecto del filtro"
+msgstr "Giá trị widget bộ lọc mặc định"
 
 #: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
-msgstr "¿Archivar esta pregunta?"
+msgstr "Lưu trữ câu hỏi này?"
 
 #: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
-msgstr "Esta pregunta se eliminará de cualquier cuadro de mando o pulso que lo usen."
+msgstr "Câu hỏi này sẽ bị xóa khỏi bất kỳ bảng điều khiển hoặc xung sử dụng nó."
 
 #: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
 msgid "Question"
-msgstr "Pregunta"
+msgstr "Câu hỏi"
 
 #: frontend/src/metabase/dashboard/components/AddToDashSelectQuestionModal.jsx:31
 msgid "Pick a question to add"
-msgstr "Elige una pregunta para añadir"
+msgstr "Chọn một câu hỏi để thêm vào"
 
 #: frontend/src/metabase/reference/components/EditHeader.jsx:19
 msgid "You are editing this page"
-msgstr "Estás editando esta página"
+msgstr "Bạn đang chỉnh sửa trang này"
 
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:78
 #: frontend/src/metabase/reference/components/ReferenceHeader.jsx:45
 msgid "See this {0}"
-msgstr "Ver este {0}"
+msgstr "Xem {0}"
 
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
-msgstr "Un subconjunto de"
+msgstr "Một tập hợp con của"
 
 #: frontend/src/metabase/reference/components/Field.jsx:48
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:31
 msgid "Select a field type"
-msgstr "Selecciona un tipo de campo"
+msgstr "Chọn một kiểu trường"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:85
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:36
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:54
 msgid "No field type"
-msgstr "Sin tipo de campo"
+msgstr "Không có kiểu trường"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/SummarizeStep.jsx:26
 msgid "by"
-msgstr "por"
+msgstr "bởi"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
 #: frontend/src/metabase/reference/databases/FieldList.jsx:156
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:157
 msgid "Field type"
-msgstr "Tipo campo"
+msgstr "Kiểu trường"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
-msgstr "Selecciona una Clabe foránea"
+msgstr "Chọn một chìa khóa nước ngoài"
 
 #: frontend/src/metabase/reference/components/Formula.jsx:56
 msgid "View the {0} formula"
-msgstr "Ver la fórmula de {0}"
+msgstr "Xem công thức {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:80
 msgid "Why this {0} is important"
-msgstr "Por qué este {0} es importante"
+msgstr "Tại sao {0} quan trọng?"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:81
 msgid "Why this {0} is interesting"
-msgstr "Por qué este {0} es interesante"
+msgstr "Tại sao {0} thú vị"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:87
 msgid "Nothing important yet"
-msgstr "Nada importante todavía"
+msgstr "Không có gì quan trọng hết"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:172
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:237
@@ -5671,11 +5644,11 @@ msgstr "Nada importante todavía"
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:248
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:233
 msgid "Nothing interesting yet"
-msgstr "Nada interesante todavía"
+msgstr "Không có gì thú vị hết"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:93
 msgid "Things to be aware of about this {0}"
-msgstr "Cosas a tener en cuenta acerca de este {0}"
+msgstr "Những điều cần biết về điều này {0}"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:182
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:247
@@ -5684,77 +5657,77 @@ msgstr "Cosas a tener en cuenta acerca de este {0}"
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:258
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:243
 msgid "Nothing to be aware of yet"
-msgstr "Nada de lo que estar enterado todavía"
+msgstr "Không có gì cần biết"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:103
 msgid "Explore this metric"
-msgstr "Explora esta métrica"
+msgstr "Khám phá số liệu này"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:105
 msgid "View this metric"
-msgstr "Ver esta métrica"
+msgstr "Xem số liệu này"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:112
 msgid "By {0}"
-msgstr "Por {0}"
+msgstr "Bởi {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:146
 msgid "Remove item"
-msgstr "Eliminar elemento"
+msgstr "Loại bỏ mục"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:155
 msgid "Why is this dashboard the most important?"
-msgstr "¿Por qué este cuadro de mando es el más importante?"
+msgstr "Tại sao bảng điều khiển này là quan trọng nhất"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:156
 msgid "What is useful or interesting about this {0}?"
-msgstr "¿Qué es útil o interesante sobre este {0}?"
+msgstr "Cái gì hữu ích và thú vị về {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:160
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:174
 msgid "Write something helpful here"
-msgstr "Escribe algo útil aquí"
+msgstr "Viết gì đó hữu ích tại đây"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:169
 msgid "Is there anything users of this dashboard should be aware of?"
-msgstr "¿Hay algo que los usuarios de este cuadro de mando deben tener en cuenta?"
+msgstr "Có bất cứ điều gì người dùng của bảng điều khiển này nên được biết về? "
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:170
 msgid "Anything users should be aware of about this {0}?"
-msgstr "¿Hay alguna cosa que los usuarios deben saber sobre este {0}?"
+msgstr "Bất cứ điều gì người dùng nên biết về điều này {0}?"
 
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:26
 msgid "Which 2-3 fields do you usually group this metric by?"
-msgstr "¿Con qué 2-3 campos se agrupa normalmente esta métrica?"
+msgstr "2-3 trường nào bạn thường nhóm số liệu này theo?"
 
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:25
 msgid "This is the perfect place to start if you’re new to your company’s data, or if you just want to check in on what’s going on."
-msgstr "Este es el lugar perfecto para comenzar si eres nuevo en los datos de tu empresa, o si solo deseas verificar lo que está sucediendo."
+msgstr "Đây là nơi hoàn hảo để bắt đầu nếu bạn mới sử dụng dữ liệu của công ty bạn hoặc nếu bạn chỉ muốn kiểm tra xem những gì diễn ra."
 
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:52
 msgid "Most useful fields to group this metric by"
-msgstr "Campos más útiles para agrupar esta métrica"
+msgstr "Các trường hữu ích nhất để nhóm số liệu này theo"
 
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:32
 msgid "Reason for changes"
-msgstr "Motivo del cambio"
+msgstr "Lí do cho thay đổi"
 
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:36
 msgid "Leave a note to explain what changes you made and why they were required"
-msgstr "Deja una nota para explicar qué cambios ha realizado y por qué fueron necesarios"
+msgstr "Để lại chú thích để giải thích những thay đổi bạn vừa tạo và tại sao chúng cần thiết."
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:170
 msgid "Why this database is interesting"
-msgstr "Por qué esta base de datos es interesante"
+msgstr "Tại sao cơ sở dữ liệu này thú vị"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:180
 msgid "Things to be aware of about this database"
-msgstr "Cosas a tener en cuenta acerca de esta base de datos"
+msgstr "Những điều cần lưu ý về cơ sở dữ liệu này"
 
 #: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
-msgstr "Bases de datos y tablas"
+msgstr "Cơ sở dữ liệu và bảng"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:28
@@ -5768,500 +5741,500 @@ msgstr "Bases de datos y tablas"
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:31
 msgid "Details"
-msgstr "Detalles"
+msgstr "Chi tiết"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
 #: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
-msgstr "Tablas en {0}"
+msgstr "Bảng trong {0}"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:226
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:204
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:222
 msgid "Actual name in database"
-msgstr "Nombre real en la base de datos"
+msgstr "Tên thực trong cơ sở dữ liệu"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:235
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:231
 msgid "Why this field is interesting"
-msgstr "Por qué este campo es interesante"
+msgstr "Tại sao trường này thú vị"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:245
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:241
 msgid "Things to be aware of about this field"
-msgstr "Cosas a tener en cuenta sobre este campo"
+msgstr "Những điều cần lưu ý về trường này"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:257
 #: frontend/src/metabase/reference/databases/FieldList.jsx:159
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:253
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:160
 msgid "Data type"
-msgstr "Tipo de dato"
+msgstr "Kiểu dữ liệu"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:39
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:39
 msgid "Fields in this table will appear here as they're added"
-msgstr "Los campos en esta tabla aparecerán aquí a medida que se añadan"
+msgstr "Các trường trong bảng này sẽ xuất hiện tại đây khi chúng được thêm vào"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:137
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
-msgstr "Campos en {0}"
+msgstr "Các trường trong {0}"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:153
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:154
 msgid "Field name"
-msgstr "Nombre de campo"
+msgstr "Tên trường"
 
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:46
 msgid "X-ray this field"
-msgstr "Aplica rayos-X a este campo"
+msgstr "X quang trường này"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:8
 msgid "Metabase is no fun without any data"
-msgstr "Metabase no es divertido sin datos"
+msgstr "Metabase không thú vị nếu không có dữ liệu"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:9
 msgid "Your databases will appear here once you connect one"
-msgstr "Tus bases de datos aparecerán aquí una vez que conectes una"
+msgstr "Cơ sở dữ liệu của bạn sẽ xuất hiện ở đây ngay khi bạn kết nối"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:10
 msgid "Databases will appear here once your admins have added some"
-msgstr "Las bases de datos aparecerán aquí una vez que los administradores hayan añadido algunas"
+msgstr "Cơ sở dữ liệu sẽ xuất hiện ở đây ngay khi quản trị viên thêm vào"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:12
 msgid "Connect a database"
-msgstr "Conecta una base de datos"
+msgstr "Kết nối một cơ sở dữ liệu"
 
 #. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
 #. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
-msgstr "Número de {0}"
+msgstr "Số đếm của {0}"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:47
 msgid "See raw data for {0}"
-msgstr "Ver datos de {0}"
+msgstr "Xem dữ liệu thô cho {0}"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:213
 msgid "Why this table is interesting"
-msgstr "Por qué esta tabla es interesante"
+msgstr "Tại sao bảng này thú vị"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:223
 msgid "Things to be aware of about this table"
-msgstr "Cosas a tener en cuenta sobre esta tabla"
+msgstr "Những điều cần lưu ý về bảng này"
 
 #: frontend/src/metabase/reference/databases/TableList.jsx:29
 msgid "Tables in this database will appear here as they're added"
-msgstr "Las tablas en esta base de datos aparecerán aquí cuando se añadan"
+msgstr "Các bảng trong cơ sở dữ liệu này sẽ xuất hiện tại đây khi chúng được thêm vào"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:33
 msgid "Questions about this table will appear here as they're added"
-msgstr "Las preguntas sobre esta tabla aparecerán aquí cuando se añadan"
+msgstr "Các câu hỏi về bảng này sẽ xuất hiện tại đây khi chúng được thêm vào"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:73
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:77
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:76
 msgid "Questions about {0}"
-msgstr "Preguntas sobre {0}"
+msgstr "Các câu hỏi về {0}"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
 msgid "Created {0} by {1}"
-msgstr "Creado hace {0} por {1}"
+msgstr "Đã tạo {0} bởi {1}"
 
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:40
 msgid "Fields in this table"
-msgstr "Campos en esta tabla"
+msgstr "Các trường trong bảng này"
 
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:46
 msgid "Questions about this table"
-msgstr "Preguntas sobre esta tabla"
+msgstr "Các câu hỏi về bảng này"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
-msgstr "Ayuda a tu equipo a empezar con tus datos."
+msgstr "Giúp nhóm của bạn bắt đầu với dữ liệu của bạn"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
-msgstr "Muestra a tu equipo lo que es más importante al elegir tu cuadro de mando, tus métricas y tus segmentos principales."
+msgstr "Hiển thị cho nhóm của bạn cái gì quan trọng nhất bằng cách chọn bảng điều khiển, số liệu và phân đoạn hàng đầu"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
-msgstr "Empieza"
+msgstr "Bắt đầu"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
-msgstr "Nuestro cuadro de mando más importante"
+msgstr "Bảng điều khiển quan trọng nhất của chúng tôi"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
-msgstr "Números a los que prestamos atención"
+msgstr "Các con số mà chúng tôi chú ý"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
-msgstr "Las métricas son números destacados que le importan a tu empresa. A menudo representan un indicador central de cómo está funcionando el negocio."
+msgstr "Số liệu là các con số quan trọng mà công ty bạn quan tâm. Chúng thường đại diện một chỉ số cốt lõi của cách mà doanh nghiệp đang thể hiện"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
-msgstr "Ver todas las métricas"
+msgstr "Xem tất cả số liệu"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
-msgstr "Segmentos y tablas"
+msgstr "Phân đoạn và bảng"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:82
 msgid "Tables"
-msgstr "Tablas"
+msgstr "Các bảng"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
-msgstr "Los segmentos y tablas son los componentes básicos de los datos de tu empresa. Las tablas son colecciones de información sin formato mientras que los segmentos son trozos acotados con significados específico, como {0}"
+msgstr "Phân đoạn và bảng là các khối xây dựng dữ liệu của công ty bạn. Bảng là tập hợp các thông tin thô trong khi các phân đoạn là các lát cụ thể với ý nghĩa cụ thể, như {0}"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
-msgstr "Las tablas son los componentes básicos de los datos de tu empresa."
+msgstr "Bảng là các khối xây dựng dữ liệu của công ty bạn."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
-msgstr "Ver todos los segmentos"
+msgstr "Xem tất cả phân đoạn"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
-msgstr "Ver todas las tablas"
+msgstr "Xem tất cả bảng"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
-msgstr "Otras cosas que debes saber sobre nuestros datos"
+msgstr "Những điều khác cần biết về dữ liệu của chúng tôi \""
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
-msgstr "Descubre más"
+msgstr "Tìm hiểu thêm"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
-msgstr "Una buena manera de conocer tus datos es dedicarle un poco de tiempo a explorar las diferentes tablas y otra información disponible. Puedes tardar un poco, pero comenzarás a reconocer nombres y significados con el tiempo."
+msgstr "Một cách tốt để biết dữ liệu của bạn là dành một chút thời gian để khám phá các bảng khác nhau và thông tin khác có sẵn cho bạn. Có thể mất một lúc, nhưng bạn sẽ bắt đầu nhận ra tên và ý nghĩa theo thời gian."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
-msgstr "Explora nuestros datos"
+msgstr "Khám phá dữ liệu của chúng tôi"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
-msgstr "¿Tienes una pregunta?"
+msgstr "Có câu hỏi?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
-msgstr "Habla con {0}"
+msgstr "Liên hệ {0}"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
-msgstr "Ayuda a los nuevos usuarios de Metabase a encontrar su camino."
+msgstr "Giúp người dùng Metabase mới tìm đường "
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
-msgstr "La guía de introducción destaca el cuadro de mando, las métricas, los segmentos y las tablas que más importan, e informa a los usuarios sobre cosas importantes que deberían saber antes de profundizar en los datos."
+msgstr "Hướng dẫn Bắt đầu làm nổi bật bảng điều khiển, số liệu, phân đoạn và bảng quan trọng nhất và thông báo cho người dùng của bạn về những điều quan trọng họ nên biết trước khi đào sâu vào dữ liệu."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
-msgstr "¿Hay un cuadro de mando importante para tu equipo?"
+msgstr "Có bảng điều khiển nào quan trọng cho team của bạn không?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
-msgstr "Crea un cuadro de mando ahora"
+msgstr "Tạo một bảng điều khiển bây giờ"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
-msgstr "¿Cuál es tu cuadro de mando más importante?"
+msgstr "Bảng điều khiển quan trọng nhất của bạn là gì?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
-msgstr "¿Tienes alguna métrica comúnmente referenciada?"
+msgstr "Bạn có số liệu tham khảo chung nào không?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
-msgstr "Aprende a definir una métrica"
+msgstr "Tìm hiểu cách định nghĩa một số liệu"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
-msgstr "¿Cuáles son las 3-5 métricas más comúnmente referenciadas?"
+msgstr "3-5 số liệu tham khảo thông thường nhất của bạn là gì?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
-msgstr "Añade otra métrica"
+msgstr "Thêm một số liệu khác"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
-msgstr "¿Tienes algún segmento o tabla comúnmente referenciado?"
+msgstr "Bạn có bất cứ phân đoạn hoặc bảng tham khảo thông thường nào không?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
-msgstr "Aprenda a crear un segmento"
+msgstr "Tìm hiểu cách tạo một phân đoạn"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
-msgstr "¿Cuáles son los 3-5 segmentos o tablas comúnmente referenciados que serían útiles paraesta audiencia?"
+msgstr "3-5 phân đoạn hoặc bảng thường được tham chiếu sẽ hữu ích cho đối tượng này là gì?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
-msgstr "Añade otro segmento o tabla"
+msgstr "Thêm phân đoạn hoặc bảng khác"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
-msgstr "¿Hay algo que tus usuarios deberían entender o saber antes de que comiencen a acceder a los datos?"
+msgstr "Có bất cứ điều gì người dùng của bạn nên hiểu hoặc biết trước khi họ bắt đầu truy cập dữ liệu không? \" "
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
-msgstr "¿Qué debe saber un usuario de estos datos antes de que comiencen a acceder a ellos?"
+msgstr "Người dùng của dữ liệu này nên biết gì trước khi họ bắt đầu truy cập nó?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
-msgstr "Por ejemplo, las expectativas sobre la privacidad y el uso de datos, peligros comunes o malentendidos, información sobre el rendimiento del almacén de datos, avisos legales, etc."
+msgstr "Ví dụ: những kỳ vọng xung quanh quyền riêng tư và sử dụng dữ liệu, những cạm bẫy hoặc hiểu lầm phổ biến, thông tin về hiệu suất kho dữ liệu, thông báo pháp lý, v.v."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
-msgstr "¿Hay alguien con quien tus usuarios puedan contactar si necesitan ayuda si están confundidos acerca de esta guía?"
+msgstr "Có ai đó mà người dùng của bạn có thể liên hệ để được giúp đỡ nếu họ bối rối về hướng dẫn này?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
-msgstr "¿A quién deben contactar los usuarios para obtener ayuda si están confundidos acerca de esta información?"
+msgstr "Người dùng nên liên hệ với ai để được giúp đỡ nếu họ bối rối về dữ liệu này?"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:76
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:97
 msgid "Please enter a revision message"
-msgstr "Por favor añade un mensaje de revisión"
+msgstr "Vui lòng nhập tin nhắn sửa đổi"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
-msgstr "Por qué esta métrica es interesante"
+msgstr "Tại sao số liệu này thú vị"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
-msgstr "Cosas a tener en cuenta acerca de esta métrica"
+msgstr "Những điều cần biết về số liệu này"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
-msgstr "Cómo se calcula esta métrica"
+msgstr "Số liệu này được tính toán thế nào"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:240
 msgid "Nothing on how it's calculated yet"
-msgstr "Nada sobre cómo se calculó aún"
+msgstr "Chưa có gì về cách tính toán"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:297
 msgid "Other fields you can group this metric by"
-msgstr "Otros campos por los que puedes agrupar esta métrica"
+msgstr "Các trường khác bạn có thể nhóm dữ liệu này theo"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:298
 msgid "Fields you can group this metric by"
-msgstr "Campos por los que puedes agrupar esta métrica"
+msgstr "Các trường bạn có thể nhóm dữ liệu này theo"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:24
 msgid "Metrics are the official numbers that your team cares about"
-msgstr "Las métricas son los números oficiales de los que tu equipo se preocupa"
+msgstr "Số liệu là các con số chính thức mà nhóm của bạn quan tâm"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Metrics will appear here once your admins have created some"
-msgstr "Las métricas aparecerán aquí una vez que tus administradores hayan creado algunas"
+msgstr "Số liệu sẽ xuất hiện tại đây ngay khi các quản trị viên của bạn tạo"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:28
 msgid "Learn how to create metrics"
-msgstr "Aprende cómo crear métricas"
+msgstr "Tìm hiều cách tạo số liệu"
 
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:34
 msgid "Questions about this metric will appear here as they're added"
-msgstr "Las preguntas sobre esta métrica aparecerán aquí cuando se añadan"
+msgstr "Các câu hỏi về số liệu này sẽ xuất hiện tại đây khi chúng được thêm vào"
 
 #: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:29
 msgid "There are no revisions for this metric"
-msgstr "No hay revisiones para esta métrica"
+msgstr "Không có sửa đổi cho số liệu này"
 
 #: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:52
 #: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:90
 msgid "Revision history for {0}"
-msgstr "Historial de revisiones de {0}"
+msgstr "Lịch sử sửa đổi cho {0}"
 
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:44
 msgid "X-ray this metric"
-msgstr "Aplica rayos-X a esta métrica"
+msgstr "X quang số liệu này"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:246
 msgid "Why this Segment is interesting"
-msgstr "Por qué este segmento es interesante"
+msgstr "Tại sao phân đoạn này thú vị"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:256
 msgid "Things to be aware of about this Segment"
-msgstr "Cosas a tener en cuenta sobre este segmento"
+msgstr "Những điều cần lưu ý về phân đoạn này"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:23
 msgid "Segments are interesting subsets of tables"
-msgstr "Los segmentos son subconjuntos interesantes de tablas"
+msgstr "Phân đoạn là tập con thú vị của bảng"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Defining common segments for your team makes it even easier to ask questions"
-msgstr "La definición de segmentos comunes para tu equipo hace que sea aún más fácil hacer preguntas"
+msgstr "Xác định các phân khúc phổ biến cho nhóm của bạn giúp đặt câu hỏi dễ dàng hơn"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Segments will appear here once your admins have created some"
-msgstr "Los segmentos aparecerán aquí una vez que los administradores hayan creado algunos"
+msgstr "Phân khúc sẽ xuất hiện ở đây khi quản lý của bạn thiết lập "
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:27
 msgid "Learn how to create segments"
-msgstr "Aprende a crear segmentos"
+msgstr "Học cách thiết lập phân khúc"
 
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:34
 msgid "Questions about this segment will appear here as they're added"
-msgstr "Las preguntas sobre este segmento aparecerán aquí cuando se añadan"
+msgstr "Câu hỏi về phân khúc sẽ xuất hiện ở đây khi nó được hỏi"
 
 #: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:28
 msgid "There are no revisions for this segment"
-msgstr "No hay revisiones para este segmento"
+msgstr "Không có sửa đổi cho phân khúc này"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:37
 msgid "Fields in this segment"
-msgstr "Campos en este segmento"
+msgstr "Các trường trong phân khúc này"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:43
 msgid "Questions about this segment"
-msgstr "Preguntas sobre este segmento"
+msgstr "Câu hỏi về phân khúc này"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:50
 msgid "X-ray this segment"
-msgstr "Aplica rayos-X a este segmento"
+msgstr "X-ray phân khúc này"
 
 #: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
 msgid "Login"
-msgstr "Iniciar sesión"
+msgstr "Đăng nhập"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:303
 #: frontend/src/metabase/containers/ItemPicker.jsx:115
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
 #: frontend/src/metabase/routes.jsx:195
 msgid "Search"
-msgstr "Buscar"
+msgstr "Tìm kiếm"
 
 #: frontend/src/metabase/routes.jsx:214
 msgid "Dashboard"
-msgstr "Cuadro de Mando"
+msgstr "Bảng điều khiển"
 
 #: frontend/src/metabase/routes.jsx:227
 msgid "New Question"
-msgstr "Nueva Pregunta"
+msgstr "Câu hỏi mới"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:127
 msgid "Select the type of Database you use"
-msgstr "Selecciona el tipo de base de datos que utilizas"
+msgstr "Chọn loại cơ sở dữ liệu bạn sử dụng"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:103
 msgid "Add your data"
-msgstr "Añade tus datos"
+msgstr "Thêm dữ liệu"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:107
 msgid "I'll add my own data later"
-msgstr "Añadiré mis propios datos más tarde"
+msgstr "Tôi sẽ thêm dữ liệu riêng sau"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:108
 msgid "Connecting to {0}"
-msgstr "Conectando con {0}"
+msgstr "Đang kết nối đến {0}"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:130
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
-msgstr "Necesitarás información sobre tu base de datos, como el nombre de usuario y la contraseña. Si no tienes eso ahora mismo, Metabase también viene con un conjunto de datos de muestra con los que puedes empezar."
+msgstr "Bạn sẽ cần vài thông tin về cơ sở dữ liệu của mình, như tên đăng nhập và mật khẩu. Nếu bạn không có thông tin đó bây giờ, Metabase sẽ đưa ra thông tin mẫu để bạn có thể bắt đầu "
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my data later"
-msgstr "Añadiré mis datos más tarde"
+msgstr "Tôi sẽ bổ sung dữ liệu sau"
 
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:42
 msgid "Control automatic scans"
-msgstr "Control de escaneos automáticos"
+msgstr "Điều khiển scan tự động"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:59
 msgid "Usage data preferences"
-msgstr "Preferencias de uso de datos"
+msgstr "Tùy chọn dữ liệu sử dụng"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:62
 msgid "Thanks for helping us improve"
-msgstr "Gracias por ayudarnos a mejorar"
+msgstr "Cảm ơn đã giúp chúng tôi cải tiến"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:63
 msgid "We won't collect any usage events"
-msgstr "No recopilaremos ningún evento de uso"
+msgstr "Chúng tôi sẽ không thu tập sự kiện được sử dụng"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:88
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
-msgstr "Para ayudarnos a mejorar Metabase, nos gustaría recopilar cierta información sobre el uso a través de Google Analytics."
+msgstr "Với mục đích cải tiến Metabase, chúng tôi muốn thu thập dữ liệu sử dụng hiện tại qua Google Analytics "
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Here's a full list of everything we track and why."
-msgstr "Aquí hay una lista completa de todo lo que rastreamos y por qué."
+msgstr "Đây là danh sách đầy đủ những gì chúng tôi theo dõi và tại sao"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
 msgid "Allow Metabase to anonymously collect usage events"
-msgstr "Permitir que Metabase recopile eventos de uso de forma anónima"
+msgstr "Cho phép Metabase thu thập sự kiện được sử dụng ẩn danh"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
 msgid "Metabase {0} collects anything about your data or question results."
-msgstr "Metabase {0} recopila información sobre tus datos o resultados de preguntas."
+msgstr "Metabase {0} thu thập mọi thứ về dữ liệu hay kết quả câu hỏi của bạn"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
 msgid "never"
-msgstr "nunca"
+msgstr "không bao giờ"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:119
 msgid "All collection is completely anonymous."
-msgstr "Toda la información obtenida es completamente anónima."
+msgstr "Tất cả bộ sưu tập đều hoàn toàn ẩn danh"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
-msgstr "La recopilación puede desactivarse en cualquier momento en la sección de configuración."
+msgstr "Có thể tắt bộ sưu tập bất cứ lúc nào trong phần cài đặt quản trị của bạn"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:59
 msgid "If you feel stuck"
-msgstr "Si te sientes abrumado"
+msgstr "Nếu bạn cảm thấy bế tắc"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:64
 msgid "our getting started guide"
-msgstr "nuestra guía de inicio"
+msgstr "Hướng dẫn khởi động của chúng tôi"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:65
 msgid "is just a click away."
-msgstr "esta a un solo click."
+msgstr "Chỉ một click nữa"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:111
 msgid "Welcome to Metabase"
-msgstr "Bienvenid@ a Metabase"
+msgstr "Chào mừng đến Metabase"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:112
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
-msgstr "Parece que todo está funcionando. ¡Ahora vamos a conocerte, conectarte con tus datos y comenzar a encontrarte algunas respuestas!"
+msgstr "Có vẻ mọi thứ đang hoạt động. Giờ để hiểu về bạn, hãy kết nối dữ liệu của bạn, và bắt đầu tìm kiếm cho bạn vài câu trả lời"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:116
 msgid "Let's get started"
-msgstr "Empecemos"
+msgstr "Cùng bắt đầu"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:166
 msgid "You're all set up!"
-msgstr "¡Estás listo!"
+msgstr "Bạn đã được trang bị đầy đủ"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:177
 msgid "Take me to Metabase"
-msgstr "Llévame a Metabase"
+msgstr "Đưa tôi đến Metabase"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:49
 msgid "What should we call you?"
-msgstr "¿Cómo deberíamos llamarte?"
+msgstr "Chúng tôi nên gọi bạn là gì"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:156
 msgid "Hi, {0}. nice to meet you!"
-msgstr "Hola {0}, ¡Encantado de conocerte!"
+msgstr "Xin chào {0}, rất vui được gặp bạn"
 
 #: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
-msgstr "Crea una contraseña"
+msgstr "Thiết lập mật khẩu"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:44
 #: frontend/src/metabase/entities/users/forms.js:50
@@ -6271,463 +6244,461 @@ msgstr "Shhh..."
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:265
 msgid "Confirm password"
-msgstr "Confirma la contraseña"
+msgstr "Xác nhận mật khẩu"
 
 #: frontend/src/metabase/entities/users/forms.js:57
 msgid "Shhh... but one more time so we get it right"
-msgstr "Shhh... otra vez, para asegurarnos que lo hacemos bien"
+msgstr "Shhh... thêm một lần nữa để chúng tôi chắc rằng nó đúng"
 
 #: frontend/src/metabase/entities/users/forms.js:85
 msgid "Your company or team name"
-msgstr "El nombre de tu empresa o equipo"
+msgstr "Tên công ty hoặc nhóm"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:291
 msgid "Department of awesome"
-msgstr "Departamento impresionante"
+msgstr "Ban tuyệt vời"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:26
 msgid "Metabot is admiring your integers…"
-msgstr "Metabot está admirando tus enteros…"
+msgstr "Metabot ngưỡng mộ số nguyên của bạn"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:27
 msgid "Metabot is performing billions of differential equations…"
-msgstr "Metabot está realizando miles de millones de ecuaciones diferenciales…"
+msgstr "Metabot đang thực hiện hàng tỉ phương trình vi phân khác nhau"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:28
 msgid "Metabot is doing science…"
-msgstr "Metabot está haciendo ciencia…"
+msgstr "Metabot đang làm khoa học"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:29
 msgid "Metabot is checking out your metrics…"
-msgstr "Metabot está revisando tus métricas…"
+msgstr "Metabot đang kiểm tra số liệu của bạn"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:30
 msgid "Metabot is looking for trends and outliers…"
-msgstr "Metabot está buscando tendencias y valores atípicos…"
+msgstr "Metabot đang tìm kiếm xu hướng và ngoại lệ"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:31
 msgid "Metabot is consulting the quantum abacus…"
-msgstr "Metabot está consultando el ábaco cuántico…"
+msgstr "Metabot đang tư vấn bàn tính lượng tử..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:32
 msgid "Metabot is feeling pretty good about all this…"
-msgstr "Metabot se siente bien con todo esto…"
+msgstr "Metabot cảm thấy khá tốt về những điều này..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:52
 msgid "We’ll show you some interesting explorations of your data in\n"
 "just a few minutes."
-msgstr "Te mostraremos algunas exploraciones interesantes de tus datos\n"
-"en solo unos minutos."
+msgstr "Chúng tôi sẽ cho bạn thấy một số khám phá thú vị về dữ liệu của bạn trong \\ n chỉ một vài phút."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:72
 msgid "This seems to be taking a while. In the meantime, you can check out one of these example explorations to see what Metabase can do for you."
-msgstr "Esto parece que está tardando un tiempo. Mientras tanto, puedes ver una de estas exploraciones de ejemplo para ver lo qué Metabase puede hacer por ti."
+msgstr "Điều này sẽ tốn chút thời gian. Trong thời gian chờ đợi, bạn có thể kiểm tra một trong những khám phá ví dụ này để xem Metabase có thể làm gì cho bạn."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:86
 msgid "I took a look at the data you just connected, and I have some explorations of interesting things I found. Hope you like them!"
-msgstr "He revisado los datos que acabas de conectar, y tengo algunas exploraciones de cosas interesantes que he encontrado. ¡Espero que te gusten!"
+msgstr "Tôi đã xem xét dữ liệu bạn vừa kết nối, và tôi có một số khám phá về những điều thú vị mà tôi tìm thấy. Hy vọng bạn thích nó!"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:98
 msgid "I'm done exploring for now"
-msgstr "He terminado de explorar por ahora"
+msgstr "Tôi đã khám phá xong"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:20
 msgid "Welcome to the Query Builder!"
-msgstr "¡Bienvenido al Generador de Consultas!"
+msgstr "Chào mừng đến Query Builder"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:22
 msgid "The Query Builder lets you assemble questions (or \"queries\") to ask about your data."
-msgstr "El generador de consultas te permite construir preguntas (o \"consultas\") para indagar sobre tus datos."
+msgstr "Trình tạo truy vấn cho phép bạn tập hợp các câu hỏi (hoặc \\ \"truy vấn \") để hỏi về dữ liệu của bạn."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:26
 msgid "Tell me more"
-msgstr "Dime más"
+msgstr "Nói với tôi nhiều hơn"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:43
 msgid "Start by picking the table with the data that you have a question about."
-msgstr "Empieza escogiendo la tabla con los datos sobre los que tienes una pregunta."
+msgstr "Bắt đầu bằng cách chọn bảng với phần dữ liệu bạn có câu hỏi về"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:45
 msgid "Go ahead and select the \"Orders\" table from the dropdown menu."
-msgstr "Adelante y selecciona la tabla  \"Pedidos\" en el menú desplegable."
+msgstr "Tiếp tục và chọn bảng \"Mệnh lệnh\"\\ từ menu thả xuống"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:78
 msgid "Filter your data to get just what you want."
-msgstr "Filtra tus datos para obtener exactamente lo que quieres."
+msgstr "Lọc dữ liệu của bạn để có được những gì bạn muốn."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:79
 msgid "Click the plus button and select the \"Created At\" field."
-msgstr "Haz clic en el botón más y selecciona el campo \"Created At\"."
+msgstr "Nhấp vào nút dấu cộng và chọn trường \\ \"Đã tạo tại \"."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:93
 msgid "Here we can pick how many days we want to see data for, try 10"
-msgstr "Aquí podemos elegir cuántos días queremos ver los datos, intenta con 10"
+msgstr "Ở đây chúng tôi có thể chọn số ngày chúng tôi muốn xem dữ liệu, hãy thử 10"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:116
 msgid "Here's where you can choose to add or average your data, count the number of rows in the table, or just view the raw data."
-msgstr "Aquí es donde puedes elegir agregar o promediar tus datos, contar el número de filas en la tabla, o simplemente ver los datos sin procesar."
+msgstr "Đây là nơi bạn có thể chọn để thêm hoặc lấy trung bình dữ liệu của mình, đếm số lượng hàng trong bảng hoặc chỉ xem dữ liệu thô."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:118
 msgid "Try it: click on <strong>Raw Data</strong> to change it to <strong>Count of rows</strong> so we can count how many orders there are in this table."
-msgstr "Pruébalo: haz clic en <strong>Datos brutos</ strong> para cambiarlo a <strong>Número de filas</ strong> para que podamos contar cuántas órdenes hay en esta tabla."
+msgstr "Hãy thử: nhấp vào <strong> Dữ liệu thô </ strong> để thay đổi thành <strong> Đếm số hàng </ strong> để chúng tôi có thể đếm được có bao nhiêu đơn hàng trong bảng này."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:142
 msgid "Add a grouping to break out your results by category, day, month, and more."
-msgstr "Añade una agrupación para dividir tus resultados por categoría, día, mes y más."
+msgstr "Thêm một nhóm để chia ra kết quả của bạn theo thể loại, ngày, tháng và hơn thế nữa"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:144
 msgid "Let's do it: click on <strong>Add a grouping</strong>, and choose <strong>Created At: by Week</strong>."
-msgstr "Hagámoslo: haz clic en <strong>Añadir una agrupación</ strong> y elige <strong>Created At: por semana</ strong>."
+msgstr "Hãy làm điều đó: nhấp vào <strong> Thêm một nhóm </ strong> và chọn <strong> Được tạo tại: theo tuần </ strong>"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:152
 msgid "Click on \"by day\" to change it to \"Week.\""
-msgstr "Haz clic en \"por día\" para cambiarlo a \"Semana\"."
+msgstr "Nhấp vào \"theo ngày \" để thay đổi thành  \"Tuần. \""
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:173
 msgid "Run Your Query."
-msgstr "Ejecuta tu consulta."
+msgstr "Chạy truy vấn của bạn."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:175
 msgid "You're doing so well! Click <strong>Run query</strong> to get your results!"
-msgstr "¡Lo estás haciendo muy bien! Haz clic en <strong>Ejecutar consulta</ strong> para obtener tus resultados."
+msgstr "Bạn đang làm rất tốt Nhấp vào <strong> Chạy truy vấn </ strong> để nhận kết quả của bạn!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:192
 msgid "You can view your results as a chart instead of a table."
-msgstr "Puedes ver sus resultados como un gráfico en lugar de una tabla."
+msgstr "Bạn có thể xem kết quả của mình dưới dạng biểu đồ thay vì bảng."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:194
 msgid "Everbody likes charts! Click the <strong>Visualization</strong> dropdown and select <strong>Line</strong>."
-msgstr "A todos nos gustan las gráficas! Haz clic en el menú desplegable <strong>Visualización</ strong> y selecciona <strong>Línea</ strong>."
+msgstr "Nhấp vào menu thả xuống <strong> Visualization </ strong> và chọn <strong> Dòng </ strong>."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:216
 msgid "Well done!"
-msgstr "¡Muy bien!"
+msgstr "Tốt lắm"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:218
 msgid "That's all! If you still have questions, check out our"
-msgstr "¡Eso es todo! Si aún tienes preguntas, revisas nuestra"
+msgstr "Đó là tất cả! Nếu bạn vẫn còn thắc mắc, hãy xem"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:223
 msgid "User's Guide"
-msgstr "Guía del Usuario"
+msgstr "Hướng dẫn sử dụng"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:223
 msgid "Have fun exploring your data!"
-msgstr "¡Diviértete explorando tus datos!"
+msgstr "Hãy vui vẻ khám phá dữ liệu của bạn!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:226
 msgid "Thanks"
-msgstr "Gracias"
+msgstr "Cảm ơn bạn"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:235
 msgid "Save Your Questions"
-msgstr "Guarda tus preguntas"
+msgstr "Lưu câu hỏi"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:237
 msgid "By the way, you can save your questions so you can refer to them later. Saved Questions can also be put into dashboards or Pulses."
-msgstr "Por cierto, puedes guardar tus preguntas para que puedas consultarlas más tarde.Las preguntas guardadas también se pueden poner en cuadros de mando o pulsos."
+msgstr "Nhân tiện, bạn có thể lưu câu hỏi của bạn để bạn có thể tham khảo chúng sau này. Câu hỏi đã lưu cũng có thể được đưa vào bảng điều khiển hoặc Xung"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:241
 msgid "Sounds good"
-msgstr "Suena bien"
+msgstr "Ổn đó"
 
 #: frontend/src/metabase/tutorial/Tutorial.jsx:248
 msgid "Whoops!"
-msgstr "¡¡uy!!"
+msgstr "Whoops!"
 
 #: frontend/src/metabase/tutorial/Tutorial.jsx:249
 msgid "Sorry, it looks like something went wrong. Please try restarting the tutorial in a minute."
-msgstr "Lo siento, parece que algo salió mal. Intenta reiniciar el tutorial en un minuto."
+msgstr "Xin lỗi, có vẻ như đã xảy ra sự cố. Vui lòng thử khởi động lại hướng dẫn trong một phút."
 
 #: frontend/src/metabase/user/actions.js:34
 msgid "Password updated successfully!"
-msgstr "¡Contraseña actualizada correctamente!"
+msgstr "Cập nhập mật khẩu thành công!"
 
 #: frontend/src/metabase/user/actions.js:53
 msgid "Account updated successfully!"
-msgstr "¡Cuenta actualizada con éxito!"
+msgstr "Tài khoản cập nhập thành công!"
 
 #: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
-msgstr "Contraseña actual"
+msgstr "Mật khẩu hiện tại "
 
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:137
 msgid "Sign in with Google Email address"
-msgstr "Inicia sesión con la dirección de correo electrónico de Google"
+msgstr "Đăng nhập bằng địa chỉ Google Email"
 
 #: frontend/src/metabase/user/components/UserSettings.jsx:65
 msgid "User Details"
-msgstr "Detalles Usuario"
+msgstr "Thông tin người sử dụng"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:344
 msgid "Reset to defaults"
-msgstr "Restablecer los valores predeterminados"
+msgstr "Đặt lại về mặc định"
 
 #: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:167
 msgid "unknown map"
-msgstr "mapa desconocido"
+msgstr "Bản đồ không rõ"
 
 #: frontend/src/metabase/visualizations/components/LeafletGridHeatMap.jsx:26
 msgid "Grid map requires binned longitude/latitude."
-msgstr "El mapa de cuadrícula requiere longitud/latitud agrupada."
+msgstr "Bản đồ lưới yêu cầu kinh độ / vĩ độ."
 
 #: frontend/src/metabase/visualizations/components/LegendVertical.jsx:117
 msgid "more"
-msgstr "más"
+msgstr "Thêm"
 
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
-msgstr "¿Qué campos quieres usar para los ejes X e Y?"
+msgstr "Những trường nào bạn muốn sử dụng cho trục X và Y"
 
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
-msgstr "Elige campos"
+msgstr "Chọn trường"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:234
 msgid "Save as default view"
-msgstr "Guardar como vista predeterminada"
+msgstr "Lưu làm mặc định"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Draw box to filter"
-msgstr "Dibujar cuadro para filtrar"
+msgstr "Vẽ hộp để lọc"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Cancel filter"
-msgstr "Cancelar Filtro"
+msgstr "Hủy lọc"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:47
 msgid "Pin Map"
-msgstr "Mapa de Pin"
+msgstr "Gắn bản đồ"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
 msgid "Unset"
-msgstr "Desmarcar"
+msgstr "Không đặt"
 
 #: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
 msgid "Rows {0}-{1} of {2}"
-msgstr "Filas {0}-{1} de {2}"
+msgstr "Hàng {0} - {1} trong số {2}"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:206
 msgid "Data truncated to {0} rows."
-msgstr "Datos truncados a {0} filas."
+msgstr "Dữ liệu bị cắt ngắn thành {0} hàng"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:403
 msgid "Could not find visualization"
-msgstr "No se pudo encontrar la visualización"
+msgstr "Không thể tìm thấy trực quan"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:410
 msgid "Could not display this chart with this data."
-msgstr "No se pudo mostrar este gráfico con esta información."
+msgstr "Không thể hiển thị biểu đồ này với dữ liệu này"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:533
 msgid "No results!"
-msgstr "¡Sin resultados!"
+msgstr "Không có kết quả"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:554
 msgid "Still Waiting..."
-msgstr "Esperando..."
+msgstr "Đang chờ..."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:557
 msgid "This usually takes an average of {0}."
-msgstr "Esto suele tardar unos {0}."
+msgstr "Điều này thường mất trung bình {0}."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:563
 msgid "(This is a bit long for a dashboard)"
-msgstr "(Es un poco largo para un cuadro de mando)"
+msgstr "(Đây là một chút dài cho một bảng điều khiển)"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:503
 msgid "This is usually pretty fast but seems to be taking awhile right now."
-msgstr "Esto suele ser bastante rápido, pero parece estar tardando en este momento."
+msgstr "Điều này thường khá nhanh nhưng dường như đang mất một lúc"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "Select a field"
-msgstr "Selecciona un campo"
+msgstr "Chọn một trường"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:45
 msgid "error"
-msgstr "error"
+msgstr "lỗi"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:117
 msgid "Click and drag to change their order"
-msgstr "Pulsa y arrastra para cambiar el orden"
+msgstr "Nhấp và kéo để thay đổi thứ tự của họ"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:130
 msgid "Add fields from the list below"
-msgstr "Añade campos de la lista inferior"
+msgstr "Thêm các trường từ danh sách dưới đây"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:24
 msgid "less than"
-msgstr "menor que"
+msgstr "ít hơn"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:25
 msgid "greater than"
-msgstr "mayor que"
+msgstr "nhiều hơn"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:26
 msgid "less than or equal to"
-msgstr "menor o igual a"
+msgstr "ít hơn hoặc bằng"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:27
 msgid "greater than or equal to"
-msgstr "nayor o igual a"
+msgstr "nhiều hơn hoặc bằng"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:28
 msgid "equal to"
-msgstr "igual a"
+msgstr "bằng"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:29
 msgid "not equal to"
-msgstr "distinto a"
+msgstr "không bằng"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:191
 msgid "Conditional formatting"
-msgstr "Formato condicional"
+msgstr "Cài đặt điều kiện"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:193
 msgid "You can add rules to make the cells in this table change color if\n"
 "they meet certain conditions."
-msgstr "Puedes añadir reglas para hacer que las celdas de esta tabla cambien\n"
-"de color si cumplen ciertas condiciones."
+msgstr "Bạn có thể thêm quy tắc để làm cho các ô trong bảng này thay đổi màu nếu \\ n Họ đáp ứng một số điều kiện nhất định."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:203
 msgid "Add a rule"
-msgstr "Añade una regla"
+msgstr "Thêm luật"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:208
 msgid "Rules will be applied in this order"
-msgstr "Las reglas se aplicarán en este orden"
+msgstr "Các quy tắc sẽ được áp dụng theo thứ tự này"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:209
 msgid "Click and drag to reorder."
-msgstr "Pulsa y arrastra para cambiar el orden"
+msgstr "Nhấp và kéo để sắp xếp lại"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:242
 msgid "No columns selected"
-msgstr "Ninguna columna seleccionada"
+msgstr "Không cột nào được chọn"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:290
 msgid "Cells in this column will be tinted based on their values."
-msgstr "Las celdas en esta columna se colorearán según sus valores."
+msgstr "Các ô trong cột này sẽ được pha màu dựa trên các giá trị của chúng"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:279
 msgid "When a cell in these columns is {0} it will be tinted this color."
-msgstr "Cuando una celda en estas columnas es {0}, estará teñida de este color."
+msgstr "Khi một ô trong các cột này là {0}, nó sẽ được tô màu này."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:313
 msgid "Which columns should be affected?"
-msgstr "¿A qué columnas se aplica?"
+msgstr "Những cột nào sẽ bị ảnh hưởng?"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:335
 msgid "Formatting style"
-msgstr "Estilo de formato"
+msgstr "Định dạng kiểu "
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:339
 msgid "Single color"
-msgstr "Color único"
+msgstr "Màu đơn"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:340
 msgid "Color range"
-msgstr "Rango de Color"
+msgstr "Dải màu"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:312
 msgid "When a cell in this column is…"
-msgstr "Cuando una celda en esta columna es…"
+msgstr "Khi một ô trong cột này là..."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:376
 msgid "…turn its background this color:"
-msgstr "…pinta el fondo de este color:"
+msgstr "...để nền màu này"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:382
 msgid "Highlight the whole row"
-msgstr "Resalta la fila entera"
+msgstr "Đánh dấu toàn bộ hàng"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
 msgid "Colors"
-msgstr "Colores"
+msgstr "Màu"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:404
 msgid "Start the range at"
-msgstr "Empieza el rango en"
+msgstr "Bắt đầu chuỗi từ"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:409
 msgid "Smallest value in this column"
-msgstr "El valor más pequeño en esta columna"
+msgstr "Giá trị nhỏ nhất cột"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:411
 msgid "Smallest value in each column"
-msgstr "El valor más pequeño en cada columna"
+msgstr "Giá trị nhỏ nhất mỗi cột"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:413
 msgid "Smallest value in all of these columns"
-msgstr "El valor más pequeño en todas estas columnas"
+msgstr "Giá trị nhỏ nhất trong tất cả các cột"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:417
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:441
 msgid "Custom value"
-msgstr "Valor personalizado"
+msgstr "Giá trị tùy chỉnh"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:428
 msgid "End the range at"
-msgstr "Finaliza el rango en"
+msgstr "Kết thúc chuỗi ở"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:433
 msgid "Largest value in this column"
-msgstr "El valor más grande en esta columna"
+msgstr "Giá trị lớn nhất trong cột"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:435
 msgid "Largest value in each column"
-msgstr "El valor más grande en cada columna"
+msgstr "Giá trị lớn nhất từng cột"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:437
 msgid "Largest value in all of these columns"
-msgstr "El valor más grande en todas estas columnas"
+msgstr "Giá trị lớn nhất trong tất cả các cột"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:471
 msgid "Add rule"
-msgstr "Añadir regla"
+msgstr "Thêm luật"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:471
 msgid "Update rule"
-msgstr "Actualizar regla"
+msgstr "Cập nhập luật"
 
 #: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
-msgstr "Visualización Vacía"
+msgstr "Trực quan rỗng"
 
 #: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
-msgstr "La visualización debe definir una variable estática 'identificadora':"
+msgstr "Trực quan hóa phải xác định biến tĩnh 'định danh'"
 
 #: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
-msgstr "La visualización con ese identificador ya está registrada:"
+msgstr "Hình dung với định danh đó đã được đăng ký:"
 
 #: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
-msgstr "No hay visualización para {0}"
+msgstr "Không trực quan hóa cho {0}"
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
-msgstr "\"{0}\" es un campo no agregado: si tienes más de un valor en un punto en el eje X, los valores se sumarán."
+msgstr "\\ \"{0} \" là trường không kết hợp: nếu nó có nhiều hơn một giá trị tại một điểm trên trục x, các giá trị sẽ được tính tổng."
 
 #: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:93
 msgid "This chart type requires at least 2 columns."
-msgstr "Este tipo de gráfico requiere al menos 2 columnas."
+msgstr "Loại biểu đồ này yêu cầu ít nhất 2 cột."
 
 #: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:98
 msgid "This chart type doesn't support more than {0} series of data."
-msgstr "Este tipo de gráfico no admite más de {0} series de datos."
+msgstr "Loại biểu đồ này không hỗ trợ nhiều hơn {0} chuỗi dữ liệu."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:297
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
-msgstr "Objetivo"
+msgstr "Mục đích"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
-msgstr "Vaya! Los datos de tu consulta no se ajustan a la opción de visualización elegida. Esta visualización requiere al menos {0} {1} de datos."
+msgstr "Đừng! Dữ liệu từ truy vấn của bạn không phù hợp với lựa chọn hiển thị đã chọn. Hình dung này yêu cầu ít nhất {0} {1} dữ liệu."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
@@ -6749,714 +6720,713 @@ msgstr "Vaya! Los datos de tu consulta no se ajustan a la opción de visualizaci
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
-msgstr "columna"
+msgstr "cột"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:23
 msgid "No dice. We have {0} data {1} to show and that's not enough for this visualization."
-msgstr "No hay suerte. Tenemos {0} datos {1} para mostrar pero no es suficiente para esta visualización."
+msgstr "Không có con xúc xắc. Chúng tôi có {0} dữ liệu {1} để hiển thị và điều đó không đủ cho hình dung này"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:23
 msgid "point"
 msgid_plural "points"
-msgstr[0] "punto"
-msgstr[1] "puntos"
+msgstr[0] "điểm"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:35
 msgid "Bummer. We can't actually do a pin map for this data because we require both a latitude and longitude column."
-msgstr "Vaya. No podemos hacer un mapa de pin para estos datos porque necesitamos una columna de latitud y longitud."
+msgstr "Bummer. Chúng tôi thực sự không thể thực hiện bản đồ pin cho dữ liệu này vì chúng tôi yêu cầu cả cột vĩ độ và kinh độ."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:55
 msgid "Please configure this chart in the chart settings"
-msgstr "Por favor, configura este gráfico en la configuración del gráfico"
+msgstr "Vui lòng định cấu hình biểu đồ này trong cài đặt biểu đồ"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:57
 msgid "Edit Settings"
-msgstr "Editar Configuración"
+msgstr "Thay đổi cài đặt"
 
 #: frontend/src/metabase/visualizations/lib/fill_data.js:39
 msgid "xValues missing!"
-msgstr "¡Faltan valores x!"
+msgstr "Giá trị thiếu"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
 msgid "X-axis"
-msgstr "Eje-X"
+msgstr "Trục X"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
-msgstr "Añade un desglose de series..."
+msgstr "Thêm chuỗi"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
 msgid "Y-axis"
-msgstr "Eje-Y"
+msgstr "trục Y"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
-msgstr "Añade otra serie..."
+msgstr "Thêm chuỗi khác..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
-msgstr "Tamaño de burbuja"
+msgstr "Kích thước bong bóng"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
 #: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
 msgid "Line"
-msgstr "Línea"
+msgstr "Dòng"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:72
 msgid "Curve"
-msgstr "Curva"
+msgstr "Đường cong"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
-msgstr "Paso"
+msgstr "Bước"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:170
 msgid "Show point markers on lines"
-msgstr "Mostrar marcadores de puntos en líneas"
+msgstr "Hiển thị điểm đánh dấu trên đường"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
-msgstr "Apilado"
+msgstr "Đang xếp chồng"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
-msgstr "No Apilado"
+msgstr "Không xếp chồng"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
-msgstr "Apilar"
+msgstr "Xếp chồng"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
-msgstr "Apilado - 100%"
+msgstr "Xếp chồng - 100%"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
-msgstr "Mostrar objetivo"
+msgstr "Hiển thị đích"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
-msgstr "Valor del Objetivo"
+msgstr "Giá trị đích"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:103
 msgid "Replace missing values with"
-msgstr "Reemplazar los valores faltantes con"
+msgstr "Thay thế giá trị thiếu bằng"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:107
 msgid "Zero"
-msgstr "Cero"
+msgstr "không"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:108
 msgid "Nothing"
-msgstr "Nada"
+msgstr "Không có gì"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:109
 msgid "Linear Interpolated"
-msgstr "Lineal Interpolado"
+msgstr "Nội suy tuyến tính"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
-msgstr "Escala Eje-X"
+msgstr "Kích thước trục X"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
-msgstr "Series de tiempo"
+msgstr "Dòng thời gian"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:425
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:443
 msgid "Linear"
-msgstr "Lineal"
+msgstr "Tuyến tính"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:444
 msgid "Power"
-msgstr "Exponente"
+msgstr "Nguồn"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:428
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:445
 msgid "Log"
-msgstr "Logarítmico"
+msgstr "Khóa"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:430
 msgid "Histogram"
-msgstr "Histograma"
+msgstr "Biểu đồ"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
-msgstr "Ordinal"
+msgstr "Bình thường"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
-msgstr "Escala Eje-Y"
+msgstr "Kích thước trục Y"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
-msgstr "Mostrar línea y marcas del Eje-X"
+msgstr "Hiển thị dòng trục x và điểm"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:349
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:457
 msgid "Compact"
-msgstr "Compacto"
+msgstr "Gọn nhẹ"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:458
 msgid "Rotate 45°"
-msgstr "Rotar 45°"
+msgstr "Xoay 45 độ"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:459
 msgid "Rotate 90°"
-msgstr "Rotar 90°"
+msgstr "Xoay 90 độ"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:466
 msgid "Show y-axis line and marks"
-msgstr "Mostrar línea y marcas del Eje-Y"
+msgstr "Hiển thị dòng trục y và điểm"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Auto y-axis range"
-msgstr "Rango del Eje-Y automático"
+msgstr "Tự động phạm vi trục y "
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:522
 msgid "Use a split y-axis when necessary"
-msgstr "Utiliza un Eje-Y dividido cuando sea necesario"
+msgstr "Dùng trục Y xoay khi cần thiết"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:529
 msgid "Show label on x-axis"
-msgstr "Mostrar etiqueta en el Eje-X"
+msgstr "Hiển thị nhãn trên trục X"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:535
 msgid "X-axis label"
-msgstr "Etiqueta Eje-X"
+msgstr "Nhãn trục "
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:544
 msgid "Show label on y-axis"
-msgstr "Mostrar etiqueta en el Eje-Y"
+msgstr "Thể hiện nhãn trên trục "
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:550
 msgid "Y-axis label"
-msgstr "Etiqueta Eje-Y"
+msgstr "Hiển thị nhãn trên trục Y"
 
 #: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Standard Deviation"
-msgstr "Desviación Estándar"
+msgstr "Độ lệch chuẩn"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
 #: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
 msgid "Area"
-msgstr "Area"
+msgstr "Vùng"
 
 #: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
 msgid "area chart"
-msgstr "Gráfico de área"
+msgstr "biểu đồ khu vực"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
 #: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
 msgid "Bar"
-msgstr "Barra"
+msgstr "Thanh"
 
 #: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
 msgid "bar chart"
-msgstr "Gráfico de barras"
+msgstr "biểu đồ thanh"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
-msgstr "¿Qué campos quieres usar?"
+msgstr "Những lĩnh vực nào bạn muốn sử dụng"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
-msgstr "Embudo"
+msgstr "Phễu"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
 msgid "Measure"
-msgstr "Medida"
+msgstr "Đo lường"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
-msgstr "Tipo Embudo"
+msgstr "Loại phễu"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
-msgstr "Gráfico de barras"
+msgstr "Biểu đồ cột"
 
 #: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
 msgid "line chart"
-msgstr "Gráfico de líneas"
+msgstr "biểu đồ đường"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
 msgid "Please select longitude and latitude columns in the chart settings."
-msgstr "Selecciona las columnas de longitud y latitud en la configuración del gráfico."
+msgstr "Vui lòng chọn các cột kinh độ và vĩ độ trong cài đặt biểu đồ."
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
 msgid "Please select a region map."
-msgstr "Por favor, selecciona un mapa de la región."
+msgstr "Vui lòng chọn một bản đồ khu vực."
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
 msgid "Please select region and metric columns in the chart settings."
-msgstr "Selecciona las columnas de región y métricas en la configuración del gráfico."
+msgstr "Vui lòng chọn các cột khu vực và số liệu trong cài đặt biểu đồ."
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
 msgid "Map"
-msgstr "Mapa"
+msgstr "Bản đồ"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
 msgid "Map type"
-msgstr "Tipo mapa"
+msgstr "Loại bản đồ"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
 msgid "Region map"
-msgstr "Mapa de la región"
+msgstr "Vùng trên bản đồ"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
 msgid "Pin map"
-msgstr "Mapa de pin"
+msgstr "Đánh dấu trên bản đồ"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
 msgid "Pin type"
-msgstr "Tipo Pin"
+msgstr "Loại đánh dấu"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Tiles"
-msgstr "Baldosas"
+msgstr "Ngói"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
 msgid "Markers"
-msgstr "Marcadores"
+msgstr "Dấu"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
 msgid "Latitude field"
-msgstr "Campo Latitud"
+msgstr "Trường vĩ độ"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
 msgid "Longitude field"
-msgstr "Campo Longitud"
+msgstr "Trường kinh độ"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
 msgid "Metric field"
-msgstr "Campo Métrica"
+msgstr "Trường số liệu"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
 msgid "Region field"
-msgstr "Campo Región"
+msgstr "Trường vùng"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
 msgid "Radius"
-msgstr "Radio"
+msgstr "Bán kính"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
 msgid "Blur"
-msgstr "Difuminar"
+msgstr "Làm nhòe"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
 msgid "Min Opacity"
-msgstr "Opacidad Mínima"
+msgstr "Độ mờ tối thiểu"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
 msgid "Max Zoom"
-msgstr "Acercamiento Máximo"
+msgstr "Thu phóng tối đa"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:234
 msgid "No relationships found."
-msgstr "No se encontraron relaciones."
+msgstr "Không tìm thấy quan hệ"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:272
 msgid "via {0}"
-msgstr "via {0}"
+msgstr "thông qua {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
 msgid "This {0} is connected to:"
-msgstr "Esta {0} está conectada a:"
+msgstr " {0} này được liên kết đến:"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "Object Detail"
-msgstr "Detalle del Objeto"
+msgstr "Chi tiết đối tượng"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:93
 msgid "object"
-msgstr "objeto"
+msgstr "đối tượng"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
 msgid "Total"
-msgstr "Total"
+msgstr "Tổng"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
 msgid "Which columns do you want to use?"
-msgstr "¿Qué columnas quieres usar?"
+msgstr "Cột bạn muốn sử dụng"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
 msgid "Pie"
-msgstr "Pastel"
+msgstr "Bánh"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
 msgid "Dimension"
-msgstr "Dimensión"
+msgstr "Kích thước"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
 msgid "Show legend"
-msgstr "Mostrar Leyenda"
+msgstr "Hiển thị huyền thoại"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
 msgid "Show percentages in legend"
-msgstr "Mostrar porcentajes en la leyenda"
+msgstr "Hiển thị phần trăm trong huyền thoại"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
 msgid "Minimum slice percentage"
-msgstr "Porcentaje mínimo de porción"
+msgstr "Tỉ lệ phần trăm tối thiểu"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
-msgstr "Objetivo conseguido"
+msgstr "Đạt được mục tiêu"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
-msgstr "Objetivo superado"
+msgstr "Vượt quá mục tiêu"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
-msgstr "Objetivo {0}"
+msgstr "Mục tiêu {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
-msgstr "La visualización del progreso requiere un número."
+msgstr "Hình dung tiến độ đòi hỏi một số"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:27
 msgid "Progress"
-msgstr "Progreso"
+msgstr "Đang thực hiện"
 
 #: frontend/src/metabase/entities/collections.js:109
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
-msgstr "Color"
+msgstr "Màu"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row Chart"
-msgstr "Gráfico de Filas"
+msgstr "Biểu đồ hàng"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
 msgid "row chart"
-msgstr "gráfico de filas"
+msgstr "biểu đồ hàng"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:381
 msgid "Separator style"
-msgstr "Estilo separador"
+msgstr "Kiểu tách"
 
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:88
 msgid "Number of decimal places"
-msgstr "Número de decimales"
+msgstr "Số vị thập phân"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:405
 msgid "Add a prefix"
-msgstr "Añade un prefijo"
+msgstr "Thêm một tiền tố"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:409
 msgid "Add a suffix"
-msgstr "Añade un sufijo"
+msgstr "Thêm một hậu tố"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:398
 msgid "Multiply by a number"
-msgstr "Multiplicar por un número"
+msgstr "Nhân với một số"
 
 #: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
 msgid "Scatter"
-msgstr "Dispersión"
+msgstr "Tiêu tan"
 
 #: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
 msgid "scatter plot"
-msgstr "gráfico de dispersión"
+msgstr "phân tán âm mưu"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
 msgid "Pivot the table"
-msgstr "Pivote la tabla"
+msgstr "Xoay bảng"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:73
 msgid "Visible fields"
-msgstr "Campos visibles"
+msgstr "Các trường nhìn thấy được"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
+#, fuzzy
 msgid "Write here, and use Markdown if you'd like"
-msgstr "Escribe aquí. Puedes utilizar Markdown"
+msgstr "Viết ở đây và sử dụng Markdown nếu bạn muốn"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
 msgid "Vertical Alignment"
-msgstr "Alineamiento Vertical"
+msgstr "Căn dọc"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:77
 msgid "Top"
-msgstr "Arriba:"
+msgstr "Đầu"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:78
 msgid "Middle"
-msgstr "Medio"
+msgstr "Giữa"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:79
 msgid "Bottom"
-msgstr "Abajo"
+msgstr "Cuối"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:86
 msgid "Horizontal Alignment"
-msgstr "Alineamiento Horizontal"
+msgstr "Căn ngang"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:126
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:90
 msgid "Left"
-msgstr "Izquierda"
+msgstr "Bên trái"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:91
 msgid "Center"
-msgstr "Centro"
+msgstr "Giữa"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:127
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:92
 msgid "Right"
-msgstr "Derecho"
+msgstr "Phải"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:99
 msgid "Show background"
-msgstr "Mostrar fondo"
+msgstr "Hiển thị nền"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:760
 msgid "{0} bin"
 msgid_plural "{0} bins"
-msgstr[0] "{0} agrupación"
-msgstr[1] "{0} agrupaciones"
+msgstr[0] "ngăn"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:766
 msgid "Auto binned"
-msgstr "Agrupación Auto"
+msgstr "tự động ngăn"
 
 #: src/metabase/api/alert.clj
 msgid "DELETE /api/alert/:id is deprecated. Instead, change its `archived` value via PUT /api/alert/:id."
-msgstr "DELETE /api/alert/:id esta descontinuado. Cambia el valor de `archived` via PUT /api/alert/:id."
+msgstr "XÓA / api / alert /: id không được dùng nữa. Thay vào đó, thay đổi giá trị `được lưu trữ của nó thông qua PUT / api / alert /: id."
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid show value"
-msgstr "valor no válido para el campo mostrar"
+msgstr "giá trị hiển thị không hợp lệ"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid value for prefix"
-msgstr "valor no válido para el prefijo"
+msgstr "giá trị không hợp lệ cho tiền tố"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid value for rule name"
-msgstr "valor no válido para nombre de regla"
+msgstr "Giá trị không hợp lệ cho luật tên"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "value couldn''t be parsed as base64 encoded JSON"
-msgstr "valor no se pudo analizar como JSON codificado base64"
+msgstr "giá trị không thể được phân tích cú pháp dưới dạng JSON được mã hóa base64"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "Invalid entity type"
-msgstr "Tipo de entidad inválida"
+msgstr "Loại thực thể không hợp lệ"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "Invalid comparison entity type. Can only be one of \"table\", \"segment\", or \"adhoc\""
-msgstr "Tipo de entidad de comparación inválida. Solo puede ser \"tabla\", \"segmento\" o \"adhoc\""
+msgstr "Loại thực thể so sánh không hợp lệ. Chỉ có thể là một trong \\ \"bảng \", \\ \"phân đoạn \" hoặc \\ \"adhoc \\"
 
 #: src/metabase/query_processor/async.clj
 msgid "Error running query to determine Card result metadata:"
-msgstr "Error determinando el tipo de resultado de la tarjeta"
+msgstr "Lỗi khi chạy truy vấn để xác định siêu dữ liệu kết quả Thẻ:"
 
 #: src/metabase/api/card.clj
 msgid "DELETE /api/card/:id is deprecated. Instead, change its `archived` value via PUT /api/card/:id."
-msgstr "DELETE /api/card/:id esta descontinuado. Cambia el valor de `archived` via PUT /api/card/:id."
+msgstr "XÓA / api / thẻ /: id không được dùng nữa. Thay vào đó, thay đổi giá trị `được lưu trữ của nó thông qua PUT / api / card /: id."
 
 #: src/metabase/api/common.clj src/metabase/api/common/internal.clj
 msgid "Invalid field: {0}"
-msgstr "Campo inválido: {0}"
+msgstr "Trường không hợp lệ: {0}"
 
 #: src/metabase/api/common.clj
 msgid "Invalid value ''{0}'' for ''{1}'': {2}"
-msgstr "Valor inválido ''{0}'' para ''{1}'': {2}"
+msgstr "Giá trị không hợp lệ '' {0} '' cho '' {1} '': {2}"
 
 #: src/metabase/api/common.clj
 msgid "must be one of: {0}"
-msgstr "debe ser uno de: {0}"
+msgstr "phải là một trong: {0}"
 
 #: src/metabase/api/common.clj
 msgid "Invalid Request."
-msgstr "Petición inválida."
+msgstr "Yêu cầu không hợp lệ."
 
 #: src/metabase/api/common.clj
 msgid "Not found."
-msgstr "No encontrado."
+msgstr "Không tìm thấy"
 
 #: src/metabase/api/common.clj
 msgid "You don''t have permissions to do that."
-msgstr "Lo siento, no tienes permiso para hacer eso."
+msgstr "Bạn không có quyền làm thế"
 
 #: src/metabase/api/common.clj
 msgid "Internal server error."
-msgstr "Error de servidor interno."
+msgstr "Nội bộ hệ thống lỗi"
 
 #: src/metabase/api/common.clj
 msgid "Warning: endpoint {0}/{1} does not have a docstring."
-msgstr "Aviso: la llamada {0}/{1} no tiene un docstring"
+msgstr "Cảnh báo: điểm cuối {0} / {1} không có chuỗi doc."
 
 #: src/metabase/api/common.clj
 msgid "starting streaming request"
-msgstr "iniciando streaming"
+msgstr "bắt đầu yêu cầu phát trực tuyến"
 
 #: src/metabase/async/api_response.clj
 msgid "connection closed, canceling request"
-msgstr "iniciando la solicitud de transmisión"
+msgstr "đóng kết nối, hủy yêu cầu"
 
 #. a newline padding character as it's harmless and will allow us to check if the client is connected. If
 #. sending this character fails because the connection is closed, the chan will then close.  Newlines are
 #. no-ops when reading JSON which this depends upon.
 #: src/metabase/async/api_response.clj
 msgid "Response not ready, writing one byte & sleeping..."
-msgstr "La respuesta no está lista, escribiendo un byte y esperando..."
+msgstr "Response not ready, writing one byte & sleeping..."
 
 #: src/metabase/api/common.clj
 msgid "Public sharing is not enabled."
-msgstr "La compartición pública no está habilitada."
+msgstr "Chia sẻ công khai không kích hoạt"
 
 #: src/metabase/api/common.clj
 msgid "Embedding is not enabled."
-msgstr "La incrustación no está habilitada."
+msgstr "Embedding is not enabled."
 
 #: src/metabase/api/common.clj
 msgid "The object has been archived."
-msgstr "El objeto ha sido archivado."
+msgstr "Đối tượng đã được lưu trữ"
 
 #: src/metabase/api/common/internal.clj
 msgid "Attempted to return a boolean as an API response. This is not allowed!"
-msgstr "Se ha intentado devolver un booleano como respuesta de API. ¡Esto no esta permitido!"
+msgstr "Đã cố trả về boolean dưới dạng phản hồi API. Điều này không được phép!"
 
 #: src/metabase/api/dataset.clj
 msgid "Source query for this query is Card {0}"
-msgstr "La consulta base de esta consulta es Tarjeta {0}"
+msgstr "Truy vấn nguồn cho truy vấn này là Thẻ {0}"
 
 #: src/metabase/api/dataset.clj
 msgid "Invalid export format: {0}"
-msgstr "Formato de exportación inválido: {0}"
+msgstr "Định dạng xuất không hợp lệ: {0}"
 
 #: src/metabase/api/geojson.clj
 msgid "Invalid JSON URL or resource: {0}"
-msgstr "Recurso o URL JSON no válido: {0}"
+msgstr "Tài nguyên hoặc URL JSON không hợp lệ: {0}"
 
 #: src/metabase/api/geojson.clj
 msgid "JSON containing information about custom GeoJSON files for use in map visualizations instead of the default US State or World GeoJSON."
-msgstr "JSON que contiene información sobre archivos GeoJSON personalizados para su uso en visualizaciones de mapas en lugar del GeoJSON por defecto de EEUU o el Mundo."
+msgstr "JSON chứa thông tin về các tệp GeoJSON tùy chỉnh để sử dụng trong trực quan hóa bản đồ thay vì trạng thái mặc định của Hoa Kỳ hoặc World GeoJSON."
 
 #: src/metabase/api/geojson.clj
 msgid "Invalid custom GeoJSON key: {0}"
-msgstr "Clave personalizada GeoJSON inválida: {0}"
+msgstr "Khóa GeoJSON tùy chỉnh không hợp lệ: {0}"
 
 #. ...but if we *still* couldn't find a match, throw an Exception, because we don't want people
 #. trying to inject new params
 #: src/metabase/api/public.clj
 msgid "Invalid param: {0}"
-msgstr "Parámetro inválido: {0}"
+msgstr "Thông số không hợp lệ: {0}"
 
 #: src/metabase/api/pulse.clj
 msgid "DELETE /api/pulse/:id is deprecated. Instead, change its `archived` value via PUT /api/pulse/:id."
-msgstr "DELETE /api/pulse/:id esta descontinuado. Cambia el valor de `archived` via PUT /api/pulse/:id."
+msgstr "XÓA / api / xung /: id không được dùng nữa. Thay vào đó, thay đổi giá trị `được lưu trữ của nó thông qua PUT / api / Pulse /: id"
 
 #: src/metabase/api/routes.clj
 msgid "API endpoint does not exist."
-msgstr "No existe este servicio API"
+msgstr "Điểm cuối API không tồn tại."
 
 #: src/metabase/api/session.clj
 msgid "Password did not match stored password."
-msgstr "La contraseña no coincide con la almacenada"
+msgstr "Mật khẩu không khớp với mật khẩu được lưu trữ."
 
 #: src/metabase/api/session.clj
 msgid "did not match stored password"
-msgstr "no coincide con la contraseña almacenada"
+msgstr "không khớp với mật khẩu đã lưu"
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fallback to local authentication {0}"
-msgstr "Problema al conectar con el servidor LDAP, se recurrirá a la autentificación local {0}"
+msgstr "Sự cố khi kết nối với máy chủ LDAP, sẽ chuyển sang xác thực cục bộ {0}"
 
 #: src/metabase/api/session.clj
 msgid "Invalid reset token"
-msgstr "Token de reinicio inválido"
+msgstr "Mã thông báo đặt lại không hợp lệ"
 
 #: src/metabase/api/session.clj
 msgid "Client ID for Google Auth SSO. If this is set, Google Auth is considered to be enabled."
-msgstr "ID de cliente para Google Auth SSO. Si esto está configurado, Google Auth se considera habilitado."
+msgstr "ID khách hàng cho Google Auth SSO. Nếu điều này được đặt, Google Auth được coi là được bật."
 
 #: src/metabase/api/session.clj
 msgid "When set, allow users to sign up on their own if their Google account email address is from this domain."
-msgstr "Permite que los usuarios se registren solos si la dirección de correo electrónico de su cuenta de Google es de este dominio."
+msgstr "Khi được đặt, cho phép người dùng tự đăng ký nếu địa chỉ email tài khoản Google của họ đến từ miền này"
 
 #: src/metabase/api/session.clj
 msgid "Invalid Google Auth token."
-msgstr "Token de autenticación de Google no válido"
+msgstr "Mã thông báo xác thực Google không hợp lệ."
 
 #: src/metabase/api/session.clj
 msgid "Email is not verified."
-msgstr "Correo no verificado."
+msgstr "Email is not verified."
 
 #: src/metabase/api/session.clj
 msgid "You''ll need an administrator to create a Metabase account before you can use Google to log in."
-msgstr "Necesitarás un administrador para crear una cuenta Metabase antes de poder usar Google para iniciar sesión."
+msgstr "Bạn sẽ cần một quản trị viên để tạo tài khoản Metabase trước khi bạn có thể sử dụng Google để đăng nhập."
 
 #: src/metabase/api/session.clj
 msgid "Successfully authenticated Google Auth token for: {0} {1}"
-msgstr "Se ha autentificado con éxito el token de Google Auth para: {0} {1}"
+msgstr "Mã thông báo Google Auth được xác thực thành công cho: {0} {1}"
 
 #: src/metabase/api/setup.clj
 msgid "Add a database"
-msgstr "Añade una Base de Datos"
+msgstr "Thêm cơ sở dữ liệu"
 
 #: src/metabase/api/setup.clj
 msgid "Get connected"
-msgstr "Conectarse"
+msgstr "Kết nối"
 
 #: src/metabase/api/setup.clj
 msgid "Connect to your data so your whole team can start to explore."
-msgstr "Conecta tus datos para que todo el equipo pueda comenzar a explorar."
+msgstr "Kết nối với dữ liệu của bạn để cả nhóm của bạn có thể bắt đầu khám phá."
 
 #: src/metabase/api/setup.clj
 msgid "Set up email"
-msgstr "Configura el email"
+msgstr "Thiết lập email"
 
 #: src/metabase/api/setup.clj
 msgid "Add email credentials so you can more easily invite team members and get updates via Pulses."
-msgstr "Añade credenciales de correo electrónico para que puedas invitar más fácilmente a los miembros del equipo y obtener actualizaciones a través de Pulsos."
+msgstr "Thêm thông tin đăng nhập email để bạn có thể dễ dàng mời các thành viên trong nhóm hơn và nhận thông tin cập nhật qua Xung."
 
 #: src/metabase/api/setup.clj
 msgid "Set Slack credentials"
-msgstr "Establecer credenciales de Slack"
+msgstr "Đặt thông tin đăng nhập Slack"
 
 #: src/metabase/api/setup.clj
 msgid "Does your team use Slack? If so, you can send automated updates via pulses and ask questions with MetaBot."
-msgstr "¿Tu equipo usa Slack? Si es así, puedes enviar actualizaciones automáticas por pulsos y hacer preguntas con MetaBot."
+msgstr "Đội của bạn có sử dụng Slack không? Nếu vậy, bạn có thể gửi cập nhật tự động qua các xung và đặt câu hỏi với MetaBot"
 
 #: src/metabase/api/setup.clj
 msgid "Invite team members"
-msgstr "Invitar a miembros del equipo"
+msgstr "Mời thành viên trong nhóm"
 
 #: src/metabase/api/setup.clj
 msgid "Share answers and data with the rest of your team."
-msgstr "Comparte respuestas y datos con el resto de tu equipo."
+msgstr "Chia sẻ câu trả lời và dữ liệu với phần còn lại của nhóm của bạn."
 
 #: src/metabase/api/setup.clj
 msgid "Hide irrelevant tables"
-msgstr "Ocultar tablas irrelevantes"
+msgstr "Ẩn bảng liên quan"
 
 #: src/metabase/api/setup.clj
 msgid "Curate your data"
-msgstr "Mima tus datos"
+msgstr "Quản lý dữ liệu của bạn"
 
 #: src/metabase/api/setup.clj
 msgid "If your data contains technical or irrelevant info you can hide it."
-msgstr "Si tus datos contienen información técnica o irrelevante, puedes ocultarla."
+msgstr "Nếu dữ liệu của bạn chứa thông tin kỹ thuật hoặc không liên quan, bạn có thể ẩn nó."
 
 #: src/metabase/api/setup.clj
 msgid "Organize questions"
-msgstr "Organizar preguntas"
+msgstr "Sắp xếp câu hỏi"
 
 #: src/metabase/api/setup.clj
 msgid "Have a lot of saved questions in {0}? Create collections to help manage them and add context."
-msgstr "¿Tienes muchas preguntas guardadas en {0}? Crea colecciones para ayudar a administrarlas y añadir contexto."
+msgstr "Có rất nhiều câu hỏi được lưu trong {0}? Tạo các bộ sưu tập để giúp quản lý chúng và thêm bối cảnh."
 
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
@@ -7466,1687 +7436,1682 @@ msgstr "¿Tienes muchas preguntas guardadas en {0}? Crea colecciones para ayudar
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
 #: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
 msgid "Metabase"
-msgstr "Metabase"
+msgstr "Cơ sở dữ liệu"
 
 #: src/metabase/api/setup.clj
 msgid "Create metrics"
-msgstr "Crear métricas"
+msgstr "Tạo số liệu"
 
 #: src/metabase/api/setup.clj
 msgid "Define canonical metrics to make it easier for the rest of your team to get the right answers."
-msgstr "Define métricas canónicas para que el resto de tu equipo obtenga las respuestas correctas."
+msgstr "Xác định các số liệu chính tắc để giúp các thành viên còn lại của bạn dễ dàng có được câu trả lời đúng."
 
 #: src/metabase/api/setup.clj
 msgid "Create segments"
-msgstr "Crear segmentos"
+msgstr "Tạo phân khúc"
 
 #: src/metabase/api/setup.clj
 msgid "Keep everyone on the same page by creating canonical sets of filters anyone can use while asking questions."
-msgstr "Mantiene a todos en la misma página mediante la creación de conjuntos canónicos de filtros que cualquier persona puede usar al hacer preguntas."
+msgstr "Giữ tất cả mọi người trên cùng một trang bằng cách tạo các bộ lọc chuẩn mà bất kỳ ai cũng có thể sử dụng trong khi đặt câu hỏi."
 
 #: src/metabase/api/table.clj
 msgid "Table ''{0}'' is now visible. Resyncing."
-msgstr "Ha aparecido la tabla ''{0}''. Sincronizando."
+msgstr "Bảng '' {0} '' hiện có thể nhìn thấy. Tái đồng bộ"
 
 #: src/metabase/api/table.clj
 msgid "Auto bin"
-msgstr "Agrupación Auto"
+msgstr "Tự động ngăn"
 
 #: src/metabase/api/table.clj
 msgid "Don''t bin"
-msgstr "Sin Agrupación"
+msgstr "Không ngăn"
 
 #: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
-msgstr[0] "Día"
-msgstr[1] "Días"
+msgstr[0] "ngày"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
 #: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
-msgstr[0] "Minuto"
-msgstr[1] "Minutos"
+msgstr[0] "Phút"
 
 #: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
-msgstr[0] "Hora"
-msgstr[1] "Horas"
+msgstr[0] "giờ"
 
+#. Quý
 #: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
+#, fuzzy
 msgid "Quarter"
 msgid_plural "Quarters"
-msgstr[0] "Trimestre"
-msgstr[1] "Trimestres"
+msgstr[0] "Quý"
 
 #: src/metabase/api/table.clj
 msgid "Minute of Hour"
-msgstr "Minuto de Hora"
+msgstr "Phút của giờ"
 
 #: src/metabase/api/table.clj
 msgid "Hour of Day"
-msgstr "Hora del Día"
+msgstr "Giờ của ngày"
 
 #: src/metabase/api/table.clj
 msgid "Day of Week"
-msgstr "Día de la Semana"
+msgstr "Ngày của tuần"
 
 #: src/metabase/api/table.clj
 msgid "Day of Month"
-msgstr "Día del Mes"
+msgstr "Ngày của tháng"
 
 #: src/metabase/api/table.clj
 msgid "Day of Year"
-msgstr "Día del Año"
+msgstr "Ngày của năm"
 
 #: src/metabase/api/table.clj
 msgid "Week of Year"
-msgstr "Semana del Año"
+msgstr "Tuần của năm"
 
 #: src/metabase/api/table.clj
 msgid "Month of Year"
-msgstr "Mes del Año"
+msgstr "Tháng của năm"
 
 #: src/metabase/api/table.clj
 msgid "Quarter of Year"
-msgstr "Trimestre del Año"
+msgstr "Quý của năm"
 
 #: src/metabase/api/table.clj
 msgid "10 bins"
-msgstr "10 agrupaciones"
+msgstr "10 thùng"
 
 #: src/metabase/api/table.clj
 msgid "50 bins"
-msgstr "50 agrupaciones"
+msgstr "50 thùng"
 
 #: src/metabase/api/table.clj
 msgid "100 bins"
-msgstr "100 agrupaciones"
+msgstr "100 thùng"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 0.1 degrees"
-msgstr "Agrupa cada 0.1 grados"
+msgstr "Ngăn mỗi 0.1 độ"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 1 degree"
-msgstr "Agrupa cada 1 grado"
+msgstr "Ngăn mỗi 1 độ"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 10 degrees"
-msgstr "Agrupa cada 10 grados"
+msgstr "Ngăn mỗi 10 độ"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 20 degrees"
-msgstr "Agrupa cada 20 grados"
+msgstr "Ngăn mỗi 20 độ"
 
 #. returns `true` if successful -- see JavaDoc
 #: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
-msgstr "¡No se encontró un escritor de imágenes apropiado!"
+msgstr "Không tìm thấy nhà văn hình ảnh thích hợp!"
 
 #: src/metabase/api/user.clj
 msgid "Email address already in use."
-msgstr "Dirección de Email ya en uso"
+msgstr "Địa chỉ email đã được sử dụng"
 
 #: src/metabase/api/user.clj
 msgid "Email address already associated to another user."
-msgstr "Dirección de Email asociado a otro usuario"
+msgstr "Địa chỉ email đã được liên kết với người dùng khác."
 
 #: src/metabase/api/user.clj
 msgid "Not able to reactivate an active user"
-msgstr "No se puede activar un usuario activo"
+msgstr "Không thể kích hoạt lại người dùng đang hoạt động"
 
 #: src/metabase/api/user.clj
 msgid "Invalid password"
-msgstr "Contraseña inválida"
+msgstr "Mật khẩu không hợp lệ"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "All {0}"
-msgstr "Todos los {0}"
+msgstr "Tất cả {0}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "{0}, all {1}"
-msgstr "{0}, todos {1}"
+msgstr "{0}, tất cả {1}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "Comparison of {0} and {1}"
-msgstr "Comparativa de {0} y {1}"
+msgstr "So sánh {0} và {1}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "Automatically generated comparison dashboard comparing {0} and {1}"
-msgstr "Crea automáticamente comparativas de {0} y {1}"
+msgstr "Bảng điều khiển so sánh được tạo tự động so sánh {0} và {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "sum"
-msgstr "suma"
+msgstr "tổng"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "average"
-msgstr "media"
+msgstr "trung bình"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "minumum"
-msgstr "mínimo"
+msgstr "nhỏ nhất"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "maximum"
-msgstr "máximo"
+msgstr "lớn nhất"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "distinct count"
-msgstr "Cuenta distinta"
+msgstr "số lượng khác biệt"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "standard deviation"
-msgstr "desviación estándar"
+msgstr "độ lệch chuẩn"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "cumulative count"
-msgstr "recuento acumulativo"
+msgstr "số tích lũy"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "cumulative sum"
-msgstr "suma acumulativa"
+msgstr "tổng tích lũy"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} and {1}"
-msgstr "{0} y {1}"
+msgstr "{0} và {1}"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
-msgstr "{0} de {1}"
+msgstr "{0} của {1}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
-msgstr "{0} por {1}"
+msgstr "{0} bởi {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} in the {1} segment"
-msgstr "{0} en el segmento {1}"
+msgstr "{0} trong phân đoạn {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} segment"
-msgstr "{0} segmento"
+msgstr "Phân đoạn {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
 msgid_plural "{0} metrics"
-msgstr[0] "{0} métrica"
-msgstr[1] "{0} métricas"
+msgstr[0] "{0} số liệu"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
-msgstr "{0} campo"
+msgstr "{0} trường"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "\"{0}\" question"
-msgstr "\"{0}\" pregunta"
+msgstr "\"{0}\" câu hỏi"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Compare with {0}"
-msgstr "Compara con {0}"
+msgstr "So sánh với {0}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Compare with entire dataset"
-msgstr "Compara con todos los datos"
+msgstr "So sánh với toàn bộ dữ liệu"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Applying heuristic %s to %s."
-msgstr "Aplicando heurística %s a %s."
+msgstr "Áp dụng heuristic% s cho% s."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Dimensions bindings:n%s"
-msgstr "Enlaces de dimensiones:n%s"
+msgstr "Kích thước ràng buộc: n% s"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Using definitions:nMetrics:n%snFilters:n%s"
-msgstr "Usando definicioness:nMétricas:n%snFiltros:n%s"
+msgstr "Sử dụng định nghĩa: nMetrics: n% snFilters: n% s"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Can''t create dashboard for {0}"
-msgstr "No se puede crear un cuadro de mando para {0}"
+msgstr "Không thể tạo bảng điều khiển cho {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}st"
-msgstr "{0}º"
+msgstr "{0}st"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}nd"
-msgstr "{0}º"
+msgstr "{0}nd"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}rd"
-msgstr "{0}º"
+msgstr "{0}rd"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}th"
-msgstr "{0}º"
+msgstr "{0}th"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "at {0}"
-msgstr "via {0}"
+msgstr "ở {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "on {0}"
-msgstr "en {0}"
+msgstr "trên {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in {0} week - {1}"
-msgstr "en {0} semana - {1}"
+msgstr "trong {0} tuần - {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in {0}"
-msgstr "en {0}"
+msgstr "trong {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in Q{0} - {1}"
-msgstr "in T{0} {1}"
+msgstr "trong Q{0} - {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Q{0}"
-msgstr "T{0}"
+msgstr "Q{0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is {1}"
-msgstr "{0} es {1}"
+msgstr "{0} là {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is between {1} and {2}"
-msgstr "{0} está entre {1} y {2}"
+msgstr "{0} ở giữa {1} và {2}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is between {1} and {2}; and {3} is between {4} and {5}"
-msgstr "{0} está entre {1} y {2} y {3} está entre {4} y {5}"
+msgstr "{0} nằm trong khoảng từ {1} đến {2}; và {3} nằm trong khoảng từ {4} đến {5}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "where {0}"
-msgstr "donde {0}"
+msgstr "ở {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "A closer look at {0}"
-msgstr "Ver más detalles de {0}"
+msgstr "Nhìn kỹ hơn vào {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "A closer look at the {0}"
-msgstr "Ver más detalles de {0}"
+msgstr "Nhìn kỹ hơn vào {0}"
 
 #: src/metabase/automagic_dashboards/populate.clj
 msgid "Adding %s cards to dashboard %s:n%s"
-msgstr "Añadiendo %s tarjetas al Cuadro de Mando %s:n%s"
+msgstr "Thêm thẻ% s vào bảng điều khiển% s: n% s"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "0 <= score <= {0}"
-msgstr "0 <= puntuación <= {0}"
+msgstr "0 <= điểm <= {0}"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "1 <= width <= {0}"
-msgstr "1 <= anchura <= {0}"
+msgstr "1 <= chiều rộng <= {0}"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid metrics references"
-msgstr "Referencias de métricas válidas"
+msgstr "Tài liệu tham khảo số liệu hợp lệ"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid filters references"
-msgstr "Referencias de filtros válidos"
+msgstr "Tham chiếu bộ lọc hợp lệ"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid group references"
-msgstr "Referencias de grupos válidos"
+msgstr "Tham chiếu nhóm hợp lệ"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid order_by references"
-msgstr "Referencias de ordenación válidas"
+msgstr "Tài liệu tham khảo order_by hợp lệ"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid dashboard filters references"
-msgstr "Referencias de filtros de cuadros de mando válidas"
+msgstr "Tài liệu tham khảo bộ lọc bảng điều khiển hợp lệ"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid dimension references"
-msgstr "Referencias de dimensiones válidas"
+msgstr "Tài liệu tham gia và trong số các tài liệu"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid card dimension references"
-msgstr "Referencias de dimensiones de tarjeta válidas"
+msgstr "Tham chiếu kích thước thẻ hợp lệ"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Error parsing %s:n%s"
-msgstr "Error procesando %s:n%s"
+msgstr "Lỗi phân tích cú pháp% s: n% s"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "No user found with email address ''{0}''. "
-msgstr "No se ha encontrado un usuario con email ''{0}''. "
+msgstr "Không tìm thấy người dùng có địa chỉ email '' {0} ''."
 
 #: src/metabase/cmd/reset_password.clj
 msgid "Please check the spelling and try again."
-msgstr "Por favor, verifícalo e intenta de nuevo"
+msgstr "Vui lòng kiểm tra chính tả và thử lại."
 
 #: src/metabase/cmd/reset_password.clj
 msgid "Resetting password for {0}..."
-msgstr "Restableciendo la contraseña de {0} ..."
+msgstr "Đặt lại mật khẩu cho {0} ..."
 
 #: src/metabase/cmd/reset_password.clj
 msgid "OK [[[{0}]]]"
-msgstr "VALE [[[{0}]]]"
+msgstr "OK [[[{0}]]]"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "FAIL [[[{0}]]]"
-msgstr "FALLO [[[{0}]]]"
+msgstr "Sai [[[{0}]]]"
 
 #: src/metabase/core.clj
 msgid "Please use the following URL to setup your Metabase installation:"
-msgstr "Utiliza la siguiente URL para configurar tu instalación de Metabase:"
+msgstr "Vui lòng sử dụng URL sau để thiết lập cài đặt Metabase của bạn:"
 
 #: src/metabase/core.clj
 msgid "Metabase Shutting Down ..."
-msgstr "Apagando Metabase ..."
+msgstr "Metabase đóng cửa ..."
 
 #: src/metabase/core.clj
 msgid "Metabase Shutdown COMPLETE"
-msgstr "Metabase apagado correctamente"
+msgstr "Tắt cơ sở dữ liệu HOÀN THÀNH"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase version {0} ..."
-msgstr "Iniciando Metabase {0} ..."
+msgstr "Bắt đầu phiên bản Metabase {0} ..."
 
 #: src/metabase/core.clj
 msgid "System timezone is ''{0}'' ..."
-msgstr "La zona horaria del sistema es ''{0}'' ..."
+msgstr "Múi giờ hệ thống là '' {0} '' ..."
 
 #. startup database.  validates connection & runs any necessary migrations
 #: src/metabase/core.clj
 msgid "Setting up and migrating Metabase DB. Please sit tight, this may take a minute..."
-msgstr "Configurando y migrando la base de datos de Metabase. Por favor, siéntate, esto puede tardar unos minutos ..."
+msgstr "Thiết lập và di chuyển Metabase DB. Hãy ngồi thật chặt, điều này có thể mất một phút ..."
 
 #: src/metabase/core.clj
 msgid "Looks like this is a new installation ... preparing setup wizard"
-msgstr "Parece que es una instalación nueva ... iniciando el asistente de configuración"
+msgstr "Có vẻ như đây là một cài đặt mới ... chuẩn bị trình hướng dẫn thiết lập"
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization COMPLETE"
-msgstr "Inicialización de Metabase COMPLETADA"
+msgstr "Khởi tạo Metabase HOÀN THÀNH"
 
 #: src/metabase/server.clj
 msgid "Launching Embedded Jetty Webserver with config:"
-msgstr "Iniciando el servidor embebido Jetty con la configuración:"
+msgstr "Khởi chạy Máy chủ web nhúng với cấu hình:"
 
 #: src/metabase/server.clj
 msgid "Shutting Down Embedded Jetty Webserver"
-msgstr "Apagando el servidor Jetty embebido"
+msgstr "Tắt Máy chủ web nhún"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase in STANDALONE mode"
-msgstr "Iniciando Metabase en modo INDEPENDIENTE"
+msgstr "Khởi chạy Metabase trong STANDALON"
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization FAILED"
-msgstr "La inicialización de Metabase ha FALLADO"
+msgstr "Lỗi khởi tạo Metabas"
 
 #: src/metabase/db/liquibase.clj
 msgid "Database has migration lock; cannot run migrations."
-msgstr "La base de datos tiene un bloqueo de migración por lo que no podemos actualizar."
+msgstr "Cơ sở dữ liệu có khóa di chuyển; không thể chạy di chuyển."
 
 #: src/metabase/db/liquibase.clj
 msgid "You can force-release these locks by running `java -jar metabase.jar migrate release-locks`."
-msgstr "Puedes forzar la liberación de estos bloqueos ejecutando `java -jar metabase.jar migrate release-locks`."
+msgstr "Bạn có thể buộc giải phóng các khóa này bằng cách chạy `java -jar metabase.jar di chuyển các khóa phát hành"
 
 #: src/metabase/db/liquibase.clj
 msgid "Checking if Database has unrun migrations..."
-msgstr "Comprobando si la base de datos tiene migraciones sin terminar..."
+msgstr "Kiểm tra xem Cơ sở dữ liệu có di chuyển không vượt quá ..."
 
 #: src/metabase/db/liquibase.clj
 msgid "Database has unrun migrations. Waiting for migration lock to be cleared..."
-msgstr "La base de datos tiene migraciones sin terminar. Esperando a que se borre el bloqueo de migración..."
+msgstr "Cơ sở dữ liệu đã di chuyển không di chuyển. Đang chờ khóa di chuyển bị xóa ..."
 
 #: src/metabase/db/liquibase.clj
 msgid "Migration lock is cleared. Running migrations..."
-msgstr "Se ha eliminado el bloqueo de migración. Ejecutando migraciones..."
+msgstr "Khóa di chuyển bị xóa. Chạy di chuyển ..."
 
 #: src/metabase/db/liquibase.clj
 msgid "Migration lock cleared, but nothing to do here! Migrations were finished by another instance."
-msgstr "Se borró el bloqueo de migración, ¡pero no hay nada que hacer aquí! Las migraciones fueron terminadas por otra instancia."
+msgstr "Xóa khóa di chuyển, nhưng không có gì để làm ở đây! Di chuyển đã được hoàn thành bởi một ví dụ khác."
 
 #. Set up liquibase and let it do its thing
 #: src/metabase/db.clj
 msgid "Setting up Liquibase..."
-msgstr "Preparando Liquibase..."
+msgstr "Thiết lập Liquibase ..."
 
 #: src/metabase/db.clj
 msgid "Liquibase is ready."
-msgstr "Liquibase preparado"
+msgstr "Liquibase đã sẵn sàng."
 
 #: src/metabase/db.clj
 msgid "Verifying {0} Database Connection ..."
-msgstr "Verificando la conexión a la base de datos {0} ..."
+msgstr "Đang xác minh {0} Kết nối cơ sở dữ liệu ... "
 
 #: src/metabase/db.clj
 msgid "Verify Database Connection ... "
-msgstr "Verifica la conexión a la base de datos ... "
+msgstr "Xác minh kết nối cơ sở dữ liệu ..."
 
 #: src/metabase/db.clj
 msgid "Running Database Migrations..."
-msgstr "Ejecutando migraciones de la base de datos..."
+msgstr "Chạy di chuyển cơ sở dữ liệu ..."
 
 #: src/metabase/db.clj
 msgid "Database Migrations Current ... "
-msgstr "Migraciones de la base de datos actuales ..."
+msgstr "Di chuyển cơ sở dữ liệu hiện tại ..."
 
 #: src/metabase/driver/common.clj
 msgid "Hmm, we couldn''t connect to the database."
-msgstr "Hmm, no he podido conectar con la base de datos."
+msgstr "Hmm, chúng tôi không thể kết nối với cơ sở dữ liệu."
 
 #: src/metabase/driver/common.clj
 msgid "Make sure your host and port settings are correct"
-msgstr "Asegúrate de que la configuración del host y del puerto sean correctas"
+msgstr "Đảm bảo rằng cài đặt máy chủ và cổng của bạn là chính xác"
 
 #: src/metabase/driver/common.clj
 msgid "We couldn''t connect to the ssh tunnel host."
-msgstr "no he podido conectar con el servidor del tunel ssh"
+msgstr "Chúng tôi không thể kết nối với máy chủ đường hầm ssh."
 
 #: src/metabase/driver/common.clj
 msgid "Check the username, password."
-msgstr "Verifica el nombre de usuario/contraseña."
+msgstr "Kiểm tra tên đăng nhập, mật khẩu."
 
 #: src/metabase/driver/common.clj
 msgid "Check the hostname and port."
-msgstr "Verifica el servidor y puerto"
+msgstr "Kiểm tra tên máy chủ và cổng."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like the database name is incorrect."
-msgstr "Parece que el nombre de la base de datos es incorrecto"
+msgstr "Hình như tên cơ sở dữ liệu không chính xác."
 
 #: src/metabase/driver/common.clj
 msgid "It looks like your host is invalid."
-msgstr "Parece que tu servidor no es válido"
+msgstr "Có vẻ như máy chủ của bạn không hợp lệ."
 
 #: src/metabase/driver/common.clj
 msgid "Please double-check it and try again."
-msgstr "Por favor, vuelve a verificarlo e intenta de nuevo"
+msgstr "Vui lòng kiểm tra lại và thử lại."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like your password is incorrect."
-msgstr "Parece que tu contraseña es incorrecta"
+msgstr "Có vẻ mật khẩu của bạn sai"
 
 #: src/metabase/driver/common.clj
 msgid "Looks like you forgot to enter your password."
-msgstr "Parece que olvidaste poner tu contraseña"
+msgstr "Có vẻ bạn quên điền mật khẩu"
 
 #: src/metabase/driver/common.clj
 msgid "Looks like your username is incorrect."
-msgstr "Parece que tu nombre de usuario es incorrecto."
+msgstr "Có vẻ tên đăng nhập của bạn không chính xác"
 
 #: src/metabase/driver/common.clj
 msgid "Looks like the username or password is incorrect."
-msgstr "Parece que el nombre de usuario o la contraseña son incorrectos."
+msgstr "Có vẻ tên đăng nhập hoặc mật khẩu không chính xác"
 
 #. ## CONFIG
 #: src/metabase/driver.clj
 msgid "Connection timezone to use when executing queries. Defaults to system timezone."
-msgstr "Zona horaria de conexión que se utilizará al ejecutar consultas. El valor predeterminado es la zona horaria del sistema."
+msgstr "Múi giờ kết nối để sử dụng khi thực hiện truy vấn. Mặc định cho múi giờ hệ thống."
 
 #: src/metabase/driver.clj
 msgid "Registered driver {0} {1}"
-msgstr "Controlador registrado {0} {1}"
+msgstr "Trình điều khiển đã đăng ký {0} {1}"
 
 #: src/metabase/driver.clj
 msgid "No -init-driver function found for ''{0}''"
-msgstr "No se ha encontrado ninguna función -init-driver para ''{0}''"
+msgstr "Không tìm thấy chức năng trình điều khiển -init cho '' {0}''"
 
 #: src/metabase/driver/common.clj
 msgid "Unable to parse date string ''{0}'' for database engine ''{1}''"
-msgstr "No se puede analizar la cadena de fecha ''{0}'' para el motor de base de datos ''{1}''"
+msgstr "Không thể phân tích chuỗi ngày '' {0} '' cho công cụ cơ sở dữ liệu '' {1} ''"
 
 #. all-NULL columns in DBs like Mongo w/o explicit types
 #: src/metabase/driver/common.clj
 msgid "Don''t know how to map class ''{0}'' to a Field base_type, falling back to :type/*."
-msgstr "No se cómo utilizar la clase ''{0}'' como tipo base de campo, volviendo a :type/*."
+msgstr "Không biết cách ánh xạ lớp '' {0} '' sang Field base_type, quay lại: type / *."
 
 #: src/metabase/driver/util.clj
 msgid "Failed to connect to database: {0}"
-msgstr "Error al conectarse a la base de datos: {0}"
+msgstr "Không thể kết nối với cơ sở dữ liệu: {0}"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Invalid BigQuery identifier: ''{0}''"
-msgstr "Identificador de BigQuery inválido: ''{0}''"
+msgstr "Mã định danh BigQuery không hợp lệ: '' {0} ''"
 
 #: src/metabase/driver/bigquery.clj
 msgid "BigQuery statements can't be parameterized!"
-msgstr "Los comandos BigQuery no soportan parámetros!"
+msgstr "Các câu lệnh BigQuery không thể được tham số hóa!"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone:"
-msgstr "No se pudo establecer la zona horaria:"
+msgstr "Không thể đặt múi giờ:"
 
 #: src/metabase/driver/googleanalytics.clj
 msgid "You must enable the Google Analytics API. Use this link to go to the Google Developers Console: {0}"
-msgstr "Debes habilitar el API de Google Analytics. Utiliza este enlace para ir a la Consola de Desarrollo de Google: {0}"
+msgstr "Bạn phải bật API Google Analytics. Sử dụng liên kết này để đi tới Bảng điều khiển dành cho nhà phát triển của Google: {0} Không thể đặt múi giờ: \""
 
 #: src/metabase/driver/h2.clj
 msgid "Running SQL queries against H2 databases using the default (admin) database user is forbidden."
-msgstr "Está prohibido ejecutar consultas SQL en bases de datos H2 utilizando el usuario de base de datos predeterminado (administrador)."
+msgstr "Ch.ạy các truy vấn SQL đối với cơ sở dữ liệu H2 bằng cách sử dụng người dùng cơ sở dữ liệu (quản trị viên) mặc định"
 
 #: src/metabase/driver/sparksql.clj
 msgid "Error: metabase.driver.FixedHiveDriver is registered, but JDBC does not seem to be using it."
-msgstr "Error: metabase.driver.FixedHiveDriver está registrado, pero parece que JDBC no lo está usando."
+msgstr "Lỗi: metabase.driver.FixedHiveDriver đã được đăng ký, nhưng JDBC dường như không sử dụng nó."
 
 #: src/metabase/driver/sparksql.clj
 msgid "Found metabase.driver.FixedHiveDriver."
-msgstr "Se ha encontrado metabase.driver.FixedHiveDriver."
+msgstr "Tìm thấy metabase.driver.FixedHiveDriver."
 
 #: src/metabase/driver/sparksql.clj
 msgid "Successfully registered metabase.driver.FixedHiveDriver with JDBC."
-msgstr "Se ha registrado metabase.driver.FixedHiveDriver con JDBC."
+msgstr "Đã đăng ký thành công metabase.driver.FixedHiveDriver với JDBC."
 
 #. CONFIG
 #. TODO - smtp-port should be switched to type :integer
 #: src/metabase/email.clj
 msgid "Email address you want to use as the sender of Metabase."
-msgstr "Dirección de correo electrónico que quieres usar como remitente de Metabase."
+msgstr "Địa chỉ email bạn muốn sử dụng làm người gửi Metabase."
 
 #: src/metabase/email.clj
 msgid "The address of the SMTP server that handles your emails."
-msgstr "La dirección del servidor SMTP que maneja tus correos electrónicos."
+msgstr "Địa chỉ của máy chủ SMTP xử lý email của bạn."
 
 #: src/metabase/email.clj
 msgid "SMTP username."
-msgstr "Usuario SMTP."
+msgstr "Tên người dùng SMTP."
 
 #: src/metabase/email.clj
 msgid "SMTP password."
-msgstr "Contraseña SMTP."
+msgstr "SMTP mật khẩu"
 
 #: src/metabase/email.clj
 msgid "The port your SMTP server uses for outgoing emails."
-msgstr "El puerto que usa tu servidor SMTP para los correos electrónicos salientes."
+msgstr "Cổng máy chủ SMTP của bạn sử dụng cho các email gửi đi."
 
 #: src/metabase/email.clj
 msgid "SMTP secure connection protocol. (tls, ssl, starttls, or none)"
-msgstr "Protocolo de conexión segura SMTP. (tls, ssl, starttls, o ninguno)"
+msgstr "Giao thức kết nối an toàn SMTP. (tls, ssl, starttls hoặc không)"
 
 #: src/metabase/email.clj
 msgid "none"
-msgstr "ninguno"
+msgstr "không"
 
 #: src/metabase/email.clj
 msgid "SMTP host is not set."
-msgstr "El servidor SMTP no está configurado."
+msgstr "Máy chủ SMTP không được đặt."
 
 #: src/metabase/email.clj
 msgid "Failed to send email"
-msgstr "No se pudo enviar el correo electrónico"
+msgstr "Không thể gửi email"
 
 #: src/metabase/email.clj
 msgid "Error testing SMTP connection"
-msgstr "Error al probar la conexión SMTP"
+msgstr "Lỗi kiểm tra kết nối SMTP"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Enable LDAP authentication."
-msgstr "Habilita la autenticación LDAP."
+msgstr "Kích hoạt xác thực LDAP."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Server hostname."
-msgstr "Nombre servidor"
+msgstr "Tên máy chủ."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Server port, usually 389 or 636 if SSL is used."
-msgstr "Puerto del servidor, generalmente 389 o 636 si se usa SSL."
+msgstr "Cổng máy chủ, thường là 389 hoặc 636 nếu SSL được sử dụng"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Use SSL, TLS or plain text."
-msgstr "Utiliza SSL, TLS o texto sin formato."
+msgstr "Sử dụng SSL, TLS hoặc văn bản thuần túy."
 
 #: src/metabase/integrations/ldap.clj
 msgid "The Distinguished Name to bind as (if any), this user will be used to lookup information about other users."
-msgstr "El nombre distinguido para enlazar como (si existe), este usuario se utilizará para buscar información sobre otros usuarios."
+msgstr "Tên Phân biệt để liên kết dưới dạng (nếu có), người dùng này sẽ được sử dụng để tra cứu thông tin về người dùng khác."
 
 #: src/metabase/integrations/ldap.clj
 msgid "The password to bind with for the lookup user."
-msgstr "La contraseña para vincularse con el usuario de búsqueda."
+msgstr "Mật khẩu để liên kết với người dùng tra cứu"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Search base for users. (Will be searched recursively)"
-msgstr "Base de búsqueda para usuarios. (Se buscará recursivamente)"
+msgstr "Tìm kiếm cơ sở cho người dùng. (Sẽ được tìm kiếm đệ quy)"
 
 #: src/metabase/integrations/ldap.clj
 msgid "User lookup filter, the placeholder '{login}' will be replaced by the user supplied login."
-msgstr "Filtro de búsqueda de usuario, el marcador de posición '{login}' se reemplazará por el inicio de sesión proporcionado por el usuario."
+msgstr "Bộ lọc tra cứu người dùng, trình giữ chỗ '{login}' sẽ được thay thế bằng thông tin đăng nhập do người dùng cung cấp."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user's email. (usually ''mail'', ''email'' or ''userPrincipalName'')"
-msgstr "Atributo de correo electrónico del usuario. (generalmente ''correo'', ''correo electrónico'' o ''userPrincipalName'')"
+msgstr "Thuộc tính để sử dụng cho email của người dùng. (thường là '' thư '', '' email '' hoặc '' userPrincipalName '')"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user''s first name. (usually ''givenName'')"
-msgstr "Atributo a usar para el primer nombre del usuario. (generalmente ''givenName'')"
+msgstr "Thuộc tính để sử dụng cho tên của người dùng. (thường là '' cho tên ''"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user''s last name. (usually ''sn'')"
-msgstr "Atributo para usar para el apellido del usuario. (generalmente ''sn'')"
+msgstr "Thuộc tính để sử dụng cho họ của người dùng. (thường là '' sn '')"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Enable group membership synchronization with LDAP."
-msgstr "Habilite la sincronización de membresía grupal con LDAP."
+msgstr "Cho phép đồng bộ hóa thành viên nhóm với LDAP."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Search base for groups, not required if your LDAP directory provides a ''memberOf'' overlay. (Will be searched recursively)"
-msgstr "Base de búsqueda para grupos, no requerida si tu directorio LDAP proporciona una superposición ''memberOf''. (Se buscará recursivamente)"
+msgstr "Tìm kiếm cơ sở cho các nhóm, không bắt buộc nếu thư mục LDAP của bạn cung cấp lớp phủ '' MemberOf ''. (Sẽ được tìm kiếm đệ quy)"
 
 #. Should be in the form: {"cn=Some Group,dc=...": [1, 2, 3]} where keys are LDAP groups and values are lists of MB groups IDs
 #: src/metabase/integrations/ldap.clj
 msgid "JSON containing LDAP to Metabase group mappings."
-msgstr "JSON que contiene las correspondencia de LDAP a grupos de Metabase."
+msgstr "JSON chứa ánh xạ nhóm LDAP sang Metabase."
 
 #. Define a setting which captures our Slack api token
 #: src/metabase/integrations/slack.clj
 msgid "Slack API bearer token obtained from https://api.slack.com/web#authentication"
-msgstr "Slack API bearer token obtenido de https://api.slack.com/web#authentication"
+msgstr "Mã thông báo mang Slack API thu được từ https://api.slack.com/web#authentication."
 
 #: src/metabase/metabot.clj
 msgid "Enable MetaBot, which lets you search for and view your saved questions directly via Slack."
-msgstr "Habilita MetaBot, que te permite buscar y ver tus preguntas guardadas directamente a través de Slack."
+msgstr "Kích hoạt MetaBot, cho phép bạn tìm kiếm và xem các câu hỏi đã lưu của bạn trực tiếp thông qua Slack."
 
 #: src/metabase/metabot/instance.clj
 msgid "Last MetaBot checkin was {0} ago."
-msgstr "Ultimo acceso de MetaBot fue hace {0}"
+msgstr "Lần đăng ký MetaBot cuối cùng là {0} trước đây."
 
 #: src/metabase/metabot/instance.clj
 msgid "This instance will now handle MetaBot duties."
-msgstr "Esta instalación ahora manejará tareas de MetaBot"
+msgstr "Trường hợp này bây giờ sẽ xử lý các nhiệm vụ MetaBot."
 
 #: src/metabase/metabot.clj
 msgid "Here''s what I can {0}:"
-msgstr "Esto es lo que puedo {0}:"
+msgstr "Đây là những gì tôi có thể {0}:"
 
 #: src/metabase/metabot.clj
 msgid "I don''t know how to {0} `{1}`.n{2}"
-msgstr "No se como {0} `{1}`.n{2}"
+msgstr "Tôi không biết làm thế nào để {0} `{1}` .n {2}"
 
 #: src/metabase/metabot/slack.clj
 msgid "Uh oh! :cry:n> {0}"
-msgstr "¡Oh! :cry:n>"
+msgstr "À! : khóc: n> {0}"
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s your {0} most recent cards:n{1}"
-msgstr "Aquí están tus {0} tarjetas más recientes: n{1}"
+msgstr "Đây là {0} thẻ gần đây nhất của bạn: n {1}"
 
 #: src/metabase/metabot/command.clj
 msgid "Could you be a little more specific? I found these cards with names that matched:n{0}"
-msgstr "¿Podrías ser un poco más específico? He encontrado estas tarjetas con nombres que coinciden: n{0}"
+msgstr "Bạn có thể nêu chi tiết hơn được không? Tôi tìm thấy những thẻ này có tên trùng khớp: n {0}"
 
 #: src/metabase/metabot/command.clj
 msgid "I don''t know what Card `{0}` is. Give me a Card ID or name."
-msgstr "No sé lo qué es la Tarjeta `{0}`. Dame un ID o nombre de tarjeta."
+msgstr "Tôi không biết Thẻ `{0}` là gì. Cho tôi ID thẻ hoặc tên."
 
 #: src/metabase/metabot/command.clj
 msgid "Show which card? Give me a part of a card name or its ID and I can show it to you. If you don''t know which card you want, try `metabot list`."
-msgstr "¿Qué tarjeta mostrar? Dame una parte del nombre de una tarjeta o su ID y te lo puedo mostrar. Si no sabes qué tarjeta quieres, prueba con `metabot list`."
+msgstr "Cho xem thẻ nào? Đưa cho tôi một phần tên thẻ hoặc ID của nó và tôi có thể cho bạn xem. Nếu bạn không biết bạn muốn thẻ nào, hãy thử `danh sách metabot`.abot.clj"
 
 #: src/metabase/metabot/command.clj
 msgid "Ok, just a second..."
-msgstr "Vale, solo un segundo..."
+msgstr "OK, chờ một giây..."
 
 #: src/metabase/metabot/command.clj
 msgid "Not Found"
-msgstr "No Encontrado"
+msgstr "Không tìm thấy"
 
 #: src/metabase/metabot/command.clj
 msgid "Loading Kanye quotes..."
-msgstr "Cargando citas de Kanye..."
+msgstr "Đang tải câu của Kanye..."
 
 #: src/metabase/metabot/events.clj
 msgid "Evaluating Metabot command:"
-msgstr "Evaluando el comando de Metabot:"
+msgstr "Đánh giá lệnh Metabot"
 
 #: src/metabase/metabot.clj
 msgid "Go home websocket, you're drunk."
-msgstr "El websocket esta borracho."
+msgstr "Về nhà websocket, bạn say rượu."
 
 #: src/metabase/metabot/websocket.clj
 msgid "Error launching metabot:"
-msgstr "Error al iniciar metabot:"
+msgstr "Lỗi khởi chạy metabot:"
 
 #: src/metabase/metabot/websocket.clj
 msgid "MetaBot WebSocket is closed. Reconnecting now."
-msgstr "MetaBot WebSocket está cerrado. Reconectando ahora."
+msgstr "MetaBot WebSocket đã bị đóng. Kết nối lại bây giờ."
 
 #: src/metabase/metabot/websocket.clj
 msgid "Error connecting websocket:"
-msgstr "Error al conectar websocket:"
+msgstr "Lỗi kết nối websocket:"
 
 #: src/metabase/metabot/instance.clj
 msgid "This instance is performing MetaBot duties."
-msgstr "Esta instalación está manejando tareas de MetaBot"
+msgstr "Trường hợp này đang thực hiện nhiệm vụ MetaBot."
 
 #: src/metabase/metabot/instance.clj
 msgid "Another instance is already handling MetaBot duties."
-msgstr "Otra instalación está manejando las tareas de MetaBot"
+msgstr "Một trường hợp khác đã xử lý các nhiệm vụ của MetaBot."
 
 #: src/metabase/metabot.clj
 msgid "Starting MetaBot threads..."
-msgstr "Iniciando hilos de MetaBot..."
+msgstr "Bắt đầu các chủ đề MetaBot ..."
 
 #: src/metabase/metabot.clj
 msgid "Stopping MetaBot...  🤖"
-msgstr "Parando MetaBot...  🤖"
+msgstr "Đang dừng Metabot..."
 
 #: src/metabase/metabot.clj
 msgid "MetaBot already running. Killing the previous WebSocket listener first."
-msgstr "MetaBot ya se está ejecutando. Matando al oyente WebSocket previo primero."
+msgstr "MetaBot đã chạy. Giết người nghe WebSocket trước đó trước."
 
 #: src/metabase/middleware/security.clj
 msgid "Base-64 encoded public key for this site's SSL certificate."
-msgstr "Clave pública codificada en Base-64 para el certificado SSL de este sitio."
+msgstr "Khóa công khai được mã hóa Base-64 cho chứng chỉ SSL của trang web này."
 
 #: src/metabase/middleware/security.clj
 msgid "Specify this to enable HTTP Public Key Pinning."
-msgstr "Especifica esto para habilitar la fijación de clave pública HTTP."
+msgstr "Chỉ định điều này để bật Ghim khóa công khai HTTP."
 
 #: src/metabase/middleware/security.clj
 msgid "See {0} for more information."
-msgstr "Ver {0} para más información."
+msgstr "Xem {0} để biết thêm thông tin."
 
 #: src/metabase/models/card.clj
 msgid "Cannot save Question: source query has circular references."
-msgstr "No se puede guardar la pregunta debido a referencias circulares."
+msgstr "Không thể lưu Câu hỏi: truy vấn nguồn có tham chiếu vòng tròn."
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
-msgstr "No existe la tarjeta {0}"
+msgstr "Thẻ {0} không tồn tại."
 
 #: src/metabase/models/card.clj
 msgid "You do not have permissions to run ad-hoc native queries against Database {0}."
-msgstr "Lo siento, no tienes permiso para ejecutar consultas directas en la base de datos {0}."
+msgstr "Bạn không có quyền để chạy các truy vấn gốc ad-hoc đối với Cơ sở dữ liệu {0}."
 
 #: src/metabase/models/collection.clj
 msgid "Invalid color"
-msgstr "Color inválido"
+msgstr "Màu sắc không hợp lệ"
 
 #: src/metabase/models/collection.clj
 msgid "must be a valid 6-character hex color code"
-msgstr "debe ser un código de color hexadecimal válido de 6 caracteres"
+msgstr "phải là mã màu lục 6 ký tự hợp lệ"
 
 #: src/metabase/models/collection.clj
 msgid "Collection name cannot be blank!"
-msgstr "¡El nombre de la colección no puede estar vacío!"
+msgstr "Tên bộ sưu tập không thể để trống!"
 
 #: src/metabase/models/collection.clj
 msgid "cannot be blank"
-msgstr "no puede ser vacío"
+msgstr "không thể để trống"
 
 #: src/metabase/models/collection.clj
 msgid "Invalid Collection location: path is invalid."
-msgstr "Ubicación de colección inválida: la ruta no es válida."
+msgstr "Vị trí Bộ sưu tập không hợp lệ: đường dẫn không hợp lệ."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Personal Collection."
-msgstr "No puedes mover una Colección Personal."
+msgstr "Bạn không thể di chuyển Bộ sưu tập cá nhân."
 
 #: src/metabase/models/collection.clj
 msgid "Invalid Collection location: some or all ancestors do not exist."
-msgstr "Ubicación de colección inválida: uno o más antepasados no existen."
+msgstr "Vị trí Bộ sưu tập không hợp lệ: một số hoặc tất cả bộ sưu tập trước không tồn tại."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot archive the Root Collection."
-msgstr "¡No puedes archivar la Colección Raíz!"
+msgstr "Bạn không thể lưu trữ Bộ sưu tập gốc."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot archive a Personal Collection."
-msgstr "No puedes archivar una Colección Personal."
+msgstr "Bạn không thể lưu trữ Bộ sưu tập cá nhân."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move the Root Collection."
-msgstr "¡No puedes mover la Colección Raíz!"
+msgstr "Bạn không thể di chuyển Bộ sưu tập gốc."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection into itself or into one of its descendants."
-msgstr "No puedes mover una Colección dentro de si misma o dentro de uno de sus descendientes."
+msgstr "Bạn không thể di chuyển Bộ sưu tập vào chính nó hoặc vào một trong những tập con của nó."
 
 #. first move this Collection
 #: src/metabase/models/collection.clj
 msgid "Moving Collection {0} and its descendants from {1} to {2}"
-msgstr "Moviendo la Colección {0} y sus descendientes de {1} a {2}"
+msgstr "Di chuyển Bộ sưu tập {0} và tập con của nó từ {1} đến {2}"
 
 #: src/metabase/models/collection.clj
 msgid "You're not allowed to change the owner of a Personal Collection."
-msgstr "No está permitido cambiar el propietario de una Colección Personal."
+msgstr "Bạn không được phép thay đổi chủ sở hữu của Bộ sưu tập cá nhân."
 
 #: src/metabase/models/collection.clj
 msgid "You're not allowed to move a Personal Collection."
-msgstr "No tienes permiso para mover una Colección Personal."
+msgstr "Bạn không được phép di chuyển Bộ sưu tập cá nhân."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection and archive it at the same time."
-msgstr "No puedes mover y archivar una Colección al mismo tiempo."
+msgstr "Bạn không thể di chuyển Bộ sưu tập và lưu trữ nó cùng một lúc."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot delete a Personal Collection!"
-msgstr "¡No puedes eliminar una Colección Personal!"
+msgstr "Bạn không thể xóa Bộ sưu tập cá nhân!"
 
 #: src/metabase/models/collection.clj
 msgid "{0} {1}''s Personal Collection"
-msgstr "Colección Personal de {0} {1}"
+msgstr "Bộ sưu tập cá nhân của {0} {1}"
 
 #: src/metabase/models/collection_revision.clj
 msgid "You cannot update a CollectionRevision!"
-msgstr "¡No puedes actualzar una revisión de Colección!"
+msgstr "Bạn không thể cập nhật CollectionRevision!"
 
 #: src/metabase/models/field_values.clj
 msgid "Field {0} was previously automatically set to show a list widget, but now has {1} values."
-msgstr "El campo {0} se estableció automáticamente para mostrar una lista, pero ahora tiene {1} valores."
+msgstr "Trường {0} trước đây được đặt tự động để hiển thị tiện ích danh sách, nhưng hiện tại có giá trị {1}."
 
 #: src/metabase/models/field_values.clj
 msgid "Switching Field to use a search widget instead."
-msgstr "Cambio de campo para usar un elemento de búsqueda en su lugar."
+msgstr "Thay đổi Trường để sử dụng widget tìm kiếm thay thế."
 
 #: src/metabase/models/field_values.clj
 msgid "Storing updated FieldValues for Field {0}..."
-msgstr "Almacenando Valores de Campo actualizados para el campo {0} ..."
+msgstr "Lưu trữ FieldValues được cập nhật cho Trường {0}.."
 
 #: src/metabase/models/field_values.clj
 msgid "Storing FieldValues for Field {0}..."
-msgstr "Almacenando Valores de Campo para el campo {0} ..."
+msgstr "Lưu trữ FieldValues cho Trường {0} ..."
 
 #: src/metabase/models/humanization.clj
 msgid "Metabase can attempt to transform your table and field names into more sensible, human-readable versions, e.g. \"somehorriblename\" becomes \"Some Horrible Name\"."
-msgstr "Metabase puede intentar transformar los nombres de tablas y campos en versiones más entendibles y legibles para el ser humano, p.e. \"unnombrehorrible\" se convierte en \"Un Nombre Horrible\". "
+msgstr "Metabase có thể cố gắng chuyển đổi tên bảng và trường của bạn thành các phiên bản hợp lý hơn, dễ đọc hơn, ví dụ: \\ \"somehorriblename \" trở thành \\ \"Một cái tên khủng khiếp \"."
 
 #: src/metabase/models/humanization.clj
 msgid "This doesn’t work all that well if the names are in a language other than English, however."
-msgstr "Sin embargo, esto no funciona muy bien si los nombres están en un idioma que no sea el inglés."
+msgstr "Tuy nhiên, điều này không hoạt động hiệu quả nếu tên đó bằng một ngôn ngữ khác tiếng Anh."
 
 #: src/metabase/models/humanization.clj
 msgid "Do you want us to take a guess?"
-msgstr "¿Quieres que adivinemos?"
+msgstr "Bạn có muốn chúng tôi đoán không?"
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot create or revoke permissions for the 'Admin' group."
-msgstr "No puedes crear o revocar permisos para el grupo 'Admin'."
+msgstr "Bạn không thể tạo hoặc thu hồi quyền cho nhóm 'Quản trị viên'."
 
 #: src/metabase/models/permissions.clj
 msgid "Invalid permissions object path: ''{0}''."
-msgstr "Ruta del objeto de permisos inválido: ''{0}''."
+msgstr "Đường dẫn cho phép không khả dụng: ''{0}''"
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot update a permissions entry!"
-msgstr "¡No puedes actualizar una entrada de permisos!"
+msgstr "Bạn không thể cập nhật mục nhập quyền!"
 
 #: src/metabase/models/permissions.clj
 msgid "Delete it and create a new one."
-msgstr "Elimínalo y crear uno nuevo."
+msgstr "Xóa nó đi và tạo một cái mới."
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot edit permissions for a Personal Collection or its descendants."
-msgstr "No puedes editar los permisos de una Colección personal ni sus descendientes."
+msgstr "Bạn không thể chỉnh sửa quyền cho Bộ sưu tập cá nhân hoặc tập con của nó."
 
 #: src/metabase/models/permissions.clj
 msgid "Looks like someone else edited the permissions and your data is out of date."
-msgstr "Parece que alguien más editó los permisos y tus datos están desactualizados."
+msgstr "Có vẻ như ai đó đã chỉnh sửa các quyền và dữ liệu của bạn đã hết hạn"
 
 #: src/metabase/models/permissions.clj
 msgid "Please fetch new data and try again."
-msgstr "Por favor, obtiene nuevos datos e intenta de nuevo"
+msgstr "Vui lòng lấy dữ liệu mới và thử lại."
 
 #: src/metabase/models/permissions_group.clj
 msgid "Created magic permissions group ''{0}'' (ID = {1})"
-msgstr "Creado grupo de permisos mágicos ''{0}'' (ID = {1})"
+msgstr "Đã tạo nhóm quyền phép thuật '' {0} '' (ID = {1})"
 
 #: src/metabase/models/permissions_group.clj
 msgid "A group with that name already exists."
-msgstr "Ya existe un grupo con ese nombre"
+msgstr "Một nhóm với tên đó đã tồn tại."
 
 #: src/metabase/models/permissions_group.clj
 msgid "You cannot edit or delete the ''{0}'' permissions group!"
-msgstr "¡No puedes editar o eliminar el grupo de permisos ''{0}''!"
+msgstr "Bạn không thể chỉnh sửa hoặc xóa nhóm quyền '' {0} ''!"
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the 'MetaBot' group."
-msgstr "No puedes añadir o eliminar usuarios a/del grupo 'MetaBot'."
+msgstr "Bạn không thể thêm hoặc xóa người dùng vào / ra khỏi nhóm 'MetaBot'."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the 'All Users' group."
-msgstr "No puedes añadir o eliminar usuarios a/del grupo 'All'."
+msgstr "Bạn không thể thêm hoặc xóa người dùng đến / khỏi nhóm 'Tất cả người dùng'."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot remove the last member of the 'Admin' group!"
-msgstr "¡No puedes eliminar al último miembro del grupo 'Admin'!"
+msgstr "Bạn không thể xóa thành viên cuối cùng của nhóm 'Quản trị viên'!"
 
 #: src/metabase/models/permissions_revision.clj
 msgid "You cannot update a PermissionsRevision!"
-msgstr "¡No puedes actualizar una revisión de permisos!"
+msgstr "Bạn không thể cập nhật Quyền hạn!"
 
 #. if there's still not a Card, throw an Exception!
 #: src/metabase/models/pulse.clj
 msgid "Invalid Alert: Alert does not have a Card assoicated with it"
-msgstr "Alerta Inválida: no tiene asociada un tarjeta"
+msgstr "Thông báo không hợp lệ: Thông báo không có Thẻ được liên kết với nó"
 
 #: src/metabase/models/pulse.clj
 msgid "value must be a map with the keys `{0}`, `{1}`, and `{2}`."
-msgstr "el valor debe ser un mapa con los índices `{0}`, `{1}`, and `{2}`."
+msgstr "giá trị phải là ánh xạ với các khóa `{0}`, `{1}` và `{2}`."
 
 #: src/metabase/models/pulse.clj
 msgid "value must be a map with the following keys `({0})`"
-msgstr "el valor debe ser un mapa con los índices `({0})`."
+msgstr "giá trị phải là ánh xạ với các khóa sau `({0})`"
 
 #: src/metabase/models/query/permissions.clj
 msgid "Error calculating permissions for query: {0}"
-msgstr "Error calculando los permisos para la consulta: {0}"
+msgstr "Lỗi tính toán quyền truy vấn: {0}"
 
 #: src/metabase/models/query/permissions.clj
 msgid "Invalid query type: {0}"
-msgstr "Tipo de consulta inválida: {0}"
+msgstr "Loại truy vấn không hợp lệ: {0}"
 
 #: src/metabase/models/query_execution.clj
 msgid "You cannot update a QueryExecution!"
-msgstr "¡No puedes actualizar una ejecución de consulta!"
+msgstr "Bạn không thể cập nhật Truy vấn thực thi!"
 
 #: src/metabase/models/revision.clj
 msgid "You cannot update a Revision!"
-msgstr "¡No puedes actualizar una revisión!"
+msgstr "Bạn không thể cập nhật Bản sửa đổi!"
 
 #: src/metabase/models/setting.clj
 msgid "Setting {0} does not exist.nFound: {1}"
-msgstr "El ajuste {0} no existe.\n"
-"Encontrado: {1}"
+msgstr "Cài đặt {0} không tồn tại.nFound: {1}"
 
 #: src/metabase/models/setting/cache.clj
 msgid "Updating value of settings-last-updated in DB..."
-msgstr "Actualizando ulitmo cambio en configuración..."
+msgstr "Cập nhật giá trị của cài đặt được cập nhật lần cuối trong cơ sở dữ liệu ..."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Checking whether settings cache is out of date (requires DB call)..."
-msgstr "Comprobando si la memoria caché de configuración está desactualizada..."
+msgstr "Kiểm tra xem bộ đệm cài đặt đã hết hạn chưa (yêu cầu cuộc gọi DB) ..."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Settings have been changed on another instance, and will be reloaded here."
-msgstr "La configuración se modificó en otra instancia y se volverá a cargar aquí."
+msgstr "Các cài đặt đã được thay đổi trong một thao tác khác và sẽ được tải lại tại đây."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Refreshing Settings cache..."
-msgstr "Actualizando caché de Configuración"
+msgstr "Làm mới bộ đệm Cài đặt ..."
 
 #: src/metabase/models/setting.clj
 msgid "Invalid value for string: must be either \"true\" or \"false\" (case-insensitive)."
-msgstr "Valor no válido para la cadena: debe ser \"true\" o \"false\" (no distingue entre mayúsculas y minúsculas)"
+msgstr "Giá trị không hợp lệ cho chuỗi: phải là \\ \"true \" hoặc \\ \"false \" (không phân biệt chữ hoa chữ thường)."
 
 #: src/metabase/models/setting.clj
 msgid "You cannot update `settings-last-updated` yourself! This is done automatically."
-msgstr "¡No puedes actualizar `settings-last-update` ! Esto se realiza automáticamente."
+msgstr "Bạn không thể tự cập nhật `cài đặt được cập nhật lần cuối`! Điều này được thực hiện tự động."
 
 #. go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
 #: src/metabase/models/setting.clj
 msgid "Error inserting a new Setting:"
-msgstr "Error insertando nueva configuración:"
+msgstr "Lỗi khi chèn Cài đặt mới:"
 
 #: src/metabase/models/setting.clj
 msgid "Assuming Setting already exists in DB and updating existing value."
-msgstr "￼Asumiendo que la configuración ya existe en DB y actualizando el valor existente."
+msgstr "Giả sử Cài đặt đã tồn tại trong cơ sở dữ liệu và cập nhật giá trị hiện có."
 
 #: src/metabase/models/user.clj
 msgid "value must be a map with each value either a string or number."
-msgstr "el valor debe ser un mapa con valores numéricos o de cadena."
+msgstr "giá trị phải là ánh  với mỗi giá trị là một chuỗi hoặc số."
 
 #: src/metabase/plugins.clj
 msgid "Loading plugins in directory {0}..."
-msgstr "Cargando complementos en el directorio {0}..."
+msgstr "Đang tải các plugin trong thư mục {0} ..."
 
 #: src/metabase/plugins.clj
 msgid "Loading plugin {0}... "
-msgstr "Cargando complemento {0}..."
+msgstr "Đang tải plugin {0} ..."
 
 #: src/metabase/plugins.clj
 msgid "It looks like you have some external dependencies in your Metabase plugins directory."
-msgstr "Parece que tienes algunas dependencias externas en tu directorio de complementos de Metabase."
+msgstr "Có vẻ như bạn có một số phụ thuộc bên ngoài trong thư mục bổ trợ Metabase của mình."
 
 #: src/metabase/plugins.clj
 msgid "With Java 9 or higher, Metabase cannot automatically add them to your classpath."
-msgstr "Con Java 9 o superior, Metabase no puede agregarlos automáticamente a tu classpath."
+msgstr "Đối với Java 9 hoặc cao hơn, Metabase không thể tự động thêm chúng vào đường dẫn lớp của bạn."
 
 #: src/metabase/plugins.clj
 msgid "Instead, you should include them at launch with the -cp option. For example:"
-msgstr "En su lugar, debes incluirlos en el lanzamiento con la opción -cp. Por ejemplo:"
+msgstr "Thay vào đó, bạn nên bao gồm chúng khi khởi chạy với tùy chọn -cp. Ví dụ"
 
 #: src/metabase/plugins.clj
 msgid "See https://metabase.com/docs/latest/operations-guide/start.html#java-versions for more details."
-msgstr "Ver https://metabase.com/docs/latest/operations-guide/start.html#java-versions para más detalles."
+msgstr "Xem https://metabase.com/docs/latest/operations-guide/start.html#java-versions để biết thêm chi tiết."
 
 #: src/metabase/plugins.clj
 msgid "(If you're already running Metabase this way, you can ignore this message.)"
-msgstr "(Si ya estás ejecutando Metabase de esta manera, puedes ignorar este mensaje.)"
+msgstr "(Nếu bạn đang chạy Metabase theo cách này, bạn có thể bỏ qua thông báo này.)"
 
 #: src/metabase/public_settings.clj
 msgid "Identify when new versions of Metabase are available."
-msgstr "Informar cuándo hay nuevas versiones de Metabase."
+msgstr "Xác định khi nào có phiên bản mới của Metabase."
 
 #: src/metabase/public_settings.clj
 msgid "Information about available versions of Metabase."
-msgstr "Información sobre las versiones disponibles de Metabase."
+msgstr "Thông tin về các phiên bản có sẵn của Metabase."
 
 #: src/metabase/public_settings.clj
 msgid "The name used for this instance of Metabase."
-msgstr "El nombre usado para esta instancia de Metabase."
+msgstr "Tên được sử dụng cho trường hợp này của Metabase."
 
 #: src/metabase/public_settings.clj
 msgid "The base URL of this Metabase instance, e.g. \"http://metabase.my-company.com\"."
-msgstr "La URL base de esta instancia de Metabase, p.e. \"http://metabase.my-company.com\"."
+msgstr "URL cơ sở của trường hợp Metabase này, ví dụ: \\ \"http: //metabase.my-company.com \"."
 
 #: src/metabase/public_settings.clj
 msgid "The default language for this Metabase instance."
-msgstr "El idioma predeterminado para esta instancia de Metabase."
+msgstr "Ngôn ngữ mặc định cho trường hợp Metabase này."
 
 #: src/metabase/public_settings.clj
 msgid "This only applies to emails, Pulses, etc. Users'' browsers will specify the language used in the user interface."
-msgstr "Esto solo se aplica a correos electrónicos, pulsos, etc. Los navegadores de los usuarios especificarán el idioma utilizado en la interfaz de usuario."
+msgstr "Điều này chỉ áp dụng cho email, Xung, v.v. Trình duyệt của người dùng sẽ chỉ định ngôn ngữ được sử dụng trong giao diện người dùng."
 
 #: src/metabase/public_settings.clj
 msgid "The email address users should be referred to if they encounter a problem."
-msgstr "La dirección de correo electrónico al que se dirigirán los usuarios si encuentran un problema."
+msgstr "địa chỉ email người dùng nên được đề cập nếu họ gặp vấn đề."
 
 #: src/metabase/public_settings.clj
 msgid "Enable the collection of anonymous usage data in order to help Metabase improve."
-msgstr "Habilita la recopilación de datos de uso anónimos para ayudar a mejorar Metabase."
+msgstr "Cho phép thu thập dữ liệu sử dụng ẩn danh để giúp Metabase cải thiện."
 
 #: src/metabase/public_settings.clj
 msgid "The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox."
-msgstr "La plantilla de URL del servidor de capas de mapa utilizada en las visualizaciones de mapas, por ejemplo desde OpenStreetMaps o MapBox."
+msgstr "Mẫu URL máy chủ lát bản đồ được sử dụng trong trực quan hóa bản đồ, ví dụ từ OpenStreetMaps hoặc MapBox."
 
 #: src/metabase/public_settings.clj
 msgid "Enable admins to create publicly viewable links (and embeddable iframes) for Questions and Dashboards?"
-msgstr "¿Habilita a los administradores para crear enlaces visibles públicamente (y iframes incrustados) para Preguntas y Cuadros de Mando?"
+msgstr "Cho phép quản trị viên tạo các liên kết có thể xem công khai (và iframe có thể nhúng) cho Câu hỏi và Bảng điều khiển?"
 
 #: src/metabase/public_settings.clj
 msgid "Allow admins to securely embed questions and dashboards within other applications?"
-msgstr "¿Permite a los administradores insertar preguntas y cuadros de mando de forma segura dentro de otras aplicaciones?"
+msgstr "Cho phép quản trị viên nhúng các câu hỏi và bảng điều khiển an toàn trong các ứng dụng khác ?"
 
 #: src/metabase/public_settings.clj
 msgid "Allow using a saved question as the source for other queries?"
-msgstr "¿Permitir usar una pregunta guardada como fuente para otras consultas?"
+msgstr "Cho phép sử dụng câu hỏi đã lưu làm nguồn cho các truy vấn khác?"
 
 #: src/metabase/public_settings.clj
 msgid "Enabling caching will save the results of queries that take a long time to run."
-msgstr "Al habilitar el almacenamiento en caché se guardan los resultados de las consultas que tardan mucho tiempo en ejecutarse."
+msgstr "Kích hoạt bộ đệm ẩn sẽ lưu kết quả của các truy vấn mất nhiều thời gian để chạy."
 
 #: src/metabase/public_settings.clj
 msgid "The maximum size of the cache, per saved question, in kilobytes:"
-msgstr "El tamaño máximo de la memoria caché, por pregunta guardada, en kilobytes:"
+msgstr "Kích thước tối đa của bộ đệm, cho mỗi câu hỏi đã lưu, tính bằng kilobyte:"
 
 #: src/metabase/public_settings.clj
 msgid "The absolute maximum time to keep any cached query results, in seconds."
-msgstr "El tiempo máximo absoluto para mantener los resultados de las consultas en caché, en segundos."
+msgstr "Thời gian tối đa tuyệt đối để giữ bất kỳ kết quả truy vấn được lưu trong bộ nhớ cache nào, tính bằng giây."
 
 #: src/metabase/public_settings.clj
 msgid "Metabase will cache all saved questions with an average query execution time longer than this many seconds:"
-msgstr "Metabase guardará en caché todas las preguntas guardadas con un tiempo promedio de ejecución de la consulta más largo que estos segundos:"
+msgstr "Metabase sẽ lưu trữ tất cả các câu hỏi đã lưu với thời gian thực hiện truy vấn trung bình dài hơn số giây này:"
 
 #: src/metabase/public_settings.clj
 msgid "To determine how long each saved question''s cached result should stick around, we take the query''s average execution time and multiply that by whatever you input here."
-msgstr "Para determinar cuánto tiempo debe permanecer el resultado guardado en la memoria de cada pregunta guardada, tomamos el tiempo de ejecución promedio de la consulta y lo multiplicamos por lo que pones aquí."
+msgstr "Để xác định thời gian mỗi kết quả được lưu trong bộ nhớ cache của câu hỏi đã lưu sẽ kéo dài bao lâu, chúng tôi lấy thời gian thực hiện trung bình của truy vấn và nhân số đó với bất cứ gì bạn nhập vào đây."
 
 #: src/metabase/public_settings.clj
 msgid "So if a query takes on average 2 minutes to run, and you input 10 for your multiplier, its cache entry will persist for 20 minutes."
-msgstr "Así que, si una consulta tarda un promedio de 2 minutos en ejecutarse, e introduces 10 para su multiplicador, su entrada en la memoria caché se mantendrá por 20 minutos."
+msgstr "Vì vậy, nếu một truy vấn mất trung bình 2 phút để chạy và bạn nhập 10 cho số nhân của mình, mục nhập bộ đệm của nó sẽ tồn tại trong 20 phút."
 
 #: src/metabase/public_settings.clj
 msgid "When using the default binning strategy and a number of bins is not provided, this number will be used as the default."
-msgstr "Cuando se usa la estrategia de agrupación predeterminada y no se proporciona una cantidad de tramos, este número se usará como el predeterminado."
+msgstr "Khi sử dụng chiến lược tạo thùng mặc định và một số thùng không được cung cấp, số này sẽ được sử dụng làm mặc định."
 
 #: src/metabase/public_settings.clj
 msgid "When using the default binning strategy for a field of type Coordinate (such as Latitude and Longitude), this number will be used as the default bin width (in degrees)."
-msgstr "Cuando se utiliza la estrategia de agrupación predeterminada para un campo de tipo Coordenada (como Latitud y Longitud), este número se utilizará como el ancho predeterminado del tramo (en grados)."
+msgstr "Khi sử dụng chiến lược tạo thùng mặc định cho trường Loại tọa độ (như Vĩ độ và Kinh độ), số này sẽ được sử dụng làm độ rộng thùng mặc định (tính theo độ)."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Unable to validate token."
-msgstr "No se puede validar el token."
+msgstr "Không thể xác thực mã thông báo."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error fetching token status:"
-msgstr "Error consultando el estado del Token:"
+msgstr "Lỗi khi tìm nạp trạng thái mã thông báo:"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "There was an error checking whether this token was valid."
-msgstr "Hubo un error al verificar si este token es válido."
+msgstr "Có lỗi khi kiểm tra xem mã thông báo này có hợp lệ không."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token validation timed out."
-msgstr "La validación de token agotó el tiempo de espera."
+msgstr "Xác thực mã thông báo đã hết thời gian."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Invalid token: token isn't in the right format."
-msgstr "Token inválido: el token no está en el formato correcto."
+msgstr "Mã thông báo không hợp lệ: mã thông báo không ở định dạng đúng."
 
 #. attempt to query the metastore API about the status of this token. If the request doesn't complete in a
 #. reasonable amount of time throw a timeout exception
 #: src/metabase/public_settings/metastore.clj
 msgid "Checking with the MetaStore to see whether {0} is valid..."
-msgstr "Verificando en el MetaStore para ver si {0} es válido ..."
+msgstr "Kiểm tra với MetaStore để xem {0} có hợp lệ không ..."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token for premium embedding. Go to the MetaStore to get yours!"
-msgstr "Token para incrustación premium. ¡Ve a MetaStore para obtener el tuyo!"
+msgstr "Mã thông báo cho nhúng cao cấp. Tới MetaStore để lấy của bạn!"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token is valid."
-msgstr "Token válido"
+msgstr "Mã thông báo hợp lệ."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error setting premium embedding token"
-msgstr "Error al configurar el Token de inserción premium"
+msgstr "Lỗi thiết lập mã thông báo nhúng cao cấp"
 
 #: src/metabase/pulse.clj
 msgid "Unable to compare results to goal for alert."
-msgstr "No se pueden comparar los resultados con el objetivo de alerta."
+msgstr "Không thể so sánh kết quả với mục tiêu để cảnh báo."
 
 #: src/metabase/pulse.clj
 msgid "Question ID is ''{0}'' with visualization settings ''{1}''"
-msgstr "El ID de la pregunta es ''{0}'' con configuración de visualización ''{1}''"
+msgstr "ID câu hỏi là '' {0} '' với cài đặt trực quan '' {1} ''"
 
 #: src/metabase/pulse.clj
 msgid "Unrecognized alert with condition ''{0}''"
-msgstr "Alerta desconocida con condición ''{0}''"
+msgstr "Cảnh báo không được nhận dạng với điều kiện '' {0} ''"
 
 #: src/metabase/pulse.clj
 msgid "Unrecognized channel type {0}"
-msgstr "El tipo de canal {0} es desconocido"
+msgstr "Loại kênh không được nhận dạng {0}"
 
 #: src/metabase/pulse.clj
 msgid "Error sending notification!"
-msgstr "¡Error enviando norificación!"
+msgstr "Lỗi gửi thông báo!"
 
 #: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
-msgstr "No se ha podido encontrar selector JS en ''{0}''"
+msgstr "Không thể tìm thấy bộ chọn màu JS tại '' {0} ''"
 
 #: src/metabase/pulse/render.clj
 msgid "Card has errors: {0}"
-msgstr "La tarjeta tiene errores: {0}"
+msgstr "Thẻ có lỗi: {0}"
 
 #: src/metabase/pulse/render.clj
 msgid "Pulse card render error"
-msgstr "Error al procesar Pulso"
+msgstr "Lỗi kết xuất thẻ xung"
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Trimming trailing comment from card with id {0}"
-msgstr "Eliminando el comentario final de la tarjeta con id {0}"
+msgstr "Cắt bình luận từ thẻ có id {0}"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Can't find field with ID: {0}"
-msgstr "No se puede encontrar el campo con ID: {0}"
+msgstr "Không thể tìm thấy trường có ID: {0}"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "''{0}'' is a required param."
-msgstr "''{0}'' es un parámetro requerido"
+msgstr "{0} '' là thông số bắt buộc."
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Found ''{0}'' with no terminating ''{1}'' in query ''{2}''"
-msgstr "Encontrado ''{0}'' sin terminación ''{1}'' en la consulta ''{2}''"
+msgstr "Đã tìm thấy '' {0} '' mà không kết thúc '' {1} '' trong truy vấn '' {2} ''"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Unable to substitute ''{0}'': param not specified.nFound: {1}"
-msgstr "No se puede sustituir ''{0}'': parámetro no especificado.\n"
-"Encontrado: {1}"
+msgstr "Không thể thay thế '' {0} '': param không được chỉ định.nFound: {1}"
 
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "You do not have permissions to view Card {0}."
-msgstr "No tienes permiso para ver la Tarjeta {0}."
+msgstr "Bạn không có quyền xem Thẻ {0}."
 
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "You do not have permissions to run this query."
-msgstr "No tienes permiso para ejecutar esta consulta."
+msgstr "Bạn không có quyền để chạy truy vấn này."
 
 #: src/metabase/sync/analyze.clj
 msgid "Fingerprint updates attempted {0}, updated {1}, no data found {2}, failed {3}"
-msgstr "Actualizaciones de huellas dactilares intentadas {0}, actualizadas {1}, no se encontraron datos {2}, fallaron {3}"
+msgstr "Cập nhật vân tay đã cố gắng {0}, đã cập nhật {1}, không tìm thấy dữ liệu {2}, không thành công {3}"
 
 #: src/metabase/sync/analyze.clj
 msgid "Total number of fields classified {0}, {1} failed"
-msgstr "El número total de campos clasificados {0}, {1} han fallado"
+msgstr "Tổng số trường được phân loại {0}, {1} không thành công"
 
 #: src/metabase/sync/analyze.clj
 msgid "Total number of tables classified {0}, {1} updated"
-msgstr "Número total de tablas clasificadas {0}, {1} actualizadas"
+msgstr "Tổng số bảng được phân loại {0}, {1} được cập nhật"
 
 #: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
 msgid "Error generating fingerprint for {0}"
-msgstr "Error generando huella para {0}"
+msgstr "Lỗi tạo vân tay cho {0}"
 
 #: src/metabase/sync/field_values.clj
 msgid "Updated {0} field value sets, created {1}, deleted {2} with {3} errors"
-msgstr "Conjuntos de valores de campo actualizados {0}, creados {1}, eliminados {2} con {3} errores"
+msgstr "Các bộ giá trị trường {0} đã cập nhật, đã tạo {1}, đã xóa {2} với {3} lỗi"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of fields sync''d {0}, number of fields updated {1}"
-msgstr "Número total de campos sincronizados {0}, número de campos actualizados {1}"
+msgstr "Tổng số trường được đồng bộ hóa {0}, số trường được cập nhật {1}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of tables sync''d {0}, number of tables updated {1}"
-msgstr "Número total de tablas sincronizados {0}, número de tablas actualizados {1}"
+msgstr "Tổng số bảng được đồng bộ hóa {0}, số lượng bảng được cập nhật {1"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Found timezone id {0}"
-msgstr "Encontrado la zona horaria {0}"
+msgstr "Đã tìm thấy id múi giờ {0}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of foreign keys sync''d {0}, {1} updated and {2} tables failed to update"
-msgstr "El número total de claves externas sincronizadas {0}, {1} actualizadas y {2} tablas han fallado"
+msgstr "Tổng số khóa nước ngoài được đồng bộ hóa {0}, {1} đã cập nhật và {2} bảng không cập nhật"
 
 #: src/metabase/sync/util.clj
 msgid "{0} Database {1} ''{2}''"
-msgstr "{0} Base de Datos {1} ''{2}''"
+msgstr "{0} Cơ sở dữ liệu {1} '' {2} ''"
 
 #: src/metabase/sync/util.clj
 msgid "Table {0} ''{1}''"
-msgstr "Tabla {0} ''{1}''"
+msgstr "Bảng {0} '' {1} ''"
 
 #: src/metabase/sync/util.clj
 msgid "Field {0} ''{1}''"
-msgstr "Campo {0} ''{1}''"
+msgstr "Trường {0} '' {1} ''"
 
 #: src/metabase/sync/util.clj
 msgid "Field ''{0}''"
-msgstr "Campo ''{0}''"
+msgstr "Trường '' {0} ''"
 
 #: src/metabase/sync/util.clj
 msgid "step ''{0}'' for {1}"
-msgstr "paso ''{0}'' para {1}"
+msgstr "bước '' {0} '' cho {1}"
 
 #: src/metabase/sync/util.clj
 msgid "Completed {0} on {1}"
-msgstr "Realizadas {0} de {1}"
+msgstr "Đã hoàn thành {0} vào {1}"
 
 #: src/metabase/sync/util.clj
 msgid "Start: {0}"
-msgstr "Inicio: {0}"
+msgstr "Bắt đầu: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "End: {0}"
-msgstr "Fin: {0}"
+msgstr "Kết thúc: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "Duration: {0}"
-msgstr "Duración: {0}"
+msgstr "Thời lượng: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "Completed step ''{0}''"
-msgstr "Realizado el paso ''{0}''"
+msgstr "Hoàn thành bước '' {0} ''"
 
 #: src/metabase/task.clj
 msgid "Loading tasks namespace:"
-msgstr "Cargando espacio de nombres para las tareas:"
+msgstr "Đang tải không gian tên tác vụ:"
 
 #: src/metabase/task.clj
 msgid "Starting Quartz Scheduler"
-msgstr "Iniciando Programador Quartz"
+msgstr "Bắt đầu lên lịch trình Quart"
 
 #: src/metabase/task.clj
 msgid "Stopping Quartz Scheduler"
-msgstr "Parando Programador Quartz"
+msgstr "Dừng lịch trình Quart"
 
 #: src/metabase/task.clj
 msgid "Job already exists:"
-msgstr "Tarea ya existe:"
+msgstr "Công việc đã tồn tại:"
 
 #. This is the very first log message that will get printed.  It's here because this is one of the very first
 #. namespaces that gets loaded, and the first that has access to the logger It shows up a solid 10-15 seconds before
 #. the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
 #: src/metabase/util.clj
 msgid "Loading Metabase..."
-msgstr "Cargando Metabase..."
+msgstr "Đang tải Metabase ..."
 
 #: src/metabase/util/date.clj
 msgid "Possible timezone conflict found on database {0}."
-msgstr "Posible conflicto de zona horaria en la base de datos {0}"
+msgstr "Xung đột múi giờ có thể có trên cơ sở dữ liệu {0}."
 
 #: src/metabase/util/date.clj
 msgid "JVM timezone is {0} and detected database timezone is {1}."
-msgstr "La zona horaria de la JVM es {0} y la zona horaria de la base de datos es {1}."
+msgstr "Múi giờ JVM là {0} và múi giờ cơ sở dữ liệu được phát hiện là {1}."
 
 #: src/metabase/util/date.clj
 msgid "Configure a report timezone to ensure proper date and time conversions."
-msgstr "Configura una zona horaria de los informes para realizar conversiones correctas de fecha y hora."
+msgstr "Định cấu hình múi giờ báo cáo để đảm bảo chuyển đổi ngày và giờ thích hợp."
 
 #: src/metabase/util/embed.clj
 msgid "Secret key used to sign JSON Web Tokens for requests to `/api/embed` endpoints."
-msgstr "Clave secreta utilizada para firmar tokens web JSON para solicitudes al API `/api/embed`."
+msgstr "Khóa bí mật được sử dụng để ký các Mã thông báo Web JSON cho các yêu cầu tới các điểm cuối `/ api / embed`"
 
 #: src/metabase/util/encryption.clj
 msgid "MB_ENCRYPTION_SECRET_KEY must be at least 16 characters."
-msgstr "MB_ENCRYPTION_SECRET_KEY debe tener al menos 16 caracteres"
+msgstr "MB_ENCRYPTION_SECRET_KEY phải có ít nhất 16 ký tự."
 
 #: src/metabase/util/encryption.clj
 msgid "Saved credentials encryption is ENABLED for this Metabase instance."
-msgstr "Guardar credenciales encriptadas está HABILITADO para esta instancia de Metabase."
+msgstr "Mã hóa thông tin đã lưu là ENABLED cho phiên bản Metabase này."
 
 #: src/metabase/util/encryption.clj
 msgid "Saved credentials encryption is DISABLED for this Metabase instance."
-msgstr "Guardar credenciales encriptadas está DESHABILITADO para esta instancia de Metabase."
+msgstr "Mã hóa thông tin đăng nhập đã lưu là DISABLED cho phiên bản Metabase này. "
 
 #: src/metabase/util/encryption.clj
 msgid "nFor more information, see"
-msgstr "Para más información, ver"
+msgstr "Để biết thêm thông tin, xem"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer."
-msgstr "el valor debe ser un entero."
+msgstr "giá trị phải là một số nguyên."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a string."
-msgstr "el valor debe ser un texto."
+msgstr "giá trị phải là một chuỗi."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a boolean."
-msgstr "el valor debe ser un booleano"
+msgstr "giá trị phải là một boolean. "
 
 #: src/metabase/util/schema.clj
 msgid "value must be a string that matches the regex `{0}`."
-msgstr "el valor debe ser un texto que cumpla la expresión regular `{0}`."
+msgstr "giá trị phải là một chuỗi khớp với regex `{0}`."
 
 #: src/metabase/util/schema.clj
 msgid "value must satisfy one of the following requirements: "
-msgstr "el valor debe satisfacer uno de los requerimientos siguientes:"
+msgstr "giá trị phải đáp ứng một trong các yêu cầu sau:"
 
 #: src/metabase/util/schema.clj
 msgid "value may be nil, or if non-nil, {0}"
-msgstr "el valor puede ser nulo, o si no es nulo, {0}"
+msgstr "giá trị có thể là 0 hoặc nếu không phải là 0, {0}"
 
 #: src/metabase/util/schema.clj
 msgid "value must be one of: {0}."
-msgstr "el valor debe ser uno de: {0}."
+msgstr "giá trị phải là một trong số: {0}."
 
 #: src/metabase/util/schema.clj
 msgid "value must be an array."
-msgstr "el valor debe ser un conjunto"
+msgstr "giá trị phải là một mảng."
 
 #: src/metabase/util/schema.clj
 msgid "Each {0}"
-msgstr "Cada {0}"
+msgstr "Mỗi {0}"
 
 #: src/metabase/util/schema.clj
 msgid "The array cannot be empty."
-msgstr "El conjunto no puede estar vacío."
+msgstr "Các mảng không thể để trống."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a non-blank string."
-msgstr "el valor debe ser un texto no vacío"
+msgstr "giá trị phải là một chuỗi không trống."
 
 #: src/metabase/util/schema.clj
 msgid "Integer greater than zero"
-msgstr "Entero mayor que cero"
+msgstr "Số nguyên lớn hơn 0"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer greater than zero."
-msgstr "el valor debe ser un entero mayor que cero."
+msgstr "giá trị phải là số nguyên lớn hơn 0."
 
 #: src/metabase/util/schema.clj
 msgid "Number greater than zero"
-msgstr "Número mayor que cero"
+msgstr "Số lớn hơn 0"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a number greater than zero."
-msgstr "el valor debe ser un número mayor que cero."
+msgstr "giá trị phải là một số lớn hơn 0."
 
 #: src/metabase/util/schema.clj
 msgid "Keyword or string"
-msgstr "Palabra clave o texto"
+msgstr "Từ khóa hoặc chuỗi"
 
 #: src/metabase/util/schema.clj
 msgid "Valid field type"
-msgstr "Tipo de campo válido"
+msgstr "Loại trường hợp lệ"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid field type."
-msgstr "el valor debe ser un tipo de campo válido"
+msgstr "giá trị phải là loại trường hợp lệ."
 
 #: src/metabase/util/schema.clj
 msgid "Valid field type (keyword or string)"
-msgstr "Tipo de campo válido (palabra clave o texto)"
+msgstr "Loại trường hợp lệ (từ khóa hoặc chuỗi)"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid field type (keyword or string)."
-msgstr "el valor debe ser un tipo de campo válido (palabra clave o texto)."
+msgstr "giá trị phải là loại trường hợp lệ (từ khóa hoặc chuỗi)."
 
 #: src/metabase/util/schema.clj
 msgid "Valid entity type (keyword or string)"
-msgstr "Tipo de campo válido (palabra clave o texto)"
+msgstr "Loại thực thể hợp lệ (từ khóa hoặc chuỗi)"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid entity type (keyword or string)."
-msgstr "el valor debe ser un tipo de campo válido (palabra clave o texto)."
+msgstr "giá trị phải là loại thực thể hợp lệ (từ khóa hoặc chuỗi)."
 
 #: src/metabase/util/schema.clj
 msgid "Valid map"
-msgstr "Mapa válido"
+msgstr "Bản đồ hợp lệ"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a map."
-msgstr "el valor debe ser un mapa"
+msgstr "giá trị phải là bản đồ."
 
 #: src/metabase/util/schema.clj
 msgid "Valid email address"
-msgstr "Dirección de Email válido"
+msgstr "Địa chỉ email hợp lệ"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid email address."
-msgstr "el valor debe ser una dirección de correo electrónico válida"
+msgstr "giá trị phải là một địa chỉ email hợp lệ."
 
 #: src/metabase/util/schema.clj
 msgid "Insufficient password strength"
-msgstr "Insuficiente complejidad de contraseña"
+msgstr "Mật khẩu không đủ mạnh"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer."
-msgstr "el valor debe ser un entero válido"
+msgstr "giá trị phải là số nguyên hợp lệ."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer greater than zero."
-msgstr "el valor debe ser un entero válido mayor que cero."
+msgstr "giá trị phải là số nguyên hợp lệ lớn hơn 0."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid boolean string (''true'' or ''false'')."
-msgstr "el valor debe ser un booleano válido (''true'' o ''false'')."
+msgstr "giá trị phải là một chuỗi boolean hợp lệ ('' true '' hoặc '' false '')."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid JSON string."
-msgstr "el valor debe ser un texto JSON válido."
+msgstr "giá trị phải là một chuỗi JSON hợp lệ."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid embedding params map."
-msgstr "el valor debe ser un mapa de parámetros de integración válido."
+msgstr "giá trị phải là một bản đồ params nhúng hợp lệ."
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx:12
 msgid "Data permissions"
-msgstr "Permisos de acceso de datos"
+msgstr "Quyền dữ liệu"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx:13
 msgid "Collection permissions"
-msgstr "Permisos de acceso de colecciones"
+msgstr "Quyền thu thập"
 
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
 msgid "See all collection permissions"
-msgstr "Ver todos los permisos de colecciones"
+msgstr "Xem tất cả các quyền thu thập"
 
 #: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
 msgid "Also change sub-collections"
-msgstr "También cambiar sub-colecciones"
+msgstr "Đồng thời thay đổi bộ sưu tập phụ"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
-msgstr "Puede editar esta colección y sus contenidos"
+msgstr "Có thể chỉnh sửa bộ sưu tập này và nội dung của nó"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
-msgstr "Puede ver artículos en esta colección"
+msgstr "Có thể xem các mục trong bộ sưu tập này"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:765
 msgid "Collection Access"
-msgstr "Acceso a Colección"
+msgstr "Có thể xem các mục trong bộ sưu tập này"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:841
 msgid "This group has permission to view at least one subcollection of this collection."
-msgstr "Este grupo tiene permiso para ver al menos una subcolección de esta colección."
+msgstr "Nhóm này có quyền xem ít nhất một bộ sưu tập của bộ sưu tập này."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "This group has permission to edit at least one subcollection of this collection."
-msgstr "Este grupo tiene permiso para editar al menos una subcolección de esta colección."
+msgstr "Nhóm này có quyền chỉnh sửa ít nhất một bộ sưu tập con của bộ sưu tập này."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:859
 msgid "View sub-collections"
-msgstr "Ver subcolección"
+msgstr "Xem các bộ sưu tập phụ "
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:245
 msgid "Remember Me"
-msgstr "Recuerdame"
+msgstr "Nhớ tôi"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:73
 msgid "X-ray this schema"
-msgstr "Aplica rayos-X a este esquema"
+msgstr "X-quang lược đồ này"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:258
 msgid "Edit the permissions for this collection"
-msgstr "Editar los permisos de acceso de esta colección"
+msgstr "Chỉnh sửa quyền cho bộ sưu tập này"
 
 #: frontend/src/metabase/containers/AddToDashSelectDashModal.jsx:55
 msgid "Add this question to a dashboard"
-msgstr "Añadir esta pregunta a un cuadro de mando"
+msgstr "Thêm câu hỏi này vào bảng điều khiển"
 
 #: frontend/src/metabase/containers/AddToDashSelectDashModal.jsx:65
 msgid "Create a new dashboard"
-msgstr "Crea un Cuadro de Mando"
+msgstr "Tạo bảng điều khiển mới"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:47
 msgid "The page you asked for couldn't be found."
-msgstr "La página que pidió no ha sido encontrada."
+msgstr "Trang bạn yêu cầu không thể được tìm thấy."
 
 #: frontend/src/metabase/containers/ItemSelect.jsx:30
 msgid "Select a {0}"
-msgstr "Seleccione un(a) {0}"
+msgstr "Chọn một {0}"
 
 #: frontend/src/metabase/containers/Overworld.jsx:234
 msgid "Save dashboards, questions, and collections in \"{0}\""
-msgstr "Guardar cuadros de mando, preguntas, y colecciones en \"{0}\""
+msgstr "Lưu bảng điều khiển, câu hỏi và bộ sưu tập trong \\ \"{0} \""
 
 #: frontend/src/metabase/containers/Overworld.jsx:235
 msgid "Access dashboards, questions, and collections in \"{0}\""
-msgstr "Acceder cuadros de mando, preguntas, y colecciones en \"{0}\""
+msgstr "Truy cập bảng điều khiển, câu hỏi và bộ sưu tập trong \\ \"{0} \""
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
-msgstr "Compara"
+msgstr "So sánh"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
-msgstr "Alejarse"
+msgstr "Thu nhỏ"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
-msgstr "Relacionado"
+msgstr "Liên quan"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
-msgstr "Más Rayos-X"
+msgstr "Thêm tia X"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
-msgstr "No hay resultados"
+msgstr "Không có kết quả"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:42
 msgid "Metabase couldn't find any results for your search."
-msgstr "Metabase no pudo encontrar ningún resultado para su busqueda."
+msgstr "Metabase không thể tìm thấy bất kỳ kết quả nào cho tìm kiếm của bạn. "
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
-msgstr "Métricas no encontradas"
+msgstr "Không có số liệu"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:41
 msgid "Aggregations"
-msgstr "Agregaciones"
+msgstr "Tập hợp"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:42
 msgid "Operators"
-msgstr "Operadores"
+msgstr "Người vận hành"
 
 #: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:35
 msgid "Custom fields"
-msgstr "Campos personalizados"
+msgstr "Trường tùy chỉnh"
 
 #. 2. Create the new collections.
 #: src/metabase/db/migrations.clj
 msgid "Migrated Dashboards"
-msgstr "Cuadros de Mando migrados"
+msgstr "Bảng điều khiển di chuyển"
 
 #: src/metabase/db/migrations.clj
 msgid "Migrated Pulses"
-msgstr "Pulsos migrados"
+msgstr "Xung di chuyển"
 
 #: src/metabase/db/migrations.clj
 msgid "Migrated Questions"
-msgstr "Preguntas migradas"
+msgstr "Câu hỏi di chuyển"
 
 #. 4. move everything not in this Collection to a new Collection
 #: src/metabase/db/migrations.clj
 msgid "Moving instances of {0} that aren't in a Collection to {1} Collection {2}"
-msgstr "Moviendo instancias de {0} que no están en ninguna colección a {1} Colección {2}"
+msgstr "Di chuyển các phiên bản của {0} không có trong Bộ sưu tập sang {1} Bộ sưu tập {2}"
 
 #: src/metabase/models/permissions.clj
 msgid "Failed to grant permissions: {0}"
-msgstr "Error al conceder permisos: {0}"
+msgstr "Không thể cấp quyền: {0}"
 
 #: src/metabase/util/encryption.clj
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
-msgstr "No se ha podido desencriptar la cadena. ¿Has configurado correctamenteMB_ENCRYPTION_SECRET_KEY?"
+msgstr "Không thể giải mã chuỗi mã hóa. Bạn đã thay đổi hoặc quên đặt MB_ENCRYPTION_SECRET_KEY?"
 
 #: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
-msgstr "Todas las colecciones personales"
+msgstr "Tất cả các bộ sưu tập cá nhân"
 
 #: src/metabase/driver/common.clj
 msgid "Host"
-msgstr "Servidor"
+msgstr "Máy chủ"
 
 #: src/metabase/driver/common.clj
 msgid "Port"
-msgstr "Puerto"
+msgstr "Cổng"
 
 #: src/metabase/driver/common.clj
 msgid "Database username"
-msgstr "nombre de usuario de base de datos"
+msgstr "Tên người dùng cơ sở dữ liệu"
 
 #: src/metabase/driver/common.clj
 msgid "What username do you use to login to the database?"
-msgstr "¿Qué nombre de usuario usas para iniciar sesión en la base de datos?"
+msgstr "Tên người dùng nào bạn sử dụng để đăng nhập vào cơ sở dữ liệu?"
 
 #: src/metabase/driver/common.clj
 msgid "Database password"
-msgstr "Contraseña de la base de datos"
+msgstr "Mật khẩu cơ sở dữ liệu"
 
 #: src/metabase/driver/common.clj
 msgid "Database name"
-msgstr "nombre de la base de datos"
+msgstr "Tên cơ sở dữ liệu"
 
 #: src/metabase/driver/common.clj
 msgid "birds_of_the_world"
-msgstr "aves_del_mundo"
+msgstr "birds_of_the_world"
 
 #: src/metabase/driver/common.clj
 msgid "Use a secure connection (SSL)?"
-msgstr "¿Utilizar una conexión segura (SSL)?"
+msgstr "Sử dụng kết nối an toàn (SSL)?"
 
 #: src/metabase/driver/common.clj
 msgid "Additional JDBC connection string options"
-msgstr "Opciones adicionales de cadena de conexión JDBC"
+msgstr "Các tùy chọn chuỗi kết nối JDBC bổ sung"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Project ID"
-msgstr "ID de proyecto"
+msgstr "ID dự án"
 
 #: src/metabase/driver/bigquery.clj
 msgid "praxis-beacon-120871"
@@ -9154,142 +9119,142 @@ msgstr "praxis-beacon-120871"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Dataset ID"
-msgstr "Conjunto de datos ID"
+msgstr "ID dữ liệu"
 
 #: src/metabase/driver/bigquery.clj
 msgid "toucanSightings"
-msgstr "avistamientosDeTucanes"
+msgstr "toucanSightings"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Client ID"
-msgstr "ID de cliente"
+msgstr "ID khách hàng"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Client Secret"
-msgstr "Clave secreta del cliente"
+msgstr "Bí mật khách hàng"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Auth Code"
-msgstr "Código de Autorización"
+msgstr "Mã xác thực"
 
 #: src/metabase/driver/crate.clj
 msgid "Hosts"
-msgstr "Servidores"
+msgstr "Máy chủ"
 
 #: src/metabase/driver/druid.clj
 msgid "Broker node port"
-msgstr "Puerto de nodo intermediario"
+msgstr "Cổng nút môi giới"
 
 #: src/metabase/driver/googleanalytics.clj
 msgid "Google Analytics Account ID"
-msgstr "ID de cuenta de Google Analytics"
+msgstr "ID tài khoản Google Analytics"
 
 #: src/metabase/driver/h2.clj
 msgid "Connection String"
-msgstr "Cadena de conexión"
+msgstr "Chuỗi kết nối"
 
 #: src/metabase/driver/h2.clj
 msgid "Users/camsaul/bird_sightings/toucans"
-msgstr "Users/camsaul/avistamientos_de_aves/tucanes"
+msgstr "Users/camsaul/bird_sightings/toucans"
 
 #: src/metabase/driver/mongo.clj
 msgid "carrierPigeonDeliveries"
-msgstr "entregasPorPalomasMensajeras"
+msgstr "CarrierPigeonDeliveries"
 
 #: src/metabase/driver/mongo.clj
 msgid "Authentication Database"
-msgstr "base de datos para autenticación"
+msgstr "Cơ sở dữ liệu xác thực"
 
 #: src/metabase/driver/mongo.clj
 msgid "Optional database to use when authenticating"
-msgstr "base de datos opcional para la autenticación"
+msgstr "Cơ sở dữ liệu xác thực"
 
 #: src/metabase/driver/mongo.clj
 msgid "Additional Mongo connection string options"
-msgstr "Opciones adicionales de cadena de conexión Mongo"
+msgstr "Tùy chọn chuỗi kết nối Mongo bổ sung"
 
 #: src/metabase/driver/oracle.clj
 msgid "Oracle system ID (SID)"
-msgstr "ID del sistema Oracle (SID)"
+msgstr "ID hệ thống Oracle (SID)"
 
 #: src/metabase/driver/oracle.clj
 msgid "Usually something like ORCL or XE."
-msgstr "Generalmente algo como ORCL o XE"
+msgstr "Thông thường một cái gì đó như ORCL hoặc XE."
 
 #: src/metabase/driver/oracle.clj
 msgid "Optional if using service name"
-msgstr "Opcional cuando se usa nombre del servicio"
+msgstr "Tùy chọn nếu sử dụng tên dịch vụ"
 
 #: src/metabase/driver/oracle.clj
 msgid "Oracle service name"
-msgstr "Nombre del servicio Oracle"
+msgstr "Tên dịch vụ của Oracle"
 
 #: src/metabase/driver/oracle.clj
 msgid "Optional TNS alias"
-msgstr "Alias TNS (opcional)"
+msgstr "Bí danh TNS tùy chọn"
 
 #: src/metabase/driver/presto.clj
 msgid "hive"
-msgstr "hive"
+msgstr "tổ ong"
 
 #: src/metabase/driver/redshift.clj
 msgid "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
-msgstr "nombre-de-mi-cluster.abcd1234.us-east-1.redshift.amazonaws.com"
+msgstr "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
 
 #: src/metabase/driver/redshift.clj
 msgid "toucan_sightings"
-msgstr "avistamientos_de_tucanes"
+msgstr "toucan_sightings"
 
 #: src/metabase/models/collection.clj
 msgid "default"
-msgstr "por defecto"
+msgstr "mặc định"
 
 #: src/metabase/driver/sqlite.clj
 msgid "Filename"
-msgstr "Nombre del archivo"
+msgstr "Tên tệp"
 
 #: src/metabase/driver/sqlite.clj
 msgid "/home/camsaul/toucan_sightings.sqlite 😋"
-msgstr "/home/camsaul/avistamientos_de_tucanes.sqlite"
+msgstr "/home/camsaul/toucan_sightings.sqlite 😋"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "BirdsOfTheWorld"
-msgstr "AvesDelMundo"
+msgstr "BirdsOfTheWorld"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "Database instance name"
-msgstr "Nombre de la instancia de base de datos"
+msgstr "Tên ví dụ cơ sở dữ liệu"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "N/A"
-msgstr "No aplica"
+msgstr "Không có"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "Windows domain"
-msgstr "Dominio de Windows"
+msgstr "Tên miền Windows"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:528
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:534
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:543
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
-msgstr "Etiquetas"
+msgstr "Nhãn"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 msgid "Add members"
-msgstr "Añadir miembros"
+msgstr "Thêm thành viên"
 
 #: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
-msgstr "Colección que se guarda en"
+msgstr "Bộ sưu tập đã được lưu trongBộ sưu tập đã được lưu trong"
 
 #: frontend/src/metabase/lib/groups.js:4
 msgid "All Users"
-msgstr "Todos los Usuarios"
+msgstr "Tất cả người dùng"
 
 #: frontend/src/metabase/lib/groups.js:5
 msgid "Administrators"
-msgstr "Administradores"
+msgstr "Quản trị viên"
 
 #: frontend/src/metabase/lib/groups.js:6
 msgid "MetaBot"
@@ -9297,7 +9262,7 @@ msgstr "MetaBot"
 
 #: frontend/src/metabase/public/components/widgets/EmbedModalContent.jsx:290
 msgid "Sharing"
-msgstr "Compartir"
+msgstr "Chia sẻ"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:218
@@ -9321,7 +9286,7 @@ msgstr "Compartir"
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
-msgstr "Visualización"
+msgstr "Hiển thị"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:402
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:437
@@ -9332,229 +9297,229 @@ msgstr "Visualización"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:521
 msgid "Axes"
-msgstr "Ejes"
+msgstr "Trục"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:219
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:62
 msgid "Formatting"
-msgstr "Formato"
+msgstr "Định dạng"
 
 #: frontend/src/metabase/containers/Overworld.jsx:121
 msgid "Try these x-rays based on your data."
-msgstr "Pruebe estos rayos-X en función de tus datos."
+msgstr "Hãy thử những tia X này dựa trên dữ liệu của bạn."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:38
 msgid "There was a problem displaying this chart."
-msgstr "Hubo un problema al mostrar esta gráfico."
+msgstr "Có một vấn đề hiển thị biểu đồ này."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:39
 msgid "Sorry, you don't have permission to see this card."
-msgstr "Lo siento, no tienes permiso para ver etsa tarjeta."
+msgstr "Xin lỗi, bạn không được phép xem thẻ này."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:55
 msgid "Just a heads up:"
-msgstr "Solo un aviso:"
+msgstr "Chỉ cần ngẩng cao đầu:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:63
 msgid "{0} without the Sample Dataset, the Query Builder tutorial won't work. You can always restore the Sample Dataset, but any questions you've saved using this data will be lost."
-msgstr "{0} sin el conjunto de datos de muestra, el tutorial del generador de consultas no funcionará. Siempre puede restaurar el conjunto de datos de muestra, pero cualquier pregunta que haya guardado con esta información se perderá"
+msgstr "{0} không có Bộ dữ liệu mẫu, hướng dẫn Trình tạo truy vấn sẽ không hoạt động. Bạn luôn có thể khôi phục Bộ dữ liệu mẫu, nhưng mọi câu hỏi bạn đã lưu bằng dữ liệu này sẽ bị mất"
 
 #: frontend/src/metabase/modes/components/drill/AutomaticDashboardDrill.jsx:33
 msgid "X-ray"
-msgstr "Aplica rayos-X"
+msgstr "tia X"
 
 #: frontend/src/metabase/modes/components/drill/CompareToRestDrill.js:34
 msgid "Compare to the rest"
-msgstr "Compara con el resto"
+msgstr "So sánh với phần còn lại"
 
 #: frontend/src/metabase/entities/databases/forms.js:18
 msgid "Use the Java Virtual Machine (JVM) timezone"
-msgstr "Utiliza la zona horaria de la máquina virtual Java"
+msgstr "Sử dụng múi giờ của Máy ảo Java (JVM)"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
-msgstr "Te sugerimos que desactives esto a menos que estés forzando manualmente la zona horaria en\n"
-"muchas o la mayoría de tus consultas con estos datos."
+msgstr "Chúng tôi khuyên bạn nên bỏ qua điều này trừ khi bạn thực hiện truyền múi giờ thủ công trong\n"
+"\"\"nhiều hoặc hầu hết các truy vấn của bạn với dữ liệu này."
 
 #: frontend/src/metabase/containers/Overworld.jsx:395
 msgid "Your team's most important dashboards go here"
-msgstr "Los cuadros de mando más importantes van aquí"
+msgstr "Bảng điều khiển quan trọng nhất của nhóm của bạn ở đây"
 
 #: frontend/src/metabase/containers/Overworld.jsx:396
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
-msgstr "Fija los cuadros de mando en {0} para que aparezcan en este espacio para todos"
+msgstr "Ghim bảng điều khiển trong {0} để chúng xuất hiện trong không gian này cho mọi người"
 
 #: src/metabase/db/liquibase.clj
 msgid "Unable to release the Liquibase lock after a migration failure"
-msgstr "No se ha podido eliminar el bloqueo Liquibase tras un error en la migración"
+msgstr "Không thể giải phóng khóa Liquibase sau khi lỗi di chuyển"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Use JVM Time Zone"
-msgstr "Utiliza la zona horaria del JVM"
+msgstr "Sử dụng múi giờ JVM"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:29
 msgid "We're currently analyzing the tables and fields to help you explore your data."
-msgstr "Estamos analizando las tablas y los campos para ayudarte a explorar tus datos."
+msgstr "Chúng tôi hiện đang phân tích các bảng và trường để giúp bạn khám phá dữ liệu của mình. "
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
 msgid "Tip: "
-msgstr "Consejo: "
+msgstr "Mẹo"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
-msgstr "Selecciona un tipo de moneda"
+msgstr "Chọn một loại tiền tệ"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
 msgid "Field Type"
-msgstr "Tipo Campo"
+msgstr "Loại lĩnh vực"
 
 #: frontend/src/metabase/admin/routes.jsx:118
 #: frontend/src/metabase/nav/containers/Navbar.jsx:267
 msgid "Troubleshooting"
-msgstr "Solución de problemas"
+msgstr "Xử lý sự cố"
 
 #: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Enable X-ray features"
-msgstr "Habilitar características de Rayos-X"
+msgstr "Kích hoạt tính năng X-quang"
 
 #: frontend/src/metabase/admin/settings/selectors.js:220
 msgid "Formatting Options"
-msgstr "Opciones de Formato"
+msgstr "Tùy chọn định dạng"
 
 #: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
-msgstr "Detalles de la tarea"
+msgstr "Chi tiết tác vụ"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:29
 msgid "Troubleshooting logs"
-msgstr "Registro de solución de problemas"
+msgstr "Nhật ký xử lý sự cố"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:31
 msgid "Trying to get to the bottom of something? This section shows logs of Metabase's background tasks, which can help shed light on what's going on."
-msgstr "¿Tratando de llegar al fondo de algo? Esta sección muestra los registros de las tareas en segundo plano de Metabase, que pueden ayudar a aclarar lo que está pasando."
+msgstr "Đang cố gắng để đi đến tận cùng của một cái gì đó? Phần này hiển thị nhật ký các tác vụ nền của Metabase, có thể giúp làm sáng tỏ những gì đang diễn ra."
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:56
 msgid "Task"
-msgstr "Tarea"
+msgstr "Tác vụ"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:57
 msgid "DB ID"
-msgstr "ID BBDD"
+msgstr "DB ID"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:58
 msgid "Started at"
-msgstr "Iniciado a las"
+msgstr "Bắt đầu lúc"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:59
 msgid "Ended at"
-msgstr "Terminado a las"
+msgstr "Đã kết thúc lúc"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:60
 msgid "Duration (ms)"
-msgstr "Duración (ms)"
+msgstr "Thời lượng (ms)"
 
 #: frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx:34
 #: frontend/src/metabase/lib/core.js:92
 msgid "Currency"
-msgstr "Moneda"
+msgstr "Tiền tệ"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
-msgstr "Elige un usuario o canal..."
+msgstr "Chọn người dùng hoặc kênh ..."
 
 #: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:90
 msgid "No formatting settings"
-msgstr "Sin ajustes de formato"
+msgstr "Không có cài đặt định dạng"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:81
 msgid "Label for this range (optional)"
-msgstr "Nombre para este rango (opcional)"
+msgstr "Nhãn cho phạm vi này (tùy chọn)"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:93
 msgid "Add a range"
-msgstr "Añade un rango"
+msgstr "Thêm một phạm vi"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:26
 msgid "is less than"
-msgstr "es menor que"
+msgstr "nhỏ hơn"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:27
 msgid "is greater than"
-msgstr "es mayor que"
+msgstr "lớn hơn"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:28
 msgid "is less than or equal to"
-msgstr "es menor o igual a"
+msgstr "nhỏ hơn hoặc bằng"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:29
 msgid "is greater than or equal to"
-msgstr "es mayor o igual a"
+msgstr "lớn hơn hoặc bằng"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:37
 msgid "is equal to"
-msgstr "es igual a"
+msgstr "bằng"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:31
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:38
 msgid "is not equal to"
-msgstr "no es igual a"
+msgstr "không bằng"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:32
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:39
 msgid "is null"
-msgstr "es nulo"
+msgstr "là không"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:33
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:40
 msgid "is not null"
-msgstr "no es nulo"
+msgstr "không phải là không"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:41
 msgid "contains"
-msgstr "contiene"
+msgstr "chứa đựng"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:42
 msgid "does not contain"
-msgstr "no contiene"
+msgstr "không chứa đựng"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:43
 msgid "starts with"
-msgstr "empieza con"
+msgstr "bắt đầu với "
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:44
 msgid "ends with"
-msgstr "termina con"
+msgstr "kết thúc bằng"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:292
 msgid "When a cell in these columns {0} it will be tinted this color."
-msgstr "Cuando una celda de estas columnas sea {0} se pintará de este color."
+msgstr "Khi một ô trong các cột này {0}, nó sẽ được tô màu này."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:351
 msgid "When a cell in this column…"
-msgstr "Cuando una celda en esta columna..."
+msgstr "Khi một ô trong cột này"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:42
 msgid "This visualization requires you to group by a field."
-msgstr "Esta visualización require agrupar por un campo."
+msgstr "Hình dung này đòi hỏi bạn phải nhóm theo một lĩnh vực."
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:184
 msgid "Date style"
-msgstr "Formato de fecha"
+msgstr "Kiểu ngày"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:207
 msgid "Date separators"
-msgstr "Separador de fecha"
+msgstr "Dấu phân cách ngày"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:226
 msgid "Abbreviate names of days and months"
-msgstr "Abreviar nombres de días y meses."
+msgstr "Tên viết tắt của ngày và tháng"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:236
 msgid "Show the time"
-msgstr "Mostrar la hora"
+msgstr "Hiển thị thời gian"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:243
 msgid "HH:MM"
@@ -9570,373 +9535,373 @@ msgstr "HH:MM:SS.MS"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:265
 msgid "Time style"
-msgstr "Formato de hora"
+msgstr "Kiểu thời gian"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:314
 msgid "Unit of currency"
-msgstr "Unidad de moneda"
+msgstr "Đơn vị tiền tệ"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:334
 msgid "Currency label style"
-msgstr "Formato etiqueta de moneda"
+msgstr "Kiểu nhãn tiền tệ"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:361
 msgid "Where to display the unit of currency"
-msgstr "Donde mostrar la unidad de moneda"
+msgstr "Nơi hiển thị đơn vị tiền tệ"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:394
 msgid "Minimum number of decimal places"
-msgstr "Número mínimo de decimales"
+msgstr "Số lượng thập phân tối thiểu"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
-msgstr "Tipo de gráfico apilado"
+msgstr "Loại biểu đồ xếp chồng"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
-msgstr "Etiqueta de Objetivo"
+msgstr "Nhãn mục tiêu"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
-msgstr "Mostrar línea de tendencia"
+msgstr "Hiển thị đường xu hướng"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:67
 msgid "Line style"
-msgstr "Formato de línea"
+msgstr "Kiểu dòng"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:84
 msgid "Show dots on lines"
-msgstr "Mostrar puntos en las líneas"
+msgstr "Hiển thị dấu chấm trên dòng"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:348
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
-msgstr "Automatico"
+msgstr "Tự động"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:120
 msgid "Which axis?"
-msgstr "¿En qué eje?"
+msgstr "Trục nào?"
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
 msgid "Line + Bar"
-msgstr "Línea + Barra"
+msgstr "Dòng + Cột"
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
 msgid "line and bar chart"
-msgstr "gráfico de línea y barra"
+msgstr "biểu đồ đường và biểu đồ cột"
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
-msgstr "La visualización del contador requiere un número."
+msgstr "Đo trực quan đòi hỏi một số."
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:60
 msgid "Gauge"
-msgstr "Contador"
+msgstr "Máy đo"
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
 msgid "Gauge ranges"
-msgstr "Rangos del contador"
+msgstr "Phạm vi đo"
 
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:107
 msgid "Field to show"
-msgstr "Campo a mostrar"
+msgstr "Lĩnh vực để hiển thị"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
 msgid "last {0}"
-msgstr "último {0}"
+msgstr "cuối {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
 msgid "{0} was {1} {2}"
-msgstr "{0} era {1} {2}"
+msgstr "{0} là {1} {2}"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
 msgid "Group by a time field to see how this has changed over time"
-msgstr "Agrupa por un campo temporal para ver como ha cambiado a lo largo del tiempo"
+msgstr "Nhóm theo trường thời gian để xem điều này đã thay đổi theo thời gian như thế nào"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:51
 msgid "Switch positive / negative colors?"
-msgstr "¿Mostrar colores positivos/negativos?"
+msgstr "Chuyển màu dương / âm?"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
 msgid "Pivot column"
-msgstr "Columna pivote"
+msgstr "Cột xoay"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
 msgid "Cell column"
-msgstr "Columna celda"
+msgstr "Cột di động"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
 msgid "Visible columns"
-msgstr "Columnas visibles"
+msgstr "Cột có thể nhìn thấy"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
 msgid "Conditional Formatting"
-msgstr "Formato condicional"
+msgstr "Định dạng có điều kiện"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
 msgid "Column title"
-msgstr "Título columna"
+msgstr "Tiêu đề cột"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:243
 msgid "Show a mini bar chart"
-msgstr "Mostrar una gráfica de barras en miniatura"
+msgstr "Hiển thị biểu đồ cột nhỏ"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:254
 msgid "Link"
-msgstr "Enlace"
+msgstr "Liên kết"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:258
 msgid "Email link"
-msgstr "Enlace Email"
+msgstr "Liên kết email"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:262
 msgid "Image"
-msgstr "Imagen"
+msgstr "Hình ảnh"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:266
 msgid "Automatic"
-msgstr "Automático"
+msgstr "Tự động"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:271
 msgid "View as link or image"
-msgstr "Ver como enlace o imagen"
+msgstr "Xem dưới dạng liên kết hoặc hình ảnh"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:281
 msgid "Link text"
-msgstr "Texto del enlace"
+msgstr "văn bản liên kết"
 
 #: src/metabase/api/common/internal.clj
 msgid "Not a valid integer: ''{0}''"
-msgstr "No es un entero válido: \"{0}\""
+msgstr "Không phải là số nguyên hợp lệ: '' {0} ''"
 
 #: src/metabase/api/embed.clj
 msgid "Embedding is not enabled for this object."
-msgstr "No se puede incluir este tipo de objeto."
+msgstr "Nhúng không được kích hoạt cho đối tượng này."
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fallback to local authentication: {0}"
-msgstr "Problema al conectarse al servidor LDAP, se recurrirá a la autenticación local: {0}"
+msgstr "Sự cố khi kết nối với máy chủ LDAP, sẽ chuyển sang xác thực cục bộ: {0}"
 
 #: src/metabase/api/task.clj
 msgid "When including an offset, a limit must also be included."
-msgstr "Al incluir un desplazamiento, también hay que indicar un límite."
+msgstr "Khi bao gồm một phần bù, một giới hạn cũng phải được đưa vào."
 
 #: src/metabase/api/task.clj
 msgid "When including a limit, an offset must also be included."
-msgstr "Al incluir un límite, también hay que indicar el desplazamiento."
+msgstr "Khi bao gồm một giới hạn, một phần bù cũng phải được đưa vào."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Applying heuristic {0} to {1}."
-msgstr "Aplicando heurística {0} a {1}."
+msgstr "Áp dụng heuristic {0} cho {1}."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Dimensions bindings:n{0}"
-msgstr "Fijaciones de dimensiones:n{0}"
+msgstr "Kích thước ràng buộc: n {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Using definitions:nMetrics:n{0}nFilters:n{1}"
-msgstr "Utilizando definiciones:\\nMétricas{0}\\nFiltros:\\n{1}"
+msgstr "Sử dụng định nghĩa: nMetrics: n {0} nFilters: n {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "minute"
-msgstr "minuto"
+msgstr "phút"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "hour"
-msgstr "hora"
+msgstr "giờ"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of week"
-msgstr "día de la semana"
+msgstr "ngày trong tuần"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of month"
-msgstr "día del mes"
+msgstr "ngày trong tháng"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of year"
-msgstr "día del año"
+msgstr "ngày trong năm"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "week"
-msgstr "semana"
+msgstr "tuần"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "month"
-msgstr "mes"
+msgstr "tháng"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "quarter"
-msgstr "trimestre"
+msgstr "quý"
 
 #: src/metabase/automagic_dashboards/populate.clj
 msgid "Adding {0} cards to dashboard {1}:n{2}"
-msgstr "Añadiendo {0} tarjetas al cuadro de mando {1}:n{2}"
+msgstr "Thêm thẻ {0} vào bảng điều khiển {1}: n {2}"
 
 #: src/metabase/util/yaml.clj
 msgid "Error parsing {0}:n{1}"
-msgstr "Error leyendo {0}:n{1}"
+msgstr "Lỗi phân tích cú pháp {0}: n {1}"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Filtering only works on dimensions! ''{0}'' is a metric. Ignoring filter."
-msgstr "ADVERTENCIA: ¡El filtrado solo funciona sobre dimensiones! ''{0}'' es una métrica, así que será ignorado."
+msgstr "CẢNH BÁO: Lọc chỉ hoạt động trên kích thước! '' {0} '' là một số liệu. Bỏ qua bộ lọc."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: A date can't belong to multiple discrete intervals, so ANDing them together doesn't make sense."
-msgstr "ADVERTENCIA: Una fecha no puede pertenecer a múltiples intervalos discretos, por lo que el hecho de unirlos con un Y no tiene sentido."
+msgstr "CẢNH BÁO: Một ngày không thể thuộc về nhiều khoảng thời gian riêng biệt, vì vậy ANDing chúng cùng nhau không có ý nghĩa."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "Ignoring these intervals: {0}"
-msgstr "Ignorando estos intérvalos: {0}"
+msgstr "Bỏ qua các khoảng này: {0}"
 
 #. We should never get to this point since the all non-string negations should get automatically rewritten
 #. by the query expander.
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Don't know how to negate: {0}"
-msgstr "ADVERTENCIA: No sé cómo negar: {0}"
+msgstr "CẢNH BÁO: Không biết cách phủ định: {0}"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "Sorting with Druid is only allowed in queries that have one or more breakout columns. Ignoring :order-by clause."
-msgstr "Ordenando con Druid solo se permite en consultas que tienen una o más columnas de ruptura. Ignorando la cláusula de orden."
+msgstr "Sắp xếp với Druid chỉ được phép trong các truy vấn có một hoặc nhiều cột đột phá. Bỏ qua: mệnh đề theo thứ tự."
 
 #. TODO - this is not really true, is it
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: It only makes sense to specify :fields for a query with no aggregation. Ignoring the clause."
-msgstr "ADVERTENCIA: Solo tiene sentido especificar campos para una consulta sin agregación. Ignorando la cláusula."
+msgstr "CẢNH BÁO: Chỉ có ý nghĩa khi chỉ định: các trường cho một truy vấn không có tổng hợp. Bỏ qua mệnh đề."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Druid doenst allow limitSpec in timeseries queries. Ignoring the LIMIT clause."
-msgstr "ADVERTENCIA: Druid no permite limitSpec en consultas de series de tiempo. Ignorando la cláusula LIMIT."
+msgstr "CẢNH BÁO: Druid doenst cho phép giới hạnSpec trong các truy vấn thời gian. Bỏ qua mệnh đề LIMIT."
 
 #: src/metabase/driver/sql/query_processor.clj
 msgid "HoneySQL Form:"
-msgstr "Formulario HoneySQL:"
+msgstr "Mẫu HoneySQL:"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Unable to parse date ''{0}''"
-msgstr "No se ha podido leer la fecha \"{0}\""
+msgstr "Không thể phân tích ngày '' {0} ''"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Client closed connection, cancelling query"
-msgstr "Conecxión cerrada por el cliente, cancelando consulta"
+msgstr "Kết nối khách hàng, hủy truy vấn"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Setting timezone with statement: {0}"
-msgstr "Establecer zona horaria con declaración: {0}"
+msgstr "Đặt múi giờ với câu lệnh: {0}"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid "Multiple date filters are not supported"
-msgstr "No se pueden hacer filtros con varias fechas."
+msgstr "Nhiều bộ lọc ngày không được hỗ trợ"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid ":not is not yet implemented"
-msgstr ":no no se ha implementado aun"
+msgstr ": chưa được thực hiện"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid "Only one Google Analytics segment allowed at a time."
-msgstr "Solo se permite un segmento de Google Analytics a la vez."
+msgstr "Mỗi lần chỉ có một phân đoạn Google Analytics."
 
 #: src/metabase/driver/mongo/query_processor.clj
 msgid "MONGO AGGREGATION PIPELINE:"
-msgstr "PIPELINE DE AGREGACION DE MONGO:"
+msgstr "MONGO AGGREGATION PIPELINE:"
 
 #: src/metabase/driver/mongo/query_processor.clj
 msgid "Error: mismatched columns in results! Expected: {0} Got: {1}"
-msgstr "Error: ¡columnas no coincidentes en los resultados! Esperaba: {0} pero se ha obtenido: {1}"
+msgstr "Lỗi: các cột không khớp trong kết quả! Dự kiến: {0} Đã nhận: {1}"
 
 #: src/metabase/email/messages.clj
 msgid "Unable to create temp file in `{0}` for email attachments "
-msgstr "No se ha podido crear fichero temporal en `{0}` para adjuntos de correo "
+msgstr "Không thể tạo tệp tạm thời trong `{0}` cho tệp đính kèm email"
 
 #: src/metabase/events/activity_feed.clj
 msgid "Error preprocessing query:"
-msgstr "Error procesando consulta:"
+msgstr "Lỗi truy vấn tiền xử lý:"
 
 #: src/metabase/mbql/normalize.clj
 msgid "Illegal filter clause: {0}"
-msgstr "Cláusula de filtro incorrecto: {0}"
+msgstr "Điều khoản lọc bất hợp pháp: {0}"
 
 #: src/metabase/mbql/normalize.clj
 msgid "Invalid clause:"
-msgstr "Cláusula inválida:"
+msgstr "Điều khoản không hợp lệ:"
 
 #: src/metabase/mbql/util.clj
 msgid "Error: query's source query has not been resolved. You probably need to `preprocess` the query first."
-msgstr "Error: la consulta fuente de la consulta no se ha resuelto. Probablemente necesite 'preprocesar' la consulta primero."
+msgstr "Lỗi: truy vấn nguồn của truy vấn chưa được giải quyết. Bạn có thể cần phải 'tiền xử lý' truy vấn trước."
 
 #: src/metabase/mbql/util.clj
 msgid "No expression named ''{0}''"
-msgstr "No hay ninguna expresión llamada \"{0}\""
+msgstr "Không có biểu thức có tên '' {0} ''"
 
 #: src/metabase/mbql/util.clj
 msgid "No aggregation at index: {0}"
-msgstr "No hay agregación en el índice: {0}"
+msgstr "Không tổng hợp tại chỉ mục: {0}"
 
 #: src/metabase/models/field_values.clj
 msgid "Field values total length is {0} (max {1})."
-msgstr "La longitud total de los valores de campo es {0} (máx {1})."
+msgstr "Tổng giá trị trường dài {{} (tối đa {1})."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues are allowed for this Field."
-msgstr "Se permiten Valores de Campo para este Campo."
+msgstr "FieldValues được phép cho Trường này."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues are NOT allowed for this Field."
-msgstr "NO se permiten Valores de Campo para este campo."
+msgstr "Trường {0} '' {1} '' nên có FieldValues và thuộc về Cơ sở dữ liệu với Cập nhật FieldValues theo yêu cầu."
 
 #: src/metabase/models/field_values.clj
 msgid "Field {0} ''{1}'' should have FieldValues and belongs to a Database with On-Demand FieldValues updating."
-msgstr "El campo {0} ''{1}'' debe tener valores de campo y pertenece a una base de datos con la actualización de valores de campo bajo demanda."
+msgstr "Trường {0} '' {1} '' nên có FieldValues và thuộc về Cơ sở dữ liệu với Cập nhật FieldValues theo yêu cầu."
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot create or revoke permissions for the ''Admin'' group."
-msgstr "No puedes crear ni revocar permisos para el grupo ''Admin''."
+msgstr "Bạn không thể tạo hoặc thu hồi quyền cho nhóm '' Quản trị viên ''."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the ''MetaBot'' group."
-msgstr "No puedes agregar o eliminar usuarios del grupo ''MetaBot''."
+msgstr "Bạn không thể thêm hoặc xóa người dùng vào / ra khỏi nhóm '' MetaBot ''."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the ''All Users'' group."
-msgstr "No puedes agregar o eliminar usuarios del grupo \"Todos los usuarios\"."
+msgstr "Bạn không thể thêm hoặc xóa người dùng vào / ra khỏi nhóm '' Tất cả người dùng '."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot remove the last member of the ''Admin'' group!"
-msgstr "¡No puedes eliminar al último miembro del grupo ''Admin''!"
+msgstr "Bạn không thể xóa thành viên cuối cùng của nhóm '' Quản trị viên ''!"
 
 #. go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
 #: src/metabase/models/setting/cache.clj
 msgid "Error inserting a new Setting: {0}"
-msgstr "Error registrando la nueva configuración: {0}"
+msgstr "Lỗi khi chèn Cài đặt mới: {0}"
 
 #: src/metabase/models/setting.clj
 msgid "defsetting descriptions strings must be `:internal?` or internationalized, found: `{0}`"
-msgstr "las cadenas de descripciones defsetting deben ser `:internal?` o traducidas, encontradas: `{0}`"
+msgstr "làm mờ các chuỗi mô tả phải là `: Internal?` hoặc được quốc tế hóa, được tìm thấy: `{0}`"
 
 #: src/metabase/plugins.clj
 msgid "Loading plugin {0}... {1}"
-msgstr "Cargando extensión {0}... {1}"
+msgstr "Đang tải plugin {0} ... {1}"
 
 #: src/metabase/public_settings.clj
 msgid "Object keyed by type, containing formatting settings"
-msgstr "Objeto tecleado por tipo, contiene ajustes de formato"
+msgstr "Đối tượng được khóa theo loại, chứa các cài đặt định dạng"
 
 #: src/metabase/public_settings.clj
 msgid "Allow users to explore data using X-rays"
-msgstr "Permitir que los usuarios hagan uso de Rayos-X"
+msgstr "Cho phép người dùng khám phá dữ liệu bằng tia X"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Using this URL to check token: {0}"
-msgstr "Utilizando esta URL para validar el símbolo: {0}"
+msgstr "Sử dụng URL này để kiểm tra mã thông báo: {0}"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Unable to validate token: 404 not found."
-msgstr "No se ha podido validar el símbolo: 404 no encontrado."
+msgstr "Không thể xác thực mã thông báo: Không tìm thấy 404."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "There was an error checking whether this token was valid:"
-msgstr "Se produjo un error al verificar si este token era válido:"
+msgstr "Có lỗi khi kiểm tra xem mã thông báo này có hợp lệ không:"
 
 #. +----------------------------------------------------------------------------------------------------------------+
 #. |                                             SETTING & RELATED FNS                                              |
@@ -9944,270 +9909,270 @@ msgstr "Se produjo un error al verificar si este token era válido:"
 #. TODO - rename this to premium-features-token?
 #: src/metabase/public_settings/metastore.clj
 msgid "Token for premium features. Go to the MetaStore to get yours!"
-msgstr "Token para características premium. ¡Ve a MetaStore para conseguir el tuyo!"
+msgstr "Mã thông báo cho các tính năng cao cấp. Truy cập MetaStore để lấy của bạn!"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token format is invalid. Token should be 64 hexadecimal characters."
-msgstr "El formato del token no es válido. El token debe tener 64 caracteres hexadecimales."
+msgstr "Định dạng mã thông báo không hợp lệ. Mã thông báo phải là 64 ký tự thập lục phân."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error setting premium features token"
-msgstr "Error al configurar el token de características premium"
+msgstr "Lỗi thiết lập mã thông báo tính năng cao cấp"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error validating token:"
-msgstr "Error validando el símbolo:"
+msgstr "Lỗi xác thực mã thông báo:"
 
 #: src/metabase/query_processor.clj
 msgid "Error preprocessing query"
-msgstr "Error procesando la consulta"
+msgstr "Lỗi truy vấn tiền xử lý"
 
 #: src/metabase/query_processor.clj
 msgid "No native form returned."
-msgstr "No se ha obtenido un formulario nativo."
+msgstr "Không có hình thức bản địa trở lại."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
-msgstr "Respuesta no válida del controlador de base de datos. No se ha definido el estado."
+msgstr "Phản hồi không hợp lệ từ trình điều khiển cơ sở dữ liệu. Không: tình trạng được cung cấp."
 
 #: src/metabase/query_processor.clj
 msgid "General error"
-msgstr "Error general"
+msgstr "Lỗi chung"
 
 #: src/metabase/query_processor.clj
 msgid "Missing query hash!"
-msgstr "¡Falta el hash de consulta!"
+msgstr "Thiếu băm truy vấn!"
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Table ''{0}'' has no Fields associated with it."
-msgstr "La tabla '' {0} '' no tiene campos asociados."
+msgstr "Bảng '' {0} '' không có Trường liên quan đến nó.Đạt đến giới hạn truy vấn đồng thời tối đa"
 
 #: src/metabase/query_processor/middleware/add_query_throttle.clj
 msgid "Max concurrent query limit reached"
-msgstr "Se ha alcanzado el máximo de consultas concurrentes"
+msgstr "Bảng '' {0} '' không có Trường liên quan đến nó.Đạt đến giới hạn truy vấn đồng thời tối đa"
 
 #. we should never reach this if our patterns are written right so this is more to catch code mistakes than
 #. something the user should expect to see
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Don't know how to get information about Field:"
-msgstr "No se cómo obtener información del Campo:"
+msgstr "Không biết cách lấy thông tin về Trường:"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "metabase.query-processor.interface/*driver* is unbound."
-msgstr "metabase.query-processor.interface/*driver* no está definido."
+msgstr "metabase.query-processor.interface/*driver* không bị ràng buộc."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Query processor error: mismatched number of columns in query and results."
-msgstr "Error del procesador de consultas: número de columnas no coincidentes en la consulta y los resultados."
+msgstr "Lỗi bộ xử lý truy vấn: số lượng cột không khớp trong truy vấn và kết quả."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected {0} fields, got {1}"
-msgstr "Esperaba {0} campos pero hay {1}"
+msgstr "Các trường {0} dự kiến, đã nhận {1}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected: {0}"
-msgstr "Esperado: {0}"
+msgstr "Dự kiến: {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Actual: {0}"
-msgstr "Actual: {0}"
+msgstr "Thực tế: {0}"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Unable to bin Field without a min/max value"
-msgstr "No se puede agrupar el campo sin un valor mínimo/máximo"
+msgstr "Không thể bin Field mà không có giá trị tối thiểu / tối đa"
 
 #: src/metabase/query_processor/middleware/check_features.clj
 msgid "{0} is not supported by this driver."
-msgstr "Este controlador no soporta {0}"
+msgstr "{0} không được trình điều khiển này hỗ trợ."
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Segment {0} does not exist, or is invalid."
-msgstr "El segmento {0} no existe o es inválido."
+msgstr "Phân đoạn {0} không tồn tại hoặc không hợp lệ."
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Metric {0} does not exist, or is invalid."
-msgstr "La Métrica {0} no existe o es inválida."
+msgstr "Số liệu {0} không tồn tại hoặc không hợp lệ."
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Missing source query in Card {0}"
-msgstr "Falta la consulta de origen en la tarjeta {0}"
+msgstr "Thiếu truy vấn nguồn trong Thẻ {0}"
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Fetched source query from Card {0}:"
-msgstr "Leído la consulta de origen de la tarjeta {0}:"
+msgstr "Truy vấn nguồn được tìm nạp từ Thẻ {0}:"
 
 #: src/metabase/query_processor/middleware/mbql_to_native.clj
 msgid "Error transforming MBQL query to native:"
-msgstr "Error al transformar la consulta MBQL a nativo:"
+msgstr "Lỗi khi chuyển đổi truy vấn MBQL thành nguồn gốc:"
 
 #: src/metabase/query_processor/middleware/resolve_source_table.clj
 msgid "Cannot run query: could not find source table {0}."
-msgstr "No se ha podido ejecutar la consulta: no se ha encontrado la tabla origen {0}."
+msgstr "Không thể chạy truy vấn: không thể tìm thấy bảng nguồn {0}."
 
 #: src/metabase/query_processor/middleware/results_metadata.clj
 msgid "Error recording results metadata for query:"
-msgstr "Error al registrar los metadatos de resultados para la consulta:"
+msgstr "Lỗi ghi siêu dữ liệu kết quả cho truy vấn:"
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Query Processor store is not initialized."
-msgstr "Error: el almacén del procesador de consultas no está inicializada."
+msgstr "Lỗi: Cửa hàng Bộ xử lý truy vấn không được khởi tạo."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Table {0} is not present in the Query Processor Store."
-msgstr "Error: la tabla {0} no está presente en el almacén del procesador de consultas."
+msgstr "Lỗi: Bảng {0} không có trong Cửa hàng Bộ xử lý truy vấn."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Field {0} is not present in the Query Processor Store."
-msgstr "Error: el campo {0} no está presente en el almacén del procesador de consultas."
+msgstr "Lỗi: Trường {0} không có trong Cửa hàng Bộ xử lý truy vấn."
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, rows were {0}deleted"
-msgstr "La limpieza del historial de tareas fue exitosa, {0} se eliminaron filas"
+msgstr "Dọn dẹp lịch sử nhiệm vụ thành công, các hàng đã bị xóa {0}"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "not"
-msgstr "no"
+msgstr "không phải"
 
 #: src/metabase/db.clj src/metabase/util/encryption.clj
 msgid "For more information, see"
-msgstr "Para obtener más información, visita"
+msgstr "Để biết thêm thông tin, xem"
 
 #: src/metabase/util/schema.clj
 msgid "Integer greater than or equal to zero"
-msgstr "Entero mayor o igual a cero"
+msgstr "Số nguyên lớn hơn hoặc bằng 0"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer greater than or equal to zero."
-msgstr "valor debe ser un entero igual o superior a cero."
+msgstr "giá trị phải là số nguyên lớn hơn hoặc bằng 0."
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer zero or greater."
-msgstr "valor debe ser un entero igual o superior a cero."
+msgstr "giá trị phải là số nguyên bằng 0 hoặc lớn hơn."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer greater than or equal to zero."
-msgstr "valor debe ser un entero igual o superior a cero."
+msgstr "giá trị phải là số nguyên hợp lệ lớn hơn hoặc bằng 0."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "New users per state in the last 30 days"
-msgstr "Nuevos usuarios por estado en los últimos 30 días"
+msgstr "Người dùng mới cho mỗi tiểu bang trong 30 ngày qua"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by day of the week"
-msgstr "Creado por día de la semana"
+msgstr "Tạo vào ngày trong tuần"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by quarter of the year"
-msgstr "Creado por trimestre"
+msgstr "Tạo vào lúc một phần tư của năm"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per country"
-msgstr "[[this.short-name]] por país"
+msgstr "[[this.short-name]] mỗi quốc gia"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Users per source"
-msgstr "Usuarios por origen"
+msgstr "Người dùng mỗi nguồn"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "The top external pages that brought users to your site"
-msgstr "Las principales páginas externas que trajeron usuarios a tu sitio."
+msgstr "Các trang bên ngoài hàng đầu đã đưa người dùng đến trang web của bạn"
 
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
-msgstr "Cómo se distribuye [[this]] y algo más."
+msgstr "Cách [[này]] được phân phối và hơn thế nữa"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "The [[this]] over time"
-msgstr "El [[this]] a lo largo del tiempo"
+msgstr "[[This]] theo thời gian"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "User growth"
-msgstr "Crecimiendo de usuarios"
+msgstr "Tăng trưởng người dùng"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Whether or not there are any patterns to when they happen."
-msgstr "Si hay o no patrones para cuando suceden."
+msgstr "Có hay không có bất kỳ mô hình nào khi chúng xảy ra."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Users per state"
-msgstr "Usuarios por provincia"
+msgstr "Người dùng mỗi tiểu bang"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions"
-msgstr "Sesiones"
+msgstr "Phiên"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "How some of the numbers in [[this]] relate to each other"
-msgstr "Cómo algunos de los números en [[this]] se relacionan entre sí"
+msgstr "Làm thế nào một số số trong [[này]] liên quan với nhau"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per country"
-msgstr "Ventas por país"
+msgstr "Bán hàng mỗi quốc gia"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by month of the year"
-msgstr "Unir fecha por el mes del año"
+msgstr "Tham gia ngày theo tháng trong năm"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by hour of the day"
-msgstr "[[Timestamp]] por hora del día"
+msgstr "[[Dấu thời gian]] theo giờ trong ngày"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "A look at the [[this]]"
-msgstr "Un vistazo a [[this]]"
+msgstr "Nhìn vào [[này]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Bottom 5 per category"
-msgstr "Ultimos 5 por categoría"
+msgstr "5 dưới cùng cho mỗi loại"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Number of orders"
-msgstr "Número de pedidos"
+msgstr "Số lượng đơn đặt hàng"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Event growth"
-msgstr "Crecimiento de Eventos"
+msgstr "Tăng trưởng sự kiện"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "Total [[GenericTable]]"
-msgstr "Total [[GenericTable]]"
+msgstr "Tổng số [[Bảng chung]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Income growth"
-msgstr "Crecimiento de Ingresos"
+msgstr "Tăng trưởng thu nhập"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top 10 countries by sales in the last 30 days"
-msgstr "Primeros 10 paises por ventas en los últimos 30 días"
+msgstr "10 quốc gia hàng đầu theo doanh số trong 30 ngày qua"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by month of the year"
-msgstr "[[this]] por mes del año"
+msgstr "[[này]] theo tháng trong năm"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per day of the week"
-msgstr "Transacciones por día de la semana"
+msgstr "Giao dịch mỗi ngày trong tuần"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by device type"
-msgstr "Sesiones por dispositivo"
+msgstr "Phiên theo loại thiết bị"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Transactions per country"
-msgstr "Transacciones por país"
+msgstr "Giao dịch mỗi quốc gia"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by quarter of the year"
-msgstr "Unir fecha por trimestre"
+msgstr "Tham gia ngày theo quý"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per hour of the day"
-msgstr "Eventos por hora del día"
+msgstr "Sự kiện mỗi giờ trong ngày"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Singleton]]"
@@ -10216,20 +10181,20 @@ msgstr "[[Singleton]]"
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Top 5 [[this]]"
-msgstr "Primeros 5 [[this]]"
+msgstr "Top 5 [[này]]"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Bottom 5 [[this]]"
-msgstr "Ultimos 5 [[this]]"
+msgstr "Dưới 5 [[này]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by day of the month"
-msgstr "[[Timestamp]] por día del mes"
+msgstr "[[Dấu thời gian]] theo ngày trong tháng"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[GenericCategoryLarge]]"
-msgstr "Por [[GenericCategoryLarge]]"
+msgstr "Mỗi [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10237,335 +10202,335 @@ msgstr "Por [[GenericCategoryLarge]]"
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "Null values"
-msgstr "Valores nulos"
+msgstr "Giá trị không"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Total events"
-msgstr "Total eventos"
+msgstr "Tổng số sự kiện"
 
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "A look at [[GenericTable]] across your [[this]], and how it changes over time."
-msgstr "Una mirada a [[GenericTable]] a través de tu [[this]], y cómo cambia con el tiempo."
+msgstr "Hãy xem [[GenericTable]] trên [[này]] và cách nó thay đổi theo thời gian."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryMedium]]"
-msgstr "[[this]] por [[GenericCategoryMedium]]"
+msgstr "[[này]] mỗi [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] changes with time"
-msgstr "Como el [[this]] cambia con el tiempo"
+msgstr "Cách [[này]] thay đổi theo thời gian"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "How they compare by seasonality"
-msgstr "Cómo se comparan por estacionalidad."
+msgstr "Làm thế nào họ so sánh theo mùa"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average income per transaction"
-msgstr "Ingreso medio por transacción"
+msgstr "Thu nhập trung bình trên mỗi giao dịch"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per country"
-msgstr "[[this]] por país"
+msgstr "[[này]] mỗi quốc gia"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Income per state"
-msgstr "Ingresos por provincia"
+msgstr "Thu nhập mỗi bang"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[GenericCategoryMedium]]"
-msgstr "Por [[GenericCategoryMedium]]"
+msgstr "Mỗi [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "A closer look at your [[this]]"
-msgstr "Una mirada detallada a tus [[this]]"
+msgstr "Nhìn kỹ hơn vào [[này]]"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "How [[GenericNumber]] is distributed"
-msgstr "Como se distribuye [[GenericNumber]]"
+msgstr "Cách [[GenericNumber]] được phân phối"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by quarter of year"
-msgstr "[[Timestamp]] por trimestre"
+msgstr "[[Dấu thời gian]] theo quý"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per country"
-msgstr "Eventos por país"
+msgstr "Sự kiện mỗi quốc gia"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Weekdays when [[this.short-name]] were added"
-msgstr "Días de la semana cuando se añadío [[this.short-name]]"
+msgstr "Các ngày trong tuần khi [[this.short-name]] đã được thêm vào"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Months when [[this.short-name]] were added"
-msgstr "Mes cuando se añadío [[this.short-name]]"
+msgstr "Các tháng khi [[this.short-name]] được thêm vào"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across different categories"
-msgstr "Cómo se comparan en diferentes categorías"
+msgstr "Làm thế nào họ so sánh giữa các loại khác nhau"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "New users per source in the last 30"
-msgstr "Nuevos usuarios por origen en los últimos 30 días"
+msgstr "Người dùng mới trên mỗi nguồn trong 30 gần nhất"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per quarter of the year"
-msgstr "Eventos por trimestre"
+msgstr "Sự kiện mỗi quý trong năm"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Heres a quick look at your [[this]]"
-msgstr "Una mirada rápida a tus [[this]]"
+msgstr "Đây là một cái nhìn nhanh về [[này]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryLarge]], top 5"
-msgstr "[[this]] por [[GenericCategoryLarge]], primeros 5"
+msgstr "[[this]] mỗi [[GenericC CategoryLarge]], top 5"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Days when [[this.short-name]] were added"
-msgstr "Días en los que se añadío [[this.short-name]]"
+msgstr "Ngày khi [[this.short-name]] được thêm vào"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Total orders per source"
-msgstr "Pedidos totales por origen"
+msgstr "Tổng số đơn hàng trên mỗi nguồn"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by quarter of the year"
-msgstr "[[this]] por trimestre"
+msgstr "[[này]] theo quý của năm"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per [[GenericCategoryMedium]]"
-msgstr "Eventos por [[GenericCategoryMedium]]"
+msgstr "Sự kiện trên [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per state"
-msgstr "Eventos por provincia"
+msgstr "Sự kiện mỗi tiểu bang"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top landing pages"
-msgstr "Las mejores páginas de aterrizaje"
+msgstr "Trang đích hàng đầu"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Heres a closer look at your [[this]] over time"
-msgstr "Una mirada detallada a tus [[this]] a lo largo del tiempo"
+msgstr "Đây là một cái nhìn gần hơn về [[này]] theo thời gian"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Sum of [[this]] by [[Country]]"
-msgstr "Suma de [[this]] por [[Country]]"
+msgstr "Tổng của [[này]] bởi [[Quốc gia]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "States that are performing best"
-msgstr "Las provincia con mejores resultados"
+msgstr "Các tiểu bang đang hoạt động tốt nhất"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by month of the year"
-msgstr "Creado por mes del año"
+msgstr "Tạo vào tháng của năm"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Sum of [[this]] by [[State]]"
-msgstr "Suma de [[this]] por [[State]]"
+msgstr "Tổng của [[này]] bởi [[Bang]]"
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "Sum of [[GenericNumber]] per [[this]]"
-msgstr "Suma de [[GenericNumber]] por [[this]]"
+msgstr "Tổng của [[GenericNumber]] mỗi [[này]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by coordinates"
-msgstr "Eventos por coordenadas"
+msgstr "Sự kiện theo tọa độ"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top referral pages"
-msgstr "Las mejores páginas de referencia"
+msgstr "Trang tham chiếu hàng đầ"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "An exploration of your users to get you started."
-msgstr "Un exploración de tus usuarios para empezar."
+msgstr "Một cuộc thăm dò người dùng của bạn để giúp bạn bắt đầu."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "An overview of your [[this]] and how its distributed across time, place, and categories."
-msgstr "Una visión general de tu [[this]] y cómo se distribuye en el tiempo, el lugar y las categorías."
+msgstr "Tổng quan về [[này]] của bạn và cách phân bổ theo thời gian, địa điểm và danh mục."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Average income per state"
-msgstr "Ingresos medios por provincia"
+msgstr "Thu nhập trung bình trên mỗi huyện"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
-msgstr "[[this]] por [[GenericCategoryMedium]]"
+msgstr "[[this]] bởi [[GenericCategoryMedium]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total transactions"
-msgstr "Total transacciones"
+msgstr "Tổng số giao dịch"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] that have joined over time"
-msgstr "[[this.short-name]] que se han unido a lo largo del tiempo"
+msgstr "[[this.short-name]] đã tham gia theo thời gian"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "The [[this]] by location"
-msgstr "Los [[this]] por ubicación"
+msgstr "[[This]] theo vị trí"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per month of the year"
-msgstr "Eventos por mes del año"
+msgstr "Sự kiện mỗi tháng trong năm"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] by [[GenericNumber]]"
-msgstr "[[this]] por [[GenericNumber]]"
+msgstr "[[this]] bởi [[GenericNumber]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Quarters when [[this.short-name]] were added"
-msgstr "Trimestres en los que se añadío [[this.short-name]]"
+msgstr " Một quý khi [[this.short-name]] đã được thêm vào"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "How these [[this.short-name]] are distributed"
-msgstr "Como se distribuyen [[this.short-name]]"
+msgstr "những [[this.short-name]] này được phân bổ như thế nào"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by [[GenericNumber]]"
-msgstr "[[this.short-name]] por [[GenericNumber]]"
+msgstr "[[this.short-name]] bởi [[GenericNumber]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Where users are coming from"
-msgstr "De donde vienen los usuarios"
+msgstr "Người dùng đến từ đâu"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "[[this]] comparisons and correlations"
-msgstr "comparaciones y correlaciones de [[this]]"
+msgstr "[[this]] so sánh và tương quan"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total income"
-msgstr "Ingreso total"
+msgstr "Tổng thu nhậ"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total income per month"
-msgstr "Inrgeso total por mes"
+msgstr "Tổng thu nhập mỗi tháng"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Number of users per source"
-msgstr "Número de usuarios por origen"
+msgstr "Số lượng người dùng trên mỗi nguồn"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Transactions per state"
-msgstr "Transacciones por provincia"
+msgstr "Giao dịch trên mỗi huyện"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "[[this]] by [[Timestamp]]"
-msgstr "[[this]] por [[Timestamp]]"
+msgstr "[[this]] bởi [[Timestamp]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "New users per source in the last 30 days"
-msgstr "Nuevos usuarios por origen en los últimos 30 días"
+msgstr "Người dùng mới trên mỗi nguồn trong 30 ngày qua"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by day of the month"
-msgstr "Unir fecha por el día del mes"
+msgstr "Ngày tham gia theo ngày trong tháng"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average discount %"
-msgstr "Descuento medio %"
+msgstr "Chiết khấu trung bình%"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Autogenerated metrics about [[GenericTable]]."
-msgstr "Métricas autogeneradas sobre [[GenericTable]]."
+msgstr "Số liệu được tạo tự động về [[GenericTable]]."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per day of the month"
-msgstr "[[this]] por día del mes"
+msgstr "[[this]] mỗi ngày trong tháng"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Total sessions in each country"
-msgstr "Sesiones totales en cada país"
+msgstr "Tổng số phiên tại mỗi quốc gia"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per month of the year"
-msgstr "Transacciones por mes"
+msgstr "Giao dịch mỗi tháng trong năm"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per product"
-msgstr "Ventas por producto"
+msgstr "Doanh số trên mỗi sản phẩm"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Users in each country"
-msgstr "Usuarios en cada país"
+msgstr "Người dùng ở mỗi quốc gia"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by hour of the day"
-msgstr "[[this]] por hora del día"
+msgstr "[[this]] theo giờ trong ngày"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events in the last 30 days"
-msgstr "Eventos en los últimos 30 días"
+msgstr "Sự kiện trong 30 ngày qua"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Transactions per source"
-msgstr "Transacciones por origen"
+msgstr "Giao dịch trên mỗi nguồn"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Where youve acquired your users"
-msgstr "De dónde provienen tus usuarios"
+msgstr "Nơi bạn đã có được người dùng của bạn"
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare acrosss location"
-msgstr "Como se comparan por ubicación"
+msgstr "Làm thế nào họ so sánh giữa các vị trí"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "[[this]] per product"
-msgstr "[[this]] por producto"
+msgstr "[[this]] trên mỗi sản phẩm"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per month of the year"
-msgstr "[[this]] por mes del año"
+msgstr "[[this]] mỗi tháng trong năm"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per country"
-msgstr "Por país"
+msgstr " Trên mỗi vùng"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "A deeper look at how different countries are performing for you."
-msgstr "Una mirada más profunda al rendimiento de los diferentes países."
+msgstr "Một cái nhìn sâu sắc hơn về cách các vùng khác nhau đang thực hiện cho bạn."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per state"
-msgstr "Ventas por provincia"
+msgstr "Doanh số trên huyệ"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by [[GenericNumber]]"
-msgstr "Eventos por [[GenericNumber]]"
+msgstr "Sự kiện theo [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales per product [[ProductCategoryMedium]]"
-msgstr "Ventas por producto [[ProductCategoryMedium]]"
+msgstr "Doanh số trên mỗi sản phẩm [[ProductC CategoryMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "User acquisition by country"
-msgstr "Adquisición de usuarios por país"
+msgstr "Người dùng mua lại theo vùn"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "[[this]] per source"
-msgstr "[[this]] por origen"
+msgstr "[[this]] trên mỗi nguồn"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by day of the week"
-msgstr "[[this]] por día de la semana"
+msgstr "[[this]] theo ngày trong tuầ"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Days of the month when [[this.short-name]] joined"
-msgstr "Días del mes cuando se juntan [[this.short-name]]"
+msgstr "Ngày trong tháng khi [[this.short-name]] tham gia"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Heres an overview of the people in your [[this]]"
-msgstr "Aquí hay una visión general de las personas en tu [[this]]"
+msgstr "Đây là tổng quan về những người trong [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "How [[GenericTable]] are distributed across this time field, and if it has any seasonal patterns."
-msgstr "Cómo [[GenericTable]] se distribuye en este campo de tiempo, y si tiene algún patrón estacional."
+msgstr "Cách [[GenericTable]] được phân bổ trên trường thời gian này nếu nó có bất kỳ mẫu theo mùa nào."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10576,200 +10541,200 @@ msgstr "Cómo [[GenericTable]] se distribuye en este campo de tiempo, y si tiene
 #: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Overview"
-msgstr "Visión general"
+msgstr "Tổng qua"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How this metric is distributed across different categories"
-msgstr "Cómo se distribuye esta métrica en diferentes categorías."
+msgstr "Cách số liệu này được phân bổ trên các danh mục khác nhau"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per state"
-msgstr "[[this.short-name]] por provincia"
+msgstr "[[this.short-name]] trên từng huyệ"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Weekdays when [[this.short-name]] joined"
-msgstr "Días de la semana cuando se une por [[this.short-name]]"
+msgstr "Các ngày trong tuần khi [[this.short-name]] tham gia"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Hours when [[this.short-name]] joined"
-msgstr "Horas cuando se une por [[this.short-name]]"
+msgstr "Giờ khi [[this.short-name]] tham gia"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Total income by month"
-msgstr "Ingreso total por mes"
+msgstr "Tổng thu nhập theo tháng"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "A breakdown of your [[this]] over time, and its min, max, average and more."
-msgstr "Un desglose de tu [[this]] a lo largo del tiempo, y su mínimo, máximo, promedio y más."
+msgstr "Phân tích [[này]] của bạn theo thời gian và giá trị tối thiểu, tối đa, trung bình và nhiều hơn."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Average quantity per state"
-msgstr "Cantidad media por provincia"
+msgstr "Số lượng trung bình trên mỗi huyện"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare by across different numbers"
-msgstr "Cómo se comparan por diferentes números"
+msgstr "Làm thế nào họ so sánh được qua các số khác nhau"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "New users per country in the last 30 days"
-msgstr "Nuevos usuarios por país en los últimos 30 días"
+msgstr "Người dùng mới mỗi vùng trong 30 ngày qua"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions over time"
-msgstr "Transacciones a lo largo del tiempo."
+msgstr "Giao dịch theo thời gian"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategorySmall]]"
-msgstr "[[this]] por [[GenericCategorySmall]]"
+msgstr "[[this]] trên mỗi [[GenericCargetSmall]]"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Some breakdown"
-msgstr "Algún desglose"
+msgstr "Một số sự cố"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Average of [[this]] by [[State]]"
-msgstr "Media de [[this]] por [[State]]"
+msgstr "Trung bình của [[this]] bởi [[state]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per quarter of the year"
-msgstr "Transacciones por trimestre"
+msgstr "Giao dịch trên một quý của nă"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "By coordinates"
-msgstr "Por coordenadas"
+msgstr "Theo hệ toạ đ"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Heres a closer look at your [[this]] by products"
-msgstr "Una mirada detallada de tus [[this]] por productos"
+msgstr "Đây là một cái nhìn cận cảnh hơn về [[this]] bởi các sản phẩm"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per quarter of the year"
-msgstr "[[this]] por trimestre"
+msgstr "[[this]] theo một quý trong nă"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Heres an overview of your [[this]] data from Google Analytics"
-msgstr "Aquí hay un resumen de tus datos [[this]] de Google Analytics"
+msgstr "Đây là tổng quan về dữ liệu [[this]] của bạn từ Google Analytics"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Quarters when [[this.short-name]] joined"
-msgstr "Trimestres cuando se une por [[this.short-name]]"
+msgstr " Quý khi [[this.short-name]] đã tham gia"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "New [[this.short-name]] in the last 30 days"
-msgstr "Nuevo [[this.short-name]] en los últimos 30 días"
+msgstr "[[this.short-name]] mới trong 30 ngày qua"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Total sessions by desktop, mobile, or tablet"
-msgstr "Sesiones totales por ordenador, móvil o tablet"
+msgstr "Tổng số phiên bằng máy tính để bàn, thiết bị di động hoặc máy tính bảng"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "Indepth example"
-msgstr "Ejemplo en profundidad"
+msgstr "Ví dụ hoàn toà"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average income per source"
-msgstr "Ingreso medio por origen"
+msgstr "Thu nhập trung bình trên mỗi nguồn"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by day of week"
-msgstr "[[Timestamp]] por día de la semana"
+msgstr "[[Timestamp]] theo ngày trong tuầ"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "Heres a closer look at your [[this]]"
-msgstr "Aquí hay una mirada más detallada a tus [[this]]"
+msgstr "Đây là một cái nhìn gần hơn về [[this]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Heres a closer look at your [[this]] field"
-msgstr "Una mirada detallada de tu campo [[this]]"
+msgstr "Đây là một cái nhìn gần hơn về trường [[this]] của bạ"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Summary"
-msgstr "Resumen"
+msgstr "Tóm lượ"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] is distributed geographically"
-msgstr "Cómo se distribuye geográficamente el [[this]]"
+msgstr "Cách [[this]] được phân bổ theo địa lý"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "The pages with the most pageviews"
-msgstr "Las páginas con más visitas"
+msgstr "Các trang có nhiều lượt xem nhất"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "How [[Number1]] is correlated with [[Number2]]"
-msgstr "La correlación entre [[Number1]] y [[Number2]]"
+msgstr "Cách [[Number1]] tương quan với [[Number2]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Top 10 states by sales in the last 30 days"
-msgstr "Primeras 10 provincias por venta en los últimos 30 días"
+msgstr "10 huyện hàng đầu theo doanh số trong 30 ngày qua"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Top 10 states by sales"
-msgstr "Primeras 10 provincia por ventas"
+msgstr "10 huyện hàng đầu theo doanh s"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Timestamp]]"
-msgstr "[[Timestamp]]"
+msgstr "[[Timestamp]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Where these transactions happened"
-msgstr "Donde occurrieron estas transacciones"
+msgstr "những giao dịch này xảy ra ở đâu"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top 10 countries by sales"
-msgstr "Primeros 10 paises por ventas"
+msgstr "10 vùng theo doanh s"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by state"
-msgstr "Ventas por provincia"
+msgstr "doanh số theo huyệ"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Where most of your sessions originate from"
-msgstr "De donde provienen la mayoría de las sesiones"
+msgstr " Nơi hầu hết các phiên của bạn bắt nguồn từ"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top acquisition channels"
-msgstr "Los mejores canales de adquisición"
+msgstr "Các kênh mua lại hàng đầu"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "These [[this.short-name]] across time"
-msgstr "Estos [[this.short-name]] a lo largo del tiempo"
+msgstr "Những [[this.short-name]] theo thời gian"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average quantity"
-msgstr "Cantidad media"
+msgstr "Số lượng trung bìn"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per source"
-msgstr "Ventas por origen"
+msgstr "Doanh số theo nguồ"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Average income per country"
-msgstr "Ingreso medio por país"
+msgstr "Thu nhập bình quân theo vùn"
 
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
-msgstr "Como se distribuye [[this]]"
+msgstr "Cách [[this]] được phân b"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Distinct [[FK]]"
-msgstr "[[FK]] distintos"
+msgstr " [[FK]] Khác biệt"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "How these transactions are distributed"
-msgstr "Como se distribuyen estas transacciones"
+msgstr "Cách những giao dịch này được phân bổ"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per state"
-msgstr "Por provincias"
+msgstr "Trên mỗi huyệ"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "Count of [[GenericCategoryMedium]] by [[this]]"
-msgstr "Cuenta de [[GenericCategoryMedium]] por [[this]]"
+msgstr "Đếm [[GenericCategoryMedium]] theo [[this]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10784,68 +10749,68 @@ msgstr "Cuenta de [[GenericCategoryMedium]] por [[this]]"
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "A look at your [[this]]"
-msgstr "Una mirada a tus [[this]]"
+msgstr "Xem [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "[[GenericNumber]] by [[this]]"
-msgstr "[[GenericNumber]] por [[this]]"
+msgstr "[[GenericNumber]] theo [[this]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Sum of [[GenericNumber]] by [[this]]"
-msgstr "Suma de [[GenericNumber]] por [[this]]"
+msgstr "Tổng [[GenericNumber]] theo [[this]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A look at your [[this]] table"
-msgstr "Una mirada a tu tabla [[this]]"
+msgstr "Xem bảng [[this]] của bạ"
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "How many [[GenericTable]] there are per state, and how each state is represented across other categories."
-msgstr "Cuántos [[GenericTable]] hay por provincia y cómo se representa cada estado en otras categorías."
+msgstr " Có bao nhiêu [[GenericTable]] mỗi huyện, và làm thế nào mỗi huyện được đại diện trên các loại khác."
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Most-viewed pages"
-msgstr "Páginas más vistas"
+msgstr "Trang được xem nhiều nhấ"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Example exploration"
-msgstr "Exploración de ejemplo"
+msgstr "Ví dụ thăm d"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales vs. rating"
-msgstr "Ventas vs. Clasificación"
+msgstr "Doanh số và xếp hạn"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per hour of the day"
-msgstr "[[this]] por hora del día"
+msgstr "[[this]] trên mỗi giờ trong ngà"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Where your [[this.short-name]] are"
-msgstr "Donde están tus [[this.short-name]]"
+msgstr "[[this.short-name]] của bạn ở đâ"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "These are the same for all your [[this.short-name]]"
-msgstr "Estos son los mismos para todos los [[this.short-name]]"
+msgstr "Tất cả đều giống [[this.short-name]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by different categories"
-msgstr "Eventos por diferentes categorías"
+msgstr "Sự kiện theo danh mục khác nhau"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Where these [[this.short-name]] are"
-msgstr "Donde están estos [[this.short-name]]"
+msgstr "Những [[this.short-name]] này ở đâ"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Over time"
-msgstr "A lo largo del tiempo"
+msgstr "theo thời gia"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A summary of the events in your [[this]] table"
-msgstr "Un resumen de los eventos en tu tabla [[this]]"
+msgstr "Tóm tắt về các sự kiện trong bảng [[this]] của bạn"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Transactions per source over time"
-msgstr "Transacciones por origen a lo largo del tiempo."
+msgstr "Giao dịch trên mỗi nguồn theo thời gia"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10853,221 +10818,221 @@ msgstr "Transacciones por origen a lo largo del tiempo."
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "How the [[this]] is distributed"
-msgstr "Como se distribuye el [[this]]"
+msgstr " Cách [[this]] được phân b"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Total income per source"
-msgstr "Ingreso total por origen"
+msgstr "Tổng thu nhập trên mỗi nguồ"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Total [[this.short-name]]"
-msgstr "Total [[this.short-name]]"
+msgstr "Tổng [[this.short-name]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Some metrics we found about your transactions."
-msgstr "Algunas métricas que encontramos sobre tus transacciones."
+msgstr "Một số số liệu chúng tôi tìm thấy về các giao dịch của bạn."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "How your different products are performing."
-msgstr "Rendimiento de tus productos."
+msgstr "các sản phẩm khác nhau của bạn đang hoạt động như thế nào."
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Where these events are happening"
-msgstr "Donde occuren estos eventos"
+msgstr "Các sự kiện này xảy ra ở đâ"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Which US states are bringing you the most business."
-msgstr "Qué estados de los EEUU te están dando más negocio"
+msgstr "Những tiểu bang nào của Hoa Kỳ đang mang lại cho bạn nhiều mối làm ăn nhất."
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
-msgstr "Como se comparan a lo largo del tiempo"
+msgstr "Làm thế nào họ so sánh theo thời gian"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average transaction income per month"
-msgstr "Ingreso medio de transacción por mes"
+msgstr "Thu nhập giao dịch trung bình mỗi tháng"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average quantity per month"
-msgstr "Cantidad media por mes"
+msgstr "Số lượng trung bình mỗi tháng"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "Seasonal patterns in the [[this]]"
-msgstr "Patrones estacionales en [[this]]"
+msgstr "Các mẫu theo mùa trong [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events over time"
-msgstr "Eventos a lo largo del tiempo"
+msgstr "Sự kiện the"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Orders and income per source"
-msgstr "Pedidos e ingresos por origen"
+msgstr "Đơn đặt hàng và thu nhập trên mỗi nguồn"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per hour of the day"
-msgstr "Transacciones por hora del día"
+msgstr "Các giao dịch mỗi giờ trong ngà"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Where most of your traffic is coming from."
-msgstr "De donde proviene la mayoría de tu tráfico"
+msgstr "Nơi mà hầu hết lưu lượng truy cập của bạn đến từ."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Heres a quick look at the [[this]]"
-msgstr "Aquí hay un vistazo rápido a [[this]]"
+msgstr "Đây là một cái nhìn nhanh về [[this]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "It looks like your [[this]] has transactions, so heres a look at them"
-msgstr "Parece que tu [[this]] tiene transacciones, así que aquí hay información"
+msgstr "Có vẻ như [[this]] của bạn có giao dịch, vì vậy đây là một cái nhìn về chúng"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average discount per month"
-msgstr "Descuento medio por mes"
+msgstr "Chiết khấu trung bình trên một thán"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by month of the year"
-msgstr "[[Timestamp]] por mes del año"
+msgstr "[[Timestamp]] theo tháng trong nă"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategorySmall]] over time"
-msgstr "[[this]] por [[GenericCategorySmall]] a lo largo del tiempo"
+msgstr "[[this]] trên [[GenericCategorySmall]] theo thời gia"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Distribution by coordinates"
-msgstr "Distribución por coordenadas"
+msgstr "Phân bổ theo hệ toạ đ"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by source"
-msgstr "Ventas por origen"
+msgstr "Doanh số theo nguồ"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales for each product category"
-msgstr "Ventas por cada categoría de producto"
+msgstr "Doanh số của mỗi loại sản phẩ"
 
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "A closer look at the metrics and dimensions used in this saved question."
-msgstr "Una mirada detallada a las métricas y dimensiones utilizadas en esta pregunta guardada."
+msgstr "Quan sát kỹ hơn các số liệu và kích thước được sử dụng trong câu hỏi đã lưu này."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per [[GenericCategoryMedium]]"
-msgstr "[[this.short-name]] por [[GenericCategoryMedium]]"
+msgstr "[[this.short-name]] trên [[GenericCategoryMedium]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales per product [[ProductCategoryLarge]]"
-msgstr "Ventas por producto [[ProductCategoryLarge]]"
+msgstr "Doanh số trên sản phẩm [[ProductCategoryLarge]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Average quantity per country"
-msgstr "Cantidad media por país"
+msgstr "Số lượng trung bình trên một huyệ"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per [[GenericCategoryLarge]]"
-msgstr "[[this.short-name]] por [[GenericCategoryLarge]]"
+msgstr "[[this.short-name]] trên [[GenericCategoryLarge]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Heres a closer look at your [[this]] per source"
-msgstr "Aquí hay una mirada detallada a tu [[this]] por origen"
+msgstr "Đây là một cái nhìn sâu hơn về [[this]] trên mỗi nguồn"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per day of the month"
-msgstr "Eventos por día del mes"
+msgstr "Sự kiện mỗi ngày trong tháng"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "If youre into correlations, this is the x-ray for you."
-msgstr "Si te interesan las correlaciones, esta es la radiografía para ti."
+msgstr "Nếu bạn đang ở trong mối tương quan, đây là X ray cho bạn."
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by Country"
-msgstr "Sesiones por País"
+msgstr "Phiên theo vùng"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Some interesting metrics about your GA stats to get you started."
-msgstr "Algunas métricas interesantes sobre tus estadísticas de GA para empezar."
+msgstr "Một số số liệu thú vị về số liệu thống kê GA của bạn để giúp bạn bắt đầu."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per state"
-msgstr "[[this]] por provincia"
+msgstr "[[this]] theo vùn"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by quarter of the year"
-msgstr "[[Timestamp]] por trimestre"
+msgstr "[[Timestamp]] theo một quý của nă"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How its distributed across time and other categories."
-msgstr "Cómo se distribuye a través del tiempo y otras categorías."
+msgstr "Làm thế nào nó phân bổ theo thời gian và các loại khác."
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A look at your events over time and by several categories."
-msgstr "Una mirada a tus eventos a lo largo del tiempo y por varias categorías."
+msgstr "Nhìn vào các sự kiện của bạn theo thời gian và theo một số loại."
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "[[GenericTable]] per [[this]]"
-msgstr "[[GenericTable]] por [[this]]"
+msgstr "[[GenericTable]] trên [[this]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average quantity per source"
-msgstr "Cantidad media por origen"
+msgstr "Số lượng trung bình trên mỗi nguồ"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Top 5 per category"
-msgstr "Primeros 5 por categoría"
+msgstr "Top 5 của mỗi loạ"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per day of the week"
-msgstr "Eventos por día de la semana"
+msgstr "Các sự kiện mỗi ngày trong tuầ"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "New [[this.short-name]] per month"
-msgstr "Nuevos [[this.short-name]] por mes"
+msgstr "[[this.short-name]] mới trên thán"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top performers"
-msgstr "Mejor desempeño"
+msgstr "Top người thực hiệ"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Transactions in the last 30 days"
-msgstr "Transacciones en los últimos 30 días"
+msgstr "Giao dịch trong 30 ngày gần đâ"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[GenericTable]] by [[this]]"
-msgstr "[[GenericTable]] por [[this]]"
+msgstr "[[GenericTable]] theo [[this]"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Overview of your [[this]] data from Google Analytics"
-msgstr "Visión general de tus datos [[this]] de Google Analytics"
+msgstr "Tổng quan về dữ liệu [[this]] của bạn từ Google Analytics"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by hour of the day"
-msgstr "Creado por hora del día"
+msgstr "Tạo vào giờ của ngày"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by month"
-msgstr "Ventas por mes"
+msgstr "Doanh số theo thán"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] is distributed across categories"
-msgstr "Cómo se distribuye [[this]] entre categorías"
+msgstr "Cách [[this]] được phân bổ qua các loạ"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by month of year"
-msgstr "[[Timestamp]] por mes del año"
+msgstr "[[Timestamp]] theo tháng trong nă"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "How many total sessions vs. how many individual users you had each day."
-msgstr "Cuántas sesiones en total vs. cuántos usuarios individuales has tenido cada día."
+msgstr "Có bao nhiêu tổng số phiên so với số lượng người dùng cá nhân bạn có mỗi ngày."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How this metric is distributed across different numbers"
-msgstr "Cómo se distribuye esta métrica entre diferentes números."
+msgstr "Cách số liệu này được phân bổ trên các số khác nhau"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by page where the session began"
-msgstr "Sesiones por página donde comenzó la sesión."
+msgstr "Phiên theo trang nơi phiên bắt đầu"
 
 #: frontend/src/metabase/lib/schema_metadata.js:503
 #: resources/automagic_dashboards/field/DateTime.yaml
@@ -11076,20 +11041,20 @@ msgstr "Sesiones por página donde comenzó la sesión."
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "Distinct values"
-msgstr "Valores distintos"
+msgstr "Giá trị riêng biệt"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Hours when [[this.short-name]] were added"
-msgstr "Horas en las que se añadío [[this.short-name]]"
+msgstr "Giờ khi [[this.short-name]] được thêm vào"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by day of the week"
-msgstr "[[Timestamp]] por día de la semana"
+msgstr "[[Timestamp]] theo ngày trong tuần"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[GenericNumber]] over time"
-msgstr "[[GenericNumber]] a lo largo del tiempo"
+msgstr "[[GenericNumber]] theo thời gia"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
@@ -11098,43 +11063,43 @@ msgstr "[[GenericNumber]] a lo largo del tiempo"
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Heres an overview of your [[this]]"
-msgstr "Aquí hay una visión general de tu [[this]]"
+msgstr "Đây là tổng quan về [[this]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by coordinates"
-msgstr "[[this.short-name]] por coordenadas"
+msgstr "[[this.short-name]] theo hệ toạ đ"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Heres a closer look at your [[this]] per state"
-msgstr "Una mirada detallada a los [[this]] por provincia"
+msgstr "Đây là một cái nhìn sâu hơn về [[this]] cho mỗi trạng thái"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by day of the month"
-msgstr "Creado por día del mes"
+msgstr "Tạo vào ngày của tháng"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales by coordinates"
-msgstr "Ventas por coordenadas"
+msgstr "Doanh số theo hệ toạ đ"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "New [[this.short-name]] over time"
-msgstr "Nuevos [[this.short-name]] a lo largo del tiempo"
+msgstr "[[this.short-name]] mới theo thời gia"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by hour of the day"
-msgstr "Unir fecha por hora del día"
+msgstr "Ngày gia nhập theo giờ trong ngà"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by hour of day"
-msgstr "[[Timestamp]] por hora del día"
+msgstr "[[Timestamp]] theo giờ trong ngà"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions and unique users per day"
-msgstr "Sesiones y usuarios únicos por día."
+msgstr "Phiên và người dùng duy nhất mỗi ngày"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per [[GenericCategoryLarge]]"
-msgstr "Eventos por [[GenericCategoryLarge]]"
+msgstr "Các sự kiện theo [[GenericCategoryLarge]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -11143,413 +11108,403 @@ msgstr "Eventos por [[GenericCategoryLarge]]"
 #: resources/automagic_dashboards/field/GenericField.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
-msgstr "Cómo se comparan por distribución"
+msgstr "Làm thế nào so sánh bằng phân bổ"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Income per country"
-msgstr "Ingreso por país"
+msgstr "Thu nhập theo vùn"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Heres a closer look at your [[this]] per country"
-msgstr "Una mirada detallada de tus [[this]] por país"
+msgstr "Đây là một cái nhìn sâu hơn về [[this]] mỗi vùn"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by product [[ProductCategory]]"
-msgstr "Ventas por producto [[ProductCategory]]"
+msgstr " Doanh số theo sản phẩm [[ProductCategory]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryLarge]], bottom 5"
-msgstr "[[this]] por [[GenericCategoryLarge]], últimos 5"
+msgstr "[[this]] trên [[GenericCategoryLarge]], dứoi "
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] added in the last 30 days"
-msgstr "[[this.short-name]] añadidos en los últimos 30 días"
+msgstr "[[this.short-name]] đã được thêm trong 30 ngày trước"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[Source]]"
-msgstr "Por [[Source]]"
+msgstr "Mỗi [[Source]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average item quantity per month"
-msgstr "Cantidad media por mes"
+msgstr "Số lượng mặt hàng trung bình mỗi tháng"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "The number of [[GenericTable]] per country, and how each country is represented in different categories."
-msgstr "El número de [[GenericTable]] por país, y cómo cada país está representado en diferentes categorías."
+msgstr "Số lượng [[GenericTable]] trên mỗi vùng và cách mỗi vùng được thể hiện trong các danh mục khác nhau."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per day of the week"
-msgstr "[[this]] por día de la semana"
+msgstr "[[this]] mỗi ngày trong tuần"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average qunatity per source"
-msgstr "Cantidad media por origen"
+msgstr "Số lượng trung bình trên mỗi nguồn"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by [[Timestamp]]"
-msgstr "[[this.short-name]] por [[Timestamp]]"
+msgstr "[[this.short-name]] theo [[Timestamp]"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Summary statistics"
-msgstr "Resumen Estadístico"
+msgstr "Tóm tắt thống k"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per month"
-msgstr "Ventas por mes"
+msgstr "Doanh số mỗi thán"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[GenericNumber]] by join date"
-msgstr "[[GenericNumber]] por unión de fecha"
+msgstr "[[GenericNumber]] theo ngày tham gi"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Average of [[this]] by [[Country]]"
-msgstr "Media de[[this]] por [[Country]]"
+msgstr "Trung bình của [[this]] theo [[Country]"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[this]] over time"
-msgstr "[[this]] a lo largo del tiempo"
+msgstr "[[this]] theo thời gia"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by day of the week"
-msgstr "Unir fecha por día de la semana"
+msgstr "Ngày gia nhập theo ngày trong tuầ"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "We crunched the numbers for your [[this]]"
-msgstr "Hemos procesado los números de tu [[this]]"
+msgstr "Chúng tôi đã xử lý các con số cho [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Months when [[this.short-name]] joined"
-msgstr "Meses cuando se une por [[this.short-name]]"
+msgstr "Tháng khi [[this.short-name]] tham gia"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to parse resource `{0}` as JSON"
-msgstr "Respuesta JSON incorrecta: `{0}`"
+msgstr "Không thể phân tích tài nguyên `{0}` dưới dạng JSON"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to find JSON via relative path `{0}`"
-msgstr "No se puede encontrar JSON a través de la ruta relativa `{0}`"
+msgstr "Không thể tìm thấy JSON thông qua đường dẫn tương đối `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Connection to host timed out for URL `{0}`"
-msgstr "La conexión con el host ha caducado para la URL `{0}`"
+msgstr "Kết nối với máy chủ đã hết thời gian cho URL `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to connect to unknown host at URL `{0}`"
-msgstr "No se puede conectar a un host desconocido en la URL `{0}`"
+msgstr "Không thể kết nối với máy chủ không xác định tại URL `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to connect to host at URL `{0}`"
-msgstr "No se puede conectar con el host en la URL `{0}`"
+msgstr "Không thể kết nối với máy chủ tại URL `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Connection refused by host at for URL `{0}`"
-msgstr "Conexión rechazada por el host en la URL `{0}`"
+msgstr "Kết nối bị từ chối bởi máy chủ tại URL `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to retrieve resource at URL `{0}`"
-msgstr "No se puede recuperar el recurso en la URL `{0}`"
+msgstr "Không thể truy xuất tài nguyên tại URL `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to parse resource at URL `{0}` as JSON"
-msgstr "No se puede analizar el recurso en la URL `{0}` como JSON"
+msgstr "Không thể phân tích tài nguyên tại URL `{0}` dưới dạng JSON"
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fall back to local authentication: {0}"
-msgstr "Problema al conectarse al servidor LDAP, se volverá a la autenticación local: {0}"
+msgstr "Sự cố khi kết nối với máy chủ LDAP, sẽ quay trở lại xác thực cục bộ: {0}"
 
 #: src/metabase/driver/bigquery.clj
 msgid "BigQuery statements can''t be parameterized!"
-msgstr "¡Las consultas BigQuery no se pueden parametrizar!"
+msgstr "Các câu lệnh BigQuery không thể được tham số hóa!"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Druid does not allow limitSpec in time series queries. Ignoring the LIMIT clause."
-msgstr "ADVERTENCIA: Druid no permite limitSpec en consultas de series de tiempo. Ignorando la cláusula LIMIT."
+msgstr "CẢNH BÁO: Druid không cho phép giới hạnSpec trong các truy vấn chuỗi thời gian. Bỏ qua mệnh đề LIMIT."
 
 #: src/metabase/driver/snowflake.clj
 msgid "Invalid Snowflake connection details: missing DB name."
-msgstr "Valores de conexión a SnowFlake inválidas: falta el nombre de la BBDD"
+msgstr "Chi tiết kết nối Snowflake không hợp lệ: thiếu tên cơ sở dữ liệu."
 
 #: src/metabase/email/messages.clj
 msgid "We’d love your feedback."
-msgstr "Nos encantaría tus comentarios."
+msgstr "Chúng tôi rất thích phản hồi của bạn."
 
 #: src/metabase/email/messages.clj
 msgid "It looks like Metabase wasn’t quite a match for you."
-msgstr "Parece que Metabase no se ha ajustado a tus expectativas."
+msgstr "Có vẻ như Metabase không phù hợp với bạn."
 
 #: src/metabase/email/messages.clj
 msgid "Would you mind taking a fast 5 question survey to help the Metabase team understand why and make things better in the future?"
-msgstr "¿Te importaría realizar una encuesta rápida de 5 preguntas para ayudar al equipo de Metabase a comprender por qué y mejorar las cosas en el futuro?"
+msgstr "Bạn có phiền khi thực hiện một cuộc khảo sát nhanh 5 câu hỏi để giúp nhóm Metabase hiểu lý do tại sao và làm cho mọi thứ tốt hơn trong tương lai không?"
 
 #: src/metabase/email/messages.clj
 msgid "We hope you''ve been enjoying Metabase."
-msgstr "Esperamos que hayas estado disfrutando de Metabase."
+msgstr "Chúng tôi hy vọng bạn đã được thưởng thức Metabase."
 
 #: src/metabase/email/messages.clj
 msgid "Would you mind taking a fast 6 question survey to tell us how it’s going?"
-msgstr "¿Te importaría hacer una encuesta rápida de 6 preguntas para decirnos cómo va?"
+msgstr "Bạn có phiền khi tham gia một cuộc khảo sát nhanh 6 câu hỏi để cho chúng tôi biết nó sẽ diễn ra như thế nào không?"
 
 #: src/metabase/email/messages.clj
 msgid "{0} created a Metabase account"
-msgstr "{0} ha creado una cuenta en Metabase"
+msgstr "{0} đã tạo tài khoản Metabase"
 
 #: src/metabase/email/messages.clj
 msgid "{0} accepted their Metabase invite"
-msgstr "{0} ha aceptado su invitación a Metabase"
+msgstr "{0} đã chấp nhận lời mời Metabase của họ"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Password Reset Request"
-msgstr "[Metabase] Solicitud Reestablecer Contraseña"
+msgstr "[Metabase] Yêu cầu cài đặt lại mật khẩ"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Notification"
-msgstr "[Metabase] Notificación"
+msgstr "[Metabase] Thông bá"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Help make Metabase better."
-msgstr "[Metabase] Ayuda a mejorar Metabase."
+msgstr "[Metabase]Giúp Metabase tốt hơ"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Tell us how things are going."
-msgstr "[Metabase] Dinos como van las cosas."
+msgstr "[Metabase]Hãy nói với chúng tôi mọi thứ đang diễn ra như thế nà"
 
 #: src/metabase/mbql/util.clj
 msgid "Error: query''s source query has not been resolved. You probably need to `preprocess` the query first."
-msgstr "Error: la consulta fuente de la consulta no se ha resuelto. Probablemente necesites 'preprocesar' la consulta primero."
+msgstr "Lỗi: truy vấn nguồn của truy vấn chưa được giải quyết. Có lẽ bạn cần phải 'tiền xử lý' truy vấn trước."
 
 #: src/metabase/models/params.clj
 msgid "Don't know what to do with:"
-msgstr "No se que hacer con:"
+msgstr "Không biết làm gì với cái nà"
 
 #: src/metabase/models/params.clj
 msgid "Don't know how to wrap:"
-msgstr "No se como envolver:"
+msgstr "Không biết cách quấ"
 
 #: src/metabase/public_settings.clj
 msgid "Failed setting `query-caching-max-kb` to {0}."
-msgstr "No se ha podido establecer `query-caching-max-kb` a {0}"
+msgstr "Lõi cài đặt `query-caching-max-kb` thành {0}"
 
 #: src/metabase/public_settings.clj
 msgid "Values greater than {1} are not allowed."
-msgstr "No se permiten valores superiores a {1}"
+msgstr "Các giá trị lớn hơn {1} không được phép."
 
 #: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
-msgstr "La base de datos {0} no existe."
+msgstr "Cơ sở dữ liệu {0} không tồn tại."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Database is not present in the Query Processor Store."
-msgstr "Error: La base de datos no está presente en el procesador de consultas."
+msgstr "Lỗi: Cơ sở dữ liệu không có trong Cửa hàng Bộ xử lý truy vấn."
 
 #: src/metabase/util/embed.clj
 msgid "Invalid embedding-secret-key! Secret key must be a hexadecimal-encoded 256-bit key (i.e., a 64-character string)."
-msgstr "¡Clave secreta no válida! La clave secreta debe ser una clave de 256 bits codificada en hexadecimal (es decir, una cadena de 64 caracteres)."
+msgstr "Khóa nhúng bí mật không hợp lệ! Khóa bí mật phải là khóa 256 bit được mã hóa thập lục phân (nghĩa là chuỗi 64 ký tự)."
 
 #: src/metabase/util/embed.clj
 msgid "JWT is missing `alg`."
-msgstr "Falta el JWT `alg`."
+msgstr "JWT bị thiếu `alg`"
 
 #: src/metabase/util/embed.clj
 msgid "JWT `alg` cannot be `none`."
-msgstr "JWT `alg` no puede ser `none`."
+msgstr "JWT `alg` không thể là` none`"
 
 #: src/metabase/util/embed.clj
 msgid "The embedding secret key has not been set."
-msgstr "No se ha establecido la clave secreta embebida."
+msgstr "Khóa nhúng bí mật chưa được cài đặt."
 
 #: src/metabase/util/embed.clj
 msgid "Token is missing value for keypath"
-msgstr "Falta el valor de keypath en el token."
+msgstr "Mã thông báo bị thiếu giá trị cho keypath"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "In-depth example"
-msgstr "Ejemplo avanzado"
+msgstr "Ví dụ chuyên sâu "
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:29
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:17
 msgid "Key"
-msgstr "Clave"
+msgstr "Khoá"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:30
 msgid "Class"
-msgstr "Clase"
+msgstr "Class"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:32
 msgid "Triggers"
-msgstr "Disparadores"
+msgstr "Triggers"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:48
 msgid "View triggers"
-msgstr "Ver disparadores"
+msgstr "Xem triggers"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
-msgstr "Información del Programador"
+msgstr "Thông tin Scheduler"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:20
 msgid "Priority"
-msgstr "Prioridad"
+msgstr "Ưu tiên"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:21
 msgid "Last Fired"
-msgstr "Última vez ejecutada"
+msgstr "Lần cuối chạy"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:22
 msgid "Next Fire Time"
-msgstr "Próxima vez que se ejecuta"
+msgstr "Thời gian chạy lần tới"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:23
 msgid "Start Time"
-msgstr "Hora Inicial"
+msgstr "Thời gian bắt đầu"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:24
 msgid "End Time"
-msgstr "Hora Final"
+msgstr "Thời gian kết thúc"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:25
 msgid "Final Fire Time"
-msgstr "Ultima Ejecución"
+msgstr "Thời gian chạy cuối cùng"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:26
 msgid "May Fire Again?"
-msgstr "¿Puede ejecutarse de nuevo?"
+msgstr "Có thể chạy tiếp?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
-msgstr "Disparadores para {0}"
+msgstr "Triggers cho {0}"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:26
 msgid "Tasks"
-msgstr "Tareas"
+msgstr "Tác vụ"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:31
 msgid "Jobs"
-msgstr "Trabajos"
+msgstr "Jobs"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:735
 msgid "Duplicated {0}"
-msgstr "Duplicado {0}"
+msgstr "Đã tạo bản sao {0}"
 
 #: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
-msgstr "Duplica este ítem"
+msgstr "Tạo bản sao"
 
 #: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
-msgstr "Archiva este ítem"
+msgstr "Lưu trữ item này"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:325
 msgid "Duplicate dashboard"
-msgstr "Duplicar Cuadro de Mando"
+msgstr "Đã tạo bản sao"
 
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:16
 msgid "Duplicate \"{0}\""
-msgstr "Duplicar \"{0}\""
+msgstr "Tạo bản sao \"{0}\""
 
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
-msgstr "Duplicar"
+msgstr "Tạo bản sao"
 
 #: frontend/src/metabase/lib/query_time.js:115
 msgid "Tomorrow"
-msgstr "Mañana"
+msgstr "Ngày mai"
 
 #: frontend/src/metabase/lib/query_time.js:129
 #: frontend/src/metabase/lib/query_time.js:143
 msgid "This {0}"
-msgstr "Este {0}"
+msgstr "{0} Này"
 
 #: frontend/src/metabase/lib/query_time.js:132
 msgid "Next {0}"
-msgstr "Siguiente {0}"
+msgstr "{0} Tiếp theo"
 
 #: frontend/src/metabase/lib/query_time.js:135
 #: src/metabase/pulse/render/datetime.clj
 msgid "Previous {0}"
-msgstr "Anterior {0}"
+msgstr "{0} Trước đó"
 
 #: frontend/src/metabase/lib/query_time.js:139
 msgid "Previous {0} {1}"
-msgstr "Anterior {0} {1}"
+msgstr "{0} {1} trước"
 
 #: frontend/src/metabase/lib/query_time.js:141
 msgid "Next {0} {1}"
-msgstr "Siguiente {0} {1}"
+msgstr "{0} {1} tiếp theo"
 
 #: frontend/src/metabase/lib/query_time.js:171
 msgid "Now"
-msgstr "Ahora"
+msgstr "Bây giờ"
 
 #: frontend/src/metabase/lib/query_time.js:174
 msgid "{0} {1} ago"
-msgstr "hace {0} {1}"
+msgstr "{0} {1} trước"
 
 #: frontend/src/metabase/lib/query_time.js:175
 msgid "{0} {1} from now"
-msgstr "{0} {1} desde ahora"
+msgstr "{0} {1} từ nay"
 
 #: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
-msgstr[0] "Periodo por defecto"
-msgstr[1] "Periodos por defecto"
+msgstr[0] "Khoảng mặc định"
 
 #: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
-msgstr[0] "Minuto de la hora"
-msgstr[1] "Minutos de la hora"
+msgstr[0] "phút mỗi giờ"
 
 #: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
-msgstr[0] "Hora del día"
-msgstr[1] "Horas del día"
+msgstr[0] "giờ mỗi ngày"
 
 #: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
-msgstr[0] "Día de la semana"
-msgstr[1] "Días de la semana"
+msgstr[0] "ngày mỗi tuần"
 
 #: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
-msgstr[0] "Día del mes"
-msgstr[1] "Días del mes"
+msgstr[0] "ngày mỗi tháng"
 
 #: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
-msgstr[0] "Día del año"
-msgstr[1] "Días del año"
+msgstr[0] "ngày mỗi năm"
 
 #: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
-msgstr[0] "Semana del año"
-msgstr[1] "Semanas del año"
+msgstr[0] "tuần mỗi năm"
 
 #: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
-msgstr[0] "Mes del año"
-msgstr[1] "Meses del año"
+msgstr[0] "tháng mỗi năm"
 
 #: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
-msgstr[0] "Trimestre del año"
-msgstr[1] "Trimestres del año"
+msgstr[0] "quý mỗi năm"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
 msgid_plural "{0} selections"
-msgstr[0] "{0} seleccionado"
-msgstr[1] "{0} seleccionados"
+msgstr[0] "lựa chọn"
 
 #: frontend/src/metabase/parameters/components/widgets/DateQuarterYearWidget.jsx:11
 msgid "[Q]Q"
@@ -11557,220 +11512,220 @@ msgstr "[Q]Q"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:28
 msgid "This"
-msgstr "Este"
+msgstr "Cái này"
 
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:136
 msgid "Invalid"
-msgstr "Inválido"
+msgstr "Không phù hợp"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
-msgstr "Añade una hora"
+msgstr "Thêm thời gian"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
 msgid "Nothing to compare for the previous {0}."
-msgstr "Nada que comparar en el {0} anterior."
+msgstr "Không có gì để so sánh với {0}."
 
 #: frontend/src/metabase-lib/lib/Dimension.js:712
 msgid "by {0}"
-msgstr "por {0}."
+msgstr "bởi {0}"
 
 #: src/metabase/api/database.clj
 msgid "value must be a valid database engine."
-msgstr "el valor debe ser un motor de base de datos válido."
+msgstr "giá trị phải là một công cụ cơ sở dữ liệu hợp lệ."
 
 #: src/metabase/api/geojson.clj
 msgid "Connection refused by host for URL `{0}`"
-msgstr "La conexión ha sido rechazada por el host a través de la URL  `{0}`"
+msgstr "Kết nối bị từ chối bởi máy chủ cho URL `{0}`"
 
 #: src/metabase/db.clj
 msgid "Warning: Postgres connection string with `ssl=true` detected."
-msgstr "Advertencia: Una conexión a Postgres con 'ssl=true' ha sido detectada."
+msgstr "Cảnh báo: Đã phát hiện chuỗi kết nối Postgres với `ssl = true`."
 
 #: src/metabase/db.clj
 msgid "You may need to add `?sslmode=require` to your application DB connection string."
-msgstr "Puedes requerir agregar `?sslmode=require` a la cadena de conexión a la BD."
+msgstr "Bạn có thể cần thêm `?sslmode = quiries` vào chuỗi kết nối cơ sở dữ liệu ứng dụng của bạn."
 
 #: src/metabase/db.clj
 msgid "If Metabase fails to launch, please add it and try again."
-msgstr "Si Metabase falla al arrancar, por favor agréguelo e intente de nuevo."
+msgstr "Nếu Metabase không khởi chạy, vui lòng thêm nó và thử lại."
 
 #: src/metabase/db.clj
 msgid "See https://github.com/metabase/metabase/issues/8908 for more details."
-msgstr "Consultar https://github.com/metabase/metabase/issues/8908 para más detalles."
+msgstr "Xem https://github.com/metabase/metabase/issues/8908 để biết thêm chi tiết."
 
 #: src/metabase/db.clj
 msgid "WARNING: Using Metabase with an H2 application database is not recomended for production deployments."
-msgstr "ADVERTENCIA: el uso de Metabase con una base de datos de aplicaciones H2 no se recomienda para implementaciones de producción."
+msgstr "CẢNH BÁO: Không nên sử dụng Metabase với cơ sở dữ liệu ứng dụng H2 để triển khai lên Production."
 
 #: src/metabase/db.clj
 msgid "For production deployments, we highly recommend using Postgres, MySQL, or MariaDB instead."
-msgstr "Para las implementaciones de producción, te recomendamos que utilices Postgres, MySQL o MariaDB."
+msgstr "Để triển khai lên Production, chúng tôi khuyên bạn nên sử dụng Postgres, MySQL hoặc MariaDB thay thế."
 
 #: src/metabase/db.clj
 msgid "If you decide to continue to use H2, please be sure to back up the database file regularly."
-msgstr "Si decides continuar usando H2, asegúrate de hacer una copia de seguridad del archivo de la base de datos con regularidad."
+msgstr "Nếu bạn quyết định tiếp tục sử dụng H2, vui lòng đảm bảo sao lưu tệp cơ sở dữ liệu thường xuyên."
 
 #: src/metabase/db.clj
 msgid "See https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres for more information."
-msgstr "Para obtener más información, consulta https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres."
+msgstr "Xem https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-USE-the-h2-database-to-mysql-or-postgres để biết thêm thông tin."
 
 #: src/metabase/db.clj
 msgid "Unable to connect to Metabase {0} DB."
-msgstr "No se ha podido conectar a la base de datos {0} de Metabase."
+msgstr "Không thể kết nối với Metabase {0} DB."
 
 #: src/metabase/db/migrations.clj
 msgid "Error adding legacy SQL directive to BigQuery saved Question"
-msgstr "Error al agregar la directiva SQL a la pregunta guardada de BigQuery"
+msgstr "Lỗi khi thêm lệnh SQL cũ vào Câu hỏi đã lưu của BigQuery"
 
 #: src/metabase/driver.clj
 msgid "Failed to notify {0} Database {1} updated"
-msgstr "Error al notificar {0} Base de datos {1} actualizada"
+msgstr "Không thể thông báo {0} Cơ sở dữ liệu {1} đã cập nhật"
 
 #: src/metabase/driver/impl.clj
 msgid "Loading driver {0} {1}"
-msgstr "Cargando controlador {0} {1}"
+msgstr "Đang tải trình điều khiển {0} {1}"
 
 #: src/metabase/driver/impl.clj
 msgid "Load driver {0}"
-msgstr "Cargar controlador {0}"
+msgstr "Tải trình điều khiển {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Driver not registered after loading: {0}"
-msgstr "Controlador no registrado después de la carga: {0}"
+msgstr "Trình điều khiển không được đăng ký sau khi tải: {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Error: attempting to change {0} property `:abstract?` from {1} to {2}."
-msgstr "Error: al intentar cambiar la propiedad {0} `:abstract?` de {1} a {2}."
+msgstr "Lỗi: cố gắng thay đổi thuộc tính {0} `:abstract?` từ {1} thành {2}."
 
 #: src/metabase/driver/impl.clj
 msgid "Registered abstract driver {0}"
-msgstr "Controlador {0} abstracto registrado"
+msgstr "Trình điều khiển abstract đã đăng ký {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Registered driver {0}"
-msgstr "Controlador {0} registrado"
+msgstr "Trình điều khiển đã đăng ký {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "(parents: {0})"
-msgstr "(superiores: {0})"
+msgstr "(cha mẹ: {0})"
 
 #: src/metabase/driver/impl.clj
 msgid "Initializing driver {0}..."
-msgstr "Inicializando controlador {0}"
+msgstr "Đang khởi tạo trình điều khiển {0} ..."
 
 #: src/metabase/driver/impl.clj
 msgid "Reason:"
-msgstr "Razón:"
+msgstr "Lý do:"
 
 #: src/metabase/driver.clj
 msgid "Invalid driver feature: {0}"
-msgstr "Característica de controlador inválida: {0}"
+msgstr "Tính năng trình điều khiển không hợp lệ: {0}"
 
 #: src/metabase/driver/sql/query_processor.clj
 msgid "Invalid HoneySQL form:"
-msgstr "Formulario HoneySQL inválido:"
+msgstr "Biểu mẫu HoneySQL không hợp lệ:"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Closing connection pool for database {0} ..."
-msgstr "Cerrando el pool de conexiones para la base de datos {0} ..."
+msgstr "Đóng nhóm kết nối cho cơ sở dữ liệu {0} ..."
 
 #: src/metabase/driver/util.clj
 msgid "Error loading namespace"
-msgstr "Error cargando el espacio de nombres"
+msgstr "Lỗi tải namespace"
 
 #: src/metabase/events.clj
 msgid "Starting events listener:"
-msgstr "Inicializando controlador de eventos:"
+msgstr "Bắt đầu events listener:"
 
 #: src/metabase/events.clj
 msgid "Unexpected error listening on events"
-msgstr "Error no esperado escuchando eventos:"
+msgstr "Lỗi bất ngờ khi nghe về các sự kiện"
 
 #: src/metabase/events/sync_database.clj
 msgid "Error syncing Database {0}"
-msgstr "Error sincronizando la base de datos {0}"
+msgstr "Lỗi đồng bộ hóa cơ sở dữ liệu {0}"
 
 #: src/metabase/events/sync_database.clj
 msgid "Failed to process sync-database event."
-msgstr "Error al procesar el evento de sincronización de la base de datos."
+msgstr "Không thể xử lý sự kiện đồng bộ hóa cơ sở dữ liệu."
 
 #: src/metabase/mbql/util.clj
 msgid "Bad nested-query-level: query does not have a source query"
-msgstr "Nivel de consulta anidado incorrecto: la consulta no tiene una consulta de origen"
+msgstr "Nested-query-level tồi: truy vấn không có truy vấn nguồn"
 
 #: src/metabase/metabot/command.clj
 msgid "I don''t know how to `{0}`."
-msgstr "No se como `{0}`."
+msgstr "Tôi không biết làm thế nào để `{0}`."
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s what I can do: "
-msgstr "Esto es lo que puedo hacer: "
+msgstr "Tôi không biết làm thế nào để `{0}`."
 
 #: src/metabase/metabot/slack.clj
 msgid "Error in Metabot command"
-msgstr "Error en el comando de Metabot"
+msgstr "Lỗi trong lệnh Metabot"
 
 #: src/metabase/metabot/websocket.clj
 msgid "Websocket associated with this Slack event is different from the websocket we're currently using."
-msgstr "El Websocket asociado con este evento Slack es diferente del websocket que estamos usando actualmente."
+msgstr "Websocket liên quan đến sự kiện Slack này khác với websocket chúng tôi hiện đang sử dụng."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues for Field {0} remain unchanged. Skipping..."
-msgstr "Los valores para el campo {0} permanecen sin cambios. Saltando..."
+msgstr "FieldValues cho Field {0} không thay đổi. Bỏ qua ..."
 
 #: src/metabase/models/interface.clj
 msgid "Unable to normalize:"
-msgstr "No se ha podido normalizar:"
+msgstr "Không thể bình thường hóa:"
 
 #: src/metabase/models/params.clj
 msgid "Could not find matching Field ID for target:"
-msgstr "No se pudo encontrar el ID de campo coincidente para el destino:"
+msgstr "Không thể tìm thấy ID trường phù hợp cho mục tiêu:"
 
 #: src/metabase/plugins.clj
 msgid "Metabase does not have permissions to write to plugins directory {0}"
-msgstr "Metabase no tiene permisos para escribir en el directorio de extensiones {0}"
+msgstr "Metabase không có quyền ghi vào thư mục plugin {0}"
 
 #: src/metabase/plugins.clj
 msgid "Metabase cannot use the plugins directory {0}"
-msgstr "Metabase no puede utilizar el directorio de extensiones {0}"
+msgstr "Metabase không thể sử dụng thư mục plugin {0}"
 
 #: src/metabase/plugins.clj
 msgid "Please make sure the directory exists and that Metabase has permission to write to it."
-msgstr "Asegúrate de que el directorio existe y que Metabase tiene permiso para escribir en él."
+msgstr "Vui lòng đảm bảo thư mục tồn tại và Metabase có quyền ghi vào thư mục đó."
 
 #: src/metabase/plugins.clj
 msgid "You can change the directory Metabase uses for modules by setting the environment variable MB_PLUGINS_DIR."
-msgstr "Puedes cambiar el directorio que utiliza Metabase para los módulos configurando la variable de entorno MB_PLUGINS_DIR."
+msgstr "Bạn có thể thay đổi thư mục Metabase sử dụng cho các mô-đun bằng cách đặt biến môi trường MB_PLUGINS_DIR."
 
 #: src/metabase/plugins.clj
 msgid "Falling back to a temporary directory for now."
-msgstr "Volviendo a un directorio temporal por ahora."
+msgstr "Quay trở lại một thư mục tạm thời bây giờ."
 
 #: src/metabase/plugins.clj
 msgid "Metabase cannot write to temporary directory. Please set MB_PLUGINS_DIR to a writable directory and restart Metabase."
-msgstr "Metabase no puede escribir en el directorio temporal. Configura MB_PLUGINS_DIR en un directorio escribible y reinicia Metabase."
+msgstr "Metabase không thể ghi vào thư mục tạm thời. Vui lòng đặt MB_PLUGINS_DIR thành thư mục có thể ghi và khởi động lại Metabase."
 
 #: src/metabase/plugins.clj
 msgid "spark-deps.jar is no longer needed by Metabase 1.0+. You can delete it from the plugins directory."
-msgstr "Metabase 1.0+ ya no necesita spark-deps.jar. Puedes eliminarlo del directorio de extensiones."
+msgstr "spark-deps.jar không còn cần bởi Metabase 1.0+. Bạn có thể xóa nó khỏi thư mục plugin."
 
 #: src/metabase/plugins.clj
 msgid "Failied to initialize plugin {0}"
-msgstr "No se ha podido inicializar la extensión {0}"
+msgstr "Không thể khởi chạy plugin {0}"
 
 #: src/metabase/plugins.clj
 msgid "Loading plugins in {0}..."
-msgstr "Cargando extensiones en {0}..."
+msgstr "Đang tải các plugin trong {0} ..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Using Clojure base loader as shared context classloader: {0}"
-msgstr "Uso del cargador base de Clojure como cargador de clases de contexto compartido: {0}"
+msgstr "Sử dụng loader cơ sở Clojure làm classloader ngữ cảnh được chia sẻ: {0}"
 
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to shared classloader {0}..."
-msgstr "Estableciendo el contexto de subprocesos al cargador de clases compartido {0}..."
+msgstr "Đặt classloader ngữ cảnh luồng hiện tại thành classloader được chia sẻ {0} ..."
 
 #. it's important that we deref the promise again here instead of using the one we just created because it is
 #. possible thru a race condition that somebody else delivered the promise before we did; in that case,
@@ -11778,318 +11733,318 @@ msgstr "Estableciendo el contexto de subprocesos al cargador de clases compartid
 #. value of it rather than one that ends up getting discarded
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to NEWLY CREATED classloader {0}..."
-msgstr "Configurando el contexto actual para el NUEVO cargador de clases {0} ..."
+msgstr "Đặt classloader ngữ cảnh luồng hiện tại thành classloader MỚI TẠO {0} ..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Added URL {0} to classpath"
-msgstr "URL {0} añadida a classpath"
+msgstr "Đã thêm URL {0} vào classpath"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugin {0} declares a dependency that Metabase does not understand: {1}"
-msgstr "La extensión {0} declara una dependencia que Metabase no entiende: {1}"
+msgstr "Plugin {0} tuyên bố một phụ thuộc mà Metabase không hiểu: {1}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Refer to the plugin manifest reference for a complete list of valid plugin dependencies:"
-msgstr "Consulta la referencia del manifest de la extensión para obtener una lista completa de las dependencias válidas del mismo:"
+msgstr "Tham khảo tham chiếu bảng kê khai plugin để biết danh sách đầy đủ các yếu tố phụ thuộc plugin hợp lệ:"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Metabase cannot initialize plugin {0} due to required dependencies."
-msgstr "Metabase no puede inicializar el complemento {0} debido a las dependencias requeridas."
+msgstr "Metabase không thể khởi chạy plugin {0} do thiếu yếu tố phụ thuộc bắt buộc."
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Class not found: {0}"
-msgstr "Clase {0} no encontrada"
+msgstr "Không tìm thấy lớp: {0}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugin ''{0}'' depends on plugin ''{1}''"
-msgstr "La extensión ''{0}'' depende de la extensión ''{1}''"
+msgstr "Plugin '' {0} '' phụ thuộc vào plugin '' {1} ''"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "{0} dependency {1} satisfied? {2}"
-msgstr "{0} dependencia {1} satisfecha? {2}"
+msgstr "{0} phụ thuộc {1} được đáp ứng? {2}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugins with unsatisfied deps: {0}"
-msgstr "Extensiones con dependencias no satisfechas: {0}"
+msgstr "Các plugin có deps không thỏa mãn: {0}"
 
 #: src/metabase/util/files.clj
 msgid "Extract file {0} -> {1}"
-msgstr "Extraer fichero {0} -> {1}"
+msgstr "Trích xuất file {0} -> {1}"
 
 #: src/metabase/util/files.clj
 msgid "Resource does not exist."
-msgstr "Recurso no existe."
+msgstr "Tài nguyên không tồn tại."
 
 #: src/metabase/plugins/init_steps.clj
 msgid "Loading plugin namespace {0}..."
-msgstr "Cargando espacio de nombres de extensiones {0}..."
+msgstr "Đang tải plugin namespace{0} ..."
 
 #: src/metabase/plugins/initialize.clj
 msgid "Dependencies satisfied; these plugins will now be loaded: {0}"
-msgstr "Dependencias satisfechas; se cargarán las extensiones: {0}"
+msgstr "Yếu tố phụ thuộc được đáp ứng; các plugin này sẽ được tải: {0}"
 
 #: src/metabase/plugins/jdbc_proxy.clj
 msgid "Registering JDBC proxy driver for {0}..."
-msgstr "Registrando el controlador proxy JDBC para {0} ..."
+msgstr "Đăng ký trình điều khiển proxy JDBC cho {0} ..."
 
 #: src/metabase/plugins/jdbc_proxy.clj
 msgid "Deregistering original JDBC driver {0}..."
-msgstr "Anulación del registro del controlador JDBC original {0} ..."
+msgstr "Hủy đăng ký trình điều khiển JDBC gốc {0} ..."
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Default connection property {0} does not exist."
-msgstr "La propiedad de conexión predeterminada {0} no existe."
+msgstr "Thuộc tính kết nối mặc định {0} không tồn tại."
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Invalid connection property {0}: not a string or map."
-msgstr "Propiedad de conexión no válida {0}: no es una cadena o un mapa."
+msgstr "Thuộc tính kết nối không hợp lệ {0}: không phải là string hoặc map."
 
 #. ok, do the init steps listed in the plugin mainfest
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Load lazy loading driver {0}"
-msgstr "Cargar el controlador de carga oportunista {0}"
+msgstr "Tải trình điều khiển chậm chạp {0}"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Cannot initialize plugin: missing required property `driver-name`"
-msgstr "No se puede inicializar la extensión: falta la propiedad requerida `driver-name`"
+msgstr "Không thể khởi tạo plugin: thiếu thuộc tính bắt buộc `driver-name`"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Warning: plugin manifest for {0} does not include connection properties"
-msgstr "Advertencia: el manifest de la extensión {0} no incluye las propiedades de conexión"
+msgstr "Cảnh báo: file kê khai plugin cho {0} không bao gồm các thuộc tính kết nối"
 
 #. finally, register the Metabase driver
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Registering lazy loading driver {0}..."
-msgstr "Registrando el controlador de carga oportunista {0} ..."
+msgstr "Đăng ký driver chậm chạp {0} ..."
 
 #: src/metabase/pulse.clj
 msgid "Error running query for Card {0}"
-msgstr "Error al ejecutar la consulta para la tarjeta {0}"
+msgstr "Lỗi khi chạy truy vấn cho Thẻ {0}"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
-msgstr "La semana pasada"
+msgstr "Tuần trước"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This week"
-msgstr "Esta semana"
+msgstr "Tuần này"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
-msgstr "El mes pasado"
+msgstr "Tháng trước"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This month"
-msgstr "Este mes"
+msgstr "Tháng này"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
-msgstr "El trimestre pasado"
+msgstr "Quý trước"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
-msgstr "Este trimestre"
+msgstr "Quý này"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
-msgstr "El año pasado"
+msgstr "Năm ngoái"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This year"
-msgstr "Este año"
+msgstr "Năm nay"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "*driver* is unbound."
-msgstr "*controlador* no consolidado."
+msgstr "*driver* không ràng buộc."
 
 #: src/metabase/sync/sync_metadata/fields.clj
 msgid "Error syncing Fields for Table ''{0}''"
-msgstr "Error sincronizando Campos de la Tabla \"{0}\""
+msgstr "Lỗi đồng bộ hóa các trường cho Bảng '' {0} ''"
 
 #: src/metabase/sync/sync_metadata/fields.clj
 msgid "Hash of {0} matches stored hash, skipping Fields sync"
-msgstr "El hash de {0} coincide con el hash almacenado, omitiendo la sincronización de campos"
+msgstr "Băm của {0} khớp với hàm băm được lưu trữ, bỏ qua đồng bộ hóa Trường"
 
 #: src/metabase/sync/sync_metadata/fields/common.clj
 msgid "Field"
-msgstr "Campo"
+msgstr "Trường"
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Error checking if Fields {0} need to be created or reactivated"
-msgstr "Error al verificar si los Campos {0} necesitan ser creados o reactivados"
+msgstr "Lỗi khi kiểm tra xem liệu Trường {0} cần được tạo hoặc kích hoạt lại"
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Marking Field ''{0}'' as inactive."
-msgstr "Marcando el campo \"{0}\" como inactivo"
+msgstr " Đánh dấu Trường '' {0} '' là không hoạt động."
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Error retiring {0}"
-msgstr "Error retirando {0}"
+msgstr "Lỗi khi nghỉ hưu {0}"
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Database type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "El tipo de base de datos de {0} ha cambiado de ''{1}'' a ''{2}''."
+msgstr "Loại cơ sở dữ liệu của {0} đã thay đổi từ '' {1} '' thành '' {2} ''."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Base type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "El tipo base de {0} ha cambiado de ''{1}'' a ''{2}''."
+msgstr "Loại cơ sở của {0} đã thay đổi từ '' {1} '' thành '' {2} ''."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Special type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "El tipo especial de {0} ha cambiado de ''{1}'' a ''{2}''."
+msgstr "Loại đặc biệt của {0} đã thay đổi từ '' {1} '' thành '' {2} ''."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Comment has been added for {0}."
-msgstr "Se ha añadido un comentario para {0}."
+msgstr "Nhận xét đã được thêm cho {0}."
 
 #: src/metabase/task.clj
 msgid "Stopping Quartz Scheduler {0}"
-msgstr "Deteniendo Porgramador {0} de Quartz"
+msgstr "Dừng lại Quartz Scheduler {0}"
 
 #: src/metabase/task.clj
 msgid "Starting Quartz Scheduler {0}"
-msgstr "Inicializando Porgramador {0} de Quartz"
+msgstr "Bắt đầu Quartz Scheduler {0}"
 
 #: src/metabase/task.clj
 msgid "Error loading tasks namespace {0}"
-msgstr "Error cargando el espacio de nombre de tareas {0}"
+msgstr "Lỗi khi tải tác vụ namespace {0}"
 
 #. don't bother logging namespace for now, maybe in the future if there's tasks of the same name in multiple
 #. namespaces we can log it
 #: src/metabase/task.clj
 msgid "Initializing task {0}"
-msgstr "Inicializando tarea {0}"
+msgstr "Đang khởi tạo tác vụ {0}"
 
 #: src/metabase/task.clj
 msgid "Error initializing task {0}"
-msgstr "Error inicializando tarea {0}"
+msgstr "Lỗi khởi tạo tác vụ {0}"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Problem sending abandonment email"
-msgstr "Problema enviando correo electrónico de abandono"
+msgstr "Sự cố khi gửi email từ bỏ"
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Sending anonymous usage stats."
-msgstr "Enviando estadísticas anónimas de uso."
+msgstr "Gửi số liệu thống kê sử dụng ẩn danh."
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Error sending anonymous usage stats"
-msgstr "Error enviando estadísticas anónimas de uso."
+msgstr "Gửi số liệu thống kê sử dụng ẩn danh."
 
 #: src/metabase/task/send_pulses.clj
 msgid "Error sending Pulse {0}"
-msgstr "Error enviando pulso {0}"
+msgstr "Lỗi gửi Pulse {0}"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Sending scheduled pulses..."
-msgstr "Enviando pulsos programados..."
+msgstr "Gửi pulses theo lịch trình ..."
 
 #: src/metabase/task/send_pulses.clj
 msgid "SendPulses task failed"
-msgstr "La tarea Enviar Pulsos ha fallado"
+msgstr "Nhiệm vụ SendPulses không thành công"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Failed to scheduler tasks for Database {0}"
-msgstr "No se ha podido programar tareas para la base de datos {0}"
+msgstr "Không thể lập lịch tác vụ cho Cơ sở dữ liệu {0}"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Cleaning up task history"
-msgstr "Limpiando el historial de tareas"
+msgstr "Dọn dẹp lịch sử tác vụ"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, rows were deleted"
-msgstr "La limpieza del historial de tareas fue exitosa, las filas fueron eliminadas"
+msgstr "Dọn dẹp lịch sử tác vụ thành công, các hàng đã bị xóa"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, no rows were deleted"
-msgstr "La limpieza del historial de tareas fue exitosa, no se ha eliminado ninguna fila"
+msgstr "Dọn dẹp lịch sử tác vụ thành công, không có hàng nào bị xóa"
 
 #: src/metabase/task/upgrade_checks.clj
 msgid "Checking for new Metabase version info."
-msgstr "Buscando información de la versión de Metabase."
+msgstr "Kiểm tra thông tin về phiên bản Metabase mới."
 
 #: src/metabase/task/upgrade_checks.clj
 msgid "Error fetching version info"
-msgstr "Error obteniendo la información de versión"
+msgstr "Lỗi khi tìm thông tin phiên bản"
 
 #: src/metabase/util.clj
 msgid "Maximum memory available to JVM: {0}"
-msgstr "Memoria máxima disponible para JVM: {0}"
+msgstr "Bộ nhớ tối đa khả dụng cho JVM: {0}"
 
 #: src/metabase/util.clj
 msgid "Not something with an ID: {0}"
-msgstr "No es algo con un ID: {0}"
+msgstr "Không phải cái có ID: {0}"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by month of the year"
-msgstr "[[CreateDate]] por mes del año"
+msgstr "[[CreatDate]] theo tháng trong năm"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Here's a quick look at your [[this]]"
-msgstr "Aquí hay un vistazo rápido a tu [[this]]"
+msgstr "Dưới đây là một cái nhìn nhanh về [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by hour of the day"
-msgstr "[[CreateTimestamp]] por hora del día"
+msgstr "[[CreateTimestamp]] theo giờ trong ngày"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Where you've acquired your users"
-msgstr "Donde has adquirido tus usuarios"
+msgstr "Nơi bạn đã có được người dùng của mình"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How it's distributed across time and other categories."
-msgstr "Cómo se distribuye a través del tiempo y otras categorías."
+msgstr "Làm thế nào nó được phân phối theo thời gian và các loại khác."
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Here's a closer look at your [[this]] per source"
-msgstr "Aquí hay una vista más detallada a tu [[this]] por origen"
+msgstr "Đây là một cái nhìn sâu hơn về [[this]] theo mỗi nguồn"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Here's a quick look at the [[this]]"
-msgstr "Aquí hay un vistazo rápido a [[this]]"
+msgstr "Dây là một cái nhìn nhanh về [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by day of the month"
-msgstr "[[CreateTimestamp]] por día del mes"
+msgstr "[[CreateTimestamp]] theo ngày trong tháng"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Here's an overview of the people in your [[this]]"
-msgstr "Aquí hay un resumen de las personas en tu [[this]]"
+msgstr "Dưới đây là tổng quan về những người trong [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by quarter of the year"
-msgstr "[[CreateTimestamp]] por trimestre del año"
+msgstr "[[CreateTimestamp]] theo quý của năm"
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
-msgstr "Cómo se comparan a través de la ubicación"
+msgstr "Cách họ so sánh giữa các vị trí"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Here's a closer look at your [[this]] by products"
-msgstr "Aquí hay una vista con más detalle de tu [[this]] por productos"
+msgstr "Đây là một cái nhìn sâu hơn về [[this]] của bạn theo sản phẩm"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by month of the year"
-msgstr "[[CreateTimestamp]] por mes del año"
+msgstr "[[CreateTimestamp]] theo tháng trong năm"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "An overview of your [[this]] and how it's distributed across time, place, and categories."
-msgstr "Una visión general de tu [[this]] y cómo se distribuye en el tiempo, el lugar y las categorías."
+msgstr "Tổng quan về [[this]] của bạn và cách phân phối theo thời gian, địa điểm và danh mục."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "Here's a closer look at your [[this]]"
-msgstr "Aquí hay una vista con más detalle de tu [[this]]"
+msgstr "Đây là một cái nhìn sâu hơn về [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by day of the week"
-msgstr "[[CreateTimestamp]] por día de la semana"
+msgstr "[[CreateTimestamp]] theo ngày trong tuần"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Here's an overview of your [[this]] data from Google Analytics"
-msgstr "Aquí hay una descripción general de tus datos [[this]] de Google Analytics"
+msgstr "Đây là tổng quan về dữ liệu [[this]] của bạn từ Google Analytics"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
@@ -12098,633 +12053,631 @@ msgstr "Aquí hay una descripción general de tus datos [[this]] de Google Analy
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
-msgstr "Aquí hay una visión general de tu [[this]]"
+msgstr "Đây là tổng quan về [[this]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Here's a closer look at your [[this]] field"
-msgstr "Aquí hay una vista con más detalle de tu campo [[this]]"
+msgstr "Đây là một cái nhìn sâu hơn về trường [[this]] của bạn"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Here's a closer look at your [[this]] per country"
-msgstr "Aquí hay una vista con más detalle de tu [[this]] por país"
+msgstr "Đây là một cái nhìn sâu hơn về [[this]] của bạn theo quốc gia"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "If you're into correlations, this is the x-ray for you."
-msgstr "Si te interesan las correlaciones, esta es la radiografía para ti."
+msgstr "Nếu bạn quan tâm đến sự tương quan, đây là bản X quang cho bạn."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by day of the week"
-msgstr "[[CreateDate]] por día de la semana"
+msgstr "[[CreateDate]] theo ngày trong tuần"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "It looks like your [[this]] has transactions, so here's a look at them"
-msgstr "Parece que tu [[this]] tiene transacciones, así que aquí hay un vistazo a ellas"
+msgstr "Có vẻ như [[this]] của bạn có giao dịch, vậy đây là một cái nhìn về chúng"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Here's a closer look at your [[this]] per state"
-msgstr "Aquí hay una vista con más detalle de tu [[this]] por estado"
+msgstr "Đây là một cái nhìn sâu hơn về [[này]] theo từng trạng thái"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by day of the month"
-msgstr "[[CreateDate]] por día del mes"
+msgstr "[[CreatDate]] theo ngày trong tháng"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTime]] by hour of the day"
-msgstr "[[CreateTime]] por hora del día"
+msgstr "[[CreatTime]] theo giờ trong ngày"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Here's a closer look at your [[this]] over time"
-msgstr "Aquí hay una mirada con más detalle de tu [[this]] a lo largo del tiempo"
+msgstr "Đây là một cái nhìn sâu hơn về [[this]] của bạn theo thời gian"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by quarter of the year"
-msgstr "[[CreateDate]] por trimestre del año"
+msgstr "[[CreatDate]] theo quý trong năm"
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:202
 msgid "Edit user"
-msgstr "Editar usuario"
+msgstr "Chỉnh sửa người dùng"
 
 #: frontend/src/metabase/admin/people/containers/NewUserModal.jsx:13
 msgid "New user"
-msgstr "Nuevo usuario"
+msgstr "Người dùng mới"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:206
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
-msgstr "Restablecer contraseña"
+msgstr "Đặt lại mật khẩu"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:210
 msgid "Deactivate user"
-msgstr "Desactivar usuario"
+msgstr "Vô hiệu hóa người dùng"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:47
 msgid "Reactivate {0}?"
-msgstr "¿Reactivar {0}?"
+msgstr "Kích hoạt lại {0}?"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:63
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
-msgstr "No se ha podido enviar la invitación por correo electrónico, así que asegúrate de decirles que inicien sesión utilizando {0} y esta contraseña que hemos generado para ellos:"
+msgstr "Chúng tôi không thể gửi cho họ lời mời qua email, vì vậy hãy yêu cầu họ đăng nhập bằng {0} và mật khẩu này mà chúng tôi đã tạo cho họ:"
 
 #: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
-msgstr "colección"
+msgstr "bộ sưu tập"
 
 #: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
-msgstr "colecciones"
+msgstr "bộ sưu tập"
 
 #: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
-msgstr "cuadro de mando"
+msgstr "bảng điều khiển"
 
 #: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
-msgstr "cuadros de mando"
+msgstr "bảng điều khiển"
 
 #: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
-msgstr "El nombre es obligatorio"
+msgstr "Tên là bắt buộc"
 
 #: frontend/src/metabase/entities/users.js:38
 #: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
-msgstr "Debe ser 100 caracteres o menos"
+msgstr "Phải từ 100 ký tự trở xuống"
 
 #: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
-msgstr "El apellido es obligatorio"
+msgstr "Họ là bắt buộc"
 
 #: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
-msgstr "El email es obligatorio"
+msgstr "Email là bắt buộc"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
-msgstr "Los artículos que archives aparecerán aquí."
+msgstr "Các mục bạn lưu trữ sẽ xuất hiện ở đây."
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:16
 msgid "No description"
-msgstr "Sin descripción"
+msgstr "Không có mô tả"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
-msgstr "Suma de todos los valores"
+msgstr "Tổng tất cả các giá trị"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
-msgstr "Ver todos los valores distintos"
+msgstr "Xem tất cả các giá trị riêng biệt"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:12
 msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started"
-msgstr "Examina el contenido de tus bases de datos, tablas y columnas. Elija una base de datos para empezar"
+msgstr "Duyệt nội dung của cơ sở dữ liệu, bảng và cột của bạn. Chọn một cơ sở dữ liệu để bắt đầu"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is VALID. Thanks!"
-msgstr "Los metadatos de resultados de tarjetas pasados a API son VÁLIDOS. ¡Gracias!"
+msgstr "Metadata của các kết quả thẻ được truyền vào API là HỢP LỆ. Xin cảm ơn!"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is INVALID. Running query to fetch correct metadata."
-msgstr "Los metadatos de resultados de tarjetas pasados a API son INVÁLIDOS. Ejecutando la consulta para obtener los metadatos correctos."
+msgstr "Metadata của các kết quả thẻ được truyền vào API là KHÔNG HỢP LỆ. Chạy truy vấn để lấy metadata chính xác."
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is  ISSING. Running query to fetch correct metadata."
-msgstr "Los metadatos de resultados de tarjetas pasados a API NO ESTÁN. Ejecutando la consulta para obtener los metadatos correctos."
+msgstr "KHÔNG TÌM THẤY metadata của các kết quả thẻ thông qua API. Chạy truy vấn để lấy metadata chính xác."
 
 #: src/metabase/api/email.clj
 msgid "{0} was autocorrected to {1}"
-msgstr "se ha autocorregido {0} a {1}"
+msgstr "{0} đã được tự động chuyển thành {1}"
 
 #: src/metabase/api/metric.clj
 msgid "DELETE /api/metric/:id is deprecated. Instead, change its `archived` value via PUT /api/metric/:id."
-msgstr "DELETE /api/metric/:id está obsoleta. En su lugar cambia el valor de `archivado` con PUT /api/metric/:id."
+msgstr "DELETE /api/metric/:id không được dùng nữa. Thay vào đó, thay đổi giá trị `archived` của nó thông qua PUT /api/metric/:id."
 
 #: src/metabase/api/segment.clj
 msgid "DELETE /api/segment/:id is deprecated. Instead, change its `archived` value via PUT /api/segment/:id."
-msgstr "DELETE /api/segment/:id está obsoleta. En su lugar cambia el valor de `archivado` con PUT /api/segment/:id."
+msgstr "DELETE /api/segment/:id không được dùng nữa. Thay vào đó, thay đổi giá trị `archived` của nó thông qua PUT /api/segment/:id."
 
 #: src/metabase/api/user.clj
 msgid "Value of is_superuser must correspond to presence of Admin group ID in group_ids."
-msgstr "El valor de is_superuser debe corresponder a la presencia de ID de grupo de administración en group_ids."
+msgstr "Giá trị của is_superuser phải tương ứng với sự hiện diện của ID của nhóm quản trị viên trong group_ids."
 
 #: src/metabase/async/api_response.clj
 msgid "Unexpected error writing keepalive characters"
-msgstr "Error inesperado al escribir caracteres keepalive"
+msgstr "Lỗi bất ngờ khi viết các ký tự cố định"
 
 #: src/metabase/async/api_response.clj
 msgid "Unexpected output in async API response"
-msgstr "Salida inesperada en la respuesta de la API asíncrona"
+msgstr "Đầu ra bất ngờ trong phản hồi API async"
 
 #: src/metabase/async/api_response.clj
 msgid "starting streaming response"
-msgstr "iniciando la respuesta de streaming"
+msgstr "bắt đầu phản hồi trực tuyến"
 
 #: src/metabase/async/api_response.clj
 msgid "Output chan closed, canceling keepalive request."
-msgstr "Salida cerrada, cancelando la solicitud de keepalive."
+msgstr "Output chan đóng lại, hủy bỏ yêu cầu keepalive."
 
 #: src/metabase/async/api_response.clj
 msgid "Async response finished, closing channels."
-msgstr "Respuesta asincrónica finalizada, cerando canales."
+msgstr "Đáp ứng Async xong, đóng kênh."
 
 #: src/metabase/async/api_response.clj
 msgid "No response after waiting {0}. Canceling request."
-msgstr "No hay respuesta después de esperar {0}. Cancelando solicitud."
+msgstr "Không có phản hồi sau khi chờ đợi {0}. Hủy yêu cầu."
 
 #: src/metabase/async/api_response.clj
 msgid "Input channel unexpectedly closed."
-msgstr "Se ha cerrado inesperadamente el canal de entrada."
+msgstr "Kênh đầu vào bất ngờ đóng."
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "f finished, permit will be returned"
-msgstr "f ha terminado, se devolverá el permiso"
+msgstr "nếu hoàn thành, giấy phép sẽ được trả lại"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "request canceled, permit will be returned"
-msgstr "solicitud cancelada, se devolverá el permiso"
+msgstr "yêu cầu hủy bỏ, giấy phép sẽ được trả lại"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Unexpected error attempting to run function after obtaining permit"
-msgstr "Error inesperado al intentar ejecutar la función después de obtener el permiso"
+msgstr "Lỗi không mong muốn khi chạy chức năng sau khi có giấy phép"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Not running pending function call: output channel already closed."
-msgstr "No se está ejecutando la llamada de función pendiente: el canal de salida ya está cerrado."
+msgstr "Không chạy chức năng đang chờ xử lý: kênh đầu ra đã bị đóng."
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Current thread already has a permit for {0}, will not wait to acquire another"
-msgstr "El hilo actual ya tiene un permiso para {0}, no esperamos a adquirir otro"
+msgstr "Chủ đề hiện tại đã có giấy phép cho {0}, sẽ không chờ để có được một giấy phép khác"
 
 #: src/metabase/async/util.clj
 msgid "Output channel closed, will skip running {0}."
-msgstr "Canal de salida cerrado, no se ejecutará {0}."
+msgstr "Kênh đầu ra đã đóng, sẽ bỏ qua việc chạy {0}."
 
 #: src/metabase/async/util.clj
 msgid "Running {0} on separate thread..."
-msgstr "Ejecutando {0} en un hilo separado..."
+msgstr "Chạy {0} trên luồng riêng ..."
 
 #: src/metabase/async/util.clj
 msgid "Caught error running {0}"
-msgstr "Error capturado ejecutando {0}"
+msgstr "Lỗi bắt gặp khi chạy {0}"
 
 #: src/metabase/async/util.clj
 msgid "Request canceled, canceling future"
-msgstr "Solicitud cancelada, cancelando futuro"
+msgstr "Yêu cầu bị hủy bỏ, đang hủy các yêu cầu tương lai"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Closing old connection pool for database {0} ..."
-msgstr "Cerrando el grupo de conexiones antiguas de la base de datos {0} ..."
+msgstr "Đóng nhóm kết nối cũ cho cơ sở dữ liệu {0} ..."
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s your {0} most recent cards:"
-msgstr "Aquí están tus {0} tarjetas más recientes:"
+msgstr "Đây là {0} thẻ gần đây nhất của bạn:"
 
 #: src/metabase/metabot/command.clj
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
-msgstr "¿Podrías ser un poco más específico, o usar la identificación? He encontrado estas tarjetas con nombres que coinciden:"
+msgstr "Bạn có thể cụ thể hơn một chút, hoặc sử dụng ID? Tôi tìm thấy những thẻ có tên phù hợp:"
 
 #: src/metabase/driver/common/parameters/values.clj
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
-msgstr "No se ha encontrado la tarjeta {0}"
+msgstr "Không tìm thấy thẻ {0}."
 
 #: src/metabase/middleware/exceptions.clj
 msgid "Exception in API call"
-msgstr "Excepción en la llamada a la API"
+msgstr "Ngoại lệ trong lệnh gọi API"
 
 #: src/metabase/middleware/exceptions.clj
 msgid "Request canceled before finishing."
-msgstr "Solicitud cancelada antes de terminar."
+msgstr "Yêu cầu bị hủy trước khi hoàn thành."
 
 #: src/metabase/middleware/json.clj
 msgid "Metabase only supports JSON requests."
-msgstr "Metabase solo admite solicitudes JSON."
+msgstr "Metabase chỉ hỗ trợ các yêu cầu JSON."
 
 #: src/metabase/middleware/json.clj
 msgid "Make sure you set a 'Content-Type: application/json' header."
-msgstr "Asegúrate de establecer un encabezado 'Content-Type: application / json'."
+msgstr "Hãy chắc chắn rằng bạn thiết lập một tiêu đề 'Content-Type: application / json' ."
 
 #: src/metabase/middleware/misc.clj
 msgid "Setting Metabase site URL to {0}"
-msgstr "Estableciendo la URL de Metabase a {0}"
+msgstr "Đặt URL trang web Metabase thành {0}"
 
 #: src/metabase/models/database.clj
 msgid "Error scheduling tasks for DB"
-msgstr "Error programando tareas para DB"
+msgstr "Lỗi khi lên lịch tác vụ cho DB"
 
 #: src/metabase/models/database.clj
 msgid "Error unscheduling tasks for DB."
-msgstr "Error desprogramando tareas para DB"
+msgstr "Lỗi khi hủy lịch tác vụ cho DB"
 
 #: src/metabase/models/database.clj
 msgid "{0} Database ''{1}'' sync/analyze schedules have changed!"
-msgstr "\"{1}\" tiempos de sincronización/análisis han cambiado en {0}"
+msgstr "{0} Lịch trình đồng bộ hóa / phân tích cơ sở dữ liệu '' {1} '' đã thay đổi!"
 
 #: src/metabase/models/database.clj
 msgid "Sync metadata was: ''{0}'' is now: ''{1}''"
-msgstr "Sincronización de metadatos: ''{0}'' es ahora: ''{1}''"
+msgstr "Đồng bộ hóa metadata là: ''{0}'' hiện là: ''{1}''"
 
 #: src/metabase/models/database.clj
 msgid "Cache FieldValues was: ''{0}'', is now: ''{1}''"
-msgstr "Valor de campo en cache era: ''{0}'', ahora es: ''{1}''"
+msgstr "Cache FieldValues là: ''{0}'' hiện là: ''{1}''"
 
 #: src/metabase/models/metric.clj
 msgid "You cannot update the creator_id of a Metric."
-msgstr "No se puede cambiar el creado de una métrica."
+msgstr "Bạn không thể cập nhật creator_id của một Metric."
 
 #: src/metabase/models/permissions.clj
 msgid "MetaBot can only have Collection permissions."
-msgstr "MetaBot solo puede tener permisos de Colección."
+msgstr "MetaBot chỉ có thể có quyền Collection."
 
 #: src/metabase/models/permissions.clj
 msgid "Failed to grant permissions"
-msgstr "Error al otorgar permisos"
+msgstr "Không thể cấp quyền"
 
 #: src/metabase/models/permissions.clj
 msgid "Changing permissions"
-msgstr "Cambiando los permisos"
+msgstr "Thay đổi quyền"
 
 #: src/metabase/models/permissions.clj
 msgid "FROM:"
-msgstr "DE:"
+msgstr "TỪ:"
 
 #: src/metabase/models/permissions.clj
 msgid "TO:"
-msgstr "A:"
+msgstr "ĐẾN:"
 
 #: src/metabase/models/segment.clj
 msgid "You cannot update the creator_id of a Segment."
-msgstr "No se puede cambiar el creador de un segmento."
+msgstr "Bạn không thể cập nhật creator_id của Segment."
 
 #: src/metabase/models/setting.clj
 msgid "Attempted to set Setting {0} to obfuscated value. Ignoring change."
-msgstr "Se intentó establecer la configuración {0} en un valor obfuscado. Ignorando el cambio."
+msgstr "Đã cố gắng đặt Cài đặt {0} thành giá trị bị xáo trộn. Bỏ qua sự thay đổi."
 
 #: src/metabase/models/setting.clj
 msgid "Using value of env var {0}"
-msgstr "Utilizando el valor de la variable de entorno {0}"
+msgstr "Sử dụng giá trị của env var {0}"
 
 #: src/metabase/models/user.clj
 msgid "Adding User {0} to All Users permissions group..."
-msgstr "Agregando el usuario {0} al grupo de todos los usuarios..."
+msgstr "Thêm người dùng {0} vào nhóm Tất cả người dùng ..."
 
 #: src/metabase/models/user.clj
 msgid "Adding User {0} to Admin permissions group..."
-msgstr "Agregando el usuario {0} al grupo de permisos de administrador..."
+msgstr "Thêm người dùng {0} vào nhóm Quản trị viên ..."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
-msgstr "Fallo en la consulta"
+msgstr "Truy vấn thất bại"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
-msgstr "Número máximo de consultas simultáneas permitidas por base de datos conectada."
+msgstr "Số lượng truy vấn đồng thời tối đa để cho phép trên mỗi Cơ sở dữ liệu được kết nối."
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
-msgstr "Tiempo agotado después de {0} milisegundos."
+msgstr "Đã hết thời gian sau {0} mili giây."
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
 msgid "Misfire Instruction"
-msgstr "Instrucciones de fallo"
+msgstr "Hướng dẫn Misfire"
 
 #: frontend/src/metabase/components/ArchiveModal.jsx:31
 msgid "Archive this?"
-msgstr "¿Archivar esto?"
+msgstr "Lưu trữ cái này?"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
-msgstr "Aprende cosas de nuestros datos"
+msgstr "Tìm hiểu về dữ liệu"
 
 #: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
-msgstr "Utiliza DNS SRV al conectar"
+msgstr "Sử dụng DNS SRV khi kết nối"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
 msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
 "an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
 "leave this disabled."
-msgstr "Esta opción requiere que el host sea FQDN. Si se conecta a un clúster Atlas, es posible que deba habilitar esta opción. Si no sabe lo que esto significa, deje esto deshabilitado."
+msgstr "Sử dụng tùy chọn này yêu cầu máy chủ được cung cấp là FQDN. Nếu kết nối với cụm Atlas, bạn có thể cần bật tùy chọn này. Nếu bạn không biết điều này có nghĩa là gì, hãy để điều này bị vô hiệu hóa."
 
 #: frontend/src/metabase/entities/databases/forms.js:273
 msgid "Automatically run queries when doing simple filtering and summarizing"
-msgstr "Ejecutar consultas automáticamente al realizar un filtrado/resumen simple"
+msgstr "Tự động chạy truy vấn khi thực hiện lọc và tóm tắt đơn giản"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
 msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
-msgstr "Cuando esto está activo en Metabase, se ejecutarán consultas automáticamente cuando los usuarios realicen exploraciones simples con los botones Resumir y Filtrar al ver una tabla o gráfico. Puedes desactivar esto si las consultas de esta base de datos son lentas. Esta configuración no afecta la obtención de detalles ni a las consultas SQL."
+msgstr "Khi cái này trên Metabase sẽ tự động chạy các truy vấn khi người dùng thực hiện các khám phá đơn giản với các nút Tóm tắt và Lọc khi xem bảng hoặc biểu đồ. Bạn có thể tắt cái này nếu truy vấn cơ sở dữ liệu này chậm. Cài đặt này không ảnh hưởng đến các truy vấn sâu hoặc truy vấn SQL."
 
 #: frontend/src/metabase/containers/Overworld.jsx:329
 msgid "Learn about this database"
-msgstr "Aprende cosas sobre esta base de datos"
+msgstr "Tìm hiểu về cơ sở dữ liệu này"
 
 #: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
 msgid "Archive this dashboard?"
-msgstr "¿Archivar este cuadro de mando?"
+msgstr "Lưu trữ bảng điều khiển này?"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:112
 msgid "All results"
-msgstr "Todos los resultados"
+msgstr "Tất cả kết quả"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:175
 msgid "Our Analytics"
-msgstr "Nuestras Analíticas"
+msgstr "Phân tích của chúng tôi"
 
 #: frontend/src/metabase/lib/schema_metadata.js:513
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
-msgstr "Suma aditiva de todos los valores de una columna.\\ne.g. ingresos totales a lo largo del tiempo."
+msgstr "Tổng cộng của tất cả các giá trị của một cột. \\ Nv.d. tổng doanh thu theo thời gian."
 
 #: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
-msgstr "Conteo aditivo del número de filas.\\ne.g. Número total de ventas en el tiempo."
+msgstr "Tổng số cộng của số lượng hàng. \\ Nv.d. tổng số lượng bán hàng theo thời gian."
 
 #: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:98
 msgid "Filter"
-msgstr "Filtro"
+msgstr "Lọc"
 
 #: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:50
 msgid "record"
 msgid_plural "records"
-msgstr[0] "registro"
-msgstr[1] "registros"
+msgstr[0] "bản ghi\n"
+"Số nhiều: các bản ghi"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:369
 msgid "Browse Data"
-msgstr "Navegar "
+msgstr "Duyệt dữ liệu"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:402
 msgid "Write SQL"
-msgstr "Escribir SQL"
+msgstr "Viết truy vấn SQL"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
-msgstr "Pregunta Simple"
+msgstr "Câu hỏi đơn giản"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:87
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
-msgstr "Elige algunos datos, visualízalos y fíltralos, resúmelos y analízalos fácilmente."
+msgstr "Chọn một số dữ liệu, xem nó và dễ dàng lọc, tóm tắt và trực quan hóa nó."
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:98
 msgid "Custom question"
-msgstr "Pregunta personalizada"
+msgstr "Câu hỏi tuỳ chỉnh"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:99
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
-msgstr "Utiliza el editor avanzado para unir datos, crear columnas personalizadas, hacer cálculos matemáticos y más."
+msgstr "Sử dụng trình chỉnh sửa sổ ghi chép nâng cao để nối dữ liệu, tạo cột tùy chỉnh, làm toán và hơn thế nữa."
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Basic Metrics"
-msgstr "Indicadores básicos"
+msgstr "Các số liệu cơ bản"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
 msgid "Custom…"
-msgstr "Personalizado..."
+msgstr "Tuỳ chỉnh..."
 
 #: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
 msgid "Add grouping"
-msgstr "Añadir agrupación"
+msgstr "Thêm gom nhóm"
 
 #: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
 msgid "Pick a limit"
-msgstr "Seleccione un límite"
+msgstr "Chọn một giới hạn"
 
 #: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
 msgid "Show maximum"
-msgstr "Mostrar máximo"
+msgstr "Hiển thị tối đa"
 
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:45
 msgid "Get Preview"
-msgstr "Vista previa"
+msgstr "Xem trước"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
 msgid "Back to previous results"
-msgstr "Volver a los resultados anteriores"
+msgstr "Trở về kết quả trước"
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
 msgid "Sample values"
-msgstr "Valores de ejemplo"
+msgstr "Giá trị mẫu"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
 msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
-msgstr "Explora el contenido de tus bases de datos, tablas y columnas. Elige una base de datos para empezar."
+msgstr "Duyệt nội dung của cơ sở dữ liệu, bảng và cột của bạn. Chọn một cơ sở dữ liệu để bắt đầu."
 
 #: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
 msgid "Visualize"
-msgstr "Visualizar"
+msgstr "Hình dung"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
 msgid "Join data"
-msgstr "Unir datos"
+msgstr "Kết nối dữ liệu"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
 msgid "Custom column"
-msgstr "Columna personalizada"
+msgstr "Cột tùy chỉnh"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
 #: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:60
 msgid "Summarize"
-msgstr "Resumir"
+msgstr "Tổng kết"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
 msgid "Aggregate"
-msgstr "Agregar"
+msgstr "Tổng hợp"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
 msgid "Breakout"
-msgstr "Desglosar"
+msgstr "Đột phá"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
 msgid "Pick the metric you want to see"
-msgstr "Elige la métrica que quieres ver"
+msgstr "Chọn một số liệu bạn muốn thấy"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
 msgid "Pick a column to group by"
-msgstr "Elige una columna para agrupar"
+msgstr "Chọn một cột để gom nhóm"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:28
 msgid "Pick your starting data"
-msgstr "Elige tus datos iniciales"
+msgstr "Chọn dữ liệu bắt đầu của bạn"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select None"
-msgstr "Selecciona Ninguno"
+msgstr "Không chọn gì"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select All"
-msgstr "Selecciona Todos"
+msgstr "Chọn tất cả"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:152
 msgid "Pick a table..."
-msgstr "Elige una tabla..."
+msgstr "Chọn một bảng..."
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
 msgid "Enter a limit"
-msgstr "Introduce un límite"
+msgstr "Điền một giới hạn"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:273
 msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
-msgstr "Los corchetes alrededor de un {0} crean una cláusula opcional en la plantilla. Si se establece \"variable\", la cláusula completa se coloca en la plantilla. Si no, se ignora toda la cláusula."
+msgstr "Các dấu ngoặc quanh {0} tạo một mệnh đề tùy chọn trong mẫu. Nếu \"biến\" được đặt, thì toàn bộ mệnh đề được đặt vào mẫu. Nếu không, thì toàn bộ mệnh đề được bỏ qua."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:290
 msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
-msgstr "Cuando se usa un Filtro de Campo, el nombre de la columna no debe incluirse en la SQL. En su lugar, la variable debe asignarse a un campo en el panel lateral."
+msgstr "Khi sử dụng Bộ lọc trường, tên cột không được đưa vào SQL. Thay vào đó, biến nên được ánh xạ tới một trường trong bảng điều khiển bên."
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
 msgid "View the native query"
-msgstr "Ver la consulta nativa"
+msgstr "Xem truy vấn gốc"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
 msgid "Native query for this question"
-msgstr "Consulta nativa de esta pregunta"
+msgstr "Truy vấn gốc cho câu hỏi này"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
 msgid "Convert this question to a native query"
-msgstr "Convertir esta pregunta en una consulta nativa"
+msgstr "Chuyển đổi câu hỏi này thành truy vấn gốc"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
 msgid "SQL for this question"
-msgstr "SQL de esta pregunta"
+msgstr "SQL cho câu hỏi này"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
 msgid "Convert this question to SQL"
-msgstr "Convertir esta pregunta a SQL"
+msgstr "Chuyển câu hỏi sang SQL"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
 msgid "Get alerts"
-msgstr "Recibir alertas"
+msgstr "Xem các cảnh báo"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
 msgid "{0} breakout"
 msgid_plural "{0} breakouts"
-msgstr[0] "desglose de {0}"
-msgstr[1] "desgloses de {0}"
+msgstr[0] "{0} đột phá"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:41
 msgid "Hide filters"
-msgstr "Esconder filtros"
+msgstr "Ẩn bộ lọc"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:41
 msgid "Show filters"
-msgstr "Mostrar filtros"
+msgstr "Hiện bộ lọc"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:18
 msgid "Started from"
-msgstr "Iniciado desde"
+msgstr "Bắt đầu từ"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
 msgid "{0} row"
 msgid_plural "{0} rows"
-msgstr[0] "{0} fila"
-msgstr[1] "{0} filas"
+msgstr[0] "{0} hàng"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
 msgid "Show all rows"
-msgstr "Mostrar todas las filas"
+msgstr "Hiển thị tất cả các hàng"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
 msgid "Show {0}"
-msgstr "Mostrar {0}"
+msgstr "Hiển thị {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
 msgid "Showing first {0}"
-msgstr "Mostrando los primeros {0}"
+msgstr "Hiển thị {0} đầu tiên"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
 msgid "Showing {0}"
-msgstr "Mostrando {0}"
+msgstr "Hiển thị {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
 msgid "Summarized"
-msgstr "Resumido"
+msgstr "Tóm tắt"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionNotebookButton.jsx:17
 msgid "Hide editor"
-msgstr "Esconder editor"
+msgstr "Ẩn công cụ biên tập"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionNotebookButton.jsx:17
 msgid "Show editor"
-msgstr "Mostrar editor"
+msgstr "Hiển thị công cụ biên tập"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
 msgid "Pick the metric you'd like to see"
-msgstr "Elige la métrica que quieres ver"
+msgstr "Chọn số liệu bạn muốn xem"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:29
 msgid "{0} options"
-msgstr "{0} opciones"
+msgstr "{0} tùy chọn"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
 msgid "Choose a visualization"
-msgstr "Elige una visualización"
+msgstr "Chọn một hiển thị"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
 msgid "Filter by"
-msgstr "Filtrar por"
+msgstr "Lọc theo"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
 msgid "Summarize by"
-msgstr "Resumir por"
+msgstr "Tóm tắt bằng"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
 msgid "Group by"
-msgstr "Agrupar por"
+msgstr "Nhóm theo"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
 msgid "Add a metric"
-msgstr "Añadir una métrica"
+msgstr "Thêm một số liệu"
 
 #: frontend/src/metabase/lib/core.js:137 frontend/src/metabase/lib/core.js:142
 #: frontend/src/metabase/lib/core.js:147 frontend/src/metabase/lib/core.js:152
 #: frontend/src/metabase/lib/core.js:157 frontend/src/metabase/lib/core.js:162
 #: frontend/src/metabase/user/components/UserSettings.jsx:64
 msgid "Profile"
-msgstr "Perfil"
+msgstr "Hồ sơ"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:567
 msgid "This is usually pretty fast but seems to be taking a while right now."
-msgstr "Esto suele ser bastante rápido, pero parece estar tardando un poco en este momento."
+msgstr "Điều này thường khá nhanh nhưng bây giờ dường như sẽ mất một lúc."
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
 msgid "Combo"
@@ -12732,1012 +12685,1012 @@ msgstr "Combo"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
 msgid "Row"
-msgstr "Fila"
+msgstr "Hàng"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
 msgid "Trend"
-msgstr "Tendencia"
+msgstr "Xu thế"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:129
 msgid "Boolean"
-msgstr "Booleano"
+msgstr "Boolean"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:62
 msgid "Unknown Segment"
-msgstr "Segmento Desconocido"
+msgstr "Phân đoạn không xác định"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:73
 msgid "Unknown Filter"
-msgstr "Filtro Desconocido"
+msgstr "Bộ lọc không xác định"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
 msgid "Left outer join"
-msgstr "Unión izquierda externa"
+msgstr "Kết nối bên ngoài bên trái"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:26
 msgid "Right outer join"
-msgstr "Unión derecha externa"
+msgstr "Kết nối bên ngoài bên phải"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:27
 msgid "Inner join"
-msgstr "Unión interna"
+msgstr "Kết nối trong"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:28
 msgid "Full outer join"
-msgstr "Unión externa completa"
+msgstr "Kết nối đầy đủ bên ngoài"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
-msgstr "FALTAN los metadatos de resultados de la tarjeta en el API. Ejecutando la consulta para obtener los metadatos correctos."
+msgstr "Siêu dữ liệu kết quả thẻ được truyền vào API là MISSING. Chạy truy vấn để lấy siêu dữ liệu chính xác."
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fall back to local authentication"
-msgstr "Problema al conectarse al servidor LDAP, utilizaré la autentificación local"
+msgstr "Có vấn đề khi kết nối tới máy chủ LDAP, chuyển về xác thực cục bộ"
 
 #: src/metabase/api/setup.clj
 msgid "Cannot create Database: cannot find driver {0}."
-msgstr "No se puede crear la base de datos: no se puede encontrar el controlador {0}."
+msgstr "Không thể tạo cơ sở dữ liệu: không thể tìm thấy trình điều khiển {0}."
 
 #: src/metabase/api/tiles.clj
 msgid "Query failed"
-msgstr "Falló la consulta"
+msgstr "Truy vấn thất bại"
 
 #: src/metabase/async/util.clj
 msgid "Warning: {0} returned `nil`"
-msgstr "Aviso: {0} devolvió `nulo`"
+msgstr "Cảnh báo: {0} đã trả lại `nil`"
 
 #: src/metabase/async/util.clj
 msgid "Unexpected error writing result to output channel: already closed"
-msgstr "Error inesperado al escribir el resultado en el canal de salida: ya cerrado"
+msgstr "Lỗi không mong muốn khi viết kết quả vào kênh đầu ra: đã đóng"
 
 #: src/metabase/async/util.clj
 msgid "Unexpected error writing exception to output channel: already closed"
-msgstr "Error inesperado al escribir la excepción en el canal de salida: ya cerrado"
+msgstr "Lỗi không mong muốn khi viết ngoại lệ vào kênh đầu ra: đã đóng"
 
 #: src/metabase/async/util.clj
 msgid "Request canceled, canceling future."
-msgstr "Solicitud cancelada, cancelando futuro."
+msgstr "Yêu cầu đã hủy, hủy trong tương lai."
 
 #: src/metabase/cmd/load_from_h2.clj
 msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
-msgstr "Metabase solo puede transferir datos de H2 a Postgres o MySQL/MariaDB."
+msgstr "Metabase chỉ có thể chuyển dữ liệu từ H2 sang Postgres hoặc MySQL / MariaDB."
 
 #: src/metabase/db.clj
 msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
-msgstr "ADVERTENCIA: No se recomienda usar Metabase con una base de datos de aplicaciones H2 para implementaciones de producción."
+msgstr "CẢNH BÁO: Không nên sử dụng Metabase với cơ sở dữ liệu ứng dụng H2 để triển khai môi trường production"
 
 #: src/metabase/db.clj
 msgid "Application database setup"
-msgstr "Configuración de la base de datos de la aplicación"
+msgstr "Thiết lập cơ sở dữ liệu ứng dụng"
 
 #: src/metabase/driver.clj
 msgid "Could not find {0} driver."
-msgstr "No se pudo encontrar el controlador {0}."
+msgstr "Không thể tìm thấy trình điều khiển {0}."
 
 #: src/metabase/driver/impl.clj
 msgid "Abstract drivers cannot derive from concrete parent drivers."
-msgstr "Los controladores abstractos no pueden derivar de controladores padres concretos."
+msgstr "Trình điều khiển trừu tượng không thể xuất phát từ trình điều khiển cha cụ thể."
 
 #: src/metabase/driver/mysql.clj
 msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
-msgstr "Es posible que tengas que añadir 'trustServerCertificate=true' a las opciones de conexión adicionales para conectarte con SSL."
+msgstr "Bạn có thể cần thêm 'trustServerCertert = true' vào các tùy chọn kết nối bổ sung để kết nối với SSL."
 
 #: src/metabase/driver/sql/util.clj
 msgid "Don't know how to alias {0}, expected an Identifer."
-msgstr "No sé cómo hacer un alias de {0}, esperaba un identificador."
+msgstr "Không biết cách đặt bí danh {0}, dự kiến một Định danh."
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Client closed connection, canceling query"
-msgstr "Conexión cerrada por el cliente, cancelando la consulta"
+msgstr "Kết nối bị đóng, huỷ truy vấn"
 
 #: src/metabase/integrations/ldap.clj
 msgid "{0} is not a valid DN."
-msgstr "{0} no es un DN válido."
+msgstr "{0} không phải là một DN hợp lệ."
 
 #: src/metabase/middleware/log.clj
 msgid "Error logging API request"
-msgstr "Error al registrar la solicitud de la API"
+msgstr "Lỗi ghi nhận yêu cầu API"
 
 #: src/metabase/middleware/misc.clj
 msgid "Failed to set site-url"
-msgstr "No he podido guardar la URL del sitio"
+msgstr "Thay đổi site-url thất bại"
 
 #: src/metabase/models/database.clj
 msgid "Error destroying thread pool for DB."
-msgstr "Error al destruir el grupo de subprocesos para la BBDD."
+msgstr "Lỗi phá hủy nhóm luồng cho DB"
 
 #: src/metabase/models/humanization.clj
 msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
-msgstr "Actualizando el nombre a mostrar de {0} \"{1}\": \"{2}\" -> \"{3}\""
+msgstr "Cập nhật tên hiển thị cho {0} '' {1} '': '' {2} '' -> '' {3} ''"
 
-#. "humanización" no tengo claro que sea la palabra correcta
 #: src/metabase/models/humanization.clj
 msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
-msgstr "Estrategia de humanización no válida \"{0}\". Las estrategias válidas son: {1}"
+msgstr "Chiến lược nhân hóa không hợp lệ '' {0} ''. Các chiến lược hợp lệ là: {1}"
 
 #. now rehumanize all the Tables and Fields using the new strategy.
 #. TODO: Should we do this in a background thread because it is potentially slow?
 #: src/metabase/models/humanization.clj
 msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
-msgstr "Cambiando la estrategia de humanización de nombres de tablas y campos de \"{0}\" a \"{1}\""
+msgstr "Thay đổi chiến lược nhân hóa tên bảng và trường từ ''{0}'' thành ''{1}''"
 
 #: src/metabase/models/task_history.clj src/metabase/sync/util.clj
 msgid "Error saving task history"
-msgstr "Error guardando el historial de tarea."
+msgstr "Lỗi lưu lịch sử nhiệm vụ"
 
 #: src/metabase/plugins.clj
 msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
-msgstr "spark-deps.jar ya no es necesario para Metabase 0.32.0+. Puede eliminarlo del directorio de plugins."
+msgstr "spark-deps.jar không còn cần thiết bởi Metabase 0.32.0+. Bạn có thể xóa nó khỏi thư mục plugin"
 
 #: src/metabase/plugins/classloader.clj
 msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
-msgstr "Utilizando la clase NEWLY CREATED como cargador de clases de contexto compartido: {0}"
+msgstr "Sử dụng trình tải lớp MỚI TẠO làm trình tải lớp ngữ cảnh được chia sẻ: {0}"
 
 #: src/metabase/util/files.clj
 msgid "Failed to copy file"
-msgstr "No se ha podido copiar el fichero"
+msgstr "Sao chép file thất bại"
 
 #. check that the URL is valid
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
-msgstr "URL inválida: {0}"
+msgstr "URL trang web không hợp lệ: {0}"
 
 #: src/metabase/public_settings.clj
 msgid "site-url is invalid; returning nil for now. Will be reset on next request."
-msgstr "la URL del sitio no es válida; devolviendo nulo por ahora. Se restablecerá en la próxima solicitud."
+msgstr "url trang web không hợp lệ; trở về nil bây giờ\n"
+"Sẽ được thiết lập lại khi yêu cầu tiếp theo."
 
 #: src/metabase/pulse/render/body.clj
 msgid "More results have been included as a file attachment"
-msgstr "Se han incluido más resultados como un archivo adjunto"
+msgstr "Nhiều kết quả đã được đưa vào dưới dạng tệp đính kèm"
 
 #: src/metabase/pulse/render/body.clj
 msgid "This question has been included as a file attachment"
-msgstr "Esta pregunta se ha incluido como un archivo adjunto"
+msgstr "Câu hỏi này đã được đưa vào dưới dạng tệp đính kèm"
 
 #: src/metabase/pulse/render/body.clj
 msgid "We were unable to display this Pulse."
-msgstr "No he podido mostrar este Pulso."
+msgstr "Chúng tôi không thể hiển thị Pulse này."
 
 #: src/metabase/pulse/render/body.clj
 msgid "Please view this card in Metabase."
-msgstr "Por favor mostrar esta tarjeta en Metabase."
+msgstr "Vui lòng xem thẻ này trong Metabase."
 
 #: src/metabase/pulse/render/body.clj
 msgid "An error occurred while displaying this card."
-msgstr "Se ha producido un error al mostrar esta tarjeta."
+msgstr "Đã xảy ra lỗi trong khi hiển thị thẻ này."
 
 #: src/metabase/query_processor.clj
 msgid "Can only determine expected columns for MBQL queries."
-msgstr "Solo puedo determinar las columnas esperadas para las consultas MBQL."
+msgstr "Chỉ có thể xác định các cột dự kiến cho các truy vấn MBQL."
 
 #: src/metabase/query_processor.clj
 msgid "No columns returned."
-msgstr "No se han obtenido columnas."
+msgstr "Không có cột nào được trả về."
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
-msgstr "Advertencia: no se pueden determinar los campos para una `consulta-fuente` explícita a menos que también incluya` metadatos-fuente`."
+msgstr "Cảnh báo: không thể xác định các trường cho `source-query` rõ ràng trừ khi bạn bao gồm `source-metadata`."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
-msgstr "No se puede resolver {0}: el campo no existe o su tabla pertenece a una base de datos diferente."
+msgstr "Không thể giải quyết {0}: Trường không tồn tại hoặc Bảng của nó thuộc về Cơ sở dữ liệu khác."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
-msgstr "No se puede resolver :field-literal inside :fk-> a menos que se una por dentro con un alias explícito."
+msgstr "Không thể giải quyết: trường theo nghĩa đen bên trong: fk-> trừ khi bên trong tham gia với bí danh rõ ràng."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot find Table ID for {0}"
-msgstr "No he podido encontrar el ID de tabla {0}"
+msgstr "Không thể tìm thấy ID bảng cho {0}"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "No matching info found."
-msgstr "No se encontró información coincidente."
+msgstr "Không tìm thấy thông tin phù hợp"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Could not resolve {0}"
-msgstr "No se pudo resolver {0}"
+msgstr "Không thể giải quyết {0}"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Invalid fk-> clause: nowhere to add corresponding join."
-msgstr "fk-> no válida: no se puede agregar el join correspondiente."
+msgstr "Mệnh đề fk-> không hợp lệ: không có nơi nào để thêm phép nối tương ứng."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "{0} driver does not support foreign keys."
-msgstr "El controlador {0} no soporta claves foráneas"
+msgstr "Trình điều khiển {0} không hỗ trợ khóa ngoại."
 
 #: src/metabase/query_processor/middleware/add_source_metadata.clj
 msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
-msgstr "No se puede inferir `:source-metadata` para la consulta de origen con consulta de origen nativa sin metadatos de origen."
+msgstr "Không thể suy ra `: source-metadata` cho truy vấn nguồn với truy vấn nguồn gốc mà không có siêu dữ liệu nguồn."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Query processor error: number of columns returned by driver does not match results."
-msgstr "Error del procesador de consultas: número de columnas devueltas por el controlador no coincide con los resultados."
+msgstr "Lỗi bộ xử lý truy vấn: số cột được trả về bởi trình điều khiển không khớp với kết quả."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected {0} columns, but first row of resuls has {1} columns."
-msgstr "Se esperaban {0} columnas, pero la primera fila de resultados tiene {1} columnas."
+msgstr "Các cột {0} dự kiến, nhưng hàng kết quả đầu tiên có các cột {1}."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "No expression named {0} found. Found: {1}"
-msgstr "No he encontrado una expresión de nombre {0}. He encontrado {1}"
+msgstr "Không tìm thấy biểu thức có tên {0}. Đã tìm thấy: {1}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Distinct values of {0}"
-msgstr "Valores únicos de {0}"
+msgstr "Giá trị khác biệt của {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Average of {0}"
-msgstr "Media de {0}"
+msgstr "Trung bình {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Sum of {0}"
-msgstr "Suma de {0}"
+msgstr "Tổng của {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "SD of {0}"
-msgstr "DS de {0}"
+msgstr "SD của {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Min of {0}"
-msgstr "Mínimo de {0}"
+msgstr "Tối thiểu {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Max of {0}"
-msgstr "Máximo de {0}"
+msgstr "Tối đa {0}"
 
 #. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Sum of {0} matching condition"
-msgstr "Suma de {0} con condición"
+msgstr "Tổng của {0} điều kiện khớp"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Share of rows matching condition"
-msgstr "Cuota de filas con condición"
+msgstr "Tỷ lệ hàng phù hợp với điều kiện"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of rows matching condition"
-msgstr "Número de filas coincidentes con la condición"
+msgstr "Đếm số lượng hàng thỏa mãn điều kiện"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Request already canceled, will not run synchronous QP code."
-msgstr "Solicitud ya cancelada, no se ejecutará el código QP síncrono."
+msgstr "Yêu cầu đã bị hủy, sẽ không chạy mã QP đồng bộ."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unexpectedly got `nil` Query Processor response."
-msgstr "Inesperadamente recibí la respuesta del procesador de consultas `nil`."
+msgstr "Bất ngờ khi có phản hồi `nil` Query Processor."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Got InterruptedException. Canceling query."
-msgstr "Se interrumpió la excepción. Cancelando consulta."
+msgstr "Bị gián đoạn ngoại lệ. Hủy truy vấn."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
-msgstr "Excepción no controlada, se espera que el middleware `catch-exceptions` lo maneje."
+msgstr "Ngoại lệ chưa được xử lý, phần mềm trung gian 'bắt ngoại lệ' dự kiến sẽ xử lý nó."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Query timed out after %s"
-msgstr "Se agotó el tiempo de espera de la consulta después de %s"
+msgstr "Truy vấn đã hết thời gian sau %s"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Creating new query thread pool for Database {0}"
-msgstr "Creando un nuevo grupo de subprocesos de consulta para la base de datos {0}"
+msgstr "Tạo nhóm luồng truy vấn mới cho Cơ sở dữ liệu {0}"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Destroying query thread pool for Database {0}"
-msgstr "Destrucción del grupo de subprocesos de consulta para la base de datos {0}"
+msgstr "Phá hủy nhóm luồng truy vấn cho Cơ sở dữ liệu {0}"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Request canceled, canceling pending query"
-msgstr "Solicitud cancelada, cancelando consulta pendiente"
+msgstr "Yêu cầu hủy, hủy truy vấn đang chờ xử lý"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: query is missing source-metadata"
-msgstr "No se puede actualizar el campo agrupado: faltan los metadatos en la consulta"
+msgstr "Không thể cập nhật trường binned: truy vấn bị thiếu siêu dữ liệu nguồn"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
-msgstr "No se puede actualizar el campo agrupado: no se encontraron metadatos coincidentes para el campo \"{0}\""
+msgstr "Không thể cập nhật trường đã bị đánh dấu: không thể tìm thấy siêu dữ liệu nguồn phù hợp cho Trường '' {0} ''"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Using query processor cache backend: {0}"
-msgstr "Uso el caché del procesador de consultas: {0}"
+msgstr "Sử dụng bộ đệm ẩn bộ xử lý truy vấn phụ trợ: {0}"
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Invalid metric: {0} reason: {1}"
-msgstr "Métrica inválida: {0} razón: {1}"
+msgstr "Số liệu không hợp lệ: {0} lý do: {1}"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Unknown error"
-msgstr "Error desconocido"
+msgstr "Lỗi không xác định"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Unexpected nil response from query processor."
-msgstr "Respuesta nula inesperada del procesador de consultas."
+msgstr "Phản ứng không mong đợi từ bộ xử lý truy vấn."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query canceled"
-msgstr "Consulta cancelada"
+msgstr "Truy vấn bị huỷ"
 
 #: src/metabase/query_processor/middleware/resolve_driver.clj
 msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
-msgstr "No es posible resolver la consulta: falta o no es válida `:database` ID."
+msgstr "Không thể giải quyết trình điều khiển cho truy vấn: thiếu hoặc không hợp lệ `: cơ sở dữ liệu` ID."
 
 #: src/metabase/query_processor/middleware/resolve_driver.clj
 msgid "Unable to resolve driver for query: Database {0} does not exist."
-msgstr "No es posible resolver la consulta: base de datos {0} no existe."
+msgstr "Không thể giải quyết trình điều khiển cho truy vấn: Cơ sở dữ liệu {0} không tồn tại."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
-msgstr "No se puede usar :fields :all in join contra la consulta de origen a menos que tenga :source-metadata."
+msgstr "Không thể sử dụng :các trường :tất cả tham gia chống lại truy vấn nguồn trừ khi nó có :siêu dữ liệu nguồn."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
-msgstr "Problema: join entre campos: el join con alias \"{0}\" no existe. Encontrado: {1}"
+msgstr "Xấu: mệnh đề trường tham gia: tham gia với bí danh '' {0} '' không tồn tại. Đã tìm thấy: {1}"
 
 #: src/metabase/query_processor/middleware/resolve_source_table.clj
 msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
-msgstr "tabla \"{0}\" inválida: ya debería haberse convertido en un ID de tabla."
+msgstr "Không hợp lệ: bảng nguồn '' {0} '': đáng nhẽ đã được giải quyết thành ID bảng."
 
 #: src/metabase/query_processor/store.clj
 msgid "Cannot store Tables or Fields before Database is stored."
-msgstr "No se pueden guardar tablas o campos antes de guardar la base de datos."
+msgstr "Không thể lưu trữ Bảng hoặc Trường trước khi Cơ sở dữ liệu được lưu trữ."
 
 #: src/metabase/query_processor/store.clj
 msgid "Attempting to fetch second Database. Queries can only reference one Database."
-msgstr "Intentando recuperar la segunda base de datos. Las consultas sólo pueden referenciar a una base de datos."
+msgstr "Đang cố gắng tìm nạp Cơ sở dữ liệu thứ hai. Truy vấn chỉ có thể tham khảo một cơ sở dữ liệu."
 
 #: src/metabase/query_processor/store.clj
 msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
-msgstr "Error al recuperar la Tabla {0}: no existe dicha tabla o pertenece a otra base de datos."
+msgstr "Không thể tìm nạp Bảng {0}: Bảng không tồn tại hoặc thuộc về Cơ sở dữ liệu khác."
 
 #: src/metabase/query_processor/store.clj
 msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
-msgstr "Error al recuperar el Campo {0}: no existe dicho campo o pertenece a otra base de datos."
+msgstr "Không thể tìm nạp Trường {0}: Trường không tồn tại hoặc thuộc về Cơ sở dữ liệu khác."
 
 #: src/metabase/routes/index.clj
 msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
-msgstr "Error al cargar la plantilla \"{0}\". ¿Te acordaste de construir la interfaz de Metabase?"
+msgstr "Không thể tải mẫu '' {0} ''. Bạn có nhớ xây dựng giao diện Metabase không?"
 
 #: src/metabase/sample_data.clj
 msgid "Sample dataset DB file ''{0}'' cannot be found."
-msgstr "No se puede encontrar el archivo de base de datos de muestra ''{0}''."
+msgstr "Không thể tìm thấy tập dữ liệu mẫu '' {0} ''."
 
 #: src/metabase/sample_data.clj
 msgid "Loading sample dataset..."
-msgstr "Cargando datos de muestra..."
+msgstr "Đang tải dữ liệu mẫu ..."
 
 #: src/metabase/sample_data.clj
 msgid "Failed to load sample dataset"
-msgstr "No se ha podido cargar los datos de muestra"
+msgstr "Không thể tải tập dữ liệu mẫu"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Found new tables:"
-msgstr "Encontrado tablas nuevas:"
+msgstr "Tìm thấy bảng mới:"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Marking tables as inactive:"
-msgstr "Marcando tablas como inactivas:"
+msgstr "Đánh dấu các bảng là không hoạt động:"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Updating description for tables:"
-msgstr "Actualizando la descripción de las tablas:"
+msgstr "Cập nhật mô tả cho các bảng:"
 
 #: src/metabase/task.clj
 msgid "Rescheduling job {0}"
-msgstr "Reprogramando el trabajo {0}"
+msgstr "Sắp xếp lại công việc {0}"
 
 #: src/metabase/task.clj
 msgid "Error rescheduling job"
-msgstr "Error al reprogramar trabajo"
+msgstr "Lỗi sắp xếp lại công việc"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Starting Pulse Execution: {0}"
-msgstr "Iniciando la ejecución del Pulso: {0}"
+msgstr "Bắt đầu thực hiện xung: {0}"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Finished Pulse Execution: {0}"
-msgstr "Finalizado la ejecución del Pulso: {0}"
+msgstr "Kết thúc thực hiện xung: {0}"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Failed to schedule tasks for Database {0}"
-msgstr "Error al programar tareas para la base de datos {0}"
+msgstr "Không thể lên lịch tác vụ cho Cơ sở dữ liệu {0}"
 
 #: src/metabase/util/schema.clj
 msgid "All elements must be distinct."
-msgstr "Todos los elementos deben ser distintos."
+msgstr "Tất cả các yếu tố phải khác biệt."
 
 #: 
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
-msgstr "Elige las columnas que quieres incluir"
+msgstr "Chọn các cột bạn muốn bao gồm"
 
 #: frontend/src/metabase/entities/databases/forms.js:274
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
-msgstr "Al activar esto, Metabase ejecutará consultas automáticamente cuando los usuarios realicen exploraciones simples con los botones Resumir y Filtrar ea tablas o gráficos. Puedes desactivar esto si las consultas de esta base de datos son lentas. Esta configuración no afecta a los detalles ni a las consultas SQL."
+msgstr "Khi điều này được bật, Metabase sẽ tự động chạy các truy vấn khi người dùng thực hiện các khám phá đơn giản với các nút Tóm tắt và Lọc khi xem bảng hoặc biểu đồ. Bạn có thể tắt cái này nếu truy vấn cơ sở dữ liệu này chậm. Cài đặt này không ảnh hưởng truy vấn khoan sâu hoặc truy vấn SQL."
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
 msgid "Change join type"
-msgstr "Cambia el tipo de unión"
+msgstr "Thay đổi kiểu JOIN"
 
 #: src/metabase/driver/sql/util.clj
 msgid "Don't know how to alias {0}, expected an Identifier."
-msgstr "No sé cómo obtener un alias de {0}, esperaba un identificador."
+msgstr "Không biết cách đặt bí danh {0}, dự kiến một Định danh."
 
 #: src/metabase/integrations/common.clj
 msgid "Error adding User {0} to Group {1}"
-msgstr "Error añadiendo el Usuario {0} al Grupo {1}"
+msgstr "Lỗi khi thêm Người dùng {0} vào Nhóm {1}"
 
 #. now rehumanize all the Tables and Fields using the new strategy.
 #. TODO: Should we do this in a background thread because it is potentially slow?
 #: src/metabase/models/humanization.clj
 msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
-msgstr "Cambiando la estrategia de humanización de nombres de tablas y campos de \"{0}\" a \"{1}\""
+msgstr "Thay đổi chiến lược nhân hóa tên bảng và trường từ ''{0}'' thành ''{1}''"
 
 #: src/metabase/query_processor.clj
 msgid "Infinite loop detected: recursively preprocessed query {0} times."
-msgstr "Bucle infinito detectado: consulta preprocesada recursivamente {0} veces."
+msgstr "Vòng lặp vô hạn được phát hiện: truy vấn được xử lý trước đệ quy {0} lần."
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
-msgstr "Advertencia: no se pueden determinar los campos de una `consulta-fuente` explícita a menos que también incluya `metadatos`."
+msgstr "Cảnh báo: không thể xác định các trường cho một 'nguồn-truy vấn' rõ ràng trừ khi bạn cũng bao gồm `siêu dữ liệu nguồn`."
 
 #: src/metabase/query_processor/middleware/add_source_metadata.clj
 msgid "Error determining expected columns for query"
-msgstr "Error al determinar las columnas esperadas de la consulta"
+msgstr "Lỗi xác định các cột dự kiến cho truy vấn"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
-msgstr "Excepción no controlada, se espera que el proceso `catch-exceptions` lo manejara."
+msgstr "Ngoại lệ chưa được xử lý, phần mềm trung gian 'bắt ngoại lệ' dự kiến sẽ xử lý nó."
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
 msgid "Diagnostic Info"
-msgstr "Información de Diagnóstico"
+msgstr "Thông tin chẩn đoán"
 
 #: frontend/src/metabase/admin/tasks/containers/Logs.jsx:123
 msgid "Select Metabase process:"
-msgstr "Selecciona el proceso de Metabase:"
+msgstr "Chọn quy trình Metabase:"
 
 #: frontend/src/metabase/admin/tasks/containers/Logs.jsx:133
 msgid "All Metabase processes"
-msgstr "Todos los procesos de Metabase"
+msgstr "Tất cả các quy trình Metabase"
 
 #: frontend/src/metabase/auth/components/GoogleButton.jsx:13
 msgid "The window was closed before completing Google Authentication."
-msgstr "Se ha cerrado la ventana sin haber completado la Autentificación con Google"
+msgstr "Cửa sổ đã bị đóng trước khi hoàn thành Google Authentication."
 
 #: frontend/src/metabase/auth/components/GoogleButton.jsx:51
 msgid "There was an issue signing in with Google. Pleast contact an administrator."
-msgstr "Ha habido un problema validando con Google. Por favor, pregunta a un administrador."
+msgstr "Có một vấn đề khi đăng nhập với Google. Vui lòng liên hệ với quản trị viên."
 
 #: frontend/src/metabase/plugins/builtin/auth/password.js:9
 msgid "Sign in with email"
-msgstr "Entrar con email"
+msgstr "Đăng ký bằng email"
 
 #: frontend/src/metabase/entities/databases/forms.js:23
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
-msgstr "El uso de esta opción requiere que el host proporcionado sea un FQDN. Si te conectas a un clúster de Atlas, es posible que debas habilitar esta opción. Si no sabes lo que significa esto, dejalo deshabilitado."
+msgstr "Sử dụng tùy chọn này yêu cầu máy chủ được cung cấp là FQDN. Nếu kết nối với cụm Atlas, bạn có thể cần bật tùy chọn này. Nếu bạn không biết điều này có nghĩa là gì, hãy để điều này bị vô hiệu hóa."
 
 #: frontend/src/metabase/entities/databases/forms.js:282
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
-msgstr "De manera predeterminada, Metabase realiza una sincronización por hora y un escaneo diario intensivo de valores de campo. Si tienes una base de datos grande, recomendamos activar esto y revisar cuándo y con qué frecuencia ocurren los escaneos de valor de campo."
+msgstr "Theo mặc định, Metabase thực hiện đồng bộ hóa hàng giờ và quét kỹ các giá trị trường hàng ngày. Nếu bạn có cơ sở dữ liệu lớn, chúng tôi khuyên bạn nên bật tính năng này và xem xét thời điểm và tần suất quét giá trị trường xảy ra."
 
 #: frontend/src/metabase/containers/Overworld.jsx:126
 msgid "Remove these suggestions"
-msgstr "Eliminar estas sugerencias"
+msgstr "Loại bỏ những gợi ý này"
 
 #: frontend/src/metabase/containers/Overworld.jsx:135
 msgid "Remove these suggestions?"
-msgstr "Eliminar estas sugerencias?"
+msgstr "Loại bỏ những gợi ý này?"
 
 #: frontend/src/metabase/containers/Overworld.jsx:151
 msgid "These won’t show up on the homepage for any of your users anymore, but you can always get to x-rays by clicking on Browse Data in the main navigation, then clicking on the lightning bolt icon on one of your tables."
-msgstr "Estos ya no aparecerán en la página de inicio de ninguno de tus usuarios, pero siempre puedes obtener radiografías haciendo clic en Examinar datos en la navegación principal y luego haciendo clic en el icono del rayo en una de las tablas."
+msgstr "Những điều này sẽ không hiển thị trên trang chủ cho bất kỳ người dùng của bạn nữa, nhưng bạn luôn có thể chiếu tia X bằng cách nhấp vào Duyệt dữ liệu trong điều hướng chính, sau đó nhấp vào biểu tượng tia sét trên một trong các bảng của bạn."
 
 #: frontend/src/metabase/containers/Overworld.jsx:274
 msgid "Hide this section"
-msgstr "Esconder esta sección"
+msgstr "Ẩn phần này"
 
 #: frontend/src/metabase/containers/Overworld.jsx:282
 msgid "Remove this section?"
-msgstr "Eliminar esta sección"
+msgstr "Loại bỏ phần này?"
 
 #: frontend/src/metabase/containers/Overworld.jsx:298
 msgid "\"Our Data\" won’t show up on the homepage for any of your users anymore, but you can always browse through your databases and tables by clicking Browse Data in the main navigation."
-msgstr "\"Nuestros datos\" ya no aparecerá en la página de inicio de ninguno de tus usuarios, pero siempre puedes navegar por tus bases de datos y tablas haciendo clic en Examinar datos en la navegación principal."
+msgstr "\"Dữ liệu của chúng tôi\" sẽ không hiển thị trên trang chủ cho bất kỳ người dùng nào của bạn nữa, nhưng bạn luôn có thể duyệt qua các cơ sở dữ liệu và bảng của bạn bằng cách nhấn vào Duyệt dữ liệu trong điều hướng chính."
 
 #: frontend/src/metabase/entities/collections.js:95
 msgid "My new fantastic collection"
-msgstr "Mi colección fantástica"
+msgstr "Bộ sưu tập mới tuyệt vời của tôi"
 
 #: frontend/src/metabase/lib/core.js:178
 msgid "Cancelation timestamp"
-msgstr "Tiempo de cancelación"
+msgstr "Dấu thời gian hủy"
 
 #: frontend/src/metabase/lib/core.js:173
 msgid "Cancelation time"
-msgstr "Tiempo de cancelación"
+msgstr "Thời gian hủy"
 
 #: frontend/src/metabase/lib/core.js:168
 msgid "Cancelation date"
-msgstr "Fecha de cancelación"
+msgstr "Ngày hủy"
 
 #: frontend/src/metabase/lib/core.js:208
 msgid "Deletion timestamp"
-msgstr "Tiempo de eliminación"
+msgstr "Xóa dấu thời gian"
 
 #: frontend/src/metabase/lib/core.js:203
 msgid "Deletion time"
-msgstr "Tiempo de eliminación"
+msgstr "Thời gian xoá"
 
 #: frontend/src/metabase/lib/core.js:198
 msgid "Deletion date"
-msgstr "Fecha de eliminación"
+msgstr "Ngày xoá"
 
 #: frontend/src/metabase/lib/core.js:298
 msgid "Only in detail views"
-msgstr "Solo en vistas de detalle"
+msgstr "Chỉ trong chế độ xem chi tiết"
 
 #: frontend/src/metabase/lib/core.js:303
 msgid "Do not include"
-msgstr "No incluir"
+msgstr "Không bao gồm"
 
 #: frontend/src/metabase/lib/core.js:304
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
-msgstr "Este campo no será visible o seleccionable en las preguntas creadas con la aplicación. Todavía será accesible en consultas SQL/nativas."
+msgstr "Trường này sẽ không hiển thị hoặc có thể lựa chọn trong các câu hỏi được tạo bằng giao diện GUI. Nó vẫn sẽ có thể truy cập được trong SQL / truy vấn gốc."
 
 #: frontend/src/metabase/lib/schema_metadata.js:512
 msgid "Cumulative sum"
-msgstr "Suma Acumulada"
+msgstr "Tổng tích lũy"
 
 #: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Standard deviation"
-msgstr "Desviacion estandar"
+msgstr "Độ lệch chuẩn"
 
 #: frontend/src/metabase/lib/settings.js:120
 msgid "must be at least {0} characters long"
-msgstr "debe tener al menos {0} caracteres de longitud"
+msgstr "phải dài ít nhất {0} ký tự"
 
 #: frontend/src/metabase/lib/settings.js:121
 msgid "Must be at least {0} characters long"
-msgstr "Debe tener al menos {0} caracteres de longitud"
+msgstr "Phải dài ít nhất {0} ký tự"
 
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:82
 msgid "Name (required)"
-msgstr "Nombre (requerido)"
+msgstr "Tên (bắt buộc)"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
 msgid "Run selected text"
-msgstr "Ejecutar texto seleccionado"
+msgstr "Chạy văn bản đã chọn"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
 msgid "Run query"
-msgstr "Ejecutar consulta"
+msgstr "Thực hiện truy vấn"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(⌘ + enter)"
-msgstr "(⌘ + intro)"
+msgstr "(⌘ + enter)"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(Ctrl + enter)"
-msgstr "(Ctrl + intro)"
+msgstr "(Ctrl + enter)"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "Here's where your results will appear"
-msgstr "Aquí es donde aparecerán tus resultados"
+msgstr "Đây là nơi kết quả của bạn sẽ xuất hiện"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:16
 msgid "You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question."
-msgstr "No realizará cambios permanentes en una pregunta guardada a menos que haga clic en Guardar y elija reemplazar la pregunta original."
+msgstr "Bạn sẽ không thực hiện bất kỳ thay đổi vĩnh viễn nào cho câu hỏi đã lưu trừ khi bạn nhấp vào Lưu và chọn thay thế câu hỏi ban đầu."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:200
 msgid "There aren't any filter widgets for this type of field yet."
-msgstr "Todavía no hay widgets de filtro para este tipo de campo."
+msgstr "Không có bất kỳ widget bộ lọc nào cho loại trường này."
 
 #: frontend/src/metabase/reference/components/FieldToGroupBy.jsx:27
 msgid "Look up this field"
-msgstr "Buscar este campo"
+msgstr "Tra cứu lĩnh vực này"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:218
 msgid "Why this metric is interesting"
-msgstr "Por que esta métrica es interesante"
+msgstr "Tại sao số liệu này thú vị"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:228
 msgid "Things to be aware of about this metric"
-msgstr "Cosas a tener en cuenta sobre esta métrica"
+msgstr "Những điều cần biết về số liệu này"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "How this metric is calculated"
-msgstr "Cómo se calcula esta métrica"
+msgstr "Cách tính số liệu này"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:215
 msgid "Table this is based on"
-msgstr "Tabla en la que está basada"
+msgstr "Bảng này dựa trên"
 
 #: frontend/src/metabase/visualizations/lib/renderer_utils.js:276
 msgid "(empty)"
-msgstr "(vacío)"
+msgstr "(trống)"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Goal line"
-msgstr "Meta"
+msgstr "Mục tiêu"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Trend line"
-msgstr "Tendencia"
+msgstr "Đường xu hướng"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:317
 msgid "Show values on data points"
-msgstr "Mostrar valores en puntos de datos"
+msgstr "Hiển thị giá trị trên các điểm dữ liệu"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:325
 msgid "Values to show"
-msgstr "Valores a mostrar"
+msgstr "Các giá trị để hiển thị"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:332
 msgid "As many as can fit nicely"
-msgstr "Tantos como quepan bien"
+msgstr "Nhiều như có thể nhét vừa đẹp"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:333
 msgid "All"
-msgstr "Todos"
+msgstr "Tất cả"
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:9
 msgid "Data includes missing dimension values."
-msgstr "Los datos incluyen valores de dimensión faltantes."
+msgstr "Dữ liệu bao gồm các giá trị kích thước bị thiếu."
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:17
 msgid "We encountered an invalid date: \"{0}\""
-msgstr "Hay una fecha no válida: \"{0}\""
+msgstr "Chúng tôi đã gặp một ngày không hợp lệ: \"{0}\""
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:38
 msgid "The query for this chart was run in {0} rather than {1} due to database or driver constraints."
-msgstr "La consulta para este gráfico se ejecutó en {0} en lugar de {1} debido a restricciones de la base de datos o del controlador."
+msgstr "Truy vấn cho biểu đồ này được chạy trong {0} thay vì {1} do các ràng buộc về cơ sở dữ liệu hoặc trình điều khiển."
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:47
 msgid "This chart contains queries run in multiple timezones: {0}"
-msgstr "Este gráfico contiene consultas ejecutadas en varias zonas horarias: {0}"
+msgstr "Biểu đồ này chứa các truy vấn chạy trong nhiều múi giờ: {0}"
 
 #: src/metabase/api/public.clj
 msgid "An error occurred while running the query."
-msgstr "Se produjo un error al ejecutar la consulta."
+msgstr "Có lỗi xảy ra trong quá trình truy vấn"
 
 #: src/metabase/cmd/dump_to_h2.clj
 msgid "Output H2 database already exists: %s, removing."
-msgstr "La base de datos H2 de salida ya existe: %s, eliminando."
+msgstr "Cơ sở dữ liệu H2 đầu ra đã tồn tại: %s, loại bỏ."
 
 #: src/metabase/cmd/dump_to_h2.clj
 msgid "Don't need to migrate, just use the existing H2 file"
-msgstr "No es necesario migrar, utiliza el archivo H2 existente"
+msgstr "Không cần di chuyển, chỉ cần sử dụng tệp H2 hiện có"
 
 #: src/metabase/cmd/load_from_h2.clj
 msgid "Target DB is already populated!"
-msgstr "¡La base de datos de destino ya contiene datos!"
+msgstr "CSDL mục tiêu đã được đưa vào!"
 
 #: src/metabase/core.clj
 msgid "System info:n {0}"
-msgstr "Información del sistema:n {0}"
+msgstr "Thông tin hệ thống: n {0}"
 
 #: src/metabase/db.clj
 msgid "Database setup"
-msgstr "Configuración de la base de datos"
+msgstr "Cài đặt cơ sở dữ liệu"
 
 #. 4. move everything not in this Collection to a new Collection
 #: src/metabase/db/migrations.clj
 msgid "Moving instances of {0} that aren''t in a Collection to {1} Collection {2}"
-msgstr "Moviendo instancias de {0} que no están en una Colección a {1} Colección {2}"
+msgstr "Di chuyển các phiên bản của {0} không có trong Bộ sưu tập sang {1} Bộ sưu tập {2}"
 
 #: src/metabase/driver/common/parameters/parse.clj
 msgid "Invalid '{{...}}' clause: expected a param name"
-msgstr "Cláusula '{{...}}' no válida: se esperaba un nombre de parámetro"
+msgstr "Mệnh đề '{{...}}' không hợp lệ: dự kiến một tên tham số"
 
 #: src/metabase/driver/common/parameters/parse.clj
 msgid "'{{...}}' clauses cannot be empty."
-msgstr "las cláusulas '{{...}}' no pueden estar vacías."
+msgstr "Mệnh đề '{{...}}' không thể để trống."
 
 #: src/metabase/driver/common/parameters/parse.clj
 msgid "'[[...]]' clauses must contain at least one '{{...}}' clause."
-msgstr "las cláusulas '[[...]]' deben contener al menos una cláusula '{{...}}'."
+msgstr "Mệnh đề '[[...]]' phải chứa ít nhất một mệnh đề '{{...}}'."
 
 #: src/metabase/driver/common/parameters/parse.clj
 msgid "Invalid query: found '[[' or '{{' with no matching ']]' or '}}'"
-msgstr "Consulta no válida: se encontró '[[' o '{{' sin coincidencias ']]' o '}}'"
+msgstr "Truy vấn không hợp lệ: được tìm thấy '[[' hoặc '{{' không khớp ']]' hoặc '}}'"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "You''ll need to pick a value for ''{0}'' before this query can run."
-msgstr "Deberá elegir un valor para \"{0}\" antes de que se pueda ejecutar esta consulta."
+msgstr "Bạn sẽ cần chọn một giá trị cho '' {0} '' trước khi truy vấn này có thể chạy."
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Can''t find field with ID: {0}"
-msgstr "No se puede encontrar el campo con ID: {0}"
+msgstr "Không thể tìm thấy trường có ID: {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Error loading driver namespace"
-msgstr "Error al cargar el espacio de nombres del controlador"
+msgstr "Lỗi khi tải không gian tên trình điều khiển"
 
 #: src/metabase/driver/impl.clj
 msgid "Could not load {0} driver."
-msgstr "No se pudo cargar el controlador {0}."
+msgstr "Không thể tải trình điều khiển {0}."
 
 #: src/metabase/driver/sql/parameters/substitute.clj
 msgid "Cannot run query: missing required parameters: {0}"
-msgstr "No se puede ejecutar la consulta: faltan los parámetros necesarios: {0}"
+msgstr "Không thể chạy truy vấn: thiếu tham số bắt buộc: {0}"
 
 #: src/metabase/driver/sql/parameters/substitution.clj
 msgid "Don''t know how to parse {0} {1}"
-msgstr "No sé cómo analizar {0} {1}"
+msgstr "Không biết cách phân tích {0} {1}"
 
 #: src/metabase/driver/sql/util.clj
 msgid "Don''t know how to alias {0}, expected an Identifier."
-msgstr "No sé cómo hacer un alias de {0}, esperaba un identificador."
+msgstr "Không biết cách đặt bí danh {0}, mong đợi một Định danh."
 
 #. it's better return a slightly broken SQL query with a probably incorrect string representation of the value than
 #. to have the entire QP run fail because of an unknown type.
 #: src/metabase/driver/sql/util/unprepare.clj
 msgid "Don''t know how to unprepare values of class {0}"
-msgstr "No sé cómo deshacer los valores de la clase {0}"
+msgstr "Không biết cách chuẩn bị các giá trị của lớp {0}"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Creating new connection pool for {0} database {1} ..."
-msgstr "Creando un nuevo grupo de conexiones para la base de datos {0} {1} ..."
+msgstr "Tạo nhóm kết nối mới cho {0} cơ sở dữ liệu {1} ..."
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Invalid timezone ''{0}''"
-msgstr "Zona horaria inválida \"{0}\""
+msgstr "Múi giờ không hợp lệ '' {0} ''"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Cannot set timezone: invalid or missing SQL format string for driver {0}."
-msgstr "No se puede establecer la zona horaria: cadena de formato SQL no válida o faltante para el controlador {0}."
+msgstr "Không thể đặt múi giờ: chuỗi định dạng SQL không hợp lệ hoặc thiếu cho trình điều khiển {0}."
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Did you implement set-timezone-sql?"
-msgstr "¿Implementaste set-timezone-sql?"
+msgstr "Bạn đã thực hiện set-timezone-sql?"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone ''{0}''"
-msgstr "Error al establecer la zona horaria \"{0}\""
+msgstr "Không thể đặt múi giờ '' {0} ''"
 
 #: src/metabase/driver/util.clj
 msgid "Database connection error"
-msgstr "Error de conexión a la base de datos"
+msgstr "Lỗi kết nối cơ sở dữ liệu"
 
 #: src/metabase/models/interface.clj
 msgid "Error parsing JSON"
-msgstr "Error analizando JSON"
+msgstr "Lỗi khi phân tích cú pháp JSON"
 
 #: src/metabase/public_settings.clj
 msgid "Whether or not to display data on the homepage. Admins might turn this off in order to direct users to better content than raw data"
-msgstr "Si mostrar o no datos en la página de inicio. Los administradores pueden desactivar esto para dirigir a los usuarios a un mejor contenido que los datos sin procesar"
+msgstr "Có hay không hiển thị dữ liệu trên trang chủ. Quản trị viên có thể tắt tính năng này để hướng người dùng đến nội dung tốt hơn dữ liệu thô"
 
 #: src/metabase/public_settings.clj
 msgid "Whether or not to display x-ray suggestions on the homepage. They will also be hidden if any dashboards are pinned. Admins might hide this to direct users to better content than raw data"
-msgstr "Si se muestran o no sugerencias de rayos X en la página de inicio. También estarán ocultos si hay paneles fijados. Los administradores pueden ocultar esto para dirigir a los usuarios a un mejor contenido que los datos sin procesar"
+msgstr "Có hay không hiển thị các đề xuất x-quang trên trang chủ. Chúng cũng sẽ bị ẩn nếu bất kỳ bảng điều khiển nào được ghim. Quản trị viên có thể ẩn điều này để hướng người dùng đến nội dung tốt hơn dữ liệu thô"
 
 #: src/metabase/public_settings.clj
 msgid "Identify the source of HTTP requests by this header's value, instead of its remote address."
-msgstr "Identifique el origen de las solicitudes HTTP por el valor de este encabezado, en lugar de su dirección remota."
+msgstr "Xác định nguồn yêu cầu HTTP theo giá trị của tiêu đề này, thay vì địa chỉ từ xa"
 
 #: src/metabase/public_settings.clj
 msgid "Could not resolve Setting {0}/{1}"
-msgstr "No se pudo resolver la configuración {0}/{1}"
+msgstr "Không thể giải quyết Cài đặt {0} / {1}"
 
 #: src/metabase/public_settings.clj
 msgid "Invalid Setting: {0}/{1}"
-msgstr "Configuración inválida: {0}/{1}"
+msgstr "Cài đặt không hợp lệ: {0} / {1}"
 
 #: src/metabase/pulse.clj
 msgid "reached its goal"
-msgstr "alcanzó su objetivo"
+msgstr "đạt được mục tiêu của nó"
 
 #: src/metabase/pulse.clj
 msgid "gone below its goal"
-msgstr "ido por debajo de su objetivo"
+msgstr "đi dưới mục tiêu của nó"
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) via email"
-msgstr "Enviando Pulso ({0}: {1}) vía email"
+msgstr "Gửi xung ({0}: {1}) qua email"
 
 #: src/metabase/pulse.clj
 msgid "Pulse: {0}"
-msgstr "Pulso: {0}"
+msgstr "Xung: {0}"
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) via Slack"
-msgstr "Enviando Pulso ({0}: {1}) vía Slack"
+msgstr "Gửi xung ({0}: {1}) qua Slack"
 
 #: src/metabase/pulse.clj
 msgid "Sending Alert ({0}: {1}) via email"
-msgstr "Enviando Alerta ({0}: {1}) vía email"
+msgstr "Gửi thông báo ({0}: {1}) qua email"
 
 #: src/metabase/pulse.clj
 msgid "Metabase alert: {0} has {1}"
-msgstr "Alerta Metabase: {0} tiene {1}"
+msgstr "Thông báo siêu dữ liệu: {0} có {1}"
 
 #: src/metabase/pulse.clj
 msgid "Sending Alert ({0}: {1}) via Slack"
-msgstr "Enviando Alerta ({0}: {1}) vía Slack"
+msgstr "Gửi thông báo ({0}: {1}) qua Slack"
 
 #: src/metabase/pulse.clj
 msgid "Alert: {0}"
-msgstr "Alerta: {0}"
+msgstr "Thông báo: {0}"
 
 #: src/metabase/pulse/render/color.clj
 msgid "Can''t find JS color selector at ''{0}''"
-msgstr "No se puede encontrar el selector de color JS en \"{0}\""
+msgstr "Không thể tìm thấy bộ chọn màu JS tại '' {0} ''"
 
 #. TODO  - there is code that calls this in `render.body` regardless of the types of values
 #: src/metabase/pulse/render/datetime.clj
 msgid "FIXME: These aren''t valid temporal literals: {0} {1}. Why are we attemping to format them as such?"
-msgstr "FIXME: Estos no son literales temporales válidos: {0} {1}. ¿Por qué estamos tratando de formatearlos como tales?"
+msgstr "SỬA: Những chữ tạm thời không hợp lệ này: {0} {1}. Tại sao chúng ta cố gắng định dạng chúng như vậy?"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "No matching info found for join against Table {0} ''{1}'' on Field {2} ''{3}'' via FK {4} ''{5}''"
-msgstr "No se encontró información coincidente para unir con la tabla {0} \"{1}\" usando el campo {2} \"{3}\" a través de la clave foránea {4} \"{5}\""
+msgstr "Không tìm thấy thông tin phù hợp để tham gia với Bảng {0} '' {1} '' trên Trường {2} '' {3} '' qua FK {4} '' {5} ''"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Don''t know how to get information about Field: {0}"
-msgstr "No sé cómo obtener información sobre el campo: {0}"
+msgstr "Không biết cách lấy thông tin về Trường: {0}"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Query timed out after {0}"
-msgstr "La consulta expiró después de {0}"
+msgstr "Truy vấn đã hết thời gian sau {0}"
 
 #: src/metabase/query_processor/middleware/format_rows.clj
 msgid "Formatting rows with results timezone ID {0}"
-msgstr "Formateando filas con resultados utilizando la zona horaria {0}"
+msgstr "Định dạng các hàng với ID múi giờ kết quả {0}"
 
 #: src/metabase/query_processor/timezone.clj
 msgid "Invalid timezone ID ''{0}''"
-msgstr "Zona horaria inválida \"{0}\""
+msgstr "ID múi giờ không hợp lệ '' {0} ''"
 
 #: src/metabase/sync/analyze/fingerprint.clj
 msgid "Saving fingerprint for {0}"
-msgstr "Guardar huella digital para {0}"
+msgstr "Lưu dấu vân tay cho {0}"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandoment email!"
-msgstr "Enviando correo electrónico de abandono!"
+msgstr "Gửi email từ bỏ!"
 
 #: src/metabase/transforms/core.clj
 msgid "Resulting transforms do not conform to expectations.nExpected: {0}"
-msgstr "Las transformaciones resultantes no se ajustan a las expectativas. Esperado: {0}"
+msgstr "Các biến đổi kết quả không phù hợp với mong đợi. Mong đợi: {0}"
 
 #: src/metabase/util.clj
 msgid "Timed out after {0}"
-msgstr "Se agotó el tiempo de espera después de {0}"
+msgstr "Đã hết thời gian sau {0}"
 
 #: src/metabase/util/date_2.clj
 msgid "No temporal adjuster named {0}"
-msgstr "Ningún ajustador temporal llamado {0}"
+msgstr "Không có bộ điều chỉnh thời gian có tên {0}"
 
 #: src/metabase/util/date_2.clj
 msgid "Invalid unit: {0}"
-msgstr "Unidad inválida: {0}"
+msgstr "Đơn vị không hợp lệ: {0}"
 
 #: src/metabase/util/date_2/parse.clj
 msgid "Don''t know how to parse {0} using format {1}"
-msgstr "No sé cómo analizar {0} usando el formato {1}"
+msgstr "Không biết cách phân tích {0} bằng định dạng {1}"
 
 #: src/metabase/util/embed.clj
 msgid "Token is missing value for keypath {0}"
-msgstr "Al token le falta el valor para keypath {0}"
+msgstr "Mã thông báo bị thiếu giá trị cho keypath {0}"
 
 #: src/metabase/util/stats.clj
 msgid "Sending usage stats FAILED"
-msgstr "Envío de estadísticas de uso FALLIDO"
+msgstr "Gửi thống kê sử dụng FAILED"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:69
 msgid "There was an error saving"
-msgstr "Se ha producido un error al guardar"
+msgstr "Có một lỗi lưu"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:75
 msgid "OK"
-msgstr "Vale"
+msgstr "Đồng ý"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:123
 msgid "To allow users to sign in with Google you'll need to give Metabase a Google Developers console application client ID. It only takes a few steps and instructions on how to create a key can be found {0}."
-msgstr "Para permitir a los usuarios iniciar sesión con Google, necesitas dar a Metabase un ID de cliente de aplicación de consola de Google Developers. solo unos pocos pasos y las instrucciones de cómo crear una clave están {0}"
+msgstr "Để cho phép người dùng đăng nhập bằng Google, bạn cần cung cấp cho Metabase ID ứng dụng khách ứng dụng bảng điều khiển Google Developers. Chỉ cần một vài bước và hướng dẫn về cách tạo khóa có thể được tìm thấy {0}."
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:134
 msgid "Be sure to include the full client ID, including the apps.googleusercontent.com suffix."
-msgstr "Asegúrate de incluir el ID de cliente completo, incluyendo el sufijo apps.googleusercontent.com"
+msgstr "Hãy chắc chắn bao gồm ID khách đầy đủ, bao gồm hậu tố apps.googleusercontent.com."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:30
 msgid "Metabase {0} is available."
-msgstr "Está disponible Metabase {0} "
+msgstr "Metabase {0} có sẵn."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:31
 msgid "You're running {0}"
-msgstr "Tienes la versión {0}"
+msgstr "Bạn đang chạy {0}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:57
 msgid "Sorry, we were unable to check for updates at this time."
-msgstr "No se pueden buscar actualizaciones en este momento."
+msgstr "Xin lỗi, chúng tôi không thể kiểm tra cập nhật tại thời điểm này."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:96
 msgid "patch release"
-msgstr "Versión de arreglos"
+msgstr "phát hành bản vá"
 
 #: frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx:10
 msgid "Dates and Times"
-msgstr "Fechas y Horas"
+msgstr "Ngày và giờ"
 
 #: frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx:25
 msgid "Numbers"
-msgstr "Números"
+msgstr "Số"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
 msgid "No mappable groups"
-msgstr "No hay grupos asignables"
+msgstr "Không có nhóm bản đồ"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
-msgstr "Documentación de Metabase"
+msgstr "Tài liệu Metabase"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
-msgstr "Incluye una guía de solución de problemas."
+msgstr "Bao gồm một hướng dẫn xử lý sự cố"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
 msgid "Post on the Metabase support forum"
-msgstr "Comparte en el foro de soporte de Metabase"
+msgstr "Đăng trên diễn đàn hỗ trợ Metabase"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:114
 msgid "A community forum for all things Metabase"
-msgstr "Un foro comunitario para todas las cosas Metabase"
+msgstr "Một diễn đàn cộng đồng cho tất cả mọi thứ Metabase"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
 msgid "File a bug report"
-msgstr "Informar sobre un error"
+msgstr "Nộp báo cáo lỗi"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:119
 msgid "Create a GitHub issue (includes the diagnostic info below)"
-msgstr "Crea una incidencia en GitHub (incluye la información de diagnóstico)"
+msgstr "Tạo sự cố GitHub (bao gồm thông tin chẩn đoán bên dưới)"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:127
 msgid "Please include these details in support requests. Thank you!"
-msgstr "Incluye estos detalles en las solicitudes de soporte. ¡Gracias!"
+msgstr "Vui lòng bao gồm các chi tiết này trong các yêu cầu hỗ trợ. Cảm ơn bạn!"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:37
 msgid "youlooknicetoday@email.com"
-msgstr "tevesbienhoy@email.com"
+msgstr "youlooknicetoday@email.com"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:50
 msgid "Remember me"
-msgstr "Recuérdame"
+msgstr "Ghi nhớ tôi"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
-msgstr "Por razones de seguridad, los enlaces de restablecimiento de contraseña caducan después de un tiempo. Si aún necesitas restablecer tu contraseña, puedes {0}."
+msgstr "Vì lý do bảo mật, liên kết đặt lại mật khẩu sẽ hết hạn sau một thời gian. Nếu bạn vẫn cần đặt lại mật khẩu, bạn có thể {0}."
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
 msgid "Save new password"
-msgstr "Guardar nueva contraseña"
+msgstr "Lưu mật khẩu mới"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:424
 msgid "No matching result"
-msgstr "Sin resultados coincidentes"
+msgstr "Không có kết quả phù hợp"
 
 #: frontend/src/metabase/components/form/CustomForm.jsx:178
 msgid "Submit"
-msgstr "Enviar"
+msgstr "Gửi đi"
 
 #: frontend/src/metabase/entities/databases/forms.js:15
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host. This option also provides an extra layer of security when a VPN is not available. Enabling this is usually slower than a direct connection."
-msgstr "Solo se puede acceder a algunas instalaciones de bases de datos conectándose a través de un host de bastión SSH. Esta opción también proporciona una capa adicional de seguridad cuando no se dispone de una VPN. Habilitar esto suele ser más lento que una conexión directa."
+msgstr "Một số cài đặt cơ sở dữ liệu chỉ có thể được truy cập bằng cách kết nối thông qua máy chủ lưu trữ SSH. Tùy chọn này cũng cung cấp thêm một lớp bảo mật khi không có VPN. Kích hoạt tính năng này thường chậm hơn kết nối trực tiếp."
 
 #: frontend/src/metabase/entities/databases/forms.js:19
 msgid "We suggest you leave this off unless you're doing manual timezone casting in many or most of your queries with this data."
-msgstr "Sugerimos que dejes esto desactivado a menos que realices una conversión manual de zona horaria en muchas o la mayoría de tus consultas con estos datos."
+msgstr "Chúng tôi khuyên bạn nên bỏ qua điều này trừ khi bạn thực hiện truyền múi giờ thủ công trong nhiều hoặc hầu hết các truy vấn của bạn với dữ liệu này."
 
 #: frontend/src/metabase/entities/databases/forms.js:128
 msgid "{0} to get an auth code."
-msgstr "{0} para obtener un código de autenticación."
+msgstr "{0} để lấy mã xác thực."
 
 #: frontend/src/metabase/entities/databases/forms.js:136
 #: src/metabase/models/collection.clj
 msgid "or"
-msgstr "o"
+msgstr "hoặc"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
 #: frontend/src/metabase/entities/databases/forms.js:226
@@ -13745,46 +13698,46 @@ msgstr "o"
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
-msgstr "obligatorio"
+msgstr "bắt buộc"
 
 #: frontend/src/metabase/entities/databases/forms.js:257
 msgid "Database type"
-msgstr "Tipo base de datos"
+msgstr "Kiểu cơ sở dữ liệu"
 
 #: frontend/src/metabase/entities/databases/forms.js:291
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
-msgstr "Este es un proceso ligero que busca actualizaciones para el esquema de esta base de datos. En la mayoría de los casos, debería estar bien dejarlo que sincronice cada hora."
+msgstr "Đây là một quy trình nhẹ kiểm tra các bản cập nhật cho lược đồ cơ sở dữ liệu này. Trong hầu hết các trường hợp, bạn sẽ ổn khi để bộ này đồng bộ hóa hàng giờ."
 
 #: frontend/src/metabase/entities/databases/forms.js:299
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
-msgstr "Metabase puede escanear los valores presentes en cada campo en esta base de datos para habilitar filtros de casillas de verificación en paneles y preguntas. Este puede ser un proceso de uso intensivo de recursos, especialmente si tienes una base de datos muy grande."
+msgstr "Metabase có thể quét các giá trị hiện diện trong từng trường trong cơ sở dữ liệu này để bật các bộ lọc hộp kiểm trong bảng điều khiển và câu hỏi. Đây có thể là một quá trình hơi tốn tài nguyên, đặc biệt nếu bạn có một cơ sở dữ liệu rất lớn."
 
 #: frontend/src/metabase/entities/questions.js:95
 msgid "Collection"
-msgstr "Colección"
+msgstr "Bộ sư tập"
 
 #: frontend/src/metabase/entities/users/forms.js:55
 msgid "Confirm your password"
-msgstr "Confirma tu contraseña"
+msgstr "Xác nhận mật khẩu"
 
 #: frontend/src/metabase/entities/users/forms.js:60
 msgid "passwords do not match"
-msgstr "las contraseñas no coinciden"
+msgstr "Mật khẩu không khớp"
 
 #: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
-msgstr "Departamento Impresionante"
+msgstr "Sở tuyệt vời"
 
 #: frontend/src/metabase/lib/core.js:88 frontend/src/metabase/lib/core.js:93
 #: frontend/src/metabase/lib/core.js:98 frontend/src/metabase/lib/core.js:103
 #: frontend/src/metabase/lib/core.js:108 frontend/src/metabase/lib/core.js:113
 msgid "Financial"
-msgstr "Financiero"
+msgstr "Tài chính"
 
 #: frontend/src/metabase/lib/core.js:120 frontend/src/metabase/lib/core.js:125
 #: frontend/src/metabase/lib/core.js:130
 msgid "Numeric"
-msgstr "Numérico"
+msgstr "Số"
 
 #: frontend/src/metabase/lib/core.js:169 frontend/src/metabase/lib/core.js:174
 #: frontend/src/metabase/lib/core.js:179 frontend/src/metabase/lib/core.js:184
@@ -13794,42 +13747,42 @@ msgstr "Numérico"
 #: frontend/src/metabase/lib/core.js:219 frontend/src/metabase/lib/core.js:224
 #: frontend/src/metabase/lib/core.js:229 frontend/src/metabase/lib/core.js:234
 msgid "Date and Time"
-msgstr "Fecha y Hora"
+msgstr "Ngày và giờ"
 
 #: frontend/src/metabase/lib/core.js:241 frontend/src/metabase/lib/core.js:246
 #: frontend/src/metabase/lib/core.js:251
 msgid "Categorical"
-msgstr "Categórico"
+msgstr "Phân minh"
 
 #: frontend/src/metabase/lib/core.js:258 frontend/src/metabase/lib/core.js:263
 #: frontend/src/metabase/lib/core.js:268
 msgid "URLs"
-msgstr "URLs"
+msgstr "Đường dẫn"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
 msgid "Returns the average of the values in the column."
-msgstr "Devuelve el promedio de los valores en la columna."
+msgstr "Trả về giá trị trung bình của các giá trị trong cột."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
 msgid "The column whose values to average."
-msgstr "La columna cuyos valores promediar."
+msgstr "Cột có giá trị trung bình."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "start"
-msgstr "inicio"
+msgstr "bắt đầu"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "end"
-msgstr "fin"
+msgstr "kết thúc"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
 msgid "Checks a date or numeric column's values to see if they're within the specified range."
-msgstr "Comprueba los valores de una fecha o columna numérica para ver si están dentro del rango especificado."
+msgstr "Kiểm tra giá trị của một ngày hoặc cột số để xem chúng có nằm trong phạm vi được chỉ định không."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
-msgstr "Clasificación"
+msgstr "Xếp hạng"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
@@ -13841,172 +13794,172 @@ msgstr "Clasificación"
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
 msgid "condition"
-msgstr "condición"
+msgstr "điều kiện"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
 msgid "output"
-msgstr "salida"
+msgstr "đầu ra"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
-msgstr "Prueba una lista de casos y devuelve el valor correspondiente del primer caso verdadero, con un valor predeterminado opcional si no se cumple ninguno."
+msgstr "Kiểm tra danh sách các trường hợp và trả về giá trị tương ứng của trường hợp đúng đầu tiên, với giá trị mặc định tùy chọn nếu không có gì khác được đáp ứng."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
 msgid "Weight"
-msgstr "Peso"
+msgstr "Trọng lượng"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
 msgid "Large"
-msgstr "Grande"
+msgstr "Lớn"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
 msgid "Medium"
-msgstr "Medio"
+msgstr "Medium"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
 msgid "Small"
-msgstr "Pequeño"
+msgstr "Nhỏ"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
 msgid "Something that should evaluate to true or false."
-msgstr "Algo que debería evaluar como verdadero o falso."
+msgstr "Một cái gì đó nên đánh giá là đúng hay sai."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:54
 msgid "The value that will be returned if the preceeding condition is true."
-msgstr "El valor que se devolverá si la condición anterior es verdadera."
+msgstr "Giá trị sẽ được trả về nếu điều kiện trước là đúng."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "value1"
-msgstr "valor1"
+msgstr "value1"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
 msgid "value2"
-msgstr "valor2"
+msgstr "value2"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
-msgstr "Mira los valores en cada argumento en orden y devuelve el primer valor no nulo para cada fila."
+msgstr "Xem xét các giá trị trong mỗi đối số theo thứ tự và trả về giá trị không null đầu tiên cho mỗi hàng."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
 msgid "Comments"
-msgstr "Comentarios"
+msgstr "Bình luận"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
 msgid "Notes"
-msgstr "Notas"
+msgstr "Ghi chú"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
 msgid "No comments"
-msgstr "Sin comentarios"
+msgstr "Không có bình luận nào"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
 msgid "A column or value."
-msgstr "Una columna o valor"
+msgstr "Một cột hoặc giá trị."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:77
 msgid "If value1 is empty, value2 gets returned if it's not empty, and so on."
-msgstr "Si valor1 está vacío, devuelve valor2 si no está vacío, y así sucesivamente."
+msgstr "Nếu value1 trống, value2 được trả về nếu nó không trống, v.v."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 msgid "Combines two or more strings of text together."
-msgstr "Combina dos o más cadenas de texto."
+msgstr "Kết hợp hai hoặc nhiều chuỗi văn bản với nhau."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
 msgid "Last Name"
-msgstr "Apellidos"
+msgstr "Họ"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 msgid "First Name"
-msgstr "Nombre"
+msgstr "Tên"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
-msgstr "valor2 se añadirá al final de esto."
+msgstr "value2 sẽ được thêm vào cuối"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
-msgstr "Esto se agregará al final del valor1."
+msgstr "Điều này sẽ được thêm vào cuối giá trị1."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
 msgid "string1"
-msgstr "cadena1"
+msgstr "string1"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
 msgid "string2"
-msgstr "cadena2"
+msgstr "string2"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
 msgid "Checks to see if string1 contains string2 within it."
-msgstr "Comprueba si string1 contiene string2."
+msgstr "Kiểm tra xem chuỗi1 có chứa chuỗi2 trong đó không."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
 msgid "Status"
-msgstr "Estado"
+msgstr "Trạng thái"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 msgid "Pass"
-msgstr "Pasar"
+msgstr "Vượt qua"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
-msgstr "Se verificará el contenido de esta cadena."
+msgstr "Nội dung của chuỗi này sẽ được kiểm tra."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
 msgid "The string of text to look for."
-msgstr "La cadena de texto a buscar."
+msgstr "Chuỗi văn bản cần tìm."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:116
 msgid "Returns the count of rows in the source data."
-msgstr "Devuelve el número de filas en los datos de origen."
+msgstr "Trả về số lượng hàng trong dữ liệu nguồn."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Only counts rows where the condition is true."
-msgstr "Solo cuenta las filas donde la condición es verdadera."
+msgstr "Chỉ tính các hàng trong đó điều kiện là đúng."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
 msgid "Subtotal"
-msgstr "Subtotal"
+msgstr "Tổng phụ"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
 msgid "The additive total of rows across a breakout."
-msgstr "El total aditivo de filas en una ruptura."
+msgstr "Tổng số phụ gia của các hàng trên một đột phá."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
 msgid "The rolling sum of a column across a breakout."
-msgstr "La suma aditiva de una columna en una ruptura."
+msgstr "Tổng số của một cột trên một đột phá."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
-msgstr "La columna a sumar."
+msgstr "Các cột để tổng hợp."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
 msgid "The number of distinct values in this column."
-msgstr "El número de valores distintos en esta columna."
+msgstr "Số lượng các giá trị riêng biệt trong cột này."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "The column whose distinct values to count."
-msgstr "La columna en la que hay que contar los valores distintos."
+msgstr "Cột có giá trị riêng biệt để tính."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
@@ -14029,1173 +13982,1168 @@ msgstr "La columna en la que hay que contar los valores distintos."
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
 msgid "text"
-msgstr "texto"
+msgstr "text"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
 msgid "comparison"
-msgstr "comparación"
+msgstr "so sánh"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
 msgid "Returns true if the end of the text matches the comparison text."
-msgstr "Devuelve verdadero si el final del texto coincide con el texto de comparación."
+msgstr "Trả về true nếu phần cuối của văn bản khớp với văn bản so sánh."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "Appetite"
-msgstr "Apetito"
+msgstr "Khao khát"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "hungry"
-msgstr "hambriento"
+msgstr "đói"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 msgid "A column or string of text to check."
-msgstr "Una columna o cadena de texto para verificar."
+msgstr "Một cột hoặc chuỗi văn bản để kiểm tra."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
 msgid "The string of text that the original text should end with."
-msgstr "La cadena de texto con la que debe terminar el texto original."
+msgstr "Chuỗi văn bản mà văn bản gốc nên kết thúc bằng."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 msgid "regular_expression"
-msgstr "expresión_regular"
+msgstr "biểu hiện thông thường"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
 msgid "Extracts matching substrings according to a regular expression."
-msgstr "Extrae subcadenas coincidentes de acuerdo con una expresión regular."
+msgstr "Chiết xuất phù hợp với chất nền theo một biểu thức thông thường."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
 msgid "Address"
-msgstr "Dirección"
+msgstr "Địa chỉ"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 msgid "The column or string of text to search though."
-msgstr "La columna o cadena de texto en la que buscar."
+msgstr "Cột hoặc chuỗi văn bản để tìm kiếm thông qua."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
 msgid "The regular expression to match."
-msgstr "La expresión regular a evaluar."
+msgstr "Các biểu thức chính quy để phù hợp."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the string of text in all lowercase."
-msgstr "Devuelve la cadena de texto en minúsculas."
+msgstr "Trả về chuỗi văn bản trong tất cả các chữ thường."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to lowercase."
-msgstr "La columna con valores para convertir a minúsculas."
+msgstr "Cột có giá trị để chuyển đổi thành chữ thường."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 msgid "Removes leading whitespace from a string of text."
-msgstr "Elimina los espacios en blanco iniciales de una cadena de texto."
+msgstr "Loại bỏ khoảng trắng hàng đầu khỏi một chuỗi văn bản."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column with values you want to trim."
-msgstr "La columna con los valores que quieres recortar."
+msgstr "Cột với các giá trị bạn muốn cắt."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "Returns the largest value found in the column."
-msgstr "Devuelve el máximo valor encontrado en la columna."
+msgstr "Trả về giá trị lớn nhất được tìm thấy trong cột."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
 msgid "Age"
-msgstr "Edad"
+msgstr "Tuổi"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
 msgid "The numeric column whose maximum you want to find."
-msgstr "La columna numérica cuyo máximo quieres encontrar."
+msgstr "Cột số có tối đa bạn muốn tìm."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "Returns the smallest value found in the column."
-msgstr "Devuelve el valor más pequeño encontrado en la columna."
+msgstr "Trả về giá trị nhỏ nhất được tìm thấy trong cột."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
 msgid "Salary"
-msgstr "Salario"
+msgstr "Lương"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
 msgid "The numeric column whose minimum you want to find."
-msgstr "La columna numérica cuyo mínimo quieres encontrar."
+msgstr "Cột số có tối thiểu bạn muốn tìm."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
 msgid "position"
-msgstr "posición"
+msgstr "vị trí"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
 msgid "length"
-msgstr "longitud"
+msgstr "length"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:185
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "new_text"
-msgstr "texto_nuevo"
+msgstr "văn bản mới"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
 msgid "Replaces a part of the input text with new text."
-msgstr "Reemplaza una parte del texto de entrada con texto nuevo."
+msgstr "Thay thế một phần của văn bản đầu vào bằng văn bản mới."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:189
 msgid "Order ID"
-msgstr "ID Pedido"
+msgstr "ID đơn hàng"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:189
 msgid "Updated Part of ID"
-msgstr "Parte actualizada de ID"
+msgstr "Phần đã cập nhật của ID"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
 msgid "The text that will be modified."
-msgstr "El texto que se modificará."
+msgstr "Các văn bản sẽ được sửa đổi."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:193
 msgid "The position where the replacing will start."
-msgstr "La posición donde comenzará la sustitución."
+msgstr "Vị trí thay thế sẽ bắt đầu."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
 msgid "The number of characters to replace."
-msgstr "El número de caracteres a reemplazar."
+msgstr "Số lượng ký tự để thay thế."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:197
 msgid "The text to use in the replacement."
-msgstr "El texto a usar en el reemplazo."
+msgstr "Các văn bản để sử dụng trong thay thế."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "Removes trailing whitespace from a string of text."
-msgstr "Elimina los espacios en blanco finales de una cadena de texto."
+msgstr "Xóa khoảng trắng theo sau khỏi một chuỗi văn bản."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
-msgstr "Devuelve el porcentaje de filas en los datos que coinciden con la condición, como un decimal."
+msgstr "Trả về phần trăm của các hàng trong dữ liệu khớp với điều kiện, dưới dạng thập phân."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
 msgid "Returns true if the beginning of the text matches the comparison text."
-msgstr "Devuelve verdadero si el comienzo del texto coincide con el texto de comparación."
+msgstr "Trả về true nếu phần đầu của văn bản khớp với văn bản so sánh."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Course Name"
-msgstr "Nombre del Curso"
+msgstr "Tên khoá học"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Computer Science"
-msgstr "Ciencias de la Computación"
+msgstr "Khoa học máy tính"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
 msgid "The string of text that the original text should start with."
-msgstr "La cadena de texto con la que debe comenzar el texto original."
+msgstr "Chuỗi văn bản mà văn bản gốc nên bắt đầu bằng."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
 msgid "Calculates the standard deviation of the column."
-msgstr "Calcula la desviación estándar de la columna."
+msgstr "Tính độ lệch chuẩn của cột."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
 msgid "Population"
-msgstr "Población"
+msgstr "Dân số"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
 msgid "A numeric column."
-msgstr "Una columna numérica"
+msgstr "Một cột số"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
 msgid "Returns a portion of the supplied text."
-msgstr "Devuelve una parte del texto proporcionado."
+msgstr "Trả về một phần của văn bản được cung cấp."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:313
 msgid "The text to return a portion of."
-msgstr "El texto del que hay que extraer una parte."
+msgstr "Các văn bản để trả lại một phần của."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
 msgid "The position to start copying characters."
-msgstr "La posición para comenzar a copiar caracteres."
+msgstr "Vị trí để bắt đầu sao chép ký tự."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
 msgid "The number of characters to return."
-msgstr "El número de caracteres a devolver."
+msgstr "Số lượng ký tự trở lại."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
 msgid "Adds up all the values of the column."
-msgstr "Suma todos los valores de la columna."
+msgstr "Thêm tất cả các giá trị của cột."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
 msgid "The numeric column to sum."
-msgstr "La columna numérica a sumar."
+msgstr "Các cột số để tổng hợp."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
-msgstr "Resume valores en una columna donde las filas coinciden con la condición."
+msgstr "Tổng các giá trị trong một cột trong đó các hàng khớp với điều kiện."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
 msgid "Order Status"
-msgstr "Estado Pedido"
+msgstr "Tình trạng đặt hàng"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
 msgid "Valid"
-msgstr "Válido"
+msgstr "Hợp lệ"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
 msgid "Removes leading and trailing whitespace from a string of text."
-msgstr "Elimina los espacios en blanco iniciales y finales de una cadena de texto."
+msgstr "Loại bỏ khoảng trắng hàng đầu và dấu kiểm khỏi một chuỗi văn bản."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
 msgid "Returns the string of text in all upper case."
-msgstr "Devuelve la cadena de texto en mayúsculas."
+msgstr "Trả về chuỗi văn bản trong tất cả các chữ hoa"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
 msgid "The column with values to convert to upper case."
-msgstr "La columna con valores para convertir a mayúsculas."
+msgstr "Cột có giá trị để chuyển đổi sang chữ hoa"
 
 #: frontend/src/metabase/lib/settings.js:190
 msgid "must be {0} and include {1}."
-msgstr "debe ser {0} e incluir {1}"
+msgstr "phải là {0} và bao gồm {1}"
 
 #: frontend/src/metabase/lib/settings.js:192
 msgid "must be {0}."
-msgstr "debe ser {0}"
+msgstr "phải là {0}."
 
 #: frontend/src/metabase/lib/settings.js:194
 msgid "must include {0}."
-msgstr "debe incluir {0}."
+msgstr "phải bao gồm {0}."
 
 #: frontend/src/metabase/lib/settings.js:207
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
-msgstr[0] "al menos {0} carácter"
-msgstr[1] "al menos {0} caracteres"
+msgstr[0] "ít nhất {0} ký tự"
 
 #: frontend/src/metabase/lib/settings.js:216
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
-msgstr[0] "{0} letra minúscula"
-msgstr[1] "{0} letras minúsculas"
+msgstr[0] "{0} chữ thường"
 
 #: frontend/src/metabase/lib/settings.js:225
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
-msgstr[0] "{0} letra mayúscula"
-msgstr[1] "{0} letras mayúsculas"
+msgstr[0] "{0} chữ in hoa"
 
 #: frontend/src/metabase/lib/settings.js:234
 msgid "{0} number"
 msgid_plural "{0} numbers"
-msgstr[0] "{0} número"
-msgstr[1] "{0} números"
+msgstr[0] "{0} số"
 
 #: frontend/src/metabase/lib/settings.js:239
 msgid "{0} special character"
 msgid_plural "{0} special characters"
-msgstr[0] "{0} carácter especial"
-msgstr[1] "{0} caracteres especiales"
+msgstr[0] "{0} ký tự đặc biệt"
 
 #: frontend/src/metabase/lib/validate.js:8
 msgid "must be a valid email address"
-msgstr "Debe ser una dirección de correo electrónico válida"
+msgstr "phải là một địa chỉ email hợp lệ"
 
 #: frontend/src/metabase/lib/validate.js:10
 msgid "must be {0} characters or less"
-msgstr "deben tener {0} caracteres o menos"
+msgstr "phải có {0} ký tự trở xuống"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:113
 msgid "Thanks for using Metabase!"
-msgstr "Gracias por utilizar Metabase!"
+msgstr "Cảm ơn đã sử dụng Metabase!"
 
 #: frontend/src/metabase/public/components/LogoBadge.jsx:20
 msgid "Powered by {0}"
-msgstr "Impulsado por {0}"
+msgstr "Được cung cấp bởi {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
 msgid "To:"
-msgstr "A:"
+msgstr "Đến:"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
-msgstr "Esta pregunta no se puede usar porque se basa en una base de datos diferente."
+msgstr "Câu hỏi này không thể được sử dụng vì nó dựa trên cơ sở dữ liệu khác nhau."
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:43
 msgid "Couldn't find a saved question with that ID number."
-msgstr "No he podido encontrar una pregunta guardada con ese número de identificación."
+msgstr "Không thể tìm thấy câu hỏi đã lưu với số ID đó."
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:54
 msgid "Pick a saved question"
-msgstr "Elige una pregunta guardada"
+msgstr "Chọn một câu hỏi đã lưu"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:56
 msgid "Pick a different question"
-msgstr "Elige una pregunta diferente"
+msgstr "Chọn một câu hỏi khác"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:61
 msgid "Loading…"
-msgstr "Cargando..."
+msgstr "Đang tải…"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:78
 msgid "Question #…"
-msgstr "Pregunta #..."
+msgstr "Câu hỏi # ..."
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
-msgstr "Pregunta #{0}"
+msgstr "Câu hỏi # {0}"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
-msgstr "Última edición {0}"
+msgstr "Chỉnh sửa lần cuối {0}"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:250
 msgid "{0} creates a variable in this query template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the query template."
-msgstr "{0} crea una variable en esta plantilla de consulta llamada \"nombre_variable\". Las variables pueden recibir tipos en el panel lateral, lo que cambia su comportamiento. Todos los tipos de variables que no sean \"Filtro de campo\" provocarán automáticamente que se coloque un widget de filtro en esta pregunta; con filtros de campo, esto es opcional. Cuando se completa este widget de filtro, ese valor reemplaza la variable en la plantilla de consulta."
+msgstr "{0} tạo ra một biến trong mẫu truy vấn này được gọi là \"variable_name\". Các biến có thể được đưa ra các loại trong bảng điều khiển bên, thay đổi hành vi của chúng. Tất cả các loại biến khác ngoài \"Bộ lọc trường\" sẽ tự động khiến tiện ích bộ lọc được đặt vào câu hỏi này; với Bộ lọc trường, đây là tùy chọn. Khi tiện ích bộ lọc này được điền vào, giá trị đó sẽ thay thế biến trong mẫu truy vấn."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:261
 msgid "Giving a variable the \"Field Filter\" type allows you to link questions to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
-msgstr "Darle a una variable el tipo de \"Filtro de campo\" te permite vincular preguntas a los widgets de filtro del tablero o usar más tipos de widgets de filtro en tu pregunta SQL. Una variable de filtro de campo inserta SQL similar al generado por el generador de consultas GUI al agregar filtros en columnas existentes."
+msgstr "Đưa ra một biến loại \"Bộ lọc trường\" cho phép bạn liên kết các câu hỏi với các tiện ích bộ lọc bảng điều khiển hoặc sử dụng nhiều loại tiện ích bộ lọc hơn cho câu hỏi SQL của bạn. Biến Bộ lọc trường chèn SQL tương tự như được tạo bởi trình tạo truy vấn GUI khi thêm bộ lọc vào các cột hiện có."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
-msgstr "Nombre de variable"
+msgstr "Tên biến"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:218
 msgid "Filter widget label"
-msgstr "Etiqueta del widget de filtro"
+msgstr "Lọc nhãn widget"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:64
 msgid "Select a foreign key"
-msgstr "Selecciona una clave foránea"
+msgstr "Chọn một khoá ngoài"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:50
 msgid "Hi, {0}. Nice to meet you!"
-msgstr "Hola, {0}. Encantada de conocerte!"
+msgstr "Xin chào, {0}. Rất vui được gặp bạn!"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:270
 msgid "12-hour clock"
-msgstr "Reloj de 12 horas"
+msgstr "Đồng hồ 12 giờ"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:274
 msgid "24-hour clock"
-msgstr "Reloj de 24 horas"
+msgstr "Đồng hồ 24 giờ"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:341
 msgid "Symbol"
-msgstr "Símbolo"
+msgstr "Ký tự"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:365
 msgid "In the column heading"
-msgstr "En el encabezado de la columna"
+msgstr "Trong tiêu đề cột"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:366
 msgid "In every table cell"
-msgstr "en cada celda de la tabla"
+msgstr "Trong mỗi ô"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:341
 msgid "Value formatting"
-msgstr "Formato de valor"
+msgstr "Định dạng dữ liệu"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:350
 msgid "Full"
-msgstr "Lleno"
+msgstr "Đầy"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
 msgid "No change from last {0}"
-msgstr "Sin cambios desde el último {0}"
+msgstr "Không thay đổi so với trước {0}"
 
 #: src/metabase/api/database.clj
 msgid "Connection to ''{0}:{1}'' successful, but could not connect to DB."
-msgstr "La conexión a \"{0}:{1}\" se realizó correctamente, pero no se ha podido conectar a la base de datos."
+msgstr "Kết nối với '' {0}: {1} '' thành công, nhưng không thể kết nối với DB."
 
 #: src/metabase/api/database.clj
 msgid "Connection to host ''{0}'' successful, but port {1} is invalid."
-msgstr "La conexión al host \"{0}\" se realizó correctamente, pero el puerto {1} no es válido."
+msgstr "Kết nối với máy chủ '' {0} '' thành công, nhưng cổng {1} không hợp lệ."
 
 #: src/metabase/api/database.clj
 msgid "Host ''{0}'' is not reachable"
-msgstr "No se puede acceder al host \"{0}\""
+msgstr "Máy chủ '' {0} '' không truy cập được"
 
 #: src/metabase/api/database.clj
 msgid "Unable to connect to database."
-msgstr "Incapaz de conectar a la base de datos."
+msgstr "Không thể kết nối tới cơ sở dữ liệu"
 
 #: src/metabase/api/database.clj
 msgid "Cannot connect to Database"
-msgstr "No se puede conectar a la base de datos"
+msgstr "Không thể kết nối với Cơ sở dữ liệu"
 
 #: src/metabase/api/embed.clj
 msgid "You''re not allowed to specify a value for {0}."
-msgstr "No tienes permiso para especificar un valor de {0}."
+msgstr "Bạn không được phép chỉ định giá trị cho {0}."
 
 #: src/metabase/api/embed.clj
 msgid "You can''t specify a value for {0} if it''s already set in the JWT."
-msgstr "No puedes especificar un valor para {0} si ya está configurado en el JWT."
+msgstr "Bạn không thể chỉ định giá trị cho {0} nếu nó đã được đặt trong JWT."
 
 #: src/metabase/api/embed.clj
 msgid "You must specify a value for {0} in the JWT."
-msgstr "Debes especificar un valor para {0} en el JWT."
+msgstr "Bạn phải chỉ định một giá trị cho {0} trong JWT."
 
 #: src/metabase/api/embed.clj
 msgid "You can only specify a value for {0} in the JWT."
-msgstr "Solo puedes especificar un valor para {0} en el JWT."
+msgstr "Bạn chỉ có thể chỉ định một giá trị cho {0} trong JWT."
 
 #: src/metabase/api/field.clj
 msgid "Error searching field values"
-msgstr "Error al buscar valores de campo"
+msgstr "Lỗi tìm kiếm giá trị trường"
 
 #: src/metabase/api/field.clj
 msgid "Error searching for remapping"
-msgstr "Error al buscar la reasignación"
+msgstr "Lỗi tìm kiếm ánh xạ lại"
 
 #: src/metabase/api/session.clj
 msgid "Google Auth token appears to be incorrect. "
-msgstr "El token de autenticación de Google parece ser incorrecto."
+msgstr "Mã thông báo Google Auth dường như không chính xác."
 
 #: src/metabase/api/session.clj
 msgid "Double check that it matches in Google and Metabase."
-msgstr "Verifica que coincida en Google y Metabase."
+msgstr "Kiểm tra kỹ xem nó có khớp với Google và Metabase không."
 
 #: src/metabase/api/table.clj
 msgid "Everything else"
-msgstr "Todo lo demás"
+msgstr "Những thứ khác"
 
 #: src/metabase/core.clj
 msgid "WARNING: You have enabled namespace tracing, which could log sensitive information like db passwords."
-msgstr "ADVERTENCIA: Has habilitado el seguimiento del espacio de nombres, que podría registrar información confidencial como contraseñas de la base de datos."
+msgstr "CẢNH BÁO: Bạn đã bật theo dõi không gian tên, có thể ghi thông tin nhạy cảm như mật khẩu db."
 
 #: src/metabase/db.clj
 msgid "Database Upgrade Required"
-msgstr "Actualización de base de datos requerida"
+msgstr "Yêu cầu nâng cấp cơ sở dữ liệu"
 
 #: src/metabase/db.clj
 msgid "NOTICE: Your database requires updates to work with this version of Metabase."
-msgstr "AVISO: tu base de datos requiere actualizaciones para funcionar con esta versión de Metabase."
+msgstr "THÔNG BÁO: Cơ sở dữ liệu của bạn cần cập nhật để làm việc với phiên bản này của Metabase."
 
 #: src/metabase/db.clj
 msgid "Please execute the following sql commands on your database before proceeding."
-msgstr "Por favor, ejecuta los siguientes comandos SQL en tu base de datos antes de continuar."
+msgstr "Vui lòng thực hiện các lệnh sql sau trên cơ sở dữ liệu của bạn trước khi tiếp tục."
 
 #: src/metabase/db.clj
 msgid "Once your database is updated try running the application again."
-msgstr "En cuanto hayas actualizado tu base de datos, intenta ejecutar la aplicación  de nuevo."
+msgstr "Khi cơ sở dữ liệu của bạn được cập nhật, hãy thử chạy lại ứng dụng."
 
 #: src/metabase/db.clj
 msgid "Database requires manual upgrade."
-msgstr "La base de datos requiere actualización manual."
+msgstr "Cơ sở dữ liệu yêu cầu nâng cấp thủ công."
 
 #. Tell transaction to automatically `.rollback` instead of `.commit` when the transaction finishes
 #: src/metabase/db.clj
 msgid "Set transaction to automatically roll back..."
-msgstr "Establecer la transacción para revertir automáticamente ..."
+msgstr "Đặt giao dịch để tự động quay lại ..."
 
 #. Disable auto-commit. This should already be off but set it just to be safe
 #: src/metabase/db.clj
 msgid "Disable auto-commit..."
-msgstr "Deshabilitar confirmación automática..."
+msgstr "Vô hiệu hóa tự động commit ..."
 
 #: src/metabase/db.clj
 msgid "Set default db connection with connection pool..."
-msgstr "Establecerla conexión al base de datos predeterminada con el grupo de conexiones..."
+msgstr "Đặt kết nối CSDL mặc định với nhóm kết nối ..."
 
 #: src/metabase/db.clj
 msgid "Successfully verified {0} {1} application database connection."
-msgstr "Se verificó correctamente la conexión de la base de datos de la aplicación {0} {1}."
+msgstr "Xác minh thành công kết nối cơ sở dữ liệu ứng dụng {0} {1}."
 
 #. if both of the decoders above fail, then the date string is invalid
 #: src/metabase/driver/common/parameters/dates.clj
 msgid "Don''t know how to parse date param ''{0}'' — invalid format"
-msgstr "No sé cómo analizar el parámetro de fecha \"{0}\" - formato no válido"
+msgstr "Không biết cách phân tích tham số ngày '' {0} '' - định dạng không hợp lệ"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "The sub-query from referenced question #{0} failed with the following error: {1}"
-msgstr "La subconsulta de la pregunta referenciada #{0} falló con el siguiente error: {1}"
+msgstr "Truy vấn phụ từ câu hỏi được tham chiếu # {0} không thành công với lỗi sau: {1}"
 
 #: src/metabase/driver/mysql.clj
 msgid "WARNING: Metabase only officially supports MySQL {0}/MariaDB {1} and above."
-msgstr "ADVERTENCIA: Metabase solo admite oficialmente MySQL {0}/MariaDB {1} y superior."
+msgstr "CẢNH BÁO: Metabase chỉ chính thức hỗ trợ MySQL {0} / MariaDB {1} trở lên."
 
 #: src/metabase/driver/mysql.clj
 msgid "All Metabase features may not work properly when using an unsupported version."
-msgstr "Es posible que alguna funcionalidad de Metabase no funcione correctamente cuando se utiliza una versión no compatible."
+msgstr "Tất cả các tính năng Metabase có thể không hoạt động đúng khi sử dụng phiên bản không được hỗ trợ."
 
 #: src/metabase/driver/sql/parameters/substitute.clj
 msgid "Unable to substitute parameters"
-msgstr "Incapaz de sustituir parámetros"
+msgstr "Không thể thay thế các tham số"
 
 #: src/metabase/driver/sql/parameters/substitute.clj
 msgid "Cannot run the query: missing required parameters: {0}"
-msgstr "No se puede ejecutar la consulta: faltan los parámetros necesarios: {0}"
+msgstr "Không thể chạy truy vấn: thiếu tham số bắt buộc: {0}"
 
 #: src/metabase/driver/sql/parameters/substitution.clj
 msgid "Don''t know how to parse {0} {1} as a temporal literal"
-msgstr "No sé cómo analizar {0} {1} como un literal temporal"
+msgstr "Không biết cách phân tích {0} {1} như một nghĩa đen tạm thời"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Setting {0} database timezone with statement: {1}"
-msgstr "Estableciendo la zona horaria de la base de datos {0} con la declaración: {1}"
+msgstr "Đặt múi giờ cơ sở dữ liệu {0} bằng câu lệnh: {1}"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting connection to readwrite"
-msgstr "Error al establecer la conexión para escritua y lectura"
+msgstr "Lỗi thiết lập kết nối để đọc ghi"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone ''{0}'' for {1} database"
-msgstr "Error al establecer la zona horaria \"{0}\" para la base de datos {1}"
+msgstr "Không thể đặt múi giờ '' {0} '' cho cơ sở dữ liệu {1}"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting transaction isolation level for {0} database to {1}"
-msgstr "Error al establecer el nivel de aislamiento de transacción para la base de datos {0} en {1}"
+msgstr "Lỗi thiết lập mức cô lập giao dịch cho cơ sở dữ liệu {0} thành {1}"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting connection to read-only"
-msgstr "Error al establecer la conexión a solo lectura"
+msgstr "Lỗi thiết lập kết nối thành chỉ đọc"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting default holdability for connection"
-msgstr "Error al establecer la capacidad de retención predeterminada para la conexión"
+msgstr "Lỗi thiết lập khả năng giữ mặc định cho kết nối"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting result set fetch direction to FETCH_FORWARD"
-msgstr "Error al establecer la dirección de recuperación del conjunto de resultados en FETCH_FORWARD"
+msgstr "Lỗi thiết lập kết quả đặt hướng tìm nạp thành FETCH_FORWARD"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Query canceled, calling PreparedStatement.cancel()"
-msgstr "Consulta cancelada, llamando a PreparedStatement.cancel()"
+msgstr "Truy vấn bị hủy, gọi PreparedStatement.cancel()"
 
 #: src/metabase/driver/util.clj
 msgid "Failed to connect to database"
-msgstr "Error al conectarse a la base de datos"
+msgstr "Kết nối cơ sở dữ liệu thất bại"
 
 #: src/metabase/driver/util.clj
 msgid "Unable to determine connection properties for driver {0}"
-msgstr "No se pueden determinar las propiedades de conexión para el controlador {0}"
+msgstr "Không thể xác định thuộc tính kết nối cho trình điều khiển {0}"
 
 #: src/metabase/models/field_values.clj
 msgid "Error fetching field values"
-msgstr "Error al recuperar valores de campo"
+msgstr "Lỗi tìm nạp các giá trị trường"
 
 #: src/metabase/models/setting.clj
 msgid "You cannot set {0}; it is a read-only setting."
-msgstr "No puedes establecer {0}; Es una configuración de solo lectura."
+msgstr "Bạn không thể đặt {0}; nó là một thiết lập chỉ đọc."
 
 #: src/metabase/models/setting.clj
 msgid "defsetting descriptions strings must have `:visibilty` `:internal`, `:setter` `:none`, or internationalized, found: `{0}`"
-msgstr "las cadenas de descripción defsetting deben tener `:visibilty` `:internal`, `:setter` `:none`, o internazionalizado, encontrado: `{0}`"
+msgstr "defsetting các chuỗi mô tả phải có `: visibilty``: Internal`, `: setter``: none`, hoặc được quốc tế hóa, được tìm thấy: `{0}`"
 
 #: src/metabase/models/setting.clj
 msgid "Setting {0} is internal"
-msgstr "La configuración {0} es interna"
+msgstr "Đặt {0} là nội bộ"
 
 #: src/metabase/plugins.clj
 msgid "Loading local plugin manifest at {0}"
-msgstr "Cargando el manifiesto del complemento local en {0}"
+msgstr "Đang tải bảng kê khai plugin cục bộ tại {0}"
 
 #: src/metabase/public_settings.clj
 msgid "Google Analytics tracking code."
-msgstr "Código de seguimiento de Google Analytics."
+msgstr "Mã tracking Google Analytics"
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) with {2} Cards via email"
-msgstr "Envío de pulso ({0}: {1}) con {2} tarjetas por correo electrónico"
+msgstr "Gửi xung ({0}: {1}) bằng {2} Thẻ qua email"
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) with {2} Cards via Slack"
-msgstr "Envío de pulso ({0}: {1}) con {2} tarjetas por Slack"
+msgstr "Gửi xung ({0}: {1}) với {2} Thẻ qua Slack"
 
 #: src/metabase/pulse/render.clj
 msgid "Rendering pulse card with chart-type {0} and render-type {1}"
-msgstr "Tarjeta de pulso de representación con tipo de gráfico {0} y tipo de representación {1}"
+msgstr "Kết xuất thẻ xung với loại biểu đồ {0} và loại kết xuất {1}"
 
 #. TODO  - there is code that calls this in `render.body` regardless of the types of values
 #: src/metabase/pulse/render/datetime.clj
 msgid "FIXME: These aren''t valid temporal literals: {0} {1}. Why are we attempting to format them as such?"
-msgstr "FIXME: Estos no son literales temporales válidos: {0} {1}. ¿Por qué estamos tratando de formatearlos como tales?"
+msgstr "SỬA: Những chữ này không đúng thời gian: {0} {1}. Tại sao chúng ta cố gắng định dạng chúng như vậy?"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Error reducing result rows"
-msgstr "Error al reducir las filas de resultados"
+msgstr "Lỗi giảm hàng kết quả"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Unexpected nil result"
-msgstr "Resultado inesperado nulo"
+msgstr "Kết quả không mong đợi"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Query timed out after {0} ms, raising timeout exception."
-msgstr "La consulta expiró después de {0} ms, generando una excepción de tiempo de espera."
+msgstr "Truy vấn đã hết thời gian sau {0} ms, tăng ngoại lệ thời gian chờ."
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Timed out after {0}."
-msgstr "Se agotó el tiempo de espera después de {0}."
+msgstr "Đã hết thời gian sau {0}."
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Query canceled before finishing."
-msgstr "Consulta cancelada antes de finalizar."
+msgstr "Truy vấn bị huỷ trước khi hoàn tất"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Unknown query type {0}"
-msgstr "Tipo de consulta desconocido {0}"
+msgstr "Loại truy vấn không xác định {0}"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Error purging old cache entires"
-msgstr "Error al depurar entradas de caché antiguas"
+msgstr "Lỗi thanh lọc các mục bộ đệm cũ"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Caching results for next time for query with hash {0}."
-msgstr "Resultados de la consulta con hash {0}, almacenados en caché para la próxima vez."
+msgstr "Kết quả bộ nhớ đệm cho lần tiếp theo cho truy vấn với hàm băm {0}."
 
 #: src/metabase/query_processor/middleware/cache.clj
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
 msgid "Error saving query results to cache."
-msgstr "Error al guardar los resultados de la consulta en la memoria caché."
+msgstr "Lỗi lưu kết quả truy vấn vào bộ đệm."
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Successfully cached results for query."
-msgstr "Resultados de la consulta almacenados en caché con éxito."
+msgstr "Kết quả lưu trữ thành công cho các truy vấn."
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Query took {0} to run; miminum for cache eligibility is {1}"
-msgstr "La consulta tardó {0} en ejecutarse; el mínimo para entrar en caché es {1}"
+msgstr "Truy vấn mất {0} để chạy; tối thiểu để đủ điều kiện bộ nhớ cache là {1}"
 
 #: src/metabase/query_processor/middleware/cache/impl.clj
 msgid "Results are too large to cache."
-msgstr "Los resultados son demasiado grandes para almacenar en caché."
+msgstr "Kết quả quá lớn để lưu trữ."
 
 #: src/metabase/query_processor/middleware/cache/impl.clj
 msgid "Serialization timed out after {0}."
-msgstr "La serialización se agotó después de {0}."
+msgstr "Tuần tự hóa đã hết thời gian sau {0}."
 
 #: src/metabase/query_processor/middleware/cache/impl.clj
 msgid "Error parsing serialized results"
-msgstr "Error al analizar resultados serializados"
+msgstr "Lỗi phân tích kết quả nối tiếp"
 
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
 msgid "Error purging old cache entries"
-msgstr "Error al eliminar entradas de caché antiguas"
+msgstr "Lỗi thanh lọc các mục bộ đệm cũ"
 
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
 msgid "Caching results for query with hash {0}."
-msgstr "Resultados de almacenamiento en caché para consulta con hash {0}."
+msgstr "Kết quả bộ đệm cho truy vấn với hàm băm {0}."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Cannot save QueryExecution, missing :context"
-msgstr "No se puede guardar QueryExecution, falta :context"
+msgstr "Không thể lưu QueryExecut, thiếu: bối cảnh"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Error saving query execution info"
-msgstr "Error al guardar la información de ejecución de la consulta"
+msgstr "Lỗi lưu thông tin thực thi truy vấn"
 
 #: src/metabase/query_processor/middleware/resolve_database_and_driver.clj
 msgid "Unable to resolve database for query: missing or invalid `:database` ID."
-msgstr "No se puede resolver la base de datos para la consulta: falta o no es válida la identificación `:database`."
+msgstr "Không thể giải quyết cơ sở dữ liệu cho truy vấn: thiếu hoặc không hợp lệ `: cơ sở dữ liệu` ID."
 
 #: src/metabase/query_processor/middleware/resolve_database_and_driver.clj
 msgid "Unable to resolve driver for query"
-msgstr "No se puede resolver el controlador para la consulta"
+msgstr "Không thể giải quyết trình điều khiển cho truy vấn"
 
 #: src/metabase/query_processor/middleware/resolve_referenced.clj
 msgid "Referenced question #{0} could not be found"
-msgstr "La pregunta de referencia #{0} no se ha podido encontrar"
+msgstr "Không thể tìm thấy câu hỏi tham khảo # {0}"
 
 #: src/metabase/query_processor/middleware/resolve_referenced.clj
 msgid "Referenced query is from a different database"
-msgstr "La consulta referenciada es de una base de datos diferente"
+msgstr "Truy vấn tham chiếu là từ một cơ sở dữ liệu khác"
 
 #: src/metabase/query_processor/middleware/resolve_referenced.clj
 msgid "This query has circular referencing sub-queries. "
-msgstr "Esta consulta tiene subconsultas de referencia circular."
+msgstr "Truy vấn này có các truy vấn phụ tham chiếu vòng tròn."
 
 #: src/metabase/query_processor/middleware/resolve_referenced.clj
 msgid "These questions seem to be part of the problem: \"{0}\" and \"{1}\"."
-msgstr "Estas preguntas parecen ser parte del problema: \"{0}\" y \"{1}\"."
+msgstr "Những câu hỏi này dường như là một phần của vấn đề: \"{0}\" và \"{1}\"."
 
 #: src/metabase/query_processor/middleware/results_metadata.clj
 msgid "Error recording results metadata for query"
-msgstr "Error al registrar metadatos de resultados para consulta"
+msgstr "Lỗi ghi siêu dữ liệu kết quả cho truy vấn"
 
 #: src/metabase/query_processor/streaming/xlsx.clj
 msgid "Query result"
-msgstr "Resultado consulta"
+msgstr "Kết quả truy vấn"
 
 #: src/metabase/sync/analyze/query_results.clj
 msgid "Error generating insights for column:"
-msgstr "Error al generar información para la columna:"
+msgstr "Lỗi tạo thông tin chi tiết cho cột:"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandonment email!"
-msgstr "Enviando correo electrónico de abandono!"
+msgstr "Gửi email từ bỏ!"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
-msgstr "Puedes crear métricas guardadas para agregar una opción de métrica con nombre. Las métricas guardadas incluyen el tipo de agregación, el campo agregado y, opcionalmente, cualquier filtro que añadas. Como ejemplo, puedes usar esto para crear algo así como la forma oficial de calcular el \"Precio promedio\" para una tabla de pedidos."
+msgstr "Bạn có thể tạo số liệu đã lưu để thêm tùy chọn số liệu được đặt tên. Số liệu đã lưu bao gồm loại tổng hợp, trường tổng hợp và tùy chọn bất kỳ bộ lọc nào bạn thêm. Ví dụ: bạn có thể sử dụng điều này để tạo ra thứ gì đó giống như cách tính chính thức \"Giá trung bình\" cho bảng Đơn hàng."
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:105
 msgid "Select and add filters to create your new segment."
-msgstr "Selecciona y añade filtros para crear tu nuevo segmento."
+msgstr "Chọn và thêm bộ lọc để tạo phân khúc mới của bạn."
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
 msgid "Alphabetical"
-msgstr "Alfabético"
+msgstr "Bảng chữ cái"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
 msgid "Smart"
-msgstr "Ingenioso"
+msgstr "Thông minh"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
 msgid "Column order: {0}"
-msgstr "Orden de Columna: {0}"
+msgstr "Thứ tự cột: {0}"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
 msgid "Unhide all"
-msgstr "Mostrar Todos"
+msgstr "Bỏ ẩn tất cả"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:204
 msgid "Hide all"
-msgstr "Esconder Todos"
+msgstr "Hide all"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:206
 msgid "Unhide"
-msgstr "Mostrar"
+msgstr "Bỏ ẩn"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:22
 msgid "New metric"
-msgstr "Nueva métrica"
+msgstr "Số liệu mới"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:45
 msgid "Create metrics to add them to the Summarize dropdown in the query builder"
-msgstr "Crea métricas para añadirlas al desplegable Resumir en el generador de consultas"
+msgstr "Tạo số liệu để thêm chúng vào danh sách thả xuống Tóm tắt trong trình tạo truy vấn"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:22
 msgid "New segment"
-msgstr "Nuevo segmento"
+msgstr "New segment"
 
 #: frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx:71
 msgid "Filter by table"
-msgstr "Filtrar por tabla"
+msgstr "Lọc theo bảng"
 
 #: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:64
 msgid "Checking HTTPS..."
-msgstr "Comprobando HTTPS..."
+msgstr "Đang kiểm tra HTTPS ..."
 
 #: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:66
 msgid "It looks like HTTPS is not properly configured"
-msgstr "Parece que HTTPS no está configurado correctamente"
+msgstr "Có vẻ như HTTPS không được cấu hình đúng"
 
 #: frontend/src/metabase/admin/settings/selectors.js:57
 msgid "Redirect to HTTPS"
-msgstr "Redireccionar a HTTPS"
+msgstr "Chuyển hướng đến HTTPS"
 
 #: frontend/src/metabase/admin/settings/selectors.js:219
 msgid "Localization"
-msgstr "Localización"
+msgstr "Localization"
 
 #: frontend/src/metabase/admin/settings/selectors.js:222
 msgid "Instance language"
-msgstr "Idioma de Aplicación"
+msgstr "Ngôn ngữ sơ thẩm"
 
 #: frontend/src/metabase/admin/settings/selectors.js:237
 msgid "Localization options"
-msgstr "Opciones de localización"
+msgstr "Tùy chọn nội địa hóa"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:51
 msgid "This database doesn't have any tables."
-msgstr "Esa base de datos no tiene ninguna tabla."
+msgstr "Cơ sở dữ liệu này không có bất kỳ bảng nào."
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
 msgid "This field only accepts a single value because it's used in a SQL query."
-msgstr "Este campo solo acepta un valor único porque se usa en una consulta SQL."
+msgstr "Trường này chỉ chấp nhận một giá trị duy nhất vì nó được sử dụng trong truy vấn SQL."
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:17
 msgid "Service Accounts"
-msgstr "Cuentas de servicio"
+msgstr "Tài khoản dịch vụ"
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:26
 msgid "Metabase connects to Big Query via {0}."
-msgstr "Metabase conecta con Big Query a través de {0}"
+msgstr "Metabase kết nối với Big Query thông qua {0}."
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:29
 msgid "Continue using an OAuth application to connect"
-msgstr "Continúa usando una aplicación OAuth para conectarte"
+msgstr "Tiếp tục sử dụng ứng dụng OAuth để kết nối"
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:43
 msgid "We recommend switching to use {0} instead of an OAuth application to connect to BigQuery"
-msgstr "Recomendamos cambiar y usar {0} en lugar de una aplicación OAuth para conectarse a BigQuery"
+msgstr "Chúng tôi khuyên bạn nên chuyển sang sử dụng {0} thay vì ứng dụng OAuth để kết nối với BigQuery"
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:48
 msgid "Connect to a Service Account instead"
-msgstr "O conecta"
+msgstr "Kết nối với tài khoản dịch vụ thay thế"
 
 #: frontend/src/metabase/entities/databases/forms.js:44
 msgid "invalid JSON"
-msgstr "JSON Inválido"
+msgstr "JSON không hợp lệ"
 
 #: frontend/src/metabase/entities/databases/forms.js:50
 msgid "SSH private key"
-msgstr "LLave privada SSH"
+msgstr "Khóa riêng SSH"
 
 #: frontend/src/metabase/entities/databases/forms.js:51
 msgid "Paste the contents of your ssh private key here"
-msgstr "Pega el contenido de tu clave privada ssh aquí"
+msgstr "Dán nội dung của khóa riêng ssh của bạn ở đây"
 
 #: frontend/src/metabase/entities/databases/forms.js:55
 msgid "Passphrase for the SSH private key"
-msgstr "Frase de contraseña para la clave privada SSH"
+msgstr "Cụm mật khẩu cho khóa riêng SSH"
 
 #: frontend/src/metabase/entities/databases/forms.js:58
 msgid "SSH Authentication"
-msgstr "Autentificación SSH"
+msgstr "Xác thực SSH"
 
 #: frontend/src/metabase/entities/databases/forms.js:60
 msgid "SSH Key"
-msgstr "Llave SSH"
+msgstr "Khóa SSH"
 
 #: frontend/src/metabase/entities/databases/forms.js:65
 msgid "Server SSL certificate chain"
-msgstr "Cadena de certificados SSL del servidor"
+msgstr "Chuỗi chứng chỉ SSL máy chủ"
 
 #: frontend/src/metabase/entities/databases/forms.js:66
 msgid "Paste the contents of the server's SSL certificate chain here"
-msgstr "Pega el contenido de la cadena de certificados SSL del servidor aquí"
+msgstr "Dán nội dung chuỗi chứng chỉ SSL của máy chủ tại đây"
 
 #: frontend/src/metabase/entities/databases/mongo-fields.js:11
 msgid "Paste a connection string"
-msgstr "Pegar una cadena de conexión"
+msgstr "Dán chuỗi kết nối"
 
 #: frontend/src/metabase/entities/databases/mongo-fields.js:12
 msgid "Fill out individual fields"
-msgstr "Rellena campos individuales"
+msgstr "Điền vào các trường riêng lẻ"
 
 #: frontend/src/metabase/entities/snippets.js:14
 msgid "Enter some SQL here so you can reuse it later"
-msgstr "Añade SQL aquí para que puedas reutilizarlo más tarde"
+msgstr "Nhập một số SQL ở đây để bạn có thể sử dụng lại sau"
 
 #: frontend/src/metabase/entities/snippets.js:24
 msgid "Give your snippet a name"
-msgstr "Dale un nombre a tu fragmento"
+msgstr "Đặt tên cho đoạn trích của bạn"
 
 #: frontend/src/metabase/entities/snippets.js:25
 msgid "Current Customers"
-msgstr "Clientes Actuales"
+msgstr "Khách hàng hiện tại"
 
 #: frontend/src/metabase/entities/snippets.js:30
 msgid "Add a description"
-msgstr "Añadir una descripción"
+msgstr "Thêm một mô tả"
 
 #: frontend/src/metabase/entities/users/forms.js:37
 msgid "Use site default"
-msgstr "Utilizar el valor por defecto del sitio"
+msgstr "Sử dụng trang mặc định"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "find"
-msgstr "encontrar"
+msgstr "tìm"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
 msgid "replace"
-msgstr "sustituir"
+msgstr "thay thế"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
 msgid "The text to find."
-msgstr "El texto a encontrar."
+msgstr "Văn bản để tìm."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
 msgid "The text to use as the replacement."
-msgstr "El texto a utilizar para sustituir."
+msgstr "Các văn bản để sử dụng như là sự thay thế."
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
 msgid "Editing {0}"
-msgstr "Editando {0}"
+msgstr "Chỉnh sửa {0}"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
 msgid "Create your new snippet"
-msgstr "Crea tu nuevo fragmento"
+msgstr "Tạo đoạn mã mới của bạn"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
 msgid "Archived snippets"
-msgstr "Fragmentos archivados"
+msgstr "Đoạn trích lưu trữ"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
 msgid "Snippets are reusable bits of SQL"
-msgstr "Fragmentos son porciones de SQL reutilizables"
+msgstr "Đoạn mã là các bit có thể tái sử dụng của SQL"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
 msgid "Create a snippet"
-msgstr "Crea un fragmento"
+msgstr "Tạo một đoạn"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets"
-msgstr "Fragmentos"
+msgstr "Đoạn mã"
 
 #: frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx:15
 msgid "SQL Snippets"
-msgstr "Fragmentos SQL"
+msgstr "Đoạn mã SQL"
 
 #: frontend/src/metabase/setup/components/LanguageStep.jsx:38
 msgid "Your language is set to {0}"
-msgstr "Tu idioma es {0}"
+msgstr "Ngôn ngữ của bạn được đặt thành {0}"
 
 #: frontend/src/metabase/setup/components/LanguageStep.jsx:50
 msgid "What's your preferred language?"
-msgstr "¿Cuál es tu idioma preferido?"
+msgstr "Ngôn ngữ ưa thích của bạn là gì?"
 
 #: frontend/src/metabase/setup/components/LanguageStep.jsx:54
 msgid "This language will be used throughout Metabase and will be the default for new users."
-msgstr "Este lenguaje se utilizará en Metabase y será el predeterminado para los nuevos usuarios."
+msgstr "Ngôn ngữ này sẽ được sử dụng trong suốt Metabase và sẽ là mặc định cho người dùng mới."
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:159
 msgid "We filtered out {0} row(s) containing null values."
-msgstr "Hemos filtrado {0} filas que contienen valores nulos."
+msgstr "Chúng tôi đã lọc ra {0} hàng chứa giá trị null."
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:133
 msgid "Show values for this series"
-msgstr "Mostrar valores para esta serie"
+msgstr "Hiển thị giá trị cho chuỗi này"
 
 #: src/metabase/api/card.clj
 msgid "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
-msgstr "La duración promedio de ejecución de la pregunta es {0}; usando el TTL ''mágico'' de {1}"
+msgstr "Thời gian thực hiện trung bình của Câu hỏi là {0}; sử dụng '' ma thuật '' TTL của {1}"
 
 #: src/metabase/api/native_query_snippet.clj
 msgid "A snippet with that name already exists. Please pick a different name."
-msgstr "Ya existe un fragmento con ese nombre. Por favor, elige un nombre diferente."
+msgstr "Một đoạn với tên đó đã tồn tại. Vui lòng chọn một tên khác."
 
 #: src/metabase/api/query_description.clj
 msgid "[Unknown Metric]"
-msgstr "[Métrica Desconocida]"
+msgstr "[Số liệu không xác định]"
 
 #: src/metabase/api/query_description.clj
 msgid "[Unknown Segment]"
-msgstr "[Segmento Desconocido]"
+msgstr "[Phân đoạn không xác định]"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Error writing error to output stream"
-msgstr "Error al escribir error en la salida"
+msgstr "Lỗi ghi lỗi vào luồng đầu ra"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Caught unexpected Exception in streaming response body"
-msgstr "Excepción inesperada en el cuerpo de respuesta al transmitir"
+msgstr "Bắt gặp ngoại lệ bất ngờ trong cơ thể phản hồi trực tuyến"
 
 #: src/metabase/async/streaming_response.clj
 msgid "bound-fn caught unexpected Exception"
-msgstr "Excepción inesperada en bound-fn"
+msgstr "bound-fn bắt ngoại lệ bất ngờ"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Error determining whether HTTP request was canceled"
-msgstr "Error al determinar si se canceló la solicitud HTTP"
+msgstr "Lỗi xác định xem yêu cầu HTTP có bị hủy không"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Check cancelation status timed out after {0}"
-msgstr "Verificación del estado de cancelación agotado después de {0}"
+msgstr "Kiểm tra trạng thái hủy đã hết thời gian sau {0}"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Unexpected exception in do-f-async"
-msgstr "Excepción inesperada en do-f-async"
+msgstr "Ngoại lệ không mong muốn trong do-f-async"
 
 #: src/metabase/async/streaming_response.clj src/metabase/server.clj
 msgid "Unexpected exception writing error response"
-msgstr "Excepción inesperada al escribir respuesta de error"
+msgstr "Phản hồi lỗi ngoại lệ bằng văn bản không mong đợi"
 
 #: src/metabase/driver/common.clj
 msgid "Server certificate not trusted - did you specify the correct SSL certificate chain?"
-msgstr "Certificado de servidor no confiable: ¿especificó la cadena de certificados SSL correcta?"
+msgstr "Chứng chỉ máy chủ không đáng tin cậy - bạn đã chỉ định chuỗi chứng chỉ SSL chính xác chưa?"
 
 #: src/metabase/driver/common.clj
 msgid "Server appears to require SSL - please enable SSL above"
-msgstr "Parece que el servidor requiere SSL; habilita SSL arriba"
+msgstr "Máy chủ dường như yêu cầu SSL - vui lòng bật SSL ở trên"
 
 #: src/metabase/driver/common.clj
 msgid "Username"
-msgstr "Nombre Usuario"
+msgstr "Tên tài khoản"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Don''t know how to parse parameter of type {0}"
-msgstr "No sé cómo analizar el parámetro de tipo {0}"
+msgstr "Không biết cách phân tích tham số loại {0}"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Invalid :card parameter: missing `:card-id`"
-msgstr ":card parameter: inválido, falta `:card-id`"
+msgstr "Không hợp lệ: tham số thẻ: thiếu `: card-id`"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Unable to resolve Snippet: missing `:snippet-id`"
-msgstr "No se puede resolver el fragmento: falta `:snippet-id`"
+msgstr "Không thể giải quyết Snippet: mất `: snippet-id`"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Snippet {0} {1} not found."
-msgstr "Fragmento {0} {1} no encontrado."
+msgstr "Đoạn mã {0} {1} không tìm thấy."
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Error determining value for parameter"
-msgstr "Error al determinar el valor del parámetro"
+msgstr "Lỗi xác định giá trị cho tham số"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Error building query parameter map"
-msgstr "Error al generar el mapa de parámetros de consulta"
+msgstr "Lỗi xây dựng bản đồ tham số truy vấn"
 
 #: src/metabase/middleware/log.clj
 msgid "ASYNC"
-msgstr "ASYNC"
+msgstr "không đồng bộ"
 
 #: src/metabase/middleware/log.clj
 msgid "{0} ({1} DB calls)"
-msgstr "{0} ({1} llamadas a la BBDD)"
+msgstr "{0} ({1} Cuộc gọi DB)"
 
 #: src/metabase/middleware/log.clj
 msgid "App DB connections: {0}/{1}"
-msgstr "Conexiones BBDD: {0}/{1}"
+msgstr "Kết nối DB ứng dụng: {0} / {1}"
 
 #: src/metabase/middleware/log.clj
 msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
-msgstr "Hilos Jetty: {0}/{1} ({2} esperando, {3} en cola)"
+msgstr "Chủ đề cầu tàu: {0} / {1} ({2} nhàn rỗi, {3} xếp hàng)"
 
 #: src/metabase/middleware/log.clj
 msgid "({0} total active threads)"
-msgstr "({0} hilos totales activos)"
+msgstr "({0} tổng số chủ đề đang hoạt động)"
 
 #: src/metabase/middleware/log.clj
 msgid "Queries in flight: {0}"
-msgstr "Consultas en ejecución: {0}"
+msgstr "Truy vấn trong chuyến bay: {0}"
 
 #: src/metabase/middleware/log.clj
 msgid "({0} queued)"
-msgstr "({0} en cola)"
+msgstr "({0} xếp hàng)"
 
 #: src/metabase/models/collection.clj
 msgid "Collection must be in the same namespace as its parent"
-msgstr "Una colección debe estar en el mismo espacio de nombres que su padre"
+msgstr "Bộ sưu tập phải ở cùng không gian tên với mẹ của nó"
 
 #: src/metabase/models/collection.clj
 msgid "Personal Collections must be in the default namespace"
-msgstr "Las colecciones personales deben estar en el espacio de nombres predeterminado"
+msgstr "Bộ sưu tập cá nhân phải ở trong không gian tên mặc định"
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection to a different namespace once it has been created."
-msgstr "No puedes mover una Colección a un espacio de nombres diferente una vez que se haya creado."
+msgstr "Bạn không thể di chuyển Bộ sưu tập sang một không gian tên khác sau khi nó được tạo."
 
 #: src/metabase/models/collection.clj src/metabase/models/permissions.clj
 msgid "Collection does not exist."
-msgstr "Colección no existe."
+msgstr "Bộ sưu tập không tồn tại."
 
 #: src/metabase/models/collection.clj
 msgid "A {0} can only go in Collections in the {1} namespace."
-msgstr "Un {0} solo puede ir en Colecciones en el espacio de nombres {1}."
+msgstr "{0} chỉ có thể đi vào Bộ sưu tập trong không gian tên {1}."
 
 #: src/metabase/models/database.clj
 msgid "Error sending database deletion notification"
-msgstr "Error al enviar la notificación de eliminación de la base de datos"
+msgstr "Lỗi gửi thông báo xóa cơ sở dữ liệu"
 
 #: src/metabase/models/native_query_snippet.clj
 msgid "You cannot update the creator_id of a NativeQuerySnippet."
-msgstr "No puedes actualizar el creator_id de un Fragmento Nativo."
+msgstr "Bạn không thể cập nhật creator_id của NativeQuerySnippet."
 
 #: src/metabase/models/setting.clj
 msgid "Error fetching value of Setting"
-msgstr "Error al recuperar el valor de la configuración"
+msgstr "Lỗi tìm nạp giá trị của Cài đặt"
 
 #: src/metabase/public_settings.clj
 msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
-msgstr "El idioma que se debe usar para la interfaz de usuario de Metabase, correos electrónicos del sistema, pulsos y alertas."
+msgstr "Ngôn ngữ nên được sử dụng cho UI của Metabase, email hệ thống, xung và cảnh báo."
 
 #: src/metabase/public_settings.clj
 msgid "This is also the default language for all users, which they can change from their own account settings."
-msgstr "Este es también el idioma predeterminado para todos los usuarios, que pueden cambiar desde la configuración de su propia cuenta."
+msgstr "Đây cũng là ngôn ngữ mặc định cho tất cả người dùng mà họ có thể thay đổi từ cài đặt tài khoản của riêng họ."
 
 #: src/metabase/public_settings.clj
 msgid "Invalid locale {0}"
-msgstr "Configuración regional {0} no válida"
+msgstr "Ngôn ngữ không hợp lệ {0}"
 
 #: src/metabase/public_settings.clj
 msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
-msgstr "Forzar todo el tráfico a usar HTTPS a través de una redirección, si la URL del sitio es HTTPS"
+msgstr "Buộc tất cả lưu lượng truy cập sử dụng HTTPS thông qua chuyển hướng, nếu URL trang web là HTTPS"
 
 #: src/metabase/public_settings.clj
 msgid "Cannot redirect requests to HTTPS unless `site-url` is HTTPS."
-msgstr "No se pueden redirigir solicitudes a HTTPS a menos que `site-url` sea HTTPS."
+msgstr "Không thể chuyển hướng yêu cầu đến HTTPS trừ khi `site-url` là HTTPS."
 
 #: src/metabase/pulse/render/png.clj
 msgid "Error registering fonts: Metabase will not be able to send Pulses."
-msgstr "Error al registrar fuentes: Metabase no podrá enviar pulsos."
+msgstr "Lỗi khi đăng ký phông chữ: Metabase sẽ không thể gửi Xung."
 
 #: src/metabase/pulse/render/png.clj
 msgid "This is a known issue with certain JVMs. See {0} and for more details."
-msgstr "Este es un problema conocido con ciertas JVM. Ver {0} para más detalles."
+msgstr "Đây là một vấn đề đã biết với các JVM nhất định. Xem {0} và để biết thêm chi tiết."
 
 #: src/metabase/pulse/render/png.clj
 msgid "Error rendering Pulse"
-msgstr "Error al procesar el pulso"
+msgstr "Lỗi kết xuất xung"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Query timed out after {0}, raising timeout exception."
-msgstr "La consulta expiró después de {0}, generando una excepción de tiempo de espera."
+msgstr "Truy vấn đã hết thời gian sau {0}, tăng ngoại lệ thời gian chờ."
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "No fields found for table {0}."
-msgstr "No se encontraron campos para la tabla {0}."
+msgstr "Không tìm thấy trường nào cho bảng {0}."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Case"
-msgstr "Caso"
+msgstr "Trường hợp"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Variance of {0}"
-msgstr "Varianza de {0}"
+msgstr "Phương sai của {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Median of {0}"
-msgstr "Mediana de {0}"
+msgstr "Trung vị của {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "{0}th percentile of {1}"
-msgstr "percentil {0} de {1}"
+msgstr "{0} phần trăm của {1}"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Not caching results: results are larger than {0} KB"
-msgstr "No se hará uso del almacenamiento en caché ya que los resultados son mayores de {0} KB"
+msgstr "Không lưu kết quả bộ đệm: kết quả lớn hơn {0} KB"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Cannot cache results: expected byte array, got {0}"
-msgstr "No se pueden almacenar los resultados en caché: esperaba una matriz de bytes, pero se obtuvo {0}"
+msgstr "Không thể kết quả bộ đệm: dự kiến byte array, đã nhận {0}"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Request is closed; no one to return cached results to"
-msgstr "La solicitud está cerrada; nadie a quien devolver los resultados almacenados en caché"
+msgstr "Yêu cầu được đóng lại; không ai trả lại kết quả được lưu trong bộ nhớ cache cho"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Error attempting to fetch cached results for query with hash {0}"
-msgstr "Error al intentar obtener resultados en caché para la consulta con el hash {0}"
+msgstr "Lỗi khi tìm nạp các kết quả được lưu trong bộ nhớ cache cho truy vấn với hàm băm {0}"
 
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
 msgid "Error preparing statement to fetch cached query results"
-msgstr "Error al preparar la declaración para recuperar resultados de consultas en caché"
+msgstr "Lỗi chuẩn bị câu lệnh để tìm nạp kết quả truy vấn được lưu trữ"
 
 #: src/metabase/query_processor/middleware/catch_exceptions.clj
 msgid "Error processing query: {0}"
-msgstr "Error procesando consulta: {0}"
+msgstr "Lỗi truy vấn xử lý: {0}"
 
 #: src/metabase/server.clj
 msgid "Unexpected exception in endpoint"
-msgstr "Excepción inesperada en la llamada"
+msgstr "Ngoại lệ bất ngờ ở điểm cuối"
 
 #: src/metabase/server.clj
 msgid "Unexpected Exception in API request handler"
-msgstr "Excepción inesperada en el controlador de solicitud de API"
+msgstr "Ngoại lệ không mong muốn trong trình xử lý yêu cầu API"
 
 #: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
 msgid "Error reducing {0}"
-msgstr "Error reduciendo {0}"
+msgstr "Lỗi giảm {0}"
 
 #: src/metabase/sync/analyze/fingerprint/insights.clj
 msgid "Error generating timeseries insight keyed by: {0}"
-msgstr "Error al generar información de series de tiempo con clave: {0}"
+msgstr "Lỗi tạo ra cái nhìn sâu theo chuỗi thời gian được khóa bởi: {0}"
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "La posición de {0} en la base de datos ha cambiado de ''{1}'' a ''{2}''."
+msgstr "Vị trí cơ sở dữ liệu của {0} đã thay đổi từ '' {1} '' thành '' {2} ''."
 
 #: src/metabase/task/sync_databases.clj
 msgid "Unscheduling task for Database {0}: trigger: {1}"
-msgstr "Quitando la tarea de la base de datos {0}: activador: {1}"
+msgstr "Bỏ lịch nhiệm vụ cho Cơ sở dữ liệu {0}: trigger: {1}"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a keyword or string."
-msgstr "El valor debe ser una palabra clave o una cadena."
+msgstr "giá trị phải là một từ khóa hoặc chuỗi."
 
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
-msgstr "La cadena debe ser un idioma ISO válido de dos letras o un código de idioma-país, p.e. 'en' o 'en_US'."
+msgstr "Chuỗi phải là ngôn ngữ ISO hai chữ cái hợp lệ hoặc mã quốc gia ngôn ngữ, ví dụ: 'en' hoặc 'en_US'."
 

--- a/locales/zh-HK.po
+++ b/locales/zh-HK.po
@@ -29,13 +29,14 @@ msgid "Select a database type"
 msgstr "選擇資料庫類型"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:411
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:154
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -48,7 +49,7 @@ msgstr "儲存"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "為了做一些預設分析的事情，Metabase需要掃描您的資料庫。我們將會定期自動掃描您的資料庫，確保資料庫欄位的資訊在 Metabase 是最新的狀態。您可以在下方更改分析的時間。"
 
-#: frontend/src/metabase/entities/databases/forms.js:221
+#: frontend/src/metabase/entities/databases/forms.js:290
 msgid "Database syncing"
 msgstr "資料庫同步中"
 
@@ -63,7 +64,7 @@ msgstr "這個程序僅僅檢查資料庫欄位的更新，並不會耗費太多
 msgid "Scan"
 msgstr "掃描"
 
-#: frontend/src/metabase/entities/databases/forms.js:228
+#: frontend/src/metabase/entities/databases/forms.js:297
 msgid "Scanning for Filter Values"
 msgstr "根據篩選值進行掃描"
 
@@ -74,7 +75,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase 可以掃描資料庫中每個欄位的值，用來壤使用者啟用查詢或資訊看板中的篩選器。當您的資料庫較大時，這個功能同時會耗費更多的系統資源。"
 
-#: frontend/src/metabase/entities/databases/forms.js:232
+#: frontend/src/metabase/entities/databases/forms.js:301
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Metabase應該在什麼時候自動掃描快取的欄位值"
 
@@ -96,6 +97,7 @@ msgid "Never, I'll do this manually if I need to"
 msgstr "不用，如果需要我會手動執行"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 msgid "Saving..."
@@ -132,9 +134,9 @@ msgid "in this box:"
 msgstr "在這個框裡:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:75
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
@@ -151,18 +153,18 @@ msgstr "在這個框裡:"
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:301
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:39
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:90
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:99
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:311
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:328
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "取消"
@@ -179,7 +181,7 @@ msgstr "刪除"
 #: frontend/src/metabase/admin/permissions/selectors.js:323
 #: frontend/src/metabase/admin/permissions/selectors.js:330
 #: frontend/src/metabase/admin/permissions/selectors.js:441
-#: frontend/src/metabase/admin/routes.jsx:57
+#: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
@@ -199,9 +201,10 @@ msgid "Scheduling"
 msgstr "排程"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:71
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
@@ -209,8 +212,8 @@ msgid "Save changes"
 msgstr "儲存修改"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:203
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:35
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
 msgstr "動作"
 
@@ -222,8 +225,8 @@ msgstr "開始同步資料庫綱要"
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:90
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:98
 msgid "Starting…"
 msgstr "開始..."
 
@@ -241,13 +244,13 @@ msgstr "現在重新掃描欄位值"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
 msgstr "無法開始掃描"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:92
 msgid "Scan triggered!"
 msgstr "掃描已觸發！"
 
@@ -270,15 +273,15 @@ msgid "Add database"
 msgstr "新增資料庫"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:28
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:28
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
 #: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:195
+#: frontend/src/metabase/entities/databases/forms.js:264
 #: frontend/src/metabase/entities/questions.js:86
 #: frontend/src/metabase/entities/questions.js:102
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
@@ -318,6 +321,7 @@ msgstr "儲存成功！"
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "編輯"
@@ -360,44 +364,43 @@ msgstr "失敗"
 msgid "Success"
 msgstr "成功"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:185
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "預覽"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:93
 msgid "No column description yet"
 msgstr "暫無欄位敘述"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:127
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:126
 msgid "Select a field visibility"
 msgstr "選擇欄位可見性"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:187
 msgid "No special type"
 msgstr "指定的類型不存在"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
 #: frontend/src/metabase/lib/core.js:275
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:44
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:37
 msgid "Other"
 msgstr "其他"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:221
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "請選擇一個指定類型"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:255
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:262
 #: frontend/src/metabase/reference/components/Field.jsx:99
 msgid "Select a target"
 msgstr "選擇目標"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
@@ -405,18 +408,18 @@ msgstr "選擇目標"
 msgid "Columns"
 msgstr "欄位"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "欄位"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:144
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:288
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
 msgid "Visibility"
 msgstr "可見性"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
 msgid "Type"
 msgstr "類型"
 
@@ -424,7 +427,7 @@ msgstr "類型"
 msgid "Current database:"
 msgstr "當前資料庫"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
 msgid "Show original schema"
 msgstr "顯示原始資料綱要結構"
 
@@ -445,27 +448,27 @@ msgid "{0} schema"
 msgid_plural "{0} schemas"
 msgstr[0] "{0}模式"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:99
 msgid "Why Hide?"
 msgstr "隱藏原因"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:100
 msgid "Technical Data"
 msgstr "日誌資料"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
 msgstr "不相關"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 msgid "Queryable"
 msgstr "可查詢"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:108
 msgid "Hidden"
 msgstr "已隱藏"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136
 msgid "No table description yet"
 msgstr "暫無資料表敘述"
 
@@ -473,30 +476,31 @@ msgstr "暫無資料表敘述"
 msgid "Metadata Strength"
 msgstr "後設資料完整度"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0}可查詢表"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:91
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0}隱藏表"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:115
 msgid "Find a table"
 msgstr "搜尋資料表"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:128
 msgid "Schemas"
 msgstr "資料表結構"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:838
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:21
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:43
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:62
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 msgid "Metrics"
 msgstr "量值"
@@ -505,8 +509,8 @@ msgstr "量值"
 msgid "Add a Metric"
 msgstr "新增量值"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "定義"
@@ -515,12 +519,12 @@ msgstr "定義"
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "建立量值並新增到查詢設計器的視圖下拉選單"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:21
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
 #: frontend/src/metabase/home/containers/SearchApp.jsx:72
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:961
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:61
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "篩選器(Segments)"
@@ -529,35 +533,35 @@ msgstr "篩選器(Segments)"
 msgid "Add a Segment"
 msgstr "新增篩選器(Segments)"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:51
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:45
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "建立篩選器(Segments)並新增到查詢設計器的篩選下拉選單"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:21
 msgid "created"
 msgstr "已建立"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "reverted to a previous version"
 msgstr "恢復到前一個版本"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:30
 msgid "edited the title"
 msgstr "編輯標題"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:32
 msgid "edited the description"
 msgstr "編輯敘述"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:34
 msgid "edited the "
 msgstr "編輯"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:40
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "made some changes"
 msgstr "做了一些改動"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
 #: frontend/src/metabase/home/components/Activity.jsx:83
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
@@ -567,84 +571,84 @@ msgstr "您"
 msgid "Datamodel"
 msgstr "資料模型"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:41
 msgid " History"
 msgstr "歷史"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
 msgstr "歷史版本"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:228
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
 msgid "{0} – Field Settings"
 msgstr "{0} - 欄位設定"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:289
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
 msgid "Where this field will appear throughout Metabase"
 msgstr "這些欄位將在哪裡顯示？"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:311
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
 msgid "Filtering on this field"
 msgstr "欄位過濾"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:312
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "當在篩選器中使用此欄位時，人們應該使用什麼形式輸入他們想要過濾的值?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:437
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
 msgid "No description for this field yet"
 msgstr "暫無篩選欄位敘述"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
 msgid "Original value"
 msgstr "原始值"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:390
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
 msgid "Mapped value"
 msgstr "對映值"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
 msgid "Enter value"
 msgstr "輸入值"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use original value"
 msgstr "使用原始值"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Use foreign key"
 msgstr "使用外鍵"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 msgid "Custom mapping"
 msgstr "自訂映射"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
 msgid "Unrecognized mapping type"
 msgstr "無法識別對應類型"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "當前欄位不是外鍵或者缺少外鍵關聯表後設資料"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
 msgid "The selected field isn't a foreign key"
 msgstr "選中的欄位不是外鍵"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:327
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
 msgid "Display values"
 msgstr "顯示值"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:328
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "選擇顯示資料庫中的原始值，或者顯示此欄位的關聯或自訂訊息。"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:278
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
 msgid "Choose a field"
 msgstr "選擇欄位"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:299
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
 msgid "Please select a column to use for display."
 msgstr "請選擇顯示欄位"
 
@@ -652,16 +656,16 @@ msgstr "請選擇顯示欄位"
 msgid "Tip:"
 msgstr "提示："
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:443
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "您可能想要更新這個欄位的名稱來確保它基於您的重新映射選擇時仍然有意義"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:344
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "快取欄位值"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:345
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase 通過掃描該欄位，以啟用資訊看板和問題的多選框篩選。"
 
@@ -670,53 +674,53 @@ msgid "Re-scan this field"
 msgstr "重新掃描該欄位"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
 msgstr "丟棄欄位快取"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
 msgstr "丟棄欄位值失敗"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 msgid "Discard triggered!"
 msgstr "丟棄處理已經觸發！"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "選擇任意資料表來顯示它的結構並且新增或編輯後設資料"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:36
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "名稱必填"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:39
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "敘述必填"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:43
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "調整訊息必填"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
 msgid "Aggregation is required"
 msgstr "聚集訊息必填"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Edit Your Metric"
 msgstr "編輯量值"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Create Your Metric"
 msgstr "建立量值"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "修改量值並留下簡要說明。"
 
@@ -724,62 +728,62 @@ msgstr "修改量值並留下簡要說明。"
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "您能夠建立已存儲的量值來新增一個已經命名的量值選項到這個表單。儲存的量值包括您新增的聚合類型，聚合欄位和可選的任何篩選項。舉個例子，您可能使用這個來為一個訂單表單創造一些像是“平均價”的官方計算方法，"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:180
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
 msgid "Result: "
 msgstr "結果："
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
 msgid "Name Your Metric"
 msgstr "命名量值"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:190
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Give your metric a name to help others find it."
 msgstr "為量值命名，方便其他人搜尋。"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:194
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:152
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "簡短的敘述"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:198
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
 msgid "Describe Your Metric"
 msgstr "敘述量值"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:199
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "敘述量值，方便其他人理解。"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:203
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "在這裡詳細敘述量值，比如不太明顯的規則"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:207
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:165
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "更改原因"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:209
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "留言以說明您所做的更改以及為何需要這些更改。"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:213
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "這將顯示在此量值的修訂歷史記錄中，以幫助每個人記住事情發生變化的原因"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
 msgstr "至少需要一個篩選條件"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
 msgstr "編輯劃分(Segment)"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
 msgstr "建立劃分(Segment)"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "更改劃分(Segment)，並敘述變動內容。"
 
@@ -787,33 +791,33 @@ msgstr "更改劃分(Segment)，並敘述變動內容。"
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "選擇並新增篩選條件以為{0}表建立新段(Segment)"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
 msgstr "命名劃分(Segment)"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:148
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
 msgstr "命名劃分(Segment)方便其他人搜尋"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:156
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
 msgstr "敘述劃分(Segment)"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "敘述劃分(Segment)，方便其他人理解。"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "在這裡詳細敘述劃分(Segment)，比如不太明顯的規則"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "這將顯示在篩選器的修訂歷史記錄中，以幫助每個人記住事情發生變化的原因"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
-#: frontend/src/metabase/admin/routes.jsx:132
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:215
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
+#: frontend/src/metabase/admin/routes.jsx:137
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
@@ -821,11 +825,11 @@ msgstr "這將顯示在篩選器的修訂歷史記錄中，以幫助每個人記
 msgid "Settings"
 msgstr "設定"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase掃描此表中的值以啟用資訊看板和問題中的複選框篩選器。"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
 msgstr "刷新表格"
 
@@ -839,11 +843,11 @@ msgstr "新增"
 msgid "Not a valid formatted email address"
 msgstr "無效的EMail地址"
 
-#: frontend/src/metabase/entities/users/forms.js:12
+#: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
 msgstr "名"
 
-#: frontend/src/metabase/entities/users/forms.js:18
+#: frontend/src/metabase/entities/users/forms.js:20
 msgid "Last name"
 msgstr "姓"
 
@@ -882,10 +886,10 @@ msgstr "組員"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
-#: frontend/src/metabase/admin/settings/selectors.js:120
-#: frontend/src/metabase/entities/users/forms.js:24
+#: frontend/src/metabase/admin/settings/selectors.js:121
+#: frontend/src/metabase/entities/users/forms.js:26
 #: frontend/src/metabase/lib/core.js:146
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:294
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:298
 msgid "Email"
 msgstr "信箱"
 
@@ -894,14 +898,14 @@ msgid "A group is only as good as its members."
 msgstr "群組內成員權限一致"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
-#: frontend/src/metabase/admin/routes.jsx:52
+#: frontend/src/metabase/admin/routes.jsx:55
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Admin"
 msgstr "管理員"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:241
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:299
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:288
 msgid "and"
 msgstr "和"
 
@@ -952,12 +956,12 @@ msgstr "移除群組"
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:42
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:294
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:397
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:317
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:334
 msgid "Done"
 msgstr "完成"
 
@@ -968,8 +972,9 @@ msgstr "群組名稱"
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
-#: frontend/src/metabase/admin/routes.jsx:92
+#: frontend/src/metabase/admin/routes.jsx:97
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "群組"
 
@@ -999,7 +1004,7 @@ msgstr "停用"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:21
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
-#: frontend/src/metabase/admin/routes.jsx:88
+#: frontend/src/metabase/admin/routes.jsx:93
 #: frontend/src/metabase/nav/containers/Navbar.jsx:235
 msgid "People"
 msgstr "人員管理"
@@ -1310,25 +1315,25 @@ msgstr "檢視集合(collection)"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:542
+#: frontend/src/metabase/admin/permissions/selectors.js:558
 msgid "Data Access"
 msgstr "允許訪問資料"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:667
-#: frontend/src/metabase/admin/permissions/selectors.js:672
+#: frontend/src/metabase/admin/permissions/selectors.js:665
+#: frontend/src/metabase/admin/permissions/selectors.js:670
 msgid "View tables"
 msgstr "檢視表格"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:608
+#: frontend/src/metabase/admin/permissions/selectors.js:606
 msgid "SQL Queries"
 msgstr "SQL查詢"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:678
+#: frontend/src/metabase/admin/permissions/selectors.js:676
 msgid "View schemas"
 msgstr "檢視綱要結構"
 
-#: frontend/src/metabase/admin/routes.jsx:63
+#: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
 msgstr "資料模型"
@@ -1358,20 +1363,24 @@ msgid "Allows users within your LDAP directory to log in to Metabase with their 
 msgstr "允許LDAP目錄中的使用者使用他們的LDAP憑證登入到Metabase，並且允許自動同步LDAP組的資料到Metabase中來。"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:19
-#: frontend/src/metabase/admin/settings/selectors.js:167
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
+#: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
 msgstr "這不是有效的電子郵件地址"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
 msgstr "那不是一個有效的整數"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
 msgstr "更改已儲存！"
 
-#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:178
+#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
 msgid "Looks like we ran into some problems"
 msgstr "看起來我們遇到了一些問題"
 
@@ -1393,7 +1402,7 @@ msgstr "完成"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:195
+#: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "認證"
 
@@ -1445,15 +1454,15 @@ msgstr "您的Google使用者端ID"
 msgid "Allow users to sign up on their own if their Google account email address is from:"
 msgstr "允許使用者用他們自己的信箱註冊，如果他們的Google帳戶地址來自："
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:242
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:249
 msgid "Answers sent right to your Slack #channels"
 msgstr "答案發送到您的Slack #channels"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:251
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:258
 msgid "Create a Slack Bot User for MetaBot"
 msgstr "為MetaBot建立一個Slack Bot使用者"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:261
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:268
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "進入後，請為其命名並單擊{0}。然後將Bot API令牌複製並黏貼到下面的欄位中。完成後，在Slack中建立“metabase_files”通道。Metabase需要這個來上傳圖表。"
 
@@ -1466,8 +1475,8 @@ msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Metabase {0}可更新。您正在執行是{1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:41
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 msgid "Update"
 msgstr "更新"
 
@@ -1494,16 +1503,16 @@ msgstr "刪除自訂地圖"
 #: frontend/src/metabase/containers/Overworld.jsx:293
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:115
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "刪除"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:165
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:141
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
 msgstr "選擇"
 
@@ -1686,48 +1695,46 @@ msgid "Generate Key"
 msgstr "生成密鑰"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:87
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:18
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enabled"
 msgstr "生效"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:92
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:19
+#: frontend/src/metabase/admin/settings/selectors.js:93
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "取消"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:112
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:113
 msgid "Unknown setting {0}"
 msgstr "未知設定{0}"
 
-#: frontend/src/metabase/admin/settings/selectors.js:34
+#: frontend/src/metabase/admin/settings/selectors.js:37
 msgid "Setup"
 msgstr "初始化"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:207
-#: frontend/src/metabase/admin/settings/selectors.js:39
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:214
+#: frontend/src/metabase/admin/settings/selectors.js:42
 msgid "General"
 msgstr "基本設定"
 
-#: frontend/src/metabase/admin/settings/selectors.js:43
+#: frontend/src/metabase/admin/settings/selectors.js:46
 msgid "Site Name"
 msgstr "網站名稱"
 
-#: frontend/src/metabase/admin/settings/selectors.js:48
+#: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Site URL"
 msgstr "網站地址"
 
-#: frontend/src/metabase/admin/settings/selectors.js:53
+#: frontend/src/metabase/admin/settings/selectors.js:64
 msgid "Email Address for Help Requests"
 msgstr "客服信箱"
 
-#: frontend/src/metabase/admin/settings/selectors.js:58
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
 msgstr "報表時區"
 
-#: frontend/src/metabase/admin/settings/selectors.js:61
+#: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
 msgstr "資料來源預設時區"
 
@@ -1735,11 +1742,11 @@ msgstr "資料來源預設時區"
 msgid "Select a timezone"
 msgstr "選擇時區"
 
-#: frontend/src/metabase/admin/settings/selectors.js:64
+#: frontend/src/metabase/admin/settings/selectors.js:75
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "並非所有資料庫支持時區設定，部分設定無法生效。"
 
-#: frontend/src/metabase/admin/settings/selectors.js:69
+#: frontend/src/metabase/entities/users/forms.js:34
 msgid "Language"
 msgstr "語系"
 
@@ -1747,64 +1754,64 @@ msgstr "語系"
 msgid "Select a language"
 msgstr "選擇語系"
 
-#: frontend/src/metabase/admin/settings/selectors.js:79
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
 msgstr "匿名跟蹤"
 
-#: frontend/src/metabase/admin/settings/selectors.js:84
+#: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
 msgstr "方便理解的資料表和欄位名稱"
 
-#: frontend/src/metabase/admin/settings/selectors.js:90
+#: frontend/src/metabase/admin/settings/selectors.js:91
 msgid "Only replace underscores and dashes with spaces"
 msgstr "僅用空格替換下劃線(underscores)和短劃線(dashes)"
 
-#: frontend/src/metabase/admin/settings/selectors.js:98
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Enable Nested Queries"
 msgstr "啟用網狀查詢"
 
-#: frontend/src/metabase/admin/settings/selectors.js:109
+#: frontend/src/metabase/admin/settings/selectors.js:110
 msgid "Updates"
 msgstr "更新"
 
-#: frontend/src/metabase/admin/settings/selectors.js:114
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
 msgstr "檢查更新"
 
-#: frontend/src/metabase/admin/settings/selectors.js:125
+#: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
 msgstr "SMTP地址"
 
-#: frontend/src/metabase/admin/settings/selectors.js:133
+#: frontend/src/metabase/admin/settings/selectors.js:134
 msgid "SMTP Port"
 msgstr "SMTP埠"
 
-#: frontend/src/metabase/admin/settings/selectors.js:137
+#: frontend/src/metabase/admin/settings/selectors.js:138
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:47
 msgid "That's not a valid port number"
 msgstr "不是有效的埠"
 
-#: frontend/src/metabase/admin/settings/selectors.js:141
+#: frontend/src/metabase/admin/settings/selectors.js:142
 msgid "SMTP Security"
 msgstr "SMTP安全"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:150
 msgid "SMTP Username"
 msgstr "SMTP使用者名稱"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "SMTP Password"
 msgstr "SMTP密碼"
 
-#: frontend/src/metabase/admin/settings/selectors.js:163
+#: frontend/src/metabase/admin/settings/selectors.js:164
 msgid "From Address"
 msgstr "選擇地址"
 
-#: frontend/src/metabase/admin/settings/selectors.js:176
+#: frontend/src/metabase/admin/settings/selectors.js:178
 msgid "Slack API Token"
 msgstr "Slack API令牌"
 
-#: frontend/src/metabase/admin/settings/selectors.js:178
+#: frontend/src/metabase/admin/settings/selectors.js:180
 msgid "Enter the token you received from Slack"
 msgstr "輸入您從Slack收到的令牌"
 
@@ -1833,8 +1840,10 @@ msgid "Username or DN"
 msgstr "使用者名稱或DN"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:43
+#: frontend/src/metabase/entities/databases/forms.js:61
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:64
-#: frontend/src/metabase/user/components/UserSettings.jsx:65
+#: frontend/src/metabase/user/components/UserSettings.jsx:66
+#: src/metabase/driver/common.clj
 msgid "Password"
 msgstr "密碼"
 
@@ -1870,79 +1879,79 @@ msgstr "同步組成員"
 msgid "Group search base"
 msgstr "使用者組搜索庫"
 
-#: frontend/src/metabase/admin/settings/selectors.js:199
+#: frontend/src/metabase/admin/settings/selectors.js:201
 msgid "Maps"
 msgstr "地圖"
 
-#: frontend/src/metabase/admin/settings/selectors.js:203
+#: frontend/src/metabase/admin/settings/selectors.js:205
 msgid "Map tile server URL"
 msgstr "地圖貼片伺服器URL"
 
-#: frontend/src/metabase/admin/settings/selectors.js:204
+#: frontend/src/metabase/admin/settings/selectors.js:206
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Metabase預設使用PoenStreet地圖"
 
-#: frontend/src/metabase/admin/settings/selectors.js:209
+#: frontend/src/metabase/admin/settings/selectors.js:211
 msgid "Custom Maps"
 msgstr "自訂地圖"
 
-#: frontend/src/metabase/admin/settings/selectors.js:210
+#: frontend/src/metabase/admin/settings/selectors.js:212
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "新增您自己的GeoJSON檔案以啟用不同的區域地圖可視化"
 
-#: frontend/src/metabase/admin/settings/selectors.js:228
+#: frontend/src/metabase/admin/settings/selectors.js:245
 msgid "Public Sharing"
 msgstr "公開分享"
 
-#: frontend/src/metabase/admin/settings/selectors.js:232
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "Enable Public Sharing"
 msgstr "開啟公開共享"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:254
 msgid "Shared Dashboards"
 msgstr "已共享資訊看板"
 
-#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Shared Questions"
 msgstr "已共享提問"
 
-#: frontend/src/metabase/admin/settings/selectors.js:250
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Embedding in other Applications"
 msgstr "嵌入在其他的應用中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:276
+#: frontend/src/metabase/admin/settings/selectors.js:293
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "啟用將Metabase嵌入到其他應用中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:286
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Embedding secret key"
 msgstr "嵌入密鑰"
 
-#: frontend/src/metabase/admin/settings/selectors.js:292
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Embedded Dashboards"
 msgstr "嵌入的資訊看板"
 
-#: frontend/src/metabase/admin/settings/selectors.js:298
+#: frontend/src/metabase/admin/settings/selectors.js:315
 msgid "Embedded Questions"
 msgstr "嵌入的問題"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:322
 msgid "Caching"
 msgstr "快取中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:326
 msgid "Enable Caching"
 msgstr "啟用快取"
 
-#: frontend/src/metabase/admin/settings/selectors.js:314
+#: frontend/src/metabase/admin/settings/selectors.js:331
 msgid "Minimum Query Duration"
 msgstr "最小查詢週期"
 
-#: frontend/src/metabase/admin/settings/selectors.js:321
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "快取生存時間（TTL）乘數"
 
-#: frontend/src/metabase/admin/settings/selectors.js:328
+#: frontend/src/metabase/admin/settings/selectors.js:345
 msgid "Max Cache Entry Size"
 msgstr "最大快取允許大小"
 
@@ -2109,7 +2118,8 @@ msgstr "此集合中的資訊看板，集合和定時通知也將被歸檔。"
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/routes.jsx:205
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
+#: frontend/src/metabase/routes.jsx:196
 msgid "Archive"
 msgstr "歸檔"
 
@@ -2125,21 +2135,21 @@ msgstr "檢視歸檔"
 msgid "Unarchive this {0}"
 msgstr "取消歸檔此{0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:39
-#: frontend/src/metabase/components/BrowseApp.jsx:102
-#: frontend/src/metabase/components/BrowseApp.jsx:194
+#: frontend/src/metabase/components/BrowseApp.jsx:46
+#: frontend/src/metabase/components/BrowseApp.jsx:112
+#: frontend/src/metabase/components/BrowseApp.jsx:204
 #: frontend/src/metabase/containers/Overworld.jsx:270
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
 msgstr "我們的資料"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:146
+#: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
 msgid "X-ray this table"
 msgstr "透視這個資料表"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:161
+#: frontend/src/metabase/components/BrowseApp.jsx:171
 msgid "Learn about this table"
 msgstr "了解這張資料表"
 
@@ -2234,7 +2244,7 @@ msgstr "固定"
 msgid "Drag something here to pin it to the top"
 msgstr "把東西拖到這裡將它固定在頂部"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:755
+#: frontend/src/metabase/admin/permissions/selectors.js:753
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2287,7 +2297,7 @@ msgstr "新建集合"
 msgid "Copied!"
 msgstr "已複製！"
 
-#: frontend/src/metabase/entities/databases/forms.js:12
+#: frontend/src/metabase/entities/databases/forms.js:14
 msgid "Use an SSH-tunnel for database connections"
 msgstr "為Metabse連接使用SSH通道"
 
@@ -2299,7 +2309,7 @@ msgstr "一些資料庫安裝只有通過SSH通道訪問的伺服器有權訪問
 "當VPN不可用時，這個選項也提供了一個額外的安全層。\n"
 "啟用這個選項，通常比直接連接速度更慢。"
 
-#: frontend/src/metabase/entities/databases/forms.js:212
+#: frontend/src/metabase/entities/databases/forms.js:281
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "這是一個大型資料庫，讓我選擇Metabase同步和掃描的時間"
 
@@ -2309,17 +2319,17 @@ msgid "By default, Metabase does a lightweight hourly sync and an intensive dail
 msgstr "預設情況下，Metabase每小時執行一次輕量級同步，每天執行一次密集掃描。\n"
 "如果您有一個大型資料庫，我們建議啟用此功能並檢視欄位值掃描的發生時間和頻率。"
 
-#: frontend/src/metabase/entities/databases/forms.js:78
+#: frontend/src/metabase/entities/databases/forms.js:113
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0}為您的項目生成使用者端ID和使用者端金鑰。"
 
-#: frontend/src/metabase/entities/databases/forms.js:80
-#: frontend/src/metabase/entities/databases/forms.js:95
-#: frontend/src/metabase/entities/databases/forms.js:131
+#: frontend/src/metabase/entities/databases/forms.js:115
+#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:166
 msgid "Click here"
 msgstr "點擊這裡"
 
-#: frontend/src/metabase/entities/databases/forms.js:83
+#: frontend/src/metabase/entities/databases/forms.js:118
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "選擇“其他”作為應用程式類型。把它命名為您想要的任何東西。"
 
@@ -2327,19 +2337,19 @@ msgstr "選擇“其他”作為應用程式類型。把它命名為您想要的
 msgid "{0} to get an auth code"
 msgstr "{0}獲取身份驗證代碼"
 
-#: frontend/src/metabase/entities/databases/forms.js:107
+#: frontend/src/metabase/entities/databases/forms.js:142
 msgid "with Google Drive permissions"
 msgstr "使用Google Driver權限"
 
-#: frontend/src/metabase/entities/databases/forms.js:129
+#: frontend/src/metabase/entities/databases/forms.js:164
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "要將Metabase用於此資料，您必須在Google Developers Console中啟用API訪問權限。"
 
-#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:165
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "如果您還沒有這樣做，請轉到控制台{0}。"
 
-#: frontend/src/metabase/entities/databases/forms.js:196
+#: frontend/src/metabase/entities/databases/forms.js:265
 msgid "How would you like to refer to this database?"
 msgstr "您想如何使用這個資料庫？"
 
@@ -2348,7 +2358,8 @@ msgstr "您想如何使用這個資料庫？"
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:143
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:70
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:123
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:96
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:126
 #: frontend/src/metabase/setup/components/UserStep.jsx:93
 msgid "Next"
 msgstr "下一步"
@@ -2531,7 +2542,7 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "回滾到一個更早的調整並且{0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:290
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "調整記錄"
@@ -2577,7 +2588,7 @@ msgid "Questions"
 msgstr "問題"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:320
+#: frontend/src/metabase/routes.jsx:311
 msgid "Pulses"
 msgstr "定時任務"
 
@@ -2622,15 +2633,16 @@ msgstr "我們有點失落......"
 msgid "Temporary Password"
 msgstr "臨時密碼"
 
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:207
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:481
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
 msgid "Hide"
 msgstr "隱藏"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:467
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:482
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:471
 msgid "Show"
 msgstr "顯示"
 
@@ -2740,7 +2752,7 @@ msgstr "對不起，您沒有權限看那些東西"
 msgid "Unknown error encountered"
 msgstr "未知錯誤發生了"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/nav/containers/Navbar.jsx:373
 msgid "Create"
 msgstr "建立"
@@ -2753,7 +2765,7 @@ msgstr "建立資訊看板"
 msgid "Table"
 msgstr "表格"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
 msgid "Database"
 msgstr "資料庫"
 
@@ -2773,7 +2785,7 @@ msgstr "嘗試調整篩選器以找到您要搜尋的內容。"
 msgid "View by"
 msgstr "檢視方式"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:122
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:121
 msgid "of"
 msgstr "的"
 
@@ -2800,33 +2812,33 @@ msgstr "分析"
 msgid "Browse all items"
 msgstr "瀏覽所有"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:118
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:117
 msgid "Replace or save as new?"
 msgstr "替換還是儲存為新的？"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:168
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace original question, \"{0}\""
 msgstr "替換原始問題''{0}''"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:172
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:171
 msgid "Save as new question"
 msgstr "儲存為新問題"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:92
 msgid "First, save your question"
 msgstr "首先，儲存您的問題"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:94
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
 msgid "Save question"
 msgstr "儲存問題"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:133
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
 msgid "What is the name of your card?"
 msgstr "這個卡片叫什麼名字？"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
 #: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/entities/questions.js:89
@@ -2842,15 +2854,16 @@ msgstr "這個卡片叫什麼名字？"
 msgid "Description"
 msgstr "敘述"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
 #: frontend/src/metabase/entities/dashboards.js:150
 #: frontend/src/metabase/entities/questions.js:91
 #: frontend/src/metabase/entities/questions.js:107
+#: frontend/src/metabase/entities/snippets.js:31
 msgid "It's optional but oh, so helpful"
 msgstr "這是可選的，但非常有幫助"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:148
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "將這個放到哪個集合中？"
@@ -2867,19 +2880,19 @@ msgstr "項"
 msgid "Undo"
 msgstr "撤銷"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:266
 msgid "Applying Question"
 msgstr "正在使用的提問"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:286
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "That question isn't compatible"
 msgstr "那個問題不相容"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:322
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:309
 msgid "Search for a question"
 msgstr "搜尋問題"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:351
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:343
 msgid "We're not sure if this question is compatible"
 msgstr "我們不確定這個提問是否相容"
 
@@ -2928,25 +2941,23 @@ msgstr "新增一個問題"
 msgid "Add a question to this dashboard"
 msgstr "新增報表到資訊看板"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
 msgid "Add a filter"
 msgstr "新增篩選"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:256
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "參數"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:276
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:280
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
 msgid "Add a text box"
 msgstr "新增文本框"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:320
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:314
 msgid "Move dashboard"
 msgstr "移動資訊看板"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:303
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
 msgid "Edit dashboard"
 msgstr "編輯資訊看板"
 
@@ -2954,11 +2965,11 @@ msgstr "編輯資訊看板"
 msgid "Edit Dashboard Layout"
 msgstr "編輯資訊看板展示"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:371
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:365
 msgid "You are editing a dashboard"
 msgstr "正在編輯資訊看板"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:376
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:370
 msgid "Select the field that should be filtered for each card"
 msgstr "選擇應該在每個卡片中都應該被過濾的欄位"
 
@@ -3046,7 +3057,7 @@ msgstr "此卡沒有可以映射到此參數類型的任何欄位或參數。"
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "此欄位中的值不會與您選擇的任何其他欄位的值重疊。"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:162
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "無可用欄位"
@@ -3114,7 +3125,7 @@ msgstr "接收最新的資料來自"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:329
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
 msgid "Unknown"
 msgstr "未知"
 
@@ -3241,6 +3252,7 @@ msgstr "{0}項已選擇"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 msgid "Unarchive"
 msgstr "取消歸檔"
 
@@ -3333,7 +3345,7 @@ msgid "Longitude"
 msgstr "經度"
 
 #: frontend/src/metabase/lib/core.js:43
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:45
 msgid "Number"
 msgstr "數字"
@@ -3390,7 +3402,7 @@ msgid "User"
 msgstr "使用者"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:211
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
 msgid "Source"
 msgstr "來源"
 
@@ -3431,16 +3443,17 @@ msgid "Score"
 msgstr "分數"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "標題"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
 msgid "Comment"
 msgstr "評論"
 
@@ -3492,9 +3505,9 @@ msgstr "不要包括"
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
 msgstr "Metabase永遠不會獲取此欄位。將此用於敏感或不相關的訊息。"
 
-#: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:300
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/query/description.js:77
+#: frontend/src/metabase/lib/query/description.js:262
+#: frontend/src/metabase/lib/schema_metadata.js:476
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
@@ -3509,8 +3522,7 @@ msgstr "計數"
 msgid "CumulativeCount"
 msgstr "累積計數"
 
-#: frontend/src/metabase/lib/expressions/config.js:9
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:485
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3520,7 +3532,6 @@ msgstr "求和"
 msgid "CumulativeSum"
 msgstr "累積求和"
 
-#: frontend/src/metabase/lib/expressions/config.js:11
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Distinct"
 msgstr "不重複"
@@ -3529,25 +3540,22 @@ msgstr "不重複"
 msgid "StandardDeviation"
 msgstr "標準差"
 
-#: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:494
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "平均值"
 
-#: frontend/src/metabase/lib/expressions/config.js:14
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:539
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "最小值"
 
-#: frontend/src/metabase/lib/expressions/config.js:15
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:548
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:503
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:492
 msgid "Max"
 msgstr "最大值"
 
@@ -3598,54 +3606,66 @@ msgstr "您在想什麼？"
 msgid "What do you want to find out?"
 msgstr "您想找出什麼？"
 
-#: frontend/src/metabase/lib/query.js:298
-#: frontend/src/metabase/lib/schema_metadata.js:466
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:250
+#: frontend/src/metabase/lib/query/description.js:75
+#: frontend/src/metabase/lib/query/description.js:260
+#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "原始資料"
 
-#: frontend/src/metabase/lib/query.js:302
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/query/description.js:79
+#: frontend/src/metabase/lib/query/description.js:264
+#: frontend/src/metabase/lib/schema_metadata.js:521
 msgid "Cumulative count"
 msgstr "累積計數"
 
-#: frontend/src/metabase/lib/query.js:305
+#: frontend/src/metabase/lib/query/description.js:82
+#: frontend/src/metabase/lib/query/description.js:266
 msgid "Average of "
 msgstr "平均值"
 
-#: frontend/src/metabase/lib/query.js:310
+#: frontend/src/metabase/lib/query/description.js:87
+#: frontend/src/metabase/lib/query/description.js:268
 msgid "Distinct values of "
 msgstr "去重複值"
 
-#: frontend/src/metabase/lib/query.js:315
+#: frontend/src/metabase/lib/query/description.js:92
+#: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
 msgstr "標準差"
 
-#: frontend/src/metabase/lib/query.js:320
+#: frontend/src/metabase/lib/query/description.js:97
+#: frontend/src/metabase/lib/query/description.js:272
 msgid "Sum of "
 msgstr "總計"
 
-#: frontend/src/metabase/lib/query.js:325
+#: frontend/src/metabase/lib/query/description.js:102
+#: frontend/src/metabase/lib/query/description.js:274
 msgid "Cumulative sum of "
 msgstr "累積和"
 
-#: frontend/src/metabase/lib/query.js:330
+#: frontend/src/metabase/lib/query/description.js:107
+#: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
 msgstr "最大"
 
-#: frontend/src/metabase/lib/query.js:335
+#: frontend/src/metabase/lib/query/description.js:112
+#: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
 msgstr "最小"
 
-#: frontend/src/metabase/lib/query.js:349
+#: frontend/src/metabase/lib/query/description.js:126
+#: frontend/src/metabase/lib/query/description.js:286
 msgid "Grouped by "
 msgstr "以……分組"
 
-#: frontend/src/metabase/lib/query.js:363
+#: frontend/src/metabase/lib/query/description.js:140
+#: frontend/src/metabase/lib/query/description.js:295
 msgid "Filtered by "
 msgstr "以……篩選"
 
-#: frontend/src/metabase/lib/query.js:392
+#: frontend/src/metabase/lib/query/description.js:169
+#: frontend/src/metabase/lib/query/description.js:320
 msgid "Sorted by "
 msgstr "以……分類"
 
@@ -3657,55 +3677,45 @@ msgstr "真"
 msgid "False"
 msgstr "假"
 
-#: frontend/src/metabase/lib/schema_metadata.js:321
+#: frontend/src/metabase/lib/schema_metadata.js:322
 msgid "Select longitude field"
 msgstr "選擇經度欄位"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:323
 msgid "Enter upper latitude"
 msgstr "輸入緯度上邊界"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:324
 msgid "Enter left longitude"
 msgstr "輸入經度左邊界"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:325
 msgid "Enter lower latitude"
 msgstr "輸入緯度下邊界"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:326
 msgid "Enter right longitude"
 msgstr "輸入經度右邊界"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:539
 #: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:397
-#: frontend/src/metabase/lib/schema_metadata.js:405
-#: frontend/src/metabase/lib/schema_metadata.js:411
-#: frontend/src/metabase/lib/schema_metadata.js:416
-msgid "Is"
-msgstr "是"
-
 #: frontend/src/metabase/lib/schema_metadata.js:362
 #: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:398
 #: frontend/src/metabase/lib/schema_metadata.js:406
 #: frontend/src/metabase/lib/schema_metadata.js:412
-msgid "Is not"
-msgstr "不是"
+#: frontend/src/metabase/lib/schema_metadata.js:417
+msgid "Is"
+msgstr "是"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:417
-msgid "Is empty"
-msgstr "為空"
+#: frontend/src/metabase/lib/schema_metadata.js:413
+msgid "Is not"
+msgstr "不是"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:378
@@ -3714,109 +3724,119 @@ msgstr "為空"
 #: frontend/src/metabase/lib/schema_metadata.js:402
 #: frontend/src/metabase/lib/schema_metadata.js:408
 #: frontend/src/metabase/lib/schema_metadata.js:418
+msgid "Is empty"
+msgstr "為空"
+
+#: frontend/src/metabase/lib/schema_metadata.js:365
+#: frontend/src/metabase/lib/schema_metadata.js:379
+#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:395
+#: frontend/src/metabase/lib/schema_metadata.js:403
+#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:419
 msgid "Not empty"
 msgstr "不為空"
 
-#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:371
 msgid "Equal to"
 msgstr "等於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:372
 msgid "Not equal to"
 msgstr "不等於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Greater than"
 msgstr "大於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Less than"
 msgstr "小於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "介於之間"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:376
 msgid "Greater than or equal to"
 msgstr "大於或等於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Less than or equal to"
 msgstr "小於或等於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
+#: frontend/src/metabase/lib/schema_metadata.js:384
 msgid "Contains"
 msgstr "包含"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:385
 msgid "Does not contain"
 msgstr "不包含"
 
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:388
 msgid "Starts with"
 msgstr "以…開始"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:389
 msgid "Ends with"
 msgstr "以…結束"
 
-#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:399
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "早於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:400
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "晚於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:414
 msgid "Inside"
 msgstr "介於中間"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "只是一個包含資料行的表格，沒有其他操作。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:474
+#: frontend/src/metabase/lib/schema_metadata.js:475
 msgid "Count of rows"
 msgstr "總行數"
 
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:477
 msgid "Total number of rows in the answer."
 msgstr "答案的總資料行數。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Sum of ..."
 msgstr "總和"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:486
 msgid "Sum of all the values of a column."
 msgstr "一個欄位所有數值的總和。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:492
+#: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Average of ..."
 msgstr "平均值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:495
 msgid "Average of all the values of a column"
 msgstr "一個欄位所有數值的平均值。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:501
+#: frontend/src/metabase/lib/schema_metadata.js:502
 msgid "Number of distinct values of ..."
 msgstr "不重複值的總數"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:504
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "一個欄位所有互不重複的值的總數"
 
-#: frontend/src/metabase/lib/schema_metadata.js:510
+#: frontend/src/metabase/lib/schema_metadata.js:511
 msgid "Cumulative sum of ..."
 msgstr "累積求和"
 
@@ -3824,7 +3844,7 @@ msgstr "累積求和"
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "一個欄位所有數值的累積加總。\\\\n比如：隨著時間推移的總收入。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:519
+#: frontend/src/metabase/lib/schema_metadata.js:520
 msgid "Cumulative count of rows"
 msgstr "累積行數"
 
@@ -3832,27 +3852,27 @@ msgstr "累積行數"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "累積的資料行數。\\\\ n比如：隨著時間的推移銷售數量。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:528
+#: frontend/src/metabase/lib/schema_metadata.js:529
 msgid "Standard deviation of ..."
 msgstr "標準差"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:531
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "一個欄位所有數值的標準差。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:537
+#: frontend/src/metabase/lib/schema_metadata.js:538
 msgid "Minimum of ..."
 msgstr "最小值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Minimum value of a column"
 msgstr "一個欄位的最小值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:546
+#: frontend/src/metabase/lib/schema_metadata.js:547
 msgid "Maximum of ..."
 msgstr "最大值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:549
 msgid "Maximum value of a column"
 msgstr "一個欄位的最大值"
 
@@ -4028,7 +4048,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "類別、類型、模型、評分等"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:43
-#: frontend/src/metabase/user/components/UserSettings.jsx:55
+#: frontend/src/metabase/user/components/UserSettings.jsx:56
 msgid "Account settings"
 msgstr "帳戶設定"
 
@@ -4040,7 +4060,7 @@ msgstr "退出管理員"
 msgid "Logs"
 msgstr "日誌"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:103
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:104
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:22
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:65
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:100
@@ -4080,9 +4100,9 @@ msgid "Metabase Admin"
 msgstr "Metabase管理員"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:36
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:36
 msgid "Ask a question"
 msgstr "建立問題"
 
@@ -4103,7 +4123,7 @@ msgstr "參考"
 msgid "Which metric?"
 msgstr "哪個量值？"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "為您的團隊定義共同量值，讓它甚至簡單到可以輕鬆的提問"
 
@@ -4115,7 +4135,7 @@ msgstr "如何建立量值"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "按地圖、趨勢檢視時間維度的資料，方便了解趨勢變化"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:149
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
 msgid "Custom"
 msgstr "自訂"
 
@@ -4128,13 +4148,13 @@ msgstr "新的提問"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "使用簡單的提問建立器來檢視趨勢、欄位表或者事物，或者建立您自己的量值。"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:107
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:110
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "原生查詢"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:108
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:111
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "為了回答更多複雜的提問，您可以寫下您自己的SQL語句或者原生查詢。"
 
@@ -4236,6 +4256,7 @@ msgid "Enter a default value..."
 msgstr "輸入一個預設值……"
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
+#: frontend/src/metabase/containers/Form.jsx:307
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "發生了一個錯誤"
@@ -4483,7 +4504,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "推薦精簡定時任務，方便整個團隊理解和使用。"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:161
-#: frontend/src/metabase/query_builder/components/view/View.jsx:131
+#: frontend/src/metabase/query_builder/components/view/View.jsx:133
 msgid "Pick your data"
 msgstr "選擇您的資料"
 
@@ -4499,47 +4520,47 @@ msgstr "電子信箱"
 msgid "Slack messages"
 msgstr "Slack消息"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:216
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "發送"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:217
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0}將會在……被發送"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:219
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "訊息"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:235
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "現在發送郵件"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:236
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "現在發送郵件給{0}"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:238
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "發送中……"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "發送失敗"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "未發送，因為定時任務沒有結果。"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "定時任務已發送。"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:282
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0}需要被設定成管理員"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:295
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:299
 msgid "Slack"
 msgstr "Slack"
 
@@ -4692,7 +4713,7 @@ msgstr "平均"
 msgid "Distincts"
 msgstr "不重複"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:55
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "查看此{0}"
@@ -4702,11 +4723,12 @@ msgstr[0] "查看此{0}"
 msgid "Zoom in"
 msgstr "放大"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "自訂表達方式"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Common Metrics"
 msgstr "共同量值"
 
@@ -4903,34 +4925,34 @@ msgstr "通常"
 msgid "Pick a segment or table"
 msgstr "選擇一個區間或者表單"
 
-#: frontend/src/metabase/entities/databases/forms.js:191
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
+#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "選擇一個資料庫"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:94
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:85
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:31
 msgid "Select..."
 msgstr "選擇……"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:134
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
 msgid "Select a table"
 msgstr "選擇一個資料表"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:819
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:926
 msgid "No tables found in this database."
 msgstr "該資料庫未發現資料表"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:856
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:901
 msgid "Is a question missing?"
 msgstr "提問缺失？"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:863
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:909
 msgid "Learn more about nested queries"
 msgstr "了解更多關於嵌套查詢"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:898
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:951
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:40
 msgid "Fields"
 msgstr "欄位"
 
@@ -4964,11 +4986,11 @@ msgstr "排序"
 msgid "Row limit"
 msgstr "行限制"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
 msgid "Unknown Field"
 msgstr "未知欄位"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:75
 msgid "field"
 msgstr "欄位"
 
@@ -4976,19 +4998,20 @@ msgstr "欄位"
 msgid "Matches"
 msgstr "匹配"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:148
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:156
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:135
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "新增篩選條件來縮小您的答案範圍"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:293
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
 msgstr "新增一個聚合"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:37
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:313
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
-#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:66
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:67
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:89
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:131
@@ -5004,16 +5027,16 @@ msgstr "新增一個聚合"
 msgid "Data"
 msgstr "資料"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:340
 msgid "Filtered by"
 msgstr "篩選條件"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:376
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:357
 msgid "View"
 msgstr "檢視"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:393
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:374
 msgid "Grouped By"
 msgstr "分組條件"
 
@@ -5021,7 +5044,7 @@ msgstr "分組條件"
 msgid "None"
 msgstr "沒有"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:471
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
 msgid "This question is written in {0}."
 msgstr "這個提問已經被寫入{0}"
 
@@ -5033,7 +5056,7 @@ msgstr "隱藏編輯器"
 msgid "Hide Query"
 msgstr "隱藏查詢"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:481
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
 msgid "Open Editor"
 msgstr "打開編輯器"
 
@@ -5273,7 +5296,7 @@ msgstr "{0}的去重值"
 msgid "Number of {0} grouped by {1}"
 msgstr "按{1}分組的{0}計數"
 
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:77
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5332,32 +5355,33 @@ msgstr "檢視{0}的所有原始資料"
 msgid "More"
 msgstr "更多"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:194
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:216
 msgid "Invalid expression"
 msgstr "不可用的表達式"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:269
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:282
 msgid "unknown error"
 msgstr "未知錯誤"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:47
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:53
 msgid "Field formula"
 msgstr "欄位公式"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:60
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:64
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "這有點像在EXCEL表中編寫公式，您可以使用數字，欄位，數學符號和一些函數，例如 Subtotal - Cost。"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:69
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:208
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
 msgid "Learn more"
 msgstr "了解更多"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:77
 msgid "Give it a name"
 msgstr "給它一個名字吧"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:79
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
 msgid "Something nice and descriptive"
 msgstr "一些超棒的、值得記錄的東西"
 
@@ -5437,11 +5461,11 @@ msgid "Enter desired number"
 msgstr "輸入期望值"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:154
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:161
 msgid "Empty"
 msgstr "空的"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:119
 msgid "Find a value"
 msgstr "尋找一個值"
 
@@ -5509,35 +5533,35 @@ msgstr "閱讀完整檔案"
 msgid "Filter label"
 msgstr "過濾標籤"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:135
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:134
 msgid "Variable type"
 msgstr "多種類型"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:143
 msgid "Text"
 msgstr "文本"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
 msgid "Date"
 msgstr "日期"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:147
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
 msgid "Field Filter"
 msgstr "欄位篩選條件"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Field to map to"
 msgstr "欄位映射到"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:180
 msgid "Filter widget type"
 msgstr "篩選器樣式"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:230
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
 msgid "Required?"
 msgstr "必填項？"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:240
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
 msgid "Default filter widget value"
 msgstr "篩選器預設值"
 
@@ -5549,7 +5573,7 @@ msgstr "歸檔提問？"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "這個提問會從已引用的資訊看板或定時任務中移除"
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:158
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
 msgid "Question"
 msgstr "提問"
 
@@ -5719,7 +5743,7 @@ msgid "Details"
 msgstr "細節"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
-#: frontend/src/metabase/reference/databases/TableList.jsx:116
+#: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
 msgstr "{0}中的報表"
 
@@ -5800,24 +5824,24 @@ msgstr "為什麼這個資料表有趣"
 msgid "Things to be aware of about this table"
 msgstr "關於這個資料表需要知道的事情"
 
-#: frontend/src/metabase/reference/databases/TableList.jsx:30
+#: frontend/src/metabase/reference/databases/TableList.jsx:29
 msgid "Tables in this database will appear here as they're added"
 msgstr "當在這個資料庫中新增資料表時，它們將會出現在這裡"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:34
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:33
 msgid "Questions about this table will appear here as they're added"
 msgstr "當關於這個資料表的提問被新增時，它們將會出現在這裡"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:73
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:77
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:76
 msgid "Questions about {0}"
 msgstr "關於{0}的提問"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
 msgid "Created {0} by {1}"
 msgstr "根據{1}建立{0}"
 
@@ -6006,19 +6030,19 @@ msgstr "您可以通過聚合這個量值形成的其他領域"
 msgid "Fields you can group this metric by"
 msgstr "您可以通過聚合這個量值得到的領域"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "量值是您的團隊關心的官方數字"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Metrics will appear here once your admins have created some"
 msgstr "一但您的管理員建立了一些量值的話，它們將會出現在這裡"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:28
 msgid "Learn how to create metrics"
 msgstr "了解如何建立量值"
 
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:34
 msgid "Questions about this metric will appear here as they're added"
 msgstr "新增這個量值的圖表會在這裡顯示。"
 
@@ -6044,23 +6068,23 @@ msgstr "為什麼這個劃分很有意思"
 msgid "Things to be aware of about this Segment"
 msgstr "關於這個劃分的注意事項"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
 msgid "Segments are interesting subsets of tables"
 msgstr "劃分是表格的子集"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "為您的團隊定義公共劃分，讓它用來提問也十分容易"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Segments will appear here once your admins have created some"
 msgstr "您的管理員新增後，劃分將會出現在這裡，"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
 msgid "Learn how to create segments"
 msgstr "學習如何建立劃分"
 
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:35
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:34
 msgid "Questions about this segment will appear here as they're added"
 msgstr "當它們被新增時，關於這個劃分的提問將會出現在這裡"
 
@@ -6080,22 +6104,22 @@ msgstr "有關這個劃分的提問"
 msgid "X-ray this segment"
 msgstr "透視這個劃分"
 
-#: frontend/src/metabase/routes.jsx:178 frontend/src/metabase/routes.jsx:179
+#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
 msgid "Login"
 msgstr "登入"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:303
 #: frontend/src/metabase/containers/ItemPicker.jsx:115
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:204
+#: frontend/src/metabase/routes.jsx:195
 msgid "Search"
 msgstr "查詢"
 
-#: frontend/src/metabase/routes.jsx:223
+#: frontend/src/metabase/routes.jsx:214
 msgid "Dashboard"
 msgstr "資訊看板"
 
-#: frontend/src/metabase/routes.jsx:236
+#: frontend/src/metabase/routes.jsx:227
 msgid "New Question"
 msgstr "新提問"
 
@@ -6139,63 +6163,63 @@ msgstr "感謝幫助我們提升"
 msgid "We won't collect any usage events"
 msgstr "我們不會收集任何使用事件訊息"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:88
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "為了提升Metabase的使用者體驗，可能需要通過Google Analytics收集特定的使用資料。"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:90
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Here's a full list of everything we track and why."
 msgstr "這個我們所有我們要收集的清單，以及為什麼要收集"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "允許Metabase匿名收集使用事件"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:113
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase{0}收集任何事情關於您的資料或者提問結果"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:114
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
 msgid "never"
 msgstr "永不"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:119
 msgid "All collection is completely anonymous."
 msgstr "所有的收集都是匿名的。"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "您隨時可以在管理設定中關閉訊息收集。"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:44
+#: frontend/src/metabase/setup/components/Setup.jsx:59
 msgid "If you feel stuck"
 msgstr "如果您不知從何下手"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:49
+#: frontend/src/metabase/setup/components/Setup.jsx:64
 msgid "our getting started guide"
 msgstr "初始化檔案"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:50
+#: frontend/src/metabase/setup/components/Setup.jsx:65
 msgid "is just a click away."
 msgstr "點擊一下"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:92
+#: frontend/src/metabase/setup/components/Setup.jsx:111
 msgid "Welcome to Metabase"
 msgstr "歡迎來到Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:93
+#: frontend/src/metabase/setup/components/Setup.jsx:112
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "看起來一切都在正常工作，現在讓我們了解您吧，連接到您的資料，並且開始尋找一些屬於您的答案！"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:97
+#: frontend/src/metabase/setup/components/Setup.jsx:116
 msgid "Let's get started"
 msgstr "讓我們開始吧"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:142
+#: frontend/src/metabase/setup/components/Setup.jsx:166
 msgid "You're all set up!"
 msgstr "您已經設定完畢了！"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:153
+#: frontend/src/metabase/setup/components/Setup.jsx:177
 msgid "Take me to Metabase"
 msgstr "帶我去Metabase"
 
@@ -6207,13 +6231,13 @@ msgstr "我們應該怎麼稱呼您？"
 msgid "Hi, {0}. nice to meet you!"
 msgstr "您好，{0}很高興見到您！"
 
-#: frontend/src/metabase/entities/users/forms.js:33
+#: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
 msgstr "建立一個密碼"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:44
-#: frontend/src/metabase/entities/users/forms.js:35
-#: frontend/src/metabase/entities/users/forms.js:82
+#: frontend/src/metabase/entities/users/forms.js:50
+#: frontend/src/metabase/entities/users/forms.js:97
 msgid "Shhh..."
 msgstr "噓……"
 
@@ -6221,11 +6245,11 @@ msgstr "噓……"
 msgid "Confirm password"
 msgstr "確認密碼"
 
-#: frontend/src/metabase/entities/users/forms.js:42
+#: frontend/src/metabase/entities/users/forms.js:57
 msgid "Shhh... but one more time so we get it right"
 msgstr "噓……再輸入一次讓我們確保它是對的"
 
-#: frontend/src/metabase/entities/users/forms.js:70
+#: frontend/src/metabase/entities/users/forms.js:85
 msgid "Your company or team name"
 msgstr "您的公司或者團隊名稱"
 
@@ -6394,7 +6418,7 @@ msgstr "密碼成功更新！"
 msgid "Account updated successfully!"
 msgstr "帳戶成功更新！"
 
-#: frontend/src/metabase/entities/users/forms.js:81
+#: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
 msgstr "當前密碼"
 
@@ -6406,7 +6430,7 @@ msgstr "用Google信箱地址登入"
 msgid "User Details"
 msgstr "使用者詳情"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:327
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:344
 msgid "Reset to defaults"
 msgstr "恢復預設值"
 
@@ -6431,15 +6455,15 @@ msgstr "橫坐標和縱坐標想使用那些欄位?"
 msgid "Choose fields"
 msgstr "選擇欄位"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:217
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:234
 msgid "Save as default view"
 msgstr "作為預設視圖存儲"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Draw box to filter"
 msgstr "新增篩選器"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Cancel filter"
 msgstr "取消篩選器"
 
@@ -6467,19 +6491,19 @@ msgstr "找不到可視化"
 msgid "Could not display this chart with this data."
 msgstr "無法顯示這個圖表顯示這些資料"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:526
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
 msgid "No results!"
 msgstr "沒有結果！"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:547
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
 msgid "Still Waiting..."
 msgstr "仍然在等待……"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:550
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
 msgid "This usually takes an average of {0}."
 msgstr "這將通常取一個{0}的平均數。"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:556
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
 msgid "(This is a bit long for a dashboard)"
 msgstr "（這對於資訊看板來說有點太長了）"
 
@@ -6638,19 +6662,19 @@ msgstr "新增規則"
 msgid "Update rule"
 msgstr "更新規則"
 
-#: frontend/src/metabase/visualizations/index.js:32
+#: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
 msgstr "可視化是空的"
 
-#: frontend/src/metabase/visualizations/index.js:37
+#: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
 msgstr "可視化圖示必須定義一個作為“標識符”的靜態變數：␣"
 
-#: frontend/src/metabase/visualizations/index.js:43
+#: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
 msgstr "具有該標識符的可視化圖表已經註冊：␣"
 
-#: frontend/src/metabase/visualizations/index.js:71
+#: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
 msgstr "沒有{0}的可視化"
 
@@ -6676,23 +6700,23 @@ msgid "Doh! The data from your query doesn't fit the chosen display choice. This
 msgstr "正在……噢！從您的查詢中獲得的數去並不適合所選的展示選項，這個可視化需要最少資料中的{0}{1}。"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:9
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:117
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:120
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:161
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:169
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:249
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:267
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "欄位"
@@ -6802,83 +6826,83 @@ msgstr "什麼也沒有"
 msgid "Linear Interpolated"
 msgstr "線性插值平滑"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
 msgstr "X軸比例"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
 msgstr "時間系欄位"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:454
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
 msgid "Linear"
 msgstr "線性"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
 msgid "Power"
 msgstr "勢"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:428
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:445
 msgid "Log"
 msgstr "日誌"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:441
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:430
 msgid "Histogram"
 msgstr "柱狀圖"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
 msgstr "序數"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
 msgstr "Y軸比例"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:462
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
 msgstr "顯示X軸線和標記"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:360
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:468
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:349
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
 msgid "Compact"
 msgstr "壓縮"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:469
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
 msgid "Rotate 45°"
 msgstr "旋轉45°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:459
 msgid "Rotate 90°"
 msgstr "旋轉90°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
 msgid "Show y-axis line and marks"
 msgstr "顯示Y軸線段和標記"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:489
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Auto y-axis range"
 msgstr "自動Y軸範圍"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:533
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:522
 msgid "Use a split y-axis when necessary"
 msgstr "當需要時使用一個分離的Y軸"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:540
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:529
 msgid "Show label on x-axis"
 msgstr "展示標籤在X軸上"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:546
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:535
 msgid "X-axis label"
 msgstr "X軸標籤"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:555
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:544
 msgid "Show label on y-axis"
 msgstr "展示標籤在Y軸上"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:561
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:550
 msgid "Y-axis label"
 msgstr "Y軸標籤"
 
@@ -7004,23 +7028,23 @@ msgstr "最小不透明度"
 msgid "Max Zoom"
 msgstr "放到最大"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:231
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:234
 msgid "No relationships found."
 msgstr "沒有發現關聯。"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:269
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:272
 msgid "via {0}"
 msgstr "通過{0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:347
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
 msgid "This {0} is connected to:"
 msgstr "這個{0}連接到"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "Object Detail"
 msgstr "對象細節"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:93
 msgid "object"
 msgstr "對象"
 
@@ -7408,7 +7432,7 @@ msgstr "在{0}中有很多已儲存的問題？建立集合以幫助管理它們
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:149 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -8922,19 +8946,19 @@ msgstr "允許修改集合及其內容"
 msgid "Can view items in this collection"
 msgstr "允許檢視該集合的內容"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:767
+#: frontend/src/metabase/admin/permissions/selectors.js:765
 msgid "Collection Access"
 msgstr "集合的權限"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:841
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "該組有權檢視此集合的至少一個子集合。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:848
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "該組有權編輯此集合的至少一個子集合。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:861
+#: frontend/src/metabase/admin/permissions/selectors.js:859
 msgid "View sub-collections"
 msgstr "檢視子集合"
 
@@ -8942,7 +8966,7 @@ msgstr "檢視子集合"
 msgid "Remember Me"
 msgstr "記住我"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:63
+#: frontend/src/metabase/components/BrowseApp.jsx:73
 msgid "X-ray this schema"
 msgstr "透視這個圖表"
 
@@ -9003,15 +9027,15 @@ msgstr "Metabase無法找到您的搜索結果。"
 msgid "No metrics"
 msgstr "沒有量值"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:31
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:41
 msgid "Aggregations"
 msgstr "聚合"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:32
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:42
 msgid "Operators"
 msgstr "運算符"
 
-#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:30
+#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:35
 msgid "Custom fields"
 msgstr "自訂欄位"
 
@@ -9177,7 +9201,7 @@ msgstr "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
 msgid "toucan_sightings"
 msgstr "toucan_sightings"
 
-#: src/metabase/driver/sparksql.clj
+#: src/metabase/models/collection.clj
 msgid "default"
 msgstr "預設"
 
@@ -9205,10 +9229,10 @@ msgstr "不適用"
 msgid "Windows domain"
 msgstr "Windows域名"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:539
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:545
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:554
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:560
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:528
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:534
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:543
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
 msgstr "標籤"
 
@@ -9243,9 +9267,9 @@ msgstr "分享"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:286
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:294
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:302
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:319
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:324
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
@@ -9260,19 +9284,18 @@ msgstr "分享"
 msgid "Display"
 msgstr "顯示"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:461
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:476
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:502
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:532
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:402
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:465
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:483
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:521
 msgid "Axes"
 msgstr "坐標軸"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:212
-#: frontend/src/metabase/admin/settings/selectors.js:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:219
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:62
 msgid "Formatting"
@@ -9306,7 +9329,7 @@ msgstr "透視"
 msgid "Compare to the rest"
 msgstr "和其餘的比較"
 
-#: frontend/src/metabase/entities/databases/forms.js:16
+#: frontend/src/metabase/entities/databases/forms.js:18
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "使用Java虛擬機時區"
 
@@ -9335,24 +9358,24 @@ msgstr "使用Java虛擬機時區"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "我們現在正在分析資料表和欄位來幫助您探索資料"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
 msgid "Tip: "
 msgstr "提示："
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:237
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
 msgstr "選擇一個統用的類型"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:300
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
 msgid "Field Type"
 msgstr "欄位類型"
 
-#: frontend/src/metabase/admin/routes.jsx:113
+#: frontend/src/metabase/admin/routes.jsx:118
 #: frontend/src/metabase/nav/containers/Navbar.jsx:267
 msgid "Troubleshooting"
 msgstr "錯誤排查"
 
-#: frontend/src/metabase/admin/settings/selectors.js:103
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Enable X-ray features"
 msgstr "開啟透視(X-ray) 功能"
 
@@ -9397,7 +9420,7 @@ msgstr "用時"
 msgid "Currency"
 msgstr "貨幣"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
 msgstr "選擇一個使用者或頻道"
 
@@ -9545,7 +9568,7 @@ msgstr "線條樣式"
 msgid "Show dots on lines"
 msgstr "在線上顯示圓圈"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:348
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
@@ -9559,7 +9582,7 @@ msgstr "哪個軸？"
 msgid "Line + Bar"
 msgstr "線狀圖+條行圖"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
 msgid "line and bar chart"
 msgstr "線狀圖和條型圖"
 
@@ -11006,7 +11029,7 @@ msgstr "該量值如何分布在不同的數字上"
 msgid "Sessions by page where the session began"
 msgstr "會話開始時的頁面會話"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:503
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -11375,7 +11398,7 @@ msgstr "複製該項目"
 msgid "Archive this item"
 msgstr "歸檔該項目"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:331
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:325
 msgid "Duplicate dashboard"
 msgstr "複製資訊看板"
 
@@ -11471,7 +11494,7 @@ msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] "季度季度"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
@@ -11486,8 +11509,8 @@ msgstr "新的[[this.short-name]]隨著時間的推移"
 msgid "This"
 msgstr "這個"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:97
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:137
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:136
 msgid "Invalid"
 msgstr "無效"
 
@@ -12250,6 +12273,7 @@ msgstr "這是您的 {0} 最近卡片"
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
 msgstr "您可以更詳細一點，或者使用ID？ 找到了符合這些名字的卡片："
 
+#: src/metabase/driver/common/parameters/values.clj
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
 msgstr "卡片 {0} 未找到."
@@ -12358,11 +12382,11 @@ msgstr "失火指令"
 msgid "Archive this?"
 msgstr "將這個歸檔?"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:243
+#: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
 msgstr "了解我們的資料"
 
-#: frontend/src/metabase/entities/databases/forms.js:20
+#: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
 msgstr "連接時使用DNS SRV（域名伺服器）"
 
@@ -12372,7 +12396,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "使用此選項要求提供的主機是一個FQDN。 如果連接到一個Atlas集群，您可能需要啟用此選項。 如果您不知道這意味著什麼，請取消使用該選項。"
 
-#: frontend/src/metabase/entities/databases/forms.js:204
+#: frontend/src/metabase/entities/databases/forms.js:273
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "在進行簡單的過濾和匯總時自動執行查詢"
 
@@ -12396,11 +12420,11 @@ msgstr "所有結果"
 msgid "Our Analytics"
 msgstr "我們的分析"
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:513
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
 msgstr "欄位所有值的加總。\\ ne.x  total revenue over time。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
 msgstr "行數的附加計數。\\ ne.x。總銷售額隨著時間的推移。"
 
@@ -12410,7 +12434,7 @@ msgstr "行數的附加計數。\\ ne.x。總銷售額隨著時間的推移。"
 msgid "Filter"
 msgstr "篩選器"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:50
 msgid "record"
 msgid_plural "records"
 msgstr[0] "記錄"
@@ -12423,27 +12447,27 @@ msgstr "瀏覽資料"
 msgid "Write SQL"
 msgstr "寫SQL"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:83
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
 msgstr "簡單問題查詢"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:84
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:87
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
 msgstr "挑選並瀏覽資料，新增簡單的過濾篩選或聚合摘要, 然後將資料可視化。"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:95
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:98
 msgid "Custom question"
 msgstr "自訂問題查詢"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:96
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:99
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "使用高級查詢編輯器完成關聯, 建立自訂欄位, 實現數學計算等更多進階功能."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Basic Metrics"
 msgstr "基礎量值"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:322
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
 msgid "Custom…"
 msgstr "自訂"
 
@@ -12512,15 +12536,15 @@ msgstr "選擇分組的欄位"
 msgid "Pick your starting data"
 msgstr "選擇您的起始資料"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select None"
 msgstr "全不選"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select All"
 msgstr "全選"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:151
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:152
 msgid "Pick a table..."
 msgstr "選擇資料表…"
 
@@ -12641,15 +12665,15 @@ msgstr "新增量值"
 #: frontend/src/metabase/lib/core.js:137 frontend/src/metabase/lib/core.js:142
 #: frontend/src/metabase/lib/core.js:147 frontend/src/metabase/lib/core.js:152
 #: frontend/src/metabase/lib/core.js:157 frontend/src/metabase/lib/core.js:162
-#: frontend/src/metabase/user/components/UserSettings.jsx:63
+#: frontend/src/metabase/user/components/UserSettings.jsx:64
 msgid "Profile"
 msgstr "首頁"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:560
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "這通常很快，但現在似乎需要一段時間。"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
 msgid "Combo"
 msgstr "組合(Combo)"
 
@@ -12665,11 +12689,11 @@ msgstr "趨勢(Trend)"
 msgid "Boolean"
 msgstr "布爾值(Boolean)"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:62
 msgid "Unknown Segment"
 msgstr "未知的劃分"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:73
 msgid "Unknown Filter"
 msgstr "未知篩選器"
 
@@ -12799,6 +12823,7 @@ msgstr "使用NEWLY CREATED 類別載入器作為共享上下文類別載入器�
 msgid "Failed to copy file"
 msgstr "複製檔案失敗"
 
+#. check that the URL is valid
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
 msgstr "無效的網站URL: {0}"
@@ -13073,7 +13098,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "選擇需要包含的欄位"
 
-#: frontend/src/metabase/entities/databases/forms.js:205
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "這個選項開啟時，當使用者在檢視表格或圖表時使用“匯總”和“過濾”按鈕進行簡單資料探索時，Metabase將自動執行查詢。 如果查詢此資料庫的速度很慢，可以將該選項關閉。 此設定不會影響資料鑽探或SQL查詢。"
 
@@ -13111,7 +13136,7 @@ msgstr "確定查詢的預期欄位時出錯"
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "無法處理的異常,  希望`catch-exceptions`能夠處理它."
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:125
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
 msgid "Diagnostic Info"
 msgstr "診斷訊息"
 
@@ -13135,11 +13160,11 @@ msgstr "使用Google登入時出現問題。 請與管理員聯繫。"
 msgid "Sign in with email"
 msgstr "使用EMail登入"
 
-#: frontend/src/metabase/entities/databases/forms.js:21
+#: frontend/src/metabase/entities/databases/forms.js:23
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "使用此選項要求提供的主機是FQDN。 如果連接到Atlas群集，則可能需要啟用此選項。 如果您不知道這意味著什麼，請取消此功能。"
 
-#: frontend/src/metabase/entities/databases/forms.js:213
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "預設情況下，Metabase每小時執行一次輕量級同步，每天執行一次密集掃描。 如果您有一個大型資料庫，我們建議啟用此功能並檢視欄位值掃描的發生時間和頻率。"
 
@@ -13207,11 +13232,11 @@ msgstr "不包含"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "在使用GUI界面建立的問題中，該欄位將不可見或不可選擇。 在SQL/原生查詢中仍然可以使用。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:512
 msgid "Cumulative sum"
 msgstr "累積和(Cumulative sum)"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Standard deviation"
 msgstr "標準差(Standard deviation)"
 
@@ -13223,23 +13248,23 @@ msgstr "必須至少為{0}個字元"
 msgid "Must be at least {0} characters long"
 msgstr "必須至少為{0}個字元"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:389
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:82
 msgid "Name (required)"
 msgstr "名稱（必填）"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:556
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
 msgid "Run selected text"
 msgstr "執行SQL陳述句"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:557
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
 msgid "Run query"
 msgstr "執行查詢"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(⌘ + enter)"
 msgstr "（command + enter）"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(Ctrl + enter)"
 msgstr "（Ctrl + enter）"
 
@@ -13251,7 +13276,7 @@ msgstr "您的結果將會在這出現"
 msgid "You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question."
 msgstr "除非您單擊“儲存”並選擇替換原始問題，否則您不會對已儲存的問題進行任何更改。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:199
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:200
 msgid "There aren't any filter widgets for this type of field yet."
 msgstr "尚無此類型欄位的篩選控制項。"
 
@@ -13287,19 +13312,19 @@ msgstr "目標線"
 msgid "Trend line"
 msgstr "趨勢線"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:320
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:317
 msgid "Show values on data points"
 msgstr "在資料點上顯示值"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:334
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:325
 msgid "Values to show"
 msgstr "資料值顯示"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:342
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:332
 msgid "As many as can fit nicely"
 msgstr "儘可能地適合"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:343
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
 msgid "All"
 msgstr "全部"
 
@@ -13591,31 +13616,31 @@ msgstr "Numbers"
 msgid "No mappable groups"
 msgstr "No mappable groups"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:107
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
 msgstr "Metabase文件資料"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
 msgstr "包含 troubleshooting guide"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:112
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
 msgid "Post on the Metabase support forum"
 msgstr "問題送出到Metabase支援論壇"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:114
 msgid "A community forum for all things Metabase"
 msgstr "Metabase社區論壇"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:117
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
 msgid "File a bug report"
 msgstr "提交臭蟲報告"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:119
 msgid "Create a GitHub issue (includes the diagnostic info below)"
 msgstr "Create a GitHub issue (includes the diagnostic info below)"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:127
 msgid "Please include these details in support requests. Thank you!"
 msgstr "Please include these details in support requests. Thank you!"
 
@@ -13643,38 +13668,40 @@ msgstr "無結果相符"
 msgid "Submit"
 msgstr "送出"
 
-#: frontend/src/metabase/entities/databases/forms.js:13
+#: frontend/src/metabase/entities/databases/forms.js:15
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host. This option also provides an extra layer of security when a VPN is not available. Enabling this is usually slower than a direct connection."
 msgstr "某些資料庫設定只允許利用SSH連線。此選項可以提供當VPN無法使用時，有額外的安全保障。若啟用此功能將會比直接連線速度慢。"
 
-#: frontend/src/metabase/entities/databases/forms.js:17
+#: frontend/src/metabase/entities/databases/forms.js:19
 msgid "We suggest you leave this off unless you're doing manual timezone casting in many or most of your queries with this data."
 msgstr "建議關閉此選項，除非要手動設定資料庫時區"
 
-#: frontend/src/metabase/entities/databases/forms.js:93
+#: frontend/src/metabase/entities/databases/forms.js:128
 msgid "{0} to get an auth code."
 msgstr "{0} to get an auth code"
 
-#: frontend/src/metabase/entities/databases/forms.js:101
+#: frontend/src/metabase/entities/databases/forms.js:136
+#: src/metabase/models/collection.clj
 msgid "or"
 msgstr "or"
 
-#: frontend/src/metabase/entities/databases/forms.js:159
-#: frontend/src/metabase/entities/databases/forms.js:197
-#: frontend/src/metabase/entities/users/forms.js:44
+#: frontend/src/metabase/entities/databases/forms.js:39
+#: frontend/src/metabase/entities/databases/forms.js:226
+#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "必須"
 
-#: frontend/src/metabase/entities/databases/forms.js:188
+#: frontend/src/metabase/entities/databases/forms.js:257
 msgid "Database type"
 msgstr "資料庫類型"
 
-#: frontend/src/metabase/entities/databases/forms.js:222
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "檢核或更新資料庫 schema 是一個輕量級的動作，大部分情況下，可以設定為每小時同步一次。"
 
-#: frontend/src/metabase/entities/databases/forms.js:230
+#: frontend/src/metabase/entities/databases/forms.js:299
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase 會掃描資料庫中每個欄位的資料值，方便在展示板與提問(查詢)點擊篩選核取方塊。這個動作會有一點耗費系統資源，尤其是資料內容非常大的時候。"
 
@@ -13682,15 +13709,15 @@ msgstr "Metabase 會掃描資料庫中每個欄位的資料值，方便在展示
 msgid "Collection"
 msgstr "Collection"
 
-#: frontend/src/metabase/entities/users/forms.js:40
+#: frontend/src/metabase/entities/users/forms.js:55
 msgid "Confirm your password"
 msgstr "確認您的密碼"
 
-#: frontend/src/metabase/entities/users/forms.js:45
+#: frontend/src/metabase/entities/users/forms.js:60
 msgid "passwords do not match"
 msgstr "密碼不符合"
 
-#: frontend/src/metabase/entities/users/forms.js:71
+#: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
 msgstr "Department of Awesome"
 
@@ -13698,12 +13725,12 @@ msgstr "Department of Awesome"
 #: frontend/src/metabase/lib/core.js:98 frontend/src/metabase/lib/core.js:103
 #: frontend/src/metabase/lib/core.js:108 frontend/src/metabase/lib/core.js:113
 msgid "Financial"
-msgstr "金融"
+msgstr "Financial"
 
 #: frontend/src/metabase/lib/core.js:120 frontend/src/metabase/lib/core.js:125
 #: frontend/src/metabase/lib/core.js:130
 msgid "Numeric"
-msgstr "數字"
+msgstr "Numeric"
 
 #: frontend/src/metabase/lib/core.js:169 frontend/src/metabase/lib/core.js:174
 #: frontend/src/metabase/lib/core.js:179 frontend/src/metabase/lib/core.js:184
@@ -13713,345 +13740,341 @@ msgstr "數字"
 #: frontend/src/metabase/lib/core.js:219 frontend/src/metabase/lib/core.js:224
 #: frontend/src/metabase/lib/core.js:229 frontend/src/metabase/lib/core.js:234
 msgid "Date and Time"
-msgstr "日期和時間"
+msgstr "Date and Time"
 
 #: frontend/src/metabase/lib/core.js:241 frontend/src/metabase/lib/core.js:246
 #: frontend/src/metabase/lib/core.js:251
 msgid "Categorical"
-msgstr "分類的"
+msgstr "Categorical"
 
 #: frontend/src/metabase/lib/core.js:258 frontend/src/metabase/lib/core.js:263
 #: frontend/src/metabase/lib/core.js:268
 msgid "URLs"
-msgstr "網址"
+msgstr "URLs"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
 msgid "Returns the average of the values in the column."
 msgstr "返回欄位資料的平均值"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:18
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
 msgid "The column whose values to average."
 msgstr "此欄位的值要計算平均"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "start"
 msgstr "開始"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "end"
 msgstr "結束"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
 msgid "Checks a date or numeric column's values to see if they're within the specified range."
 msgstr "檢查欄位資料看看數值是否符合特定範圍"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
 msgstr "評分"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:24
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:98
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
-msgid "condition"
-msgstr "條件"
-
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+msgid "condition"
+msgstr "健康）狀況"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
 msgid "output"
 msgstr "輸出"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
-msgstr "測試案例列表並返回第一個真實案例的對應值，如果不滿足其他條件，則返回一個可選的默認值"
+msgstr "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
 msgid "Weight"
 msgstr "重量"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
 msgid "Large"
 msgstr "大"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
-msgid "Medium"
-msgstr "介質"
-
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+msgid "Medium"
+msgstr "中"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
 msgid "Small"
 msgstr "小"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
 msgid "Something that should evaluate to true or false."
 msgstr "某些情況將被評估為真或假"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:54
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "假如進行的條件為真則返回的資料數值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:62
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "value1"
 msgstr "value1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:74
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
 msgid "value2"
 msgstr "value2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Looks at the values in each argument in order and returns the first non-null value for each row"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:56
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
 msgid "Comments"
 msgstr "評論"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
 msgid "Notes"
 msgstr "筆記"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
 msgid "No comments"
 msgstr "沒有評論"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
 msgid "A column or value."
 msgstr "一個欄位或數值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:65
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:77
 msgid "If value1 is empty, value2 gets returned if it's not empty, and so on."
 msgstr "假如 value1 是空的，則返回非空值的 value2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 msgid "Combines two or more strings of text together."
 msgstr "合併兩個或兩個以上的文字"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
 msgid "Last Name"
 msgstr "名字"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 msgid "First Name"
 msgstr "姓氏"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
 msgstr "value2將會加在這個的後面"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
 msgstr "這將會加在 value1的後面"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
 msgid "string1"
 msgstr "string1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
 msgid "string2"
 msgstr "string2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:80
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "檢查 string1 是否含 string2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:284
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
 msgid "Status"
-msgstr "狀態"
+msgstr "Status"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 msgid "Pass"
-msgstr "通過"
+msgstr "Pass"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
 msgstr "字串內容將被檢核"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
 msgid "The string of text to look for."
 msgstr "欲尋找的文字字串"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:90
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:116
 msgid "Returns the count of rows in the source data."
 msgstr "返回原始資料的行數"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Only counts rows where the condition is true."
 msgstr "只計算符合條件為真的資料行數"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:97
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:261
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
 msgid "Subtotal"
-msgstr "小計"
+msgstr "Subtotal"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
 msgid "The additive total of rows across a breakout."
-msgstr "突破中行的累加總數"
+msgstr "The additive total of rows across a breakout"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:110
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
 msgid "The rolling sum of a column across a breakout."
-msgstr "突破中列的滾動總和"
+msgstr "The rolling sum of a column across a breakout"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:113
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:268
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
 msgstr "欲加總之欄位"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
 msgid "The number of distinct values in this column."
 msgstr "此欄位中相異資料的個數"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "The column whose distinct values to count."
 msgstr "計算欄位相異資料個數"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:128
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:145
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:153
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:201
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:274
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
 msgid "text"
-msgstr "文本"
+msgstr "text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:130
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:223
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
 msgid "comparison"
 msgstr "比較"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "假如文字結尾符合對比文字則返回真"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "Appetite"
-msgstr "食慾"
+msgstr "Appetite"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "hungry"
-msgstr "飢餓"
+msgstr "hungry"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 msgid "A column or string of text to check."
 msgstr "欲檢核的欄位或字串"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
 msgid "The string of text that the original text should end with."
 msgstr "原始文字結尾的文字字串"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 msgid "regular_expression"
 msgstr "正則表達式"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:136
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "擷取符合正則表達式的文字或數字資料"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:137
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
 msgid "Address"
-msgstr "地址"
+msgstr "Address"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 msgid "The column or string of text to search though."
 msgstr "欲搜尋的欄位或文字字串"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
 msgid "The regular expression to match."
 msgstr "符合的正則表達式"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the string of text in all lowercase."
 msgstr "返回小寫字串"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:149
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to lowercase."
 msgstr "欄位資料將轉換為小寫"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:154
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 msgid "Removes leading whitespace from a string of text."
 msgstr "刪除字串開頭空白"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:157
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column with values you want to trim."
 msgstr "欲截除的欄位資料"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "Returns the largest value found in the column."
 msgstr "返回此欄位的最大值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
 msgid "Age"
 msgstr "年齡"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:165
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
 msgid "The numeric column whose maximum you want to find."
 msgstr "數值欄位中欲尋找的最大值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:170
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "Returns the smallest value found in the column."
 msgstr "返回此欄位的最小值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
 msgid "Salary"
 msgstr "薪水"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:173
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
 msgid "The numeric column whose minimum you want to find."
 msgstr "數值欄位中欲尋找的最小值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:181
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:242
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
 msgid "position"
 msgstr "位置"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:194
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
 msgid "length"
 msgstr "長度"
 
@@ -14060,19 +14083,19 @@ msgstr "長度"
 msgid "new_text"
 msgstr "new_text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:187
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
 msgid "Replaces a part of the input text with new text."
 msgstr "以新文字替換部分輸入文字"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:189
 msgid "Order ID"
-msgstr "訂單識別"
+msgstr "訂購ID"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:189
 msgid "Updated Part of ID"
 msgstr "更新部分ID"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
 msgid "The text that will be modified."
 msgstr "文字將被修改"
 
@@ -14088,87 +14111,87 @@ msgstr "欲置換的字元數目"
 msgid "The text to use in the replacement."
 msgstr "欲置換的文字資料"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "Removes trailing whitespace from a string of text."
 msgstr "刪除文字結尾空白"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:210
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "以數字表示返回符合條件的資料行數百分比"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:218
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "假如文字開頭符合比較的文字則返回結果為真"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Course Name"
 msgstr "課程名"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Computer Science"
 msgstr "計算機科學"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
 msgid "The string of text that the original text should start with."
 msgstr "原始文字開頭的字元"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:229
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
 msgid "Calculates the standard deviation of the column."
 msgstr "計算此欄位的標準差"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:230
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
 msgid "Population"
 msgstr "人口"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
 msgid "A numeric column."
 msgstr "數字欄位"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
 msgid "Returns a portion of the supplied text."
 msgstr "返回部分提供的文字"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:241
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:313
 msgid "The text to return a portion of."
 msgstr "此文字返回某部分的"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
 msgid "The position to start copying characters."
 msgstr "開始複製字元的位置"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:245
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
 msgid "The number of characters to return."
 msgstr "欲返回字元的數目"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
 msgid "Adds up all the values of the column."
 msgstr "將列的所有值相加"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:253
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
 msgid "The numeric column to sum."
 msgstr "數字欄位加總"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
 msgstr "匯總行匹配條件的列中的值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
 msgid "Order Status"
 msgstr "訂單狀態"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
 msgid "Valid"
 msgstr "有效"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "刪除文字開頭及結尾空白"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
 msgid "Returns the string of text in all upper case."
 msgstr "返回大寫文字"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
 msgid "The column with values to convert to upper case."
 msgstr "欄位資料轉換成大寫"
 
@@ -14223,41 +14246,41 @@ msgstr "感謝使用 Metabase ！"
 
 #: frontend/src/metabase/public/components/LogoBadge.jsx:20
 msgid "Powered by {0}"
-msgstr "Powered by {0}"
+msgstr "供電 {0}"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:191
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
 msgid "To:"
 msgstr "至:"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:40
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
 msgstr "這個提問無法使用，因為它是基於另一個資料庫。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:44
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:43
 msgid "Couldn't find a saved question with that ID number."
 msgstr "無法找到以此ID number儲存的問題(查詢)"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:55
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:54
 msgid "Pick a saved question"
 msgstr "請挑選一個儲存的問題(查詢)"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:57
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:56
 msgid "Pick a different question"
 msgstr "請挑選一個不同的問題(查詢)"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:62
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:61
 msgid "Loading…"
 msgstr "載入中..."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:79
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:78
 msgid "Question #…"
-msgstr "題 ＃…"
+msgstr "題 #…"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:81
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
-msgstr "問題＃{0}"
+msgstr "題 #{0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:115
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
 msgstr "最後編輯 {0}"
 
@@ -14270,11 +14293,11 @@ msgid "Giving a variable the \"Field Filter\" type allows you to link questions 
 msgstr "設定過濾篩選變數來連結到展示板上的相關SQL提問(查詢)的篩選元件。\n"
 "當加入欲篩選欄位時，欄位篩選變數會插入一段SQL語法到視覺查詢建構器所產生的查詢語句"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:131
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
 msgstr "變數名稱"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:217
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:218
 msgid "Filter widget label"
 msgstr "篩選元件標籤"
 
@@ -14306,17 +14329,17 @@ msgstr "欄位開頭"
 msgid "In every table cell"
 msgstr "每一資料表單元格"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:351
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:341
 msgid "Value formatting"
 msgstr "資料格式"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:361
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
 msgid "Full"
-msgstr "Full"
+msgstr "充分"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
 msgid "No change from last {0}"
-msgstr "No change from last {0}"
+msgstr "從上沒有變化 {0}"
 
 #: src/metabase/api/database.clj
 msgid "Connection to ''{0}:{1}'' successful, but could not connect to DB."
@@ -14328,7 +14351,7 @@ msgstr "連線至主機 \"{0}\" 成功，但是 port {1} 是無效的"
 
 #: src/metabase/api/database.clj
 msgid "Host ''{0}'' is not reachable"
-msgstr "Host ''{0}'' is not reachable"
+msgstr "主辦 ''{0}'' 無法到達"
 
 #: src/metabase/api/database.clj
 msgid "Unable to connect to database."
@@ -14340,7 +14363,7 @@ msgstr "無法連線至資料庫"
 
 #: src/metabase/api/embed.clj
 msgid "You''re not allowed to specify a value for {0}."
-msgstr "You''re not allowed to specify a value for {0}"
+msgstr "您不允許為 {0}"
 
 #: src/metabase/api/embed.clj
 msgid "You can''t specify a value for {0} if it''s already set in the JWT."
@@ -14360,7 +14383,7 @@ msgstr "搜尋欄位資料錯誤"
 
 #: src/metabase/api/field.clj
 msgid "Error searching for remapping"
-msgstr "Error searching for remapping"
+msgstr "搜索重新映射時出錯"
 
 #: src/metabase/api/session.clj
 msgid "Google Auth token appears to be incorrect. "
@@ -14368,7 +14391,7 @@ msgstr "Google Auth token似乎是錯誤的"
 
 #: src/metabase/api/session.clj
 msgid "Double check that it matches in Google and Metabase."
-msgstr "Double check that it matches in Google and Metabase"
+msgstr "仔細檢查它在Google和Metabase中是否匹配"
 
 #: src/metabase/api/table.clj
 msgid "Everything else"
@@ -14401,7 +14424,7 @@ msgstr "資料庫需要手動更新"
 #. Tell transaction to automatically `.rollback` instead of `.commit` when the transaction finishes
 #: src/metabase/db.clj
 msgid "Set transaction to automatically roll back..."
-msgstr "Set transaction to automatically roll back..."
+msgstr "將交易設置為自動回滾..."
 
 #. Disable auto-commit. This should already be off but set it just to be safe
 #: src/metabase/db.clj
@@ -14503,11 +14526,11 @@ msgstr "設定 {0} 是內部的"
 
 #: src/metabase/plugins.clj
 msgid "Loading local plugin manifest at {0}"
-msgstr "正在{0}加載本地插件清單"
+msgstr "正在加載本地插件清單{0}"
 
 #: src/metabase/public_settings.clj
 msgid "Google Analytics tracking code."
-msgstr "Google Analytics tracking code."
+msgstr "Google Analytics（分析）跟踪代碼。"
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) with {2} Cards via email"
@@ -14637,4 +14660,483 @@ msgstr "從欄位產生 insights 錯誤"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandonment email!"
-msgstr "發送遺棄電子郵件！"
+msgstr "送出 abandonment email ！"
+
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
+msgstr "您可以創建保存的指標以添加命名指標選項。保存的指標包括聚合類型，聚合字段以及您添加的任何過濾器（可選）。例如，您可以使用它來創建類似於為Orders表計算“平均價格”的官方方法。"
+
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:105
+msgid "Select and add filters to create your new segment."
+msgstr "選擇並添加過濾器以創建新的細分。"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+msgid "Alphabetical"
+msgstr "按字母順序"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+msgid "Smart"
+msgstr "聰明"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+msgid "Column order: {0}"
+msgstr "列順序：{0}"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
+msgid "Unhide all"
+msgstr "全部取消隱藏"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:204
+msgid "Hide all"
+msgstr "全部藏起來"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:206
+msgid "Unhide"
+msgstr "取消隱藏"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:22
+msgid "New metric"
+msgstr "新指標"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:45
+msgid "Create metrics to add them to the Summarize dropdown in the query builder"
+msgstr "創建指標以將其添加到查詢構建器的“匯總”下拉列表中"
+
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:22
+msgid "New segment"
+msgstr "新細分"
+
+#: frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx:71
+msgid "Filter by table"
+msgstr "依表格篩選"
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:64
+msgid "Checking HTTPS..."
+msgstr "正在檢查HTTPS ..."
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:66
+msgid "It looks like HTTPS is not properly configured"
+msgstr "看來HTTPS配置不正確"
+
+#: frontend/src/metabase/admin/settings/selectors.js:57
+msgid "Redirect to HTTPS"
+msgstr "重定向到HTTPS"
+
+#: frontend/src/metabase/admin/settings/selectors.js:219
+msgid "Localization"
+msgstr "本土化"
+
+#: frontend/src/metabase/admin/settings/selectors.js:222
+msgid "Instance language"
+msgstr "實例語言"
+
+#: frontend/src/metabase/admin/settings/selectors.js:237
+msgid "Localization options"
+msgstr "本地化選項"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:51
+msgid "This database doesn't have any tables."
+msgstr "該數據庫沒有任何表。"
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
+msgid "This field only accepts a single value because it's used in a SQL query."
+msgstr "該字段僅接受一個值，因為它在SQL查詢中使用。"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:17
+msgid "Service Accounts"
+msgstr "服務帳號"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:26
+msgid "Metabase connects to Big Query via {0}."
+msgstr "配置數據庫通過{0}連接到Big Query。"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:29
+msgid "Continue using an OAuth application to connect"
+msgstr "繼續使用OAuth應用程序進行連接"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:43
+msgid "We recommend switching to use {0} instead of an OAuth application to connect to BigQuery"
+msgstr "我們建議切換為使用{0}而不是OAuth應用程序來連接到BigQuery"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:48
+msgid "Connect to a Service Account instead"
+msgstr "改為連接到服務帳戶"
+
+#: frontend/src/metabase/entities/databases/forms.js:44
+msgid "invalid JSON"
+msgstr "無效的JSON"
+
+#: frontend/src/metabase/entities/databases/forms.js:50
+msgid "SSH private key"
+msgstr "SSH私鑰"
+
+#: frontend/src/metabase/entities/databases/forms.js:51
+msgid "Paste the contents of your ssh private key here"
+msgstr "將ssh私鑰的內容粘貼到此處"
+
+#: frontend/src/metabase/entities/databases/forms.js:55
+msgid "Passphrase for the SSH private key"
+msgstr "SSH私鑰的密碼"
+
+#: frontend/src/metabase/entities/databases/forms.js:58
+msgid "SSH Authentication"
+msgstr "SSH驗證"
+
+#: frontend/src/metabase/entities/databases/forms.js:60
+msgid "SSH Key"
+msgstr "SSH密鑰"
+
+#: frontend/src/metabase/entities/databases/forms.js:65
+msgid "Server SSL certificate chain"
+msgstr "服務器SSL證書鏈"
+
+#: frontend/src/metabase/entities/databases/forms.js:66
+msgid "Paste the contents of the server's SSL certificate chain here"
+msgstr "在此處粘貼服務器的SSL證書鏈的內容"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:11
+msgid "Paste a connection string"
+msgstr "粘貼連接字符串"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:12
+msgid "Fill out individual fields"
+msgstr "填寫各個字段"
+
+#: frontend/src/metabase/entities/snippets.js:14
+msgid "Enter some SQL here so you can reuse it later"
+msgstr "在此處輸入一些SQL，以便稍後使用"
+
+#: frontend/src/metabase/entities/snippets.js:24
+msgid "Give your snippet a name"
+msgstr "給您的代碼片段起個名字"
+
+#: frontend/src/metabase/entities/snippets.js:25
+msgid "Current Customers"
+msgstr "現有客戶"
+
+#: frontend/src/metabase/entities/snippets.js:30
+msgid "Add a description"
+msgstr "增加一個說明"
+
+#: frontend/src/metabase/entities/users/forms.js:37
+msgid "Use site default"
+msgstr "使用網站默認"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+msgid "find"
+msgstr "找"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+msgid "replace"
+msgstr "更換"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+msgid "The text to find."
+msgstr "要查找的文字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "The text to use as the replacement."
+msgstr "用作替代的文本。"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+msgid "Editing {0}"
+msgstr "編輯{0}"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+msgid "Create your new snippet"
+msgstr "創建您的新片段"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+msgid "Archived snippets"
+msgstr "存檔片段"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+msgid "Snippets are reusable bits of SQL"
+msgstr "片段是SQL的可重用位"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+msgid "Create a snippet"
+msgstr "創建一個片段"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+msgid "Snippets"
+msgstr "片段"
+
+#: frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx:15
+msgid "SQL Snippets"
+msgstr "SQL片段"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:38
+msgid "Your language is set to {0}"
+msgstr "您的語言設置為{0}"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:50
+msgid "What's your preferred language?"
+msgstr "您首選的語言是什麼？"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:54
+msgid "This language will be used throughout Metabase and will be the default for new users."
+msgstr "該語言將在整個Metabase中使用，並將成為新用戶的默認語言。"
+
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:159
+msgid "We filtered out {0} row(s) containing null values."
+msgstr "我們過濾掉包含空值的{0}行。"
+
+#: frontend/src/metabase/visualizations/lib/settings/series.js:133
+msgid "Show values for this series"
+msgstr "顯示該系列的值"
+
+#: src/metabase/api/card.clj
+msgid "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
+msgstr "問題的平均執行持續時間為{0}；使用{1}的“魔術” TTL"
+
+#: src/metabase/api/native_query_snippet.clj
+msgid "A snippet with that name already exists. Please pick a different name."
+msgstr "具有該名稱的代碼段已存在。請選擇其他名稱。"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Metric]"
+msgstr "[未知指標]"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Segment]"
+msgstr "[未知細分]"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error writing error to output stream"
+msgstr "將錯誤寫入輸出流時出錯"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Caught unexpected Exception in streaming response body"
+msgstr "流式響應正文中捕獲了意外的異常"
+
+#: src/metabase/async/streaming_response.clj
+msgid "bound-fn caught unexpected Exception"
+msgstr "bound-fn捕獲了意外的異常"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error determining whether HTTP request was canceled"
+msgstr "確定HTTP請求是否已取消時出錯"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Check cancelation status timed out after {0}"
+msgstr "{0}後檢查取消狀態超時"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Unexpected exception in do-f-async"
+msgstr "do-f-async中發生意外的異常"
+
+#: src/metabase/async/streaming_response.clj src/metabase/server.clj
+msgid "Unexpected exception writing error response"
+msgstr "意外的異常寫入錯誤響應"
+
+#: src/metabase/driver/common.clj
+msgid "Server certificate not trusted - did you specify the correct SSL certificate chain?"
+msgstr "服務器證書不受信任-您是否指定了正確的SSL證書鏈？"
+
+#: src/metabase/driver/common.clj
+msgid "Server appears to require SSL - please enable SSL above"
+msgstr "服務器似乎需要SSL-請在上面啟用SSL"
+
+#: src/metabase/driver/common.clj
+msgid "Username"
+msgstr "用戶名"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Don''t know how to parse parameter of type {0}"
+msgstr "不知道如何解析類型為{0}的參數"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Invalid :card parameter: missing `:card-id`"
+msgstr "：card參數無效：缺少`：card-id`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Unable to resolve Snippet: missing `:snippet-id`"
+msgstr "無法解析代碼段：缺少`：snippet-id`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Snippet {0} {1} not found."
+msgstr "找不到代碼段{0} {1}。"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error determining value for parameter"
+msgstr "確定參數值時出錯"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error building query parameter map"
+msgstr "建立查詢參數圖時出錯"
+
+#: src/metabase/middleware/log.clj
+msgid "ASYNC"
+msgstr "異步"
+
+#: src/metabase/middleware/log.clj
+msgid "{0} ({1} DB calls)"
+msgstr "{0}（{1}個數據庫調用）"
+
+#: src/metabase/middleware/log.clj
+msgid "App DB connections: {0}/{1}"
+msgstr "應用數據庫連接：{0} / {1}"
+
+#: src/metabase/middleware/log.clj
+msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
+msgstr "碼頭線程：{0} / {1}（{2}空閒，{3}排隊）"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} total active threads)"
+msgstr "（{0}個活動線程總數）"
+
+#: src/metabase/middleware/log.clj
+msgid "Queries in flight: {0}"
+msgstr "進行中的查詢：{0}"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} queued)"
+msgstr "（{0}已排隊）"
+
+#: src/metabase/models/collection.clj
+msgid "Collection must be in the same namespace as its parent"
+msgstr "集合必須與其父集合位於同一名稱空間中"
+
+#: src/metabase/models/collection.clj
+msgid "Personal Collections must be in the default namespace"
+msgstr "個人收藏集必須位於默認名稱空間中"
+
+#: src/metabase/models/collection.clj
+msgid "You cannot move a Collection to a different namespace once it has been created."
+msgstr "創建集合後，您無法將其移動到其他名稱空間。"
+
+#: src/metabase/models/collection.clj src/metabase/models/permissions.clj
+msgid "Collection does not exist."
+msgstr "集合不存在。"
+
+#: src/metabase/models/collection.clj
+msgid "A {0} can only go in Collections in the {1} namespace."
+msgstr "{0}只能進入{1}名稱空間的Collections中。"
+
+#: src/metabase/models/database.clj
+msgid "Error sending database deletion notification"
+msgstr "發送數據庫刪除通知時出錯"
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "You cannot update the creator_id of a NativeQuerySnippet."
+msgstr "您無法更新NativeQuerySnippet的creator_id。"
+
+#: src/metabase/models/setting.clj
+msgid "Error fetching value of Setting"
+msgstr "獲取設置值時出錯"
+
+#: src/metabase/public_settings.clj
+msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
+msgstr "Metabase的UI，系統電子郵件，脈沖和警報應使用的語言。"
+
+#: src/metabase/public_settings.clj
+msgid "This is also the default language for all users, which they can change from their own account settings."
+msgstr "這也是所有用戶的默認語言，他們可以從自己的帳戶設置中更改。"
+
+#: src/metabase/public_settings.clj
+msgid "Invalid locale {0}"
+msgstr "無效的語言環境{0}"
+
+#: src/metabase/public_settings.clj
+msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
+msgstr "如果站點URL為HTTPS，則強制所有流量通過重定向使用HTTPS"
+
+#: src/metabase/public_settings.clj
+msgid "Cannot redirect requests to HTTPS unless `site-url` is HTTPS."
+msgstr "除非`site-url`是HTTPS，否則不能將請求重定向到HTTPS。"
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error registering fonts: Metabase will not be able to send Pulses."
+msgstr "註冊字體時出錯：Metabase無法發送Pulse。"
+
+#: src/metabase/pulse/render/png.clj
+msgid "This is a known issue with certain JVMs. See {0} and for more details."
+msgstr "這是某些JVM的已知問題。有關更多詳細信息，請參見{0}。"
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error rendering Pulse"
+msgstr "錯誤呈現脈衝"
+
+#: src/metabase/query_processor/context/default.clj
+msgid "Query timed out after {0}, raising timeout exception."
+msgstr "查詢在{0}之後超時，引發超時異常。"
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "No fields found for table {0}."
+msgstr "找不到表{0}的字段。"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Case"
+msgstr "案件"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Variance of {0}"
+msgstr "{0}的方差"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Median of {0}"
+msgstr "{0}的中位數"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "{0}th percentile of {1}"
+msgstr "{1}的第{0}個百分點"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Not caching results: results are larger than {0} KB"
+msgstr "不緩存結果：結果大於{0} KB"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Cannot cache results: expected byte array, got {0}"
+msgstr "無法緩存結果：預期的字節數組，得到了{0}"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Request is closed; no one to return cached results to"
+msgstr "請求已關閉；沒有人將緩存的結果返回給"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Error attempting to fetch cached results for query with hash {0}"
+msgstr "嘗試獲取哈希值為{0}的查詢的緩存結果時出錯"
+
+#: src/metabase/query_processor/middleware/cache_backend/db.clj
+msgid "Error preparing statement to fetch cached query results"
+msgstr "錯誤準備語句以獲取緩存的查詢結果"
+
+#: src/metabase/query_processor/middleware/catch_exceptions.clj
+msgid "Error processing query: {0}"
+msgstr "處理查詢時出錯：{0}"
+
+#: src/metabase/server.clj
+msgid "Unexpected exception in endpoint"
+msgstr "端點中的意外異常"
+
+#: src/metabase/server.clj
+msgid "Unexpected Exception in API request handler"
+msgstr "API請求處理程序中的異常"
+
+#: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+msgid "Error reducing {0}"
+msgstr "減少{0}時出錯"
+
+#: src/metabase/sync/analyze/fingerprint/insights.clj
+msgid "Error generating timeseries insight keyed by: {0}"
+msgstr "生成時間序列洞察力時出錯，輸入鍵為：{0}"
+
+#: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
+msgstr "{0}的數據庫位置已從“ {1}”更改為“ {2}”。"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Unscheduling task for Database {0}: trigger: {1}"
+msgstr "數據庫{0}的未調度任務：觸發器：{1}"
+
+#: src/metabase/util/schema.clj
+msgid "value must be a keyword or string."
+msgstr "值必須是關鍵字或字符串。"
+
+#: src/metabase/util/schema.clj
+msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
+msgstr "字符串必須是有效的兩個字母的ISO語言或語言國家/地區代碼，例如“ en”或“ en_US”。"

--- a/locales/zh-TW.po
+++ b/locales/zh-TW.po
@@ -29,13 +29,14 @@ msgid "Select a database type"
 msgstr "選擇資料庫類型"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:411
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:154
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -48,7 +49,7 @@ msgstr "儲存"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "為了做一些預設分析的事情，Metabase需要掃描您的資料庫。我們將會定期自動掃描您的資料庫，確保資料庫欄位的後設資料在 Metabase 是最新的狀態。您可以在下方更改更新掃描時間。"
 
-#: frontend/src/metabase/entities/databases/forms.js:221
+#: frontend/src/metabase/entities/databases/forms.js:290
 msgid "Database syncing"
 msgstr "資料庫同步中"
 
@@ -63,7 +64,7 @@ msgstr "這個程序僅僅檢查資料庫欄位後設資料的更新，並不會
 msgid "Scan"
 msgstr "掃描"
 
-#: frontend/src/metabase/entities/databases/forms.js:228
+#: frontend/src/metabase/entities/databases/forms.js:297
 msgid "Scanning for Filter Values"
 msgstr "根據篩選值進行掃描"
 
@@ -74,7 +75,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase 可以掃描資料庫中每個欄位的值，用來讓使用者啟用查詢或資訊看板中的篩選器。當您的資料庫較大時，這個功能同時會耗費更多的系統資源。"
 
-#: frontend/src/metabase/entities/databases/forms.js:232
+#: frontend/src/metabase/entities/databases/forms.js:301
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Metabase應該在什麼時候自動掃描快取的欄位值？"
 
@@ -96,6 +97,7 @@ msgid "Never, I'll do this manually if I need to"
 msgstr "不用，如果需要我會手動執行"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 msgid "Saving..."
@@ -132,9 +134,9 @@ msgid "in this box:"
 msgstr "在輸入框裡："
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:75
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
@@ -151,18 +153,18 @@ msgstr "在輸入框裡："
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:301
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:39
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:90
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:99
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:311
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:328
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "取消"
@@ -179,7 +181,7 @@ msgstr "刪除"
 #: frontend/src/metabase/admin/permissions/selectors.js:323
 #: frontend/src/metabase/admin/permissions/selectors.js:330
 #: frontend/src/metabase/admin/permissions/selectors.js:441
-#: frontend/src/metabase/admin/routes.jsx:57
+#: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
@@ -199,9 +201,10 @@ msgid "Scheduling"
 msgstr "排程"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:71
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
@@ -209,8 +212,8 @@ msgid "Save changes"
 msgstr "儲存修改"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:203
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:35
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
 msgstr "動作"
 
@@ -222,8 +225,8 @@ msgstr "開始同步資料庫綱要"
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:90
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:98
 msgid "Starting…"
 msgstr "開始..."
 
@@ -241,13 +244,13 @@ msgstr "現在重新掃描欄位值"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
 msgstr "無法開始掃描"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:92
 msgid "Scan triggered!"
 msgstr "掃描已觸發！"
 
@@ -270,15 +273,15 @@ msgid "Add database"
 msgstr "新增資料庫"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:28
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:28
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
 #: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:195
+#: frontend/src/metabase/entities/databases/forms.js:264
 #: frontend/src/metabase/entities/questions.js:86
 #: frontend/src/metabase/entities/questions.js:102
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
@@ -318,6 +321,7 @@ msgstr "儲存成功！"
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "編輯"
@@ -360,44 +364,43 @@ msgstr "失敗"
 msgid "Success"
 msgstr "成功"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:185
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "預覽"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:93
 msgid "No column description yet"
 msgstr "暫無欄位敘述"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:127
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:126
 msgid "Select a field visibility"
 msgstr "選擇欄位可見性"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:187
 msgid "No special type"
 msgstr "指定的類型不存在"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
 #: frontend/src/metabase/lib/core.js:275
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:44
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:37
 msgid "Other"
 msgstr "其他"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:221
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "請選擇一個指定類型"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:255
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:262
 #: frontend/src/metabase/reference/components/Field.jsx:99
 msgid "Select a target"
 msgstr "選擇目標"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
@@ -405,18 +408,18 @@ msgstr "選擇目標"
 msgid "Columns"
 msgstr "欄位"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "欄位"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:144
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:288
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
 msgid "Visibility"
 msgstr "可見性"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
 msgid "Type"
 msgstr "類型"
 
@@ -424,7 +427,7 @@ msgstr "類型"
 msgid "Current database:"
 msgstr "當前資料庫"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
 msgid "Show original schema"
 msgstr "顯示原始資料綱要結構"
 
@@ -445,27 +448,27 @@ msgid "{0} schema"
 msgid_plural "{0} schemas"
 msgstr[0] "{0} 綱要結構"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:99
 msgid "Why Hide?"
 msgstr "隱藏原因"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:100
 msgid "Technical Data"
 msgstr "日誌資料"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
 msgstr "不相關"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 msgid "Queryable"
 msgstr "可查詢"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:108
 msgid "Hidden"
 msgstr "已隱藏"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136
 msgid "No table description yet"
 msgstr "暫無資料表敘述"
 
@@ -473,30 +476,31 @@ msgstr "暫無資料表敘述"
 msgid "Metadata Strength"
 msgstr "後設資料完整度"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0}可查詢的資料表"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:91
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0}隱藏的資料表"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:115
 msgid "Find a table"
 msgstr "搜尋資料表"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:128
 msgid "Schemas"
 msgstr "資料表結構"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:838
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:21
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:43
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:62
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 msgid "Metrics"
 msgstr "量值"
@@ -505,8 +509,8 @@ msgstr "量值"
 msgid "Add a Metric"
 msgstr "新增量值"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "定義"
@@ -515,12 +519,12 @@ msgstr "定義"
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "建立量值並新增到查詢設計器的視圖下拉選單"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:21
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
 #: frontend/src/metabase/home/containers/SearchApp.jsx:72
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:961
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:61
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "篩選器(Segments)"
@@ -529,35 +533,35 @@ msgstr "篩選器(Segments)"
 msgid "Add a Segment"
 msgstr "新增篩選器(Segments)"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:51
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:45
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "建立篩選器(Segments)並新增到查詢設計器的篩選下拉選單"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:21
 msgid "created"
 msgstr "已建立"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "reverted to a previous version"
 msgstr "恢復到前一個版本"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:30
 msgid "edited the title"
 msgstr "編輯標題"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:32
 msgid "edited the description"
 msgstr "編輯敘述"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:34
 msgid "edited the "
 msgstr "編輯"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:40
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "made some changes"
 msgstr "做了一些變動"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
 #: frontend/src/metabase/home/components/Activity.jsx:83
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
@@ -567,84 +571,84 @@ msgstr "您"
 msgid "Datamodel"
 msgstr "資料模型"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:41
 msgid " History"
 msgstr "歷史"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
 msgstr "歷史版本"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:228
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
 msgid "{0} – Field Settings"
 msgstr "{0} - 欄位設定"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:289
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
 msgid "Where this field will appear throughout Metabase"
 msgstr "這些欄位將在哪裡顯示？"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:311
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
 msgid "Filtering on this field"
 msgstr "欄位過濾"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:312
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "當在篩選器中使用此欄位時，使用者應該用什麼形式輸入他們想要過濾的值?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:437
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
 msgid "No description for this field yet"
 msgstr "暫無篩選欄位敘述"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
 msgid "Original value"
 msgstr "原始值"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:390
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
 msgid "Mapped value"
 msgstr "對應值"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
 msgid "Enter value"
 msgstr "輸入值"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use original value"
 msgstr "使用原始值"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Use foreign key"
 msgstr "使用外鍵"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 msgid "Custom mapping"
 msgstr "自訂對應"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
 msgid "Unrecognized mapping type"
 msgstr "無法識別對應類型"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "當前欄位不是外鍵或者缺少外鍵關聯表後設資料"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
 msgid "The selected field isn't a foreign key"
 msgstr "選中的欄位不是外鍵"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:327
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
 msgid "Display values"
 msgstr "顯示值"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:328
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "選擇顯示資料庫中的原始值，或者顯示此欄位的相關或自訂訊息。"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:278
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
 msgid "Choose a field"
 msgstr "選擇欄位"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:299
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
 msgid "Please select a column to use for display."
 msgstr "請選擇欄位來做展示"
 
@@ -652,16 +656,16 @@ msgstr "請選擇欄位來做展示"
 msgid "Tip:"
 msgstr "提示："
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:443
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "您可能想要更新這個欄位的名稱來確保它基於您的重新對應選擇時仍然有意義"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:344
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "快取欄位值"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:345
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase 會掃描該欄位，來啟用資訊看板和提問的多選框篩選。"
 
@@ -670,53 +674,53 @@ msgid "Re-scan this field"
 msgstr "重新掃描該欄位"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
 msgstr "丟棄欄位值快取"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
 msgstr "丟棄欄位值失敗"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 msgid "Discard triggered!"
 msgstr "丟棄處理已經觸發！"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "選擇任意資料表來顯示它的結構並且新增或編輯後設資料"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:36
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "名稱必填"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:39
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "敘述必填"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:43
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "版本訊息必填"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
 msgid "Aggregation is required"
 msgstr "聚集訊息必填"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Edit Your Metric"
 msgstr "編輯量值"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Create Your Metric"
 msgstr "建立量值"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "修改量值並留下簡要說明。"
 
@@ -724,62 +728,62 @@ msgstr "修改量值並留下簡要說明。"
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "您能夠建立已存儲的量值來新增一個已經命名的量值選項到這個表單。儲存的量值包括您新增的聚合類型，聚合欄位和可選的任何篩選項。舉個例子，您可能使用這個來為一個訂單表單創造一些像是“平均價”的官方計算方法，"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:180
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
 msgid "Result: "
 msgstr "結果："
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
 msgid "Name Your Metric"
 msgstr "命名量值"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:190
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Give your metric a name to help others find it."
 msgstr "為量值命名，方便其他人搜尋。"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:194
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:152
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "簡短的敘述"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:198
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
 msgid "Describe Your Metric"
 msgstr "敘述量值"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:199
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "敘述量值，方便其他人理解。"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:203
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "在這裡詳細敘述量值，比如不太明顯的規則"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:207
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:165
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "更改原因"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:209
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "留言以說明您所做的更改以及為何需要這些更改。"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:213
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "這將顯示在此量值的修訂歷史記錄中，以幫助每個人記住事情發生變化的原因"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
 msgstr "至少需要一個篩選條件"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
 msgstr "編輯劃分(Segment)"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
 msgstr "建立劃分(Segment)"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "更改劃分(Segment)，並敘述變動內容。"
 
@@ -787,33 +791,33 @@ msgstr "更改劃分(Segment)，並敘述變動內容。"
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "選擇並新增篩選條件以為{0}表建立新段(Segment)"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
 msgstr "命名劃分(Segment)"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:148
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
 msgstr "命名劃分(Segment)方便其他人搜尋"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:156
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
 msgstr "敘述劃分(Segment)"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "敘述劃分(Segment)，方便其他人理解。"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "在這裡詳細敘述劃分(Segment)，比如不太明顯的規則"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "這將顯示在篩選器的修訂歷史記錄中，以幫助每個人記住事情發生變化的原因"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
-#: frontend/src/metabase/admin/routes.jsx:132
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:215
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
+#: frontend/src/metabase/admin/routes.jsx:137
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
@@ -821,11 +825,11 @@ msgstr "這將顯示在篩選器的修訂歷史記錄中，以幫助每個人記
 msgid "Settings"
 msgstr "設定"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase掃描此表中的值以啟用資訊看板和提問中的複選框篩選器。"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
 msgstr "刷新表格"
 
@@ -839,11 +843,11 @@ msgstr "新增"
 msgid "Not a valid formatted email address"
 msgstr "無效的EMail地址"
 
-#: frontend/src/metabase/entities/users/forms.js:12
+#: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
 msgstr "名"
 
-#: frontend/src/metabase/entities/users/forms.js:18
+#: frontend/src/metabase/entities/users/forms.js:20
 msgid "Last name"
 msgstr "姓"
 
@@ -882,10 +886,10 @@ msgstr "組員"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
-#: frontend/src/metabase/admin/settings/selectors.js:120
-#: frontend/src/metabase/entities/users/forms.js:24
+#: frontend/src/metabase/admin/settings/selectors.js:121
+#: frontend/src/metabase/entities/users/forms.js:26
 #: frontend/src/metabase/lib/core.js:146
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:294
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:298
 msgid "Email"
 msgstr "電子郵件設定"
 
@@ -894,14 +898,14 @@ msgid "A group is only as good as its members."
 msgstr "群組內成員權限一致"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
-#: frontend/src/metabase/admin/routes.jsx:52
+#: frontend/src/metabase/admin/routes.jsx:55
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Admin"
 msgstr "系統管理"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:241
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:299
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:288
 msgid "and"
 msgstr "和"
 
@@ -952,12 +956,12 @@ msgstr "移除群組"
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:42
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:294
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:397
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:317
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:334
 msgid "Done"
 msgstr "完成"
 
@@ -968,8 +972,9 @@ msgstr "群組名稱"
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
-#: frontend/src/metabase/admin/routes.jsx:92
+#: frontend/src/metabase/admin/routes.jsx:97
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "所屬群組"
 
@@ -999,7 +1004,7 @@ msgstr "停用"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:21
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
-#: frontend/src/metabase/admin/routes.jsx:88
+#: frontend/src/metabase/admin/routes.jsx:93
 #: frontend/src/metabase/nav/containers/Navbar.jsx:235
 msgid "People"
 msgstr "帳號管理"
@@ -1310,25 +1315,25 @@ msgstr "檢視集合(collection)"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:542
+#: frontend/src/metabase/admin/permissions/selectors.js:558
 msgid "Data Access"
 msgstr "允許資料存取權限"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:667
-#: frontend/src/metabase/admin/permissions/selectors.js:672
+#: frontend/src/metabase/admin/permissions/selectors.js:665
+#: frontend/src/metabase/admin/permissions/selectors.js:670
 msgid "View tables"
 msgstr "檢視資料表權限"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:608
+#: frontend/src/metabase/admin/permissions/selectors.js:606
 msgid "SQL Queries"
 msgstr "SQL查詢"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:678
+#: frontend/src/metabase/admin/permissions/selectors.js:676
 msgid "View schemas"
 msgstr "檢視綱要結構"
 
-#: frontend/src/metabase/admin/routes.jsx:63
+#: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
 msgstr "資料模型"
@@ -1358,20 +1363,24 @@ msgid "Allows users within your LDAP directory to log in to Metabase with their 
 msgstr "允許LDAP目錄中的使用者使用他們的LDAP憑證登入到Metabase，並且允許自動同步LDAP組的資料到Metabase中來。"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:19
-#: frontend/src/metabase/admin/settings/selectors.js:167
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
+#: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
 msgstr "這不是有效的電子郵件地址"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
 msgstr "那不是一個有效的整數"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
 msgstr "更改已儲存！"
 
-#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:178
+#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
 msgid "Looks like we ran into some problems"
 msgstr "看起來我們遇到了一些問題"
 
@@ -1393,7 +1402,7 @@ msgstr "完成"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:195
+#: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "授權認證"
 
@@ -1445,15 +1454,15 @@ msgstr "您的Google客戶端ID"
 msgid "Allow users to sign up on their own if their Google account email address is from:"
 msgstr "允許使用者用他們自己的信箱註冊，如果他們的Google帳戶地址來自："
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:242
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:249
 msgid "Answers sent right to your Slack #channels"
 msgstr "答案發送到您的Slack #channels"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:251
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:258
 msgid "Create a Slack Bot User for MetaBot"
 msgstr "為MetaBot建立一個Slack Bot使用者"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:261
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:268
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "進入後，請為其命名並單擊{0}。然後將Bot API令牌複製並黏貼到下面的欄位中。完成後，在Slack中建立“metabase_files”通道。Metabase需要這個來上傳圖表。"
 
@@ -1466,8 +1475,8 @@ msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Metabase {0}可更新。您正在執行是{1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:41
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 msgid "Update"
 msgstr "更新"
 
@@ -1494,16 +1503,16 @@ msgstr "刪除自訂地圖"
 #: frontend/src/metabase/containers/Overworld.jsx:293
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:115
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "刪除"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:165
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:141
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
 msgstr "選擇"
 
@@ -1686,48 +1695,46 @@ msgid "Generate Key"
 msgstr "生成密鑰"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:87
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:18
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enabled"
 msgstr "生效"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:92
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:19
+#: frontend/src/metabase/admin/settings/selectors.js:93
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "取消"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:112
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:113
 msgid "Unknown setting {0}"
 msgstr "未知設定{0}"
 
-#: frontend/src/metabase/admin/settings/selectors.js:34
+#: frontend/src/metabase/admin/settings/selectors.js:37
 msgid "Setup"
 msgstr "初始化設定"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:207
-#: frontend/src/metabase/admin/settings/selectors.js:39
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:214
+#: frontend/src/metabase/admin/settings/selectors.js:42
 msgid "General"
 msgstr "一般設定"
 
-#: frontend/src/metabase/admin/settings/selectors.js:43
+#: frontend/src/metabase/admin/settings/selectors.js:46
 msgid "Site Name"
 msgstr "網站名稱"
 
-#: frontend/src/metabase/admin/settings/selectors.js:48
+#: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Site URL"
 msgstr "網站地址"
 
-#: frontend/src/metabase/admin/settings/selectors.js:53
+#: frontend/src/metabase/admin/settings/selectors.js:64
 msgid "Email Address for Help Requests"
 msgstr "客服信箱"
 
-#: frontend/src/metabase/admin/settings/selectors.js:58
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
 msgstr "報表時區"
 
-#: frontend/src/metabase/admin/settings/selectors.js:61
+#: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
 msgstr "資料來源預設時區"
 
@@ -1735,11 +1742,11 @@ msgstr "資料來源預設時區"
 msgid "Select a timezone"
 msgstr "選擇時區"
 
-#: frontend/src/metabase/admin/settings/selectors.js:64
+#: frontend/src/metabase/admin/settings/selectors.js:75
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "並非所有資料庫支持時區設定，部分設定無法生效。"
 
-#: frontend/src/metabase/admin/settings/selectors.js:69
+#: frontend/src/metabase/entities/users/forms.js:34
 msgid "Language"
 msgstr "語系"
 
@@ -1747,64 +1754,64 @@ msgstr "語系"
 msgid "Select a language"
 msgstr "選擇語系"
 
-#: frontend/src/metabase/admin/settings/selectors.js:79
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
 msgstr "匿名跟蹤"
 
-#: frontend/src/metabase/admin/settings/selectors.js:84
+#: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
 msgstr "方便理解的資料表和欄位名稱"
 
-#: frontend/src/metabase/admin/settings/selectors.js:90
+#: frontend/src/metabase/admin/settings/selectors.js:91
 msgid "Only replace underscores and dashes with spaces"
 msgstr "僅用空格替換下劃線(underscores)和短劃線(dashes)"
 
-#: frontend/src/metabase/admin/settings/selectors.js:98
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Enable Nested Queries"
 msgstr "啟用網狀查詢"
 
-#: frontend/src/metabase/admin/settings/selectors.js:109
+#: frontend/src/metabase/admin/settings/selectors.js:110
 msgid "Updates"
 msgstr "更新"
 
-#: frontend/src/metabase/admin/settings/selectors.js:114
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
 msgstr "檢查更新"
 
-#: frontend/src/metabase/admin/settings/selectors.js:125
+#: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
 msgstr "SMTP地址"
 
-#: frontend/src/metabase/admin/settings/selectors.js:133
+#: frontend/src/metabase/admin/settings/selectors.js:134
 msgid "SMTP Port"
 msgstr "SMTP埠"
 
-#: frontend/src/metabase/admin/settings/selectors.js:137
+#: frontend/src/metabase/admin/settings/selectors.js:138
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:47
 msgid "That's not a valid port number"
 msgstr "不是有效的埠"
 
-#: frontend/src/metabase/admin/settings/selectors.js:141
+#: frontend/src/metabase/admin/settings/selectors.js:142
 msgid "SMTP Security"
 msgstr "SMTP安全"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:150
 msgid "SMTP Username"
 msgstr "SMTP使用者名稱"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "SMTP Password"
 msgstr "SMTP密碼"
 
-#: frontend/src/metabase/admin/settings/selectors.js:163
+#: frontend/src/metabase/admin/settings/selectors.js:164
 msgid "From Address"
 msgstr "選擇地址"
 
-#: frontend/src/metabase/admin/settings/selectors.js:176
+#: frontend/src/metabase/admin/settings/selectors.js:178
 msgid "Slack API Token"
 msgstr "Slack API令牌"
 
-#: frontend/src/metabase/admin/settings/selectors.js:178
+#: frontend/src/metabase/admin/settings/selectors.js:180
 msgid "Enter the token you received from Slack"
 msgstr "輸入您從Slack收到的令牌"
 
@@ -1833,8 +1840,10 @@ msgid "Username or DN"
 msgstr "使用者名稱或DN"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:43
+#: frontend/src/metabase/entities/databases/forms.js:61
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:64
-#: frontend/src/metabase/user/components/UserSettings.jsx:65
+#: frontend/src/metabase/user/components/UserSettings.jsx:66
+#: src/metabase/driver/common.clj
 msgid "Password"
 msgstr "密碼設定"
 
@@ -1870,79 +1879,79 @@ msgstr "同步群組成員"
 msgid "Group search base"
 msgstr "使用者群組搜索庫"
 
-#: frontend/src/metabase/admin/settings/selectors.js:199
+#: frontend/src/metabase/admin/settings/selectors.js:201
 msgid "Maps"
 msgstr "地圖"
 
-#: frontend/src/metabase/admin/settings/selectors.js:203
+#: frontend/src/metabase/admin/settings/selectors.js:205
 msgid "Map tile server URL"
 msgstr "地圖貼片伺服器URL"
 
-#: frontend/src/metabase/admin/settings/selectors.js:204
+#: frontend/src/metabase/admin/settings/selectors.js:206
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Metabase預設使用PoenStreet地圖"
 
-#: frontend/src/metabase/admin/settings/selectors.js:209
+#: frontend/src/metabase/admin/settings/selectors.js:211
 msgid "Custom Maps"
 msgstr "自訂地圖"
 
-#: frontend/src/metabase/admin/settings/selectors.js:210
+#: frontend/src/metabase/admin/settings/selectors.js:212
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "新增您自己的GeoJSON檔案以啟用不同的區域地圖可視化"
 
-#: frontend/src/metabase/admin/settings/selectors.js:228
+#: frontend/src/metabase/admin/settings/selectors.js:245
 msgid "Public Sharing"
 msgstr "公開分享"
 
-#: frontend/src/metabase/admin/settings/selectors.js:232
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "Enable Public Sharing"
 msgstr "開啟公開共享"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:254
 msgid "Shared Dashboards"
 msgstr "已共享資訊看板"
 
-#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Shared Questions"
 msgstr "已共享提問"
 
-#: frontend/src/metabase/admin/settings/selectors.js:250
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Embedding in other Applications"
 msgstr "嵌入在其他的應用中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:276
+#: frontend/src/metabase/admin/settings/selectors.js:293
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "啟用將Metabase嵌入到其他應用中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:286
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Embedding secret key"
 msgstr "嵌入密鑰"
 
-#: frontend/src/metabase/admin/settings/selectors.js:292
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Embedded Dashboards"
 msgstr "嵌入的資訊看板"
 
-#: frontend/src/metabase/admin/settings/selectors.js:298
+#: frontend/src/metabase/admin/settings/selectors.js:315
 msgid "Embedded Questions"
 msgstr "嵌入的問題"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:322
 msgid "Caching"
 msgstr "快取中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:326
 msgid "Enable Caching"
 msgstr "啟用快取"
 
-#: frontend/src/metabase/admin/settings/selectors.js:314
+#: frontend/src/metabase/admin/settings/selectors.js:331
 msgid "Minimum Query Duration"
 msgstr "最小查詢週期"
 
-#: frontend/src/metabase/admin/settings/selectors.js:321
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "快取生存時間（TTL）乘數"
 
-#: frontend/src/metabase/admin/settings/selectors.js:328
+#: frontend/src/metabase/admin/settings/selectors.js:345
 msgid "Max Cache Entry Size"
 msgstr "最大快取允許大小"
 
@@ -2109,7 +2118,8 @@ msgstr "此集合中的資訊看板，集合和定時通知也將被歸檔。"
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/routes.jsx:205
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
+#: frontend/src/metabase/routes.jsx:196
 msgid "Archive"
 msgstr "歸檔"
 
@@ -2125,21 +2135,21 @@ msgstr "檢視歸檔"
 msgid "Unarchive this {0}"
 msgstr "取消歸檔此{0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:39
-#: frontend/src/metabase/components/BrowseApp.jsx:102
-#: frontend/src/metabase/components/BrowseApp.jsx:194
+#: frontend/src/metabase/components/BrowseApp.jsx:46
+#: frontend/src/metabase/components/BrowseApp.jsx:112
+#: frontend/src/metabase/components/BrowseApp.jsx:204
 #: frontend/src/metabase/containers/Overworld.jsx:270
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
 msgstr "我們的資料"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:146
+#: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
 msgid "X-ray this table"
 msgstr "透視這個資料表"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:161
+#: frontend/src/metabase/components/BrowseApp.jsx:171
 msgid "Learn about this table"
 msgstr "了解這張資料表"
 
@@ -2234,7 +2244,7 @@ msgstr "固定"
 msgid "Drag something here to pin it to the top"
 msgstr "把東西拖到這裡將它固定在頂部"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:755
+#: frontend/src/metabase/admin/permissions/selectors.js:753
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2287,7 +2297,7 @@ msgstr "新建集合"
 msgid "Copied!"
 msgstr "已複製！"
 
-#: frontend/src/metabase/entities/databases/forms.js:12
+#: frontend/src/metabase/entities/databases/forms.js:14
 msgid "Use an SSH-tunnel for database connections"
 msgstr "為Metabse連接使用SSH通道"
 
@@ -2299,7 +2309,7 @@ msgstr "一些資料庫安裝只有通過SSH通道訪問的伺服器有權訪問
 "當VPN不可用時，這個選項也提供了一個額外的安全層。\n"
 "啟用這個選項，通常比直接連接速度更慢。"
 
-#: frontend/src/metabase/entities/databases/forms.js:212
+#: frontend/src/metabase/entities/databases/forms.js:281
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "這是一個大型資料庫，讓我選擇Metabase同步和掃描的時間"
 
@@ -2309,17 +2319,17 @@ msgid "By default, Metabase does a lightweight hourly sync and an intensive dail
 msgstr "預設情況下，Metabase每小時執行一次輕量級同步，每天執行一次密集掃描。\n"
 "如果您有一個大型資料庫，我們建議啟用此功能並檢視欄位值掃描的發生時間和頻率。"
 
-#: frontend/src/metabase/entities/databases/forms.js:78
+#: frontend/src/metabase/entities/databases/forms.js:113
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0}為您的項目生成使用者端ID和使用者端金鑰。"
 
-#: frontend/src/metabase/entities/databases/forms.js:80
-#: frontend/src/metabase/entities/databases/forms.js:95
-#: frontend/src/metabase/entities/databases/forms.js:131
+#: frontend/src/metabase/entities/databases/forms.js:115
+#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:166
 msgid "Click here"
 msgstr "點擊這裡"
 
-#: frontend/src/metabase/entities/databases/forms.js:83
+#: frontend/src/metabase/entities/databases/forms.js:118
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "選擇“其他”作為應用程式類型。把它命名為您想要的任何東西。"
 
@@ -2327,19 +2337,19 @@ msgstr "選擇“其他”作為應用程式類型。把它命名為您想要的
 msgid "{0} to get an auth code"
 msgstr "{0}獲取身份驗證代碼"
 
-#: frontend/src/metabase/entities/databases/forms.js:107
+#: frontend/src/metabase/entities/databases/forms.js:142
 msgid "with Google Drive permissions"
 msgstr "使用Google Driver權限"
 
-#: frontend/src/metabase/entities/databases/forms.js:129
+#: frontend/src/metabase/entities/databases/forms.js:164
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "要將Metabase用於此資料，您必須在Google Developers Console中啟用API訪問權限。"
 
-#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:165
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "如果您還沒有這樣做，請轉到控制台{0}。"
 
-#: frontend/src/metabase/entities/databases/forms.js:196
+#: frontend/src/metabase/entities/databases/forms.js:265
 msgid "How would you like to refer to this database?"
 msgstr "您想如何使用這個資料庫？"
 
@@ -2348,7 +2358,8 @@ msgstr "您想如何使用這個資料庫？"
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:143
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:70
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:123
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:96
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:126
 #: frontend/src/metabase/setup/components/UserStep.jsx:93
 msgid "Next"
 msgstr "下一步"
@@ -2531,7 +2542,7 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "回溯到一個更早的版本並且{0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:290
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "版本記錄"
@@ -2577,7 +2588,7 @@ msgid "Questions"
 msgstr "問題"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:320
+#: frontend/src/metabase/routes.jsx:311
 msgid "Pulses"
 msgstr "定時任務"
 
@@ -2622,15 +2633,16 @@ msgstr "我們有點失落......"
 msgid "Temporary Password"
 msgstr "臨時密碼"
 
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:207
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:481
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
 msgid "Hide"
 msgstr "隱藏"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:467
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:482
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:471
 msgid "Show"
 msgstr "顯示"
 
@@ -2740,7 +2752,7 @@ msgstr "對不起，您沒有權限看那些東西"
 msgid "Unknown error encountered"
 msgstr "未知錯誤發生了"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/nav/containers/Navbar.jsx:373
 msgid "Create"
 msgstr "建立"
@@ -2753,7 +2765,7 @@ msgstr "建立資訊看板"
 msgid "Table"
 msgstr "表格"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
 msgid "Database"
 msgstr "資料庫"
 
@@ -2773,7 +2785,7 @@ msgstr "嘗試調整篩選器以找到您要搜尋的內容。"
 msgid "View by"
 msgstr "檢視方式"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:122
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:121
 msgid "of"
 msgstr "的"
 
@@ -2800,33 +2812,33 @@ msgstr "分析"
 msgid "Browse all items"
 msgstr "瀏覽所有"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:118
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:117
 msgid "Replace or save as new?"
 msgstr "替換還是儲存為新的？"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:168
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace original question, \"{0}\""
 msgstr "替換原始提問''{0}''"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:172
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:171
 msgid "Save as new question"
 msgstr "儲存為新提問"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:92
 msgid "First, save your question"
 msgstr "首先，儲存您的提問"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:94
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
 msgid "Save question"
 msgstr "儲存提問"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:133
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
 msgid "What is the name of your card?"
 msgstr "這個卡片叫什麼名字？"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
 #: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/entities/questions.js:89
@@ -2842,15 +2854,16 @@ msgstr "這個卡片叫什麼名字？"
 msgid "Description"
 msgstr "敘述"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
 #: frontend/src/metabase/entities/dashboards.js:150
 #: frontend/src/metabase/entities/questions.js:91
 #: frontend/src/metabase/entities/questions.js:107
+#: frontend/src/metabase/entities/snippets.js:31
 msgid "It's optional but oh, so helpful"
 msgstr "這是可選的，但非常有幫助"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:148
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "將這個放到哪個集合中？"
@@ -2867,19 +2880,19 @@ msgstr "項"
 msgid "Undo"
 msgstr "撤銷"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:266
 msgid "Applying Question"
 msgstr "正在使用的提問"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:286
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "That question isn't compatible"
 msgstr "那個提問不相容"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:322
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:309
 msgid "Search for a question"
 msgstr "搜尋提問"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:351
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:343
 msgid "We're not sure if this question is compatible"
 msgstr "我們不確定這個提問是否相容"
 
@@ -2928,25 +2941,23 @@ msgstr "新增一個問題"
 msgid "Add a question to this dashboard"
 msgstr "新增報表到資訊看板"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
 msgid "Add a filter"
 msgstr "新增篩選"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:256
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "參數"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:276
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:280
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
 msgid "Add a text box"
 msgstr "新增文本框"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:320
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:314
 msgid "Move dashboard"
 msgstr "移動資訊看板"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:303
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
 msgid "Edit dashboard"
 msgstr "編輯資訊看板"
 
@@ -2954,11 +2965,11 @@ msgstr "編輯資訊看板"
 msgid "Edit Dashboard Layout"
 msgstr "編輯資訊看板展示"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:371
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:365
 msgid "You are editing a dashboard"
 msgstr "正在編輯資訊看板"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:376
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:370
 msgid "Select the field that should be filtered for each card"
 msgstr "選擇應該在每個卡片中都應該被過濾的欄位"
 
@@ -3046,7 +3057,7 @@ msgstr "此卡沒有可以映射到此參數類型的任何欄位或參數。"
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "此欄位中的值不會與您選擇的任何其他欄位的值重疊。"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:162
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "無可用欄位"
@@ -3114,7 +3125,7 @@ msgstr "接收最新的資料來自"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:329
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
 msgid "Unknown"
 msgstr "未知"
 
@@ -3241,6 +3252,7 @@ msgstr "{0}項已選擇"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 msgid "Unarchive"
 msgstr "取消歸檔"
 
@@ -3333,7 +3345,7 @@ msgid "Longitude"
 msgstr "經度"
 
 #: frontend/src/metabase/lib/core.js:43
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:45
 msgid "Number"
 msgstr "數字"
@@ -3390,7 +3402,7 @@ msgid "User"
 msgstr "使用者"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:211
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
 msgid "Source"
 msgstr "來源"
 
@@ -3431,16 +3443,17 @@ msgid "Score"
 msgstr "分數"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "標題"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
 msgid "Comment"
 msgstr "評論"
 
@@ -3492,9 +3505,9 @@ msgstr "不要包括"
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
 msgstr "Metabase永遠不會獲取此欄位。將此用於敏感或不相關的訊息。"
 
-#: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:300
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/query/description.js:77
+#: frontend/src/metabase/lib/query/description.js:262
+#: frontend/src/metabase/lib/schema_metadata.js:476
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
@@ -3509,8 +3522,7 @@ msgstr "計數"
 msgid "CumulativeCount"
 msgstr "累積計數"
 
-#: frontend/src/metabase/lib/expressions/config.js:9
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:485
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3520,7 +3532,6 @@ msgstr "總和"
 msgid "CumulativeSum"
 msgstr "累積總和"
 
-#: frontend/src/metabase/lib/expressions/config.js:11
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Distinct"
 msgstr "不重複"
@@ -3529,25 +3540,22 @@ msgstr "不重複"
 msgid "StandardDeviation"
 msgstr "標準差"
 
-#: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:494
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "平均值"
 
-#: frontend/src/metabase/lib/expressions/config.js:14
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:539
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "最小值"
 
-#: frontend/src/metabase/lib/expressions/config.js:15
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:548
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:503
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:492
 msgid "Max"
 msgstr "最大值"
 
@@ -3598,54 +3606,66 @@ msgstr "您在想什麼？"
 msgid "What do you want to find out?"
 msgstr "您想找出什麼？"
 
-#: frontend/src/metabase/lib/query.js:298
-#: frontend/src/metabase/lib/schema_metadata.js:466
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:250
+#: frontend/src/metabase/lib/query/description.js:75
+#: frontend/src/metabase/lib/query/description.js:260
+#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "原始資料"
 
-#: frontend/src/metabase/lib/query.js:302
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/query/description.js:79
+#: frontend/src/metabase/lib/query/description.js:264
+#: frontend/src/metabase/lib/schema_metadata.js:521
 msgid "Cumulative count"
 msgstr "累積計數"
 
-#: frontend/src/metabase/lib/query.js:305
+#: frontend/src/metabase/lib/query/description.js:82
+#: frontend/src/metabase/lib/query/description.js:266
 msgid "Average of "
 msgstr "平均值"
 
-#: frontend/src/metabase/lib/query.js:310
+#: frontend/src/metabase/lib/query/description.js:87
+#: frontend/src/metabase/lib/query/description.js:268
 msgid "Distinct values of "
 msgstr "去重複值"
 
-#: frontend/src/metabase/lib/query.js:315
+#: frontend/src/metabase/lib/query/description.js:92
+#: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
 msgstr "標準差"
 
-#: frontend/src/metabase/lib/query.js:320
+#: frontend/src/metabase/lib/query/description.js:97
+#: frontend/src/metabase/lib/query/description.js:272
 msgid "Sum of "
 msgstr "總計"
 
-#: frontend/src/metabase/lib/query.js:325
+#: frontend/src/metabase/lib/query/description.js:102
+#: frontend/src/metabase/lib/query/description.js:274
 msgid "Cumulative sum of "
 msgstr "累積和"
 
-#: frontend/src/metabase/lib/query.js:330
+#: frontend/src/metabase/lib/query/description.js:107
+#: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
 msgstr "最大"
 
-#: frontend/src/metabase/lib/query.js:335
+#: frontend/src/metabase/lib/query/description.js:112
+#: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
 msgstr "最小"
 
-#: frontend/src/metabase/lib/query.js:349
+#: frontend/src/metabase/lib/query/description.js:126
+#: frontend/src/metabase/lib/query/description.js:286
 msgid "Grouped by "
 msgstr "以……分組"
 
-#: frontend/src/metabase/lib/query.js:363
+#: frontend/src/metabase/lib/query/description.js:140
+#: frontend/src/metabase/lib/query/description.js:295
 msgid "Filtered by "
 msgstr "以……篩選"
 
-#: frontend/src/metabase/lib/query.js:392
+#: frontend/src/metabase/lib/query/description.js:169
+#: frontend/src/metabase/lib/query/description.js:320
 msgid "Sorted by "
 msgstr "以……分類"
 
@@ -3657,55 +3677,45 @@ msgstr "真"
 msgid "False"
 msgstr "假"
 
-#: frontend/src/metabase/lib/schema_metadata.js:321
+#: frontend/src/metabase/lib/schema_metadata.js:322
 msgid "Select longitude field"
 msgstr "選擇經度欄位"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:323
 msgid "Enter upper latitude"
 msgstr "輸入緯度上邊界"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:324
 msgid "Enter left longitude"
 msgstr "輸入經度左邊界"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:325
 msgid "Enter lower latitude"
 msgstr "輸入緯度下邊界"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:326
 msgid "Enter right longitude"
 msgstr "輸入經度右邊界"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:539
 #: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:397
-#: frontend/src/metabase/lib/schema_metadata.js:405
-#: frontend/src/metabase/lib/schema_metadata.js:411
-#: frontend/src/metabase/lib/schema_metadata.js:416
-msgid "Is"
-msgstr "是"
-
 #: frontend/src/metabase/lib/schema_metadata.js:362
 #: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:398
 #: frontend/src/metabase/lib/schema_metadata.js:406
 #: frontend/src/metabase/lib/schema_metadata.js:412
-msgid "Is not"
-msgstr "不是"
+#: frontend/src/metabase/lib/schema_metadata.js:417
+msgid "Is"
+msgstr "是"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:417
-msgid "Is empty"
-msgstr "為空"
+#: frontend/src/metabase/lib/schema_metadata.js:413
+msgid "Is not"
+msgstr "不是"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:378
@@ -3714,109 +3724,119 @@ msgstr "為空"
 #: frontend/src/metabase/lib/schema_metadata.js:402
 #: frontend/src/metabase/lib/schema_metadata.js:408
 #: frontend/src/metabase/lib/schema_metadata.js:418
+msgid "Is empty"
+msgstr "為空"
+
+#: frontend/src/metabase/lib/schema_metadata.js:365
+#: frontend/src/metabase/lib/schema_metadata.js:379
+#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:395
+#: frontend/src/metabase/lib/schema_metadata.js:403
+#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:419
 msgid "Not empty"
 msgstr "不為空"
 
-#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:371
 msgid "Equal to"
 msgstr "等於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:372
 msgid "Not equal to"
 msgstr "不等於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Greater than"
 msgstr "大於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Less than"
 msgstr "小於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "介於之間"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:376
 msgid "Greater than or equal to"
 msgstr "大於或等於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Less than or equal to"
 msgstr "小於或等於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
+#: frontend/src/metabase/lib/schema_metadata.js:384
 msgid "Contains"
 msgstr "包含"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:385
 msgid "Does not contain"
 msgstr "不包含"
 
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:388
 msgid "Starts with"
 msgstr "以…開始"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:389
 msgid "Ends with"
 msgstr "以…結束"
 
-#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:399
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "早於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:400
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "晚於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:414
 msgid "Inside"
 msgstr "介於中間"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "只是一個包含資料行的表格，沒有其他操作。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:474
+#: frontend/src/metabase/lib/schema_metadata.js:475
 msgid "Count of rows"
 msgstr "總行數"
 
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:477
 msgid "Total number of rows in the answer."
 msgstr "答案的總資料行數。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Sum of ..."
 msgstr "總和"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:486
 msgid "Sum of all the values of a column."
 msgstr "一個欄位所有數值的總和。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:492
+#: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Average of ..."
 msgstr "平均值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:495
 msgid "Average of all the values of a column"
 msgstr "一個欄位所有數值的平均值。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:501
+#: frontend/src/metabase/lib/schema_metadata.js:502
 msgid "Number of distinct values of ..."
 msgstr "不重複值的總數"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:504
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "一個欄位所有互不重複的值的總數"
 
-#: frontend/src/metabase/lib/schema_metadata.js:510
+#: frontend/src/metabase/lib/schema_metadata.js:511
 msgid "Cumulative sum of ..."
 msgstr "累積求和"
 
@@ -3824,7 +3844,7 @@ msgstr "累積求和"
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "一個欄位所有數值的累積加總。\\\\n比如：隨著時間推移的總收入。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:519
+#: frontend/src/metabase/lib/schema_metadata.js:520
 msgid "Cumulative count of rows"
 msgstr "累積行數"
 
@@ -3832,27 +3852,27 @@ msgstr "累積行數"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "累積的資料行數。\\\\ n比如：隨著時間的推移銷售數量。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:528
+#: frontend/src/metabase/lib/schema_metadata.js:529
 msgid "Standard deviation of ..."
 msgstr "標準差"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:531
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "一個欄位所有數值的標準差。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:537
+#: frontend/src/metabase/lib/schema_metadata.js:538
 msgid "Minimum of ..."
 msgstr "最小值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Minimum value of a column"
 msgstr "一個欄位的最小值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:546
+#: frontend/src/metabase/lib/schema_metadata.js:547
 msgid "Maximum of ..."
 msgstr "最大值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:549
 msgid "Maximum value of a column"
 msgstr "一個欄位的最大值"
 
@@ -4028,7 +4048,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "類別、類型、模型、評分等"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:43
-#: frontend/src/metabase/user/components/UserSettings.jsx:55
+#: frontend/src/metabase/user/components/UserSettings.jsx:56
 msgid "Account settings"
 msgstr "帳號設定"
 
@@ -4040,7 +4060,7 @@ msgstr "退出系統管理"
 msgid "Logs"
 msgstr "日誌"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:103
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:104
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:22
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:65
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:100
@@ -4080,9 +4100,9 @@ msgid "Metabase Admin"
 msgstr "Metabase 系統管理員"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:36
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:36
 msgid "Ask a question"
 msgstr "建立問題"
 
@@ -4103,7 +4123,7 @@ msgstr "參考"
 msgid "Which metric?"
 msgstr "哪個量值？"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "為您的團隊定義共同量值，讓它甚至簡單到可以輕鬆的提問"
 
@@ -4115,7 +4135,7 @@ msgstr "如何建立量值"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "按地圖、趨勢檢視時間維度的資料，方便了解趨勢變化"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:149
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
 msgid "Custom"
 msgstr "自訂"
 
@@ -4128,13 +4148,13 @@ msgstr "新的提問"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "使用簡單的提問建立器來檢視趨勢、欄位表或者事物，或者建立您自己的量值。"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:107
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:110
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "原生查詢"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:108
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:111
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "為了回答更多複雜的提問，您可以寫下您自己的SQL語句或者原生查詢。"
 
@@ -4236,6 +4256,7 @@ msgid "Enter a default value..."
 msgstr "輸入一個預設值……"
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
+#: frontend/src/metabase/containers/Form.jsx:307
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "發生了一個錯誤"
@@ -4483,7 +4504,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "推薦精簡定時任務，方便整個團隊理解和使用。"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:161
-#: frontend/src/metabase/query_builder/components/view/View.jsx:131
+#: frontend/src/metabase/query_builder/components/view/View.jsx:133
 msgid "Pick your data"
 msgstr "選擇您的資料"
 
@@ -4499,47 +4520,47 @@ msgstr "電子郵件"
 msgid "Slack messages"
 msgstr "Slack消息"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:216
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "發送"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:217
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0}將會在……被發送"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:219
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "訊息"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:235
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "現在發送郵件"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:236
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "現在發送郵件給{0}"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:238
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "發送中……"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "發送失敗"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "未發送，因為定時任務沒有結果。"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "定時任務已發送。"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:282
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0}需要被設定成系統管理員"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:295
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:299
 msgid "Slack"
 msgstr "Slack"
 
@@ -4692,7 +4713,7 @@ msgstr "平均"
 msgid "Distincts"
 msgstr "不重複"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:55
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "檢視這個{0}\n"
@@ -4703,11 +4724,12 @@ msgstr[0] "檢視這個{0}\n"
 msgid "Zoom in"
 msgstr "放大"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "自訂表達方式"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Common Metrics"
 msgstr "共同量值"
 
@@ -4904,34 +4926,34 @@ msgstr "通常"
 msgid "Pick a segment or table"
 msgstr "選擇一個區間或者表單"
 
-#: frontend/src/metabase/entities/databases/forms.js:191
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
+#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "選擇一個資料庫"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:94
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:85
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:31
 msgid "Select..."
 msgstr "選擇……"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:134
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
 msgid "Select a table"
 msgstr "選擇一個資料表"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:819
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:926
 msgid "No tables found in this database."
 msgstr "該資料庫未發現資料表"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:856
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:901
 msgid "Is a question missing?"
 msgstr "提問缺失？"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:863
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:909
 msgid "Learn more about nested queries"
 msgstr "了解更多關於嵌套查詢"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:898
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:951
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:40
 msgid "Fields"
 msgstr "欄位"
 
@@ -4965,11 +4987,11 @@ msgstr "排序"
 msgid "Row limit"
 msgstr "行限制"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
 msgid "Unknown Field"
 msgstr "未知欄位"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:75
 msgid "field"
 msgstr "欄位"
 
@@ -4977,19 +4999,20 @@ msgstr "欄位"
 msgid "Matches"
 msgstr "匹配"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:148
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:156
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:135
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "新增篩選條件來縮小您的答案範圍"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:293
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
 msgstr "新增一個聚合"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:37
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:313
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
-#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:66
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:67
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:89
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:131
@@ -5005,16 +5028,16 @@ msgstr "新增一個聚合"
 msgid "Data"
 msgstr "資料"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:340
 msgid "Filtered by"
 msgstr "篩選條件"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:376
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:357
 msgid "View"
 msgstr "檢視"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:393
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:374
 msgid "Grouped By"
 msgstr "分組條件"
 
@@ -5022,7 +5045,7 @@ msgstr "分組條件"
 msgid "None"
 msgstr "沒有"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:471
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
 msgid "This question is written in {0}."
 msgstr "這個提問已經被寫入{0}"
 
@@ -5034,7 +5057,7 @@ msgstr "隱藏編輯器"
 msgid "Hide Query"
 msgstr "隱藏查詢"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:481
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
 msgid "Open Editor"
 msgstr "打開編輯器"
 
@@ -5274,7 +5297,7 @@ msgstr "{0}的去重複值"
 msgid "Number of {0} grouped by {1}"
 msgstr "按{1}分組的{0}計數"
 
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:77
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5333,32 +5356,33 @@ msgstr "檢視{0}的所有原始資料"
 msgid "More"
 msgstr "更多"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:194
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:216
 msgid "Invalid expression"
 msgstr "不可用的表達式"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:269
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:282
 msgid "unknown error"
 msgstr "未知錯誤"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:47
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:53
 msgid "Field formula"
 msgstr "欄位公式"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:60
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:64
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "這有點像在EXCEL表中編寫公式，您可以使用數字，欄位，數學符號和一些函數，例如 Subtotal - Cost。"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:69
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:208
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
 msgid "Learn more"
 msgstr "了解更多"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:77
 msgid "Give it a name"
 msgstr "給它一個名字吧"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:79
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
 msgid "Something nice and descriptive"
 msgstr "一些超棒的、值得記錄的東西"
 
@@ -5438,11 +5462,11 @@ msgid "Enter desired number"
 msgstr "輸入期望值"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:154
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:161
 msgid "Empty"
 msgstr "空的"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:119
 msgid "Find a value"
 msgstr "尋找一個值"
 
@@ -5510,35 +5534,35 @@ msgstr "閱讀完整檔案"
 msgid "Filter label"
 msgstr "過濾標籤"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:135
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:134
 msgid "Variable type"
 msgstr "變數類型"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:143
 msgid "Text"
 msgstr "文本"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
 msgid "Date"
 msgstr "日期"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:147
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
 msgid "Field Filter"
 msgstr "欄位篩選條件"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Field to map to"
 msgstr "欄位對應到"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:180
 msgid "Filter widget type"
 msgstr "篩選器樣式"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:230
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
 msgid "Required?"
 msgstr "必填項？"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:240
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
 msgid "Default filter widget value"
 msgstr "篩選器預設值"
 
@@ -5550,7 +5574,7 @@ msgstr "歸檔提問？"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "這個提問會從已引用的資訊看板或定時任務中移除"
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:158
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
 msgid "Question"
 msgstr "提問"
 
@@ -5720,7 +5744,7 @@ msgid "Details"
 msgstr "相關資訊"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
-#: frontend/src/metabase/reference/databases/TableList.jsx:116
+#: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
 msgstr "{0}中的資料表"
 
@@ -5801,24 +5825,24 @@ msgstr "為什麼這個資料表有趣"
 msgid "Things to be aware of about this table"
 msgstr "關於這個資料表需要知道的事情"
 
-#: frontend/src/metabase/reference/databases/TableList.jsx:30
+#: frontend/src/metabase/reference/databases/TableList.jsx:29
 msgid "Tables in this database will appear here as they're added"
 msgstr "當在這個資料庫中新增資料表時，它們將會出現在這裡"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:34
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:33
 msgid "Questions about this table will appear here as they're added"
 msgstr "當關於這個資料表的提問被新增時，它們將會出現在這裡"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:73
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:77
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:76
 msgid "Questions about {0}"
 msgstr "關於{0}的提問"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
 msgid "Created {0} by {1}"
 msgstr "根據{1}建立{0}"
 
@@ -6007,19 +6031,19 @@ msgstr "您可以通過聚合這個量值形成的其他欄位"
 msgid "Fields you can group this metric by"
 msgstr "您可以通過聚合這個量值得到的欄位"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "量值是您的團隊關心的數值"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Metrics will appear here once your admins have created some"
 msgstr "一但您的系統管理員建立了一些量值的話，它們將會出現在這裡"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:28
 msgid "Learn how to create metrics"
 msgstr "了解如何建立量值"
 
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:34
 msgid "Questions about this metric will appear here as they're added"
 msgstr "新增這個量值的圖表會在這裡顯示。"
 
@@ -6045,23 +6069,23 @@ msgstr "為什麼這個劃分很有意思"
 msgid "Things to be aware of about this Segment"
 msgstr "關於這個劃分的注意事項"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
 msgid "Segments are interesting subsets of tables"
 msgstr "劃分是表格的子集"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "為您的團隊定義公共劃分，讓它用來提問也十分容易"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Segments will appear here once your admins have created some"
 msgstr "您的系統管理員新增後，劃分將會出現在這裡，"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
 msgid "Learn how to create segments"
 msgstr "學習如何建立劃分"
 
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:35
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:34
 msgid "Questions about this segment will appear here as they're added"
 msgstr "當它們被新增時，關於這個劃分的提問將會出現在這裡"
 
@@ -6081,22 +6105,22 @@ msgstr "有關這個劃分的提問"
 msgid "X-ray this segment"
 msgstr "透視這個劃分"
 
-#: frontend/src/metabase/routes.jsx:178 frontend/src/metabase/routes.jsx:179
+#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
 msgid "Login"
 msgstr "登入"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:303
 #: frontend/src/metabase/containers/ItemPicker.jsx:115
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:204
+#: frontend/src/metabase/routes.jsx:195
 msgid "Search"
 msgstr "查詢"
 
-#: frontend/src/metabase/routes.jsx:223
+#: frontend/src/metabase/routes.jsx:214
 msgid "Dashboard"
 msgstr "資訊看板"
 
-#: frontend/src/metabase/routes.jsx:236
+#: frontend/src/metabase/routes.jsx:227
 msgid "New Question"
 msgstr "新提問"
 
@@ -6140,63 +6164,63 @@ msgstr "感謝幫助我們提升"
 msgid "We won't collect any usage events"
 msgstr "我們不會收集任何使用事件訊息"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:88
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "為了提升Metabase的使用者體驗，可能需要通過Google Analytics收集特定的使用資料。"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:90
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Here's a full list of everything we track and why."
 msgstr "這個我們所有我們要收集的清單，以及為什麼要收集"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "允許Metabase匿名收集使用事件"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:113
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase{0}收集任何事情關於您的資料或者提問結果"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:114
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
 msgid "never"
 msgstr "永不"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:119
 msgid "All collection is completely anonymous."
 msgstr "所有的收集都是匿名的。"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "您隨時可以在管理設定中關閉訊息收集。"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:44
+#: frontend/src/metabase/setup/components/Setup.jsx:59
 msgid "If you feel stuck"
 msgstr "如果您不知從何下手"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:49
+#: frontend/src/metabase/setup/components/Setup.jsx:64
 msgid "our getting started guide"
 msgstr "初級上手教學"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:50
+#: frontend/src/metabase/setup/components/Setup.jsx:65
 msgid "is just a click away."
 msgstr "點擊一下"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:92
+#: frontend/src/metabase/setup/components/Setup.jsx:111
 msgid "Welcome to Metabase"
 msgstr "歡迎來到Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:93
+#: frontend/src/metabase/setup/components/Setup.jsx:112
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "看起來一切都在正常工作，現在讓我們了解您吧，連接到您的資料，並且開始尋找一些屬於您的答案！"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:97
+#: frontend/src/metabase/setup/components/Setup.jsx:116
 msgid "Let's get started"
 msgstr "讓我們開始吧"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:142
+#: frontend/src/metabase/setup/components/Setup.jsx:166
 msgid "You're all set up!"
 msgstr "您已經設定完畢了！"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:153
+#: frontend/src/metabase/setup/components/Setup.jsx:177
 msgid "Take me to Metabase"
 msgstr "開始使用Metabase"
 
@@ -6208,13 +6232,13 @@ msgstr "我們應該怎麼稱呼您？"
 msgid "Hi, {0}. nice to meet you!"
 msgstr "您好，{0}很高興見到您！"
 
-#: frontend/src/metabase/entities/users/forms.js:33
+#: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
 msgstr "建立一個密碼"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:44
-#: frontend/src/metabase/entities/users/forms.js:35
-#: frontend/src/metabase/entities/users/forms.js:82
+#: frontend/src/metabase/entities/users/forms.js:50
+#: frontend/src/metabase/entities/users/forms.js:97
 msgid "Shhh..."
 msgstr "噓……"
 
@@ -6222,11 +6246,11 @@ msgstr "噓……"
 msgid "Confirm password"
 msgstr "確認密碼"
 
-#: frontend/src/metabase/entities/users/forms.js:42
+#: frontend/src/metabase/entities/users/forms.js:57
 msgid "Shhh... but one more time so we get it right"
 msgstr "噓……再輸入一次讓我們確保它是對的"
 
-#: frontend/src/metabase/entities/users/forms.js:70
+#: frontend/src/metabase/entities/users/forms.js:85
 msgid "Your company or team name"
 msgstr "您的公司或者團隊名稱"
 
@@ -6395,7 +6419,7 @@ msgstr "密碼成功更新！"
 msgid "Account updated successfully!"
 msgstr "帳戶成功更新！"
 
-#: frontend/src/metabase/entities/users/forms.js:81
+#: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
 msgstr "目前密碼"
 
@@ -6407,7 +6431,7 @@ msgstr "用Google電子郵件地址登入"
 msgid "User Details"
 msgstr "使用者詳情"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:327
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:344
 msgid "Reset to defaults"
 msgstr "恢復預設值"
 
@@ -6432,15 +6456,15 @@ msgstr "橫坐標和縱坐標想使用那些欄位?"
 msgid "Choose fields"
 msgstr "選擇欄位"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:217
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:234
 msgid "Save as default view"
 msgstr "作為預設視圖存儲"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Draw box to filter"
 msgstr "新增篩選器"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Cancel filter"
 msgstr "取消篩選器"
 
@@ -6468,19 +6492,19 @@ msgstr "找不到可視化"
 msgid "Could not display this chart with this data."
 msgstr "無法顯示這個圖表顯示這些資料"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:526
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
 msgid "No results!"
 msgstr "沒有結果！"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:547
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
 msgid "Still Waiting..."
 msgstr "仍然在等待……"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:550
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
 msgid "This usually takes an average of {0}."
 msgstr "這將通常取一個{0}的平均數。"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:556
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
 msgid "(This is a bit long for a dashboard)"
 msgstr "（這對於資訊看板來說有點太長了）"
 
@@ -6639,19 +6663,19 @@ msgstr "新增規則"
 msgid "Update rule"
 msgstr "更新規則"
 
-#: frontend/src/metabase/visualizations/index.js:32
+#: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
 msgstr "可視化是空的"
 
-#: frontend/src/metabase/visualizations/index.js:37
+#: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
 msgstr "可視化圖示必須定義一個作為“標識符”的靜態變數：␣"
 
-#: frontend/src/metabase/visualizations/index.js:43
+#: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
 msgstr "具有該標識符的可視化圖表已經註冊：␣"
 
-#: frontend/src/metabase/visualizations/index.js:71
+#: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
 msgstr "沒有{0}的可視化"
 
@@ -6677,23 +6701,23 @@ msgid "Doh! The data from your query doesn't fit the chosen display choice. This
 msgstr "正在……噢！從您的查詢中獲得的數去並不適合所選的展示選項，這個可視化需要最少資料中的{0}{1}。"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:9
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:117
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:120
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:161
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:169
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:249
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:267
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "欄位"
@@ -6803,83 +6827,83 @@ msgstr "什麼也沒有"
 msgid "Linear Interpolated"
 msgstr "線性插值平滑"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
 msgstr "X軸比例"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
 msgstr "時間序列欄位"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:454
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
 msgid "Linear"
 msgstr "線性"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
 msgid "Power"
 msgstr "勢"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:428
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:445
 msgid "Log"
 msgstr "日誌"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:441
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:430
 msgid "Histogram"
 msgstr "柱狀圖(Histogram)"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
 msgstr "序數"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
 msgstr "Y軸比例"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:462
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
 msgstr "顯示X軸線和標記"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:360
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:468
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:349
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
 msgid "Compact"
 msgstr "壓縮"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:469
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
 msgid "Rotate 45°"
 msgstr "旋轉45°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:459
 msgid "Rotate 90°"
 msgstr "旋轉90°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
 msgid "Show y-axis line and marks"
 msgstr "顯示Y軸線段和標記"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:489
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Auto y-axis range"
 msgstr "自動Y軸範圍"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:533
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:522
 msgid "Use a split y-axis when necessary"
 msgstr "當需要時使用一個分離的Y軸"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:540
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:529
 msgid "Show label on x-axis"
 msgstr "在X軸上呈現標籤"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:546
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:535
 msgid "X-axis label"
 msgstr "X軸標籤"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:555
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:544
 msgid "Show label on y-axis"
 msgstr "在Y軸上呈現標籤"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:561
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:550
 msgid "Y-axis label"
 msgstr "Y軸標籤"
 
@@ -7005,23 +7029,23 @@ msgstr "最小不透明度"
 msgid "Max Zoom"
 msgstr "放到最大"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:231
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:234
 msgid "No relationships found."
 msgstr "沒有發現關聯。"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:269
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:272
 msgid "via {0}"
 msgstr "通過{0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:347
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
 msgid "This {0} is connected to:"
 msgstr "這個{0}連接到"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "Object Detail"
 msgstr "對象細節"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:93
 msgid "object"
 msgstr "對象"
 
@@ -7409,7 +7433,7 @@ msgstr "在{0}中有很多已儲存的問題？建立集合以幫助管理它們
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:149 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -8924,19 +8948,19 @@ msgstr "允許修改集合及其內容"
 msgid "Can view items in this collection"
 msgstr "允許檢視該集合的內容"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:767
+#: frontend/src/metabase/admin/permissions/selectors.js:765
 msgid "Collection Access"
 msgstr "集合的權限"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:841
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "該組有權檢視此集合的至少一個子集合。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:848
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "該組有權編輯此集合的至少一個子集合。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:861
+#: frontend/src/metabase/admin/permissions/selectors.js:859
 msgid "View sub-collections"
 msgstr "檢視子集合"
 
@@ -8944,7 +8968,7 @@ msgstr "檢視子集合"
 msgid "Remember Me"
 msgstr "記住我"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:63
+#: frontend/src/metabase/components/BrowseApp.jsx:73
 msgid "X-ray this schema"
 msgstr "透視這個圖表"
 
@@ -9005,15 +9029,15 @@ msgstr "Metabase無法找到您的搜索結果。"
 msgid "No metrics"
 msgstr "沒有量值"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:31
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:41
 msgid "Aggregations"
 msgstr "聚合"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:32
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:42
 msgid "Operators"
 msgstr "運算符"
 
-#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:30
+#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:35
 msgid "Custom fields"
 msgstr "自訂欄位"
 
@@ -9179,7 +9203,7 @@ msgstr "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
 msgid "toucan_sightings"
 msgstr "toucan_sightings"
 
-#: src/metabase/driver/sparksql.clj
+#: src/metabase/models/collection.clj
 msgid "default"
 msgstr "預設"
 
@@ -9207,10 +9231,10 @@ msgstr "不適用"
 msgid "Windows domain"
 msgstr "Windows域名"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:539
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:545
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:554
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:560
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:528
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:534
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:543
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
 msgstr "標籤"
 
@@ -9245,9 +9269,9 @@ msgstr "分享"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:286
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:294
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:302
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:319
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:324
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
@@ -9262,19 +9286,18 @@ msgstr "分享"
 msgid "Display"
 msgstr "顯示"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:461
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:476
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:502
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:532
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:402
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:465
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:483
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:521
 msgid "Axes"
 msgstr "坐標軸"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:212
-#: frontend/src/metabase/admin/settings/selectors.js:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:219
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:62
 msgid "Formatting"
@@ -9308,7 +9331,7 @@ msgstr "透視"
 msgid "Compare to the rest"
 msgstr "和其餘的比較"
 
-#: frontend/src/metabase/entities/databases/forms.js:16
+#: frontend/src/metabase/entities/databases/forms.js:18
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "使用Java虛擬機時區"
 
@@ -9337,24 +9360,24 @@ msgstr "使用Java虛擬機時區"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "我們現在正在分析資料表和欄位來幫助您探索資料"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
 msgid "Tip: "
 msgstr "提示："
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:237
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
 msgstr "選擇一個統用的類型"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:300
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
 msgid "Field Type"
 msgstr "欄位類型"
 
-#: frontend/src/metabase/admin/routes.jsx:113
+#: frontend/src/metabase/admin/routes.jsx:118
 #: frontend/src/metabase/nav/containers/Navbar.jsx:267
 msgid "Troubleshooting"
 msgstr "錯誤排查"
 
-#: frontend/src/metabase/admin/settings/selectors.js:103
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Enable X-ray features"
 msgstr "開啟透視(X-ray) 功能"
 
@@ -9399,7 +9422,7 @@ msgstr "執行時間(ms)"
 msgid "Currency"
 msgstr "貨幣"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
 msgstr "選擇一個使用者或頻道"
 
@@ -9547,7 +9570,7 @@ msgstr "線條樣式"
 msgid "Show dots on lines"
 msgstr "在線上顯示圓圈"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:348
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
@@ -9561,7 +9584,7 @@ msgstr "哪個軸？"
 msgid "Line + Bar"
 msgstr "線狀圖+條行圖"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
 msgid "line and bar chart"
 msgstr "線狀圖和條型圖"
 
@@ -11008,7 +11031,7 @@ msgstr "該量值如何分布在不同的數字上"
 msgid "Sessions by page where the session began"
 msgstr "會話開始時的頁面會話"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:503
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -11377,7 +11400,7 @@ msgstr "複製該項目"
 msgid "Archive this item"
 msgstr "歸檔該項目"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:331
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:325
 msgid "Duplicate dashboard"
 msgstr "複製資訊看板"
 
@@ -11473,7 +11496,7 @@ msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] "季度"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
@@ -11488,8 +11511,8 @@ msgstr "新的[[this.short-name]]隨著時間的推移"
 msgid "This"
 msgstr "這個"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:97
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:137
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:136
 msgid "Invalid"
 msgstr "無效"
 
@@ -12252,6 +12275,7 @@ msgstr "這是您的 {0} 最近卡片"
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
 msgstr "您可以更詳細一點，或者使用ID？ 找到了符合這些名字的卡片："
 
+#: src/metabase/driver/common/parameters/values.clj
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
 msgstr "卡片 {0} 未找到."
@@ -12360,11 +12384,11 @@ msgstr "失火指令"
 msgid "Archive this?"
 msgstr "將這個歸檔?"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:243
+#: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
 msgstr "了解我們的資料"
 
-#: frontend/src/metabase/entities/databases/forms.js:20
+#: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
 msgstr "連接時使用DNS SRV（域名伺服器）"
 
@@ -12374,7 +12398,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "使用此選項要求提供的主機是一個FQDN。 如果連接到一個Atlas集群，您可能需要啟用此選項。 如果您不知道這意味著什麼，請取消使用該選項。"
 
-#: frontend/src/metabase/entities/databases/forms.js:204
+#: frontend/src/metabase/entities/databases/forms.js:273
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "在進行簡單的過濾和匯總時自動執行查詢"
 
@@ -12398,11 +12422,11 @@ msgstr "所有結果"
 msgid "Our Analytics"
 msgstr "我們的分析"
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:513
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
 msgstr "欄位所有值的加總。\\ ne.x  total revenue over time。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
 msgstr "行數的附加計數。\\ ne.x。總銷售額隨著時間的推移。"
 
@@ -12412,7 +12436,7 @@ msgstr "行數的附加計數。\\ ne.x。總銷售額隨著時間的推移。"
 msgid "Filter"
 msgstr "篩選器"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:50
 msgid "record"
 msgid_plural "records"
 msgstr[0] "記錄"
@@ -12425,27 +12449,27 @@ msgstr "瀏覽資料"
 msgid "Write SQL"
 msgstr "寫SQL"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:83
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
 msgstr "簡單問題查詢"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:84
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:87
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
 msgstr "挑選並瀏覽資料，新增簡單的過濾篩選或聚合摘要, 然後將資料可視化。"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:95
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:98
 msgid "Custom question"
 msgstr "自訂問題查詢"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:96
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:99
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "使用高級查詢編輯器完成關聯, 建立自訂欄位, 實現數學計算等更多進階功能."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Basic Metrics"
 msgstr "基礎量值"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:322
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
 msgid "Custom…"
 msgstr "自訂"
 
@@ -12514,15 +12538,15 @@ msgstr "選擇分組的欄位"
 msgid "Pick your starting data"
 msgstr "選擇您的起始資料"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select None"
 msgstr "全不選"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select All"
 msgstr "全選"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:151
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:152
 msgid "Pick a table..."
 msgstr "選擇資料表…"
 
@@ -12643,15 +12667,15 @@ msgstr "新增量值"
 #: frontend/src/metabase/lib/core.js:137 frontend/src/metabase/lib/core.js:142
 #: frontend/src/metabase/lib/core.js:147 frontend/src/metabase/lib/core.js:152
 #: frontend/src/metabase/lib/core.js:157 frontend/src/metabase/lib/core.js:162
-#: frontend/src/metabase/user/components/UserSettings.jsx:63
+#: frontend/src/metabase/user/components/UserSettings.jsx:64
 msgid "Profile"
 msgstr "基本資料"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:560
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "這通常很快，但現在似乎需要一段時間。"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
 msgid "Combo"
 msgstr "組合(Combo)"
 
@@ -12667,11 +12691,11 @@ msgstr "趨勢(Trend)"
 msgid "Boolean"
 msgstr "布爾值(Boolean)"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:62
 msgid "Unknown Segment"
 msgstr "未知的劃分"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:73
 msgid "Unknown Filter"
 msgstr "未知篩選器"
 
@@ -12801,6 +12825,7 @@ msgstr "使用NEWLY CREATED 類別載入器作為共享上下文類別載入器�
 msgid "Failed to copy file"
 msgstr "複製檔案失敗"
 
+#. check that the URL is valid
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
 msgstr "無效的網站URL: {0}"
@@ -13075,7 +13100,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "選擇需要包含的欄位"
 
-#: frontend/src/metabase/entities/databases/forms.js:205
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "這個選項開啟時，當使用者在檢視表格或圖表時使用“匯總”和“過濾”按鈕進行簡單資料探索時，Metabase將自動執行查詢。 如果查詢此資料庫的速度很慢，可以將該選項關閉。 此設定不會影響資料鑽探或SQL查詢。"
 
@@ -13113,7 +13138,7 @@ msgstr "確定查詢的預期欄位時出錯"
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "無法處理的異常,  希望`catch-exceptions`能夠處理它."
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:125
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
 msgid "Diagnostic Info"
 msgstr "診斷訊息"
 
@@ -13137,11 +13162,11 @@ msgstr "使用Google登入時出現問題。 請與系統管理員聯繫。"
 msgid "Sign in with email"
 msgstr "使用EMail登入"
 
-#: frontend/src/metabase/entities/databases/forms.js:21
+#: frontend/src/metabase/entities/databases/forms.js:23
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "使用此選項要求提供的主機是FQDN。 如果連接到Atlas群集，則可能需要啟用此選項。 如果您不知道這意味著什麼，請取消此功能。"
 
-#: frontend/src/metabase/entities/databases/forms.js:213
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "預設情況下，Metabase每小時執行一次輕量級同步，每天執行一次密集掃描。 如果您有一個大型資料庫，我們建議啟用此功能並檢視欄位值掃描的發生時間和頻率。"
 
@@ -13209,11 +13234,11 @@ msgstr "不包含"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "在使用GUI界面建立的問題中，該欄位將不可見或不可選擇。 在SQL/原生查詢中仍然可以使用。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:512
 msgid "Cumulative sum"
 msgstr "累積和(Cumulative sum)"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Standard deviation"
 msgstr "標準差(Standard deviation)"
 
@@ -13225,23 +13250,23 @@ msgstr "必須至少為{0}個字元"
 msgid "Must be at least {0} characters long"
 msgstr "必須至少為{0}個字元"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:389
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:82
 msgid "Name (required)"
 msgstr "名稱（必填）"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:556
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
 msgid "Run selected text"
 msgstr "執行SQL陳述句"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:557
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
 msgid "Run query"
 msgstr "執行查詢"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(⌘ + enter)"
 msgstr "（command + enter）"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(Ctrl + enter)"
 msgstr "（Ctrl + enter）"
 
@@ -13253,7 +13278,7 @@ msgstr "您的結果將會在這出現"
 msgid "You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question."
 msgstr "除非您單擊“儲存”並選擇替換原始問題，否則您不會對已儲存的問題進行任何更改。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:199
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:200
 msgid "There aren't any filter widgets for this type of field yet."
 msgstr "尚無此類型欄位的篩選控制項。"
 
@@ -13289,19 +13314,19 @@ msgstr "目標線"
 msgid "Trend line"
 msgstr "趨勢線"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:320
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:317
 msgid "Show values on data points"
 msgstr "在資料點上顯示值"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:334
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:325
 msgid "Values to show"
 msgstr "資料值顯示"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:342
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:332
 msgid "As many as can fit nicely"
 msgstr "儘可能地適合"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:343
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
 msgid "All"
 msgstr "全部"
 
@@ -13593,31 +13618,31 @@ msgstr "Numbers"
 msgid "No mappable groups"
 msgstr "No mappable groups"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:107
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
 msgstr "Metabase文件資料"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
 msgstr "包含 troubleshooting guide"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:112
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
 msgid "Post on the Metabase support forum"
 msgstr "問題送出到Metabase支援論壇"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:114
 msgid "A community forum for all things Metabase"
 msgstr "Metabase社區論壇"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:117
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
 msgid "File a bug report"
 msgstr "提交臭蟲報告"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:119
 msgid "Create a GitHub issue (includes the diagnostic info below)"
 msgstr "Create a GitHub issue (includes the diagnostic info below)"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:127
 msgid "Please include these details in support requests. Thank you!"
 msgstr "Please include these details in support requests. Thank you!"
 
@@ -13645,38 +13670,40 @@ msgstr "無結果相符"
 msgid "Submit"
 msgstr "送出"
 
-#: frontend/src/metabase/entities/databases/forms.js:13
+#: frontend/src/metabase/entities/databases/forms.js:15
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host. This option also provides an extra layer of security when a VPN is not available. Enabling this is usually slower than a direct connection."
 msgstr "某些資料庫設定只允許利用SSH連線。此選項可以提供當VPN無法使用時，有額外的安全保障。若啟用此功能將會比直接連線速度慢。"
 
-#: frontend/src/metabase/entities/databases/forms.js:17
+#: frontend/src/metabase/entities/databases/forms.js:19
 msgid "We suggest you leave this off unless you're doing manual timezone casting in many or most of your queries with this data."
 msgstr "建議關閉此選項，除非要手動設定資料庫時區"
 
-#: frontend/src/metabase/entities/databases/forms.js:93
+#: frontend/src/metabase/entities/databases/forms.js:128
 msgid "{0} to get an auth code."
 msgstr "{0} to get an auth code"
 
-#: frontend/src/metabase/entities/databases/forms.js:101
+#: frontend/src/metabase/entities/databases/forms.js:136
+#: src/metabase/models/collection.clj
 msgid "or"
 msgstr "or"
 
-#: frontend/src/metabase/entities/databases/forms.js:159
-#: frontend/src/metabase/entities/databases/forms.js:197
-#: frontend/src/metabase/entities/users/forms.js:44
+#: frontend/src/metabase/entities/databases/forms.js:39
+#: frontend/src/metabase/entities/databases/forms.js:226
+#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "必須"
 
-#: frontend/src/metabase/entities/databases/forms.js:188
+#: frontend/src/metabase/entities/databases/forms.js:257
 msgid "Database type"
 msgstr "資料庫類型"
 
-#: frontend/src/metabase/entities/databases/forms.js:222
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "檢核或更新資料庫 schema 是一個輕量級的動作，大部分情況下，可以設定為每小時同步一次。"
 
-#: frontend/src/metabase/entities/databases/forms.js:230
+#: frontend/src/metabase/entities/databases/forms.js:299
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase 會掃描資料庫中每個欄位的資料值，方便在展示板與提問(查詢)點擊篩選核取方塊。這個動作會有一點耗費系統資源，尤其是資料內容非常大的時候。"
 
@@ -13684,15 +13711,15 @@ msgstr "Metabase 會掃描資料庫中每個欄位的資料值，方便在展示
 msgid "Collection"
 msgstr "Collection"
 
-#: frontend/src/metabase/entities/users/forms.js:40
+#: frontend/src/metabase/entities/users/forms.js:55
 msgid "Confirm your password"
 msgstr "確認您的密碼"
 
-#: frontend/src/metabase/entities/users/forms.js:45
+#: frontend/src/metabase/entities/users/forms.js:60
 msgid "passwords do not match"
 msgstr "密碼不符合"
 
-#: frontend/src/metabase/entities/users/forms.js:71
+#: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
 msgstr "Department of Awesome"
 
@@ -13700,7 +13727,7 @@ msgstr "Department of Awesome"
 #: frontend/src/metabase/lib/core.js:98 frontend/src/metabase/lib/core.js:103
 #: frontend/src/metabase/lib/core.js:108 frontend/src/metabase/lib/core.js:113
 msgid "Financial"
-msgstr "金融"
+msgstr "Financial"
 
 #: frontend/src/metabase/lib/core.js:120 frontend/src/metabase/lib/core.js:125
 #: frontend/src/metabase/lib/core.js:130
@@ -13732,349 +13759,345 @@ msgid "Returns the average of the values in the column."
 msgstr "返回欄位資料的平均值"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:18
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
 msgid "The column whose values to average."
 msgstr "此欄位的值要計算平均"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "start"
 msgstr "開始"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "end"
 msgstr "結束"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
 msgid "Checks a date or numeric column's values to see if they're within the specified range."
 msgstr "檢查欄位資料看看數值是否符合特定範圍"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
 msgstr "評分"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:24
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:98
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
-msgid "condition"
-msgstr "條件"
-
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+msgid "condition"
+msgstr "健康）狀況"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
 msgid "output"
 msgstr "輸出"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
-msgstr "測試案例列表並返回第一個真實案例的對應值，如果不滿足其他條件，則返回一個可選的默認值"
+msgstr "測試案例列表並返回第一個真實案例的對應值，如果不滿足其他條件，則返回一個可選的默認值。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
 msgid "Weight"
 msgstr "重量"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
 msgid "Large"
 msgstr "大"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
-msgid "Medium"
-msgstr "介質"
-
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+msgid "Medium"
+msgstr "中"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
 msgid "Small"
 msgstr "小"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
 msgid "Something that should evaluate to true or false."
 msgstr "某些情況將被評估為真或假"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:54
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "假如進行的條件為真則返回的資料數值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:62
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "value1"
 msgstr "value1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:74
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
 msgid "value2"
 msgstr "value2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Looks at the values in each argument in order and returns the first non-null value for each row"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:56
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
 msgid "Comments"
 msgstr "評論"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
 msgid "Notes"
 msgstr "筆記"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
 msgid "No comments"
 msgstr "沒有評論"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
 msgid "A column or value."
 msgstr "一個欄位或數值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:65
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:77
 msgid "If value1 is empty, value2 gets returned if it's not empty, and so on."
 msgstr "假如 value1 是空的，則返回非空值的 value2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 msgid "Combines two or more strings of text together."
 msgstr "合併兩個或兩個以上的文字"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
 msgid "Last Name"
 msgstr "名字"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 msgid "First Name"
 msgstr "姓氏"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
 msgstr "value2將會加在這個的後面"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
 msgstr "這將會加在 value1的後面"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
 msgid "string1"
 msgstr "string1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
 msgid "string2"
 msgstr "string2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:80
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "檢查 string1 是否含 string2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:284
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
 msgid "Status"
-msgstr "狀態"
+msgstr "Status"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 msgid "Pass"
-msgstr "通過"
+msgstr "Pass"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
 msgstr "字串內容將被檢核"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
 msgid "The string of text to look for."
 msgstr "欲尋找的文字字串"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:90
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:116
 msgid "Returns the count of rows in the source data."
 msgstr "返回原始資料的行數"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Only counts rows where the condition is true."
 msgstr "只計算符合條件為真的資料行數"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:97
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:261
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
 msgid "Subtotal"
-msgstr "小計"
+msgstr "Subtotal"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
 msgid "The additive total of rows across a breakout."
-msgstr "突破中行的累加總數"
+msgstr "The additive total of rows across a breakout"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:110
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
 msgid "The rolling sum of a column across a breakout."
-msgstr "突破中列的滾動總和"
+msgstr "The rolling sum of a column across a breakout"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:113
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:268
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
 msgstr "欲加總之欄位"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
 msgid "The number of distinct values in this column."
 msgstr "此欄位中相異資料的個數"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "The column whose distinct values to count."
 msgstr "計算欄位相異資料個數"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:128
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:145
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:153
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:201
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:274
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
 msgid "text"
-msgstr "文本"
+msgstr "text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:130
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:223
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
 msgid "comparison"
 msgstr "比較"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "假如文字結尾符合對比文字則返回真"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "Appetite"
-msgstr "食慾"
+msgstr "Appetite"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "hungry"
-msgstr "飢餓"
+msgstr "hungry"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 msgid "A column or string of text to check."
 msgstr "欲檢核的欄位或字串"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
 msgid "The string of text that the original text should end with."
 msgstr "原始文字結尾的文字字串"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 msgid "regular_expression"
 msgstr "正則表達式"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:136
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "擷取符合正則表達式的文字或數字資料"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:137
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
 msgid "Address"
-msgstr "地址"
+msgstr "Address"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 msgid "The column or string of text to search though."
 msgstr "欲搜尋的欄位或文字字串"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
 msgid "The regular expression to match."
 msgstr "符合的正則表達式"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the string of text in all lowercase."
 msgstr "返回小寫字串"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:149
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to lowercase."
 msgstr "欄位資料將轉換為小寫"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:154
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 msgid "Removes leading whitespace from a string of text."
 msgstr "刪除字串開頭空白"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:157
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column with values you want to trim."
 msgstr "欲截除的欄位資料"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "Returns the largest value found in the column."
 msgstr "返回此欄位的最大值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
 msgid "Age"
 msgstr "年齡"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:165
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
 msgid "The numeric column whose maximum you want to find."
 msgstr "數值欄位中欲尋找的最大值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:170
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "Returns the smallest value found in the column."
 msgstr "返回此欄位的最小值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
 msgid "Salary"
 msgstr "薪水"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:173
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
 msgid "The numeric column whose minimum you want to find."
 msgstr "數值欄位中欲尋找的最小值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:181
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:242
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
 msgid "position"
 msgstr "位置"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:194
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
 msgid "length"
 msgstr "長度"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:185
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "new_text"
-msgstr "new_text"
+msgstr "新文字"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:187
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
 msgid "Replaces a part of the input text with new text."
 msgstr "以新文字替換部分輸入文字"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:189
 msgid "Order ID"
-msgstr "訂單識別"
+msgstr "訂購ID"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:189
 msgid "Updated Part of ID"
 msgstr "更新部分ID"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
 msgid "The text that will be modified."
 msgstr "文字將被修改"
 
@@ -14090,87 +14113,87 @@ msgstr "欲置換的字元數目"
 msgid "The text to use in the replacement."
 msgstr "欲置換的文字資料"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "Removes trailing whitespace from a string of text."
 msgstr "刪除文字結尾空白"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:210
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "以數字表示返回符合條件的資料行數百分比"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:218
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "假如文字開頭符合比較的文字則返回結果為真"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Course Name"
 msgstr "課程名"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Computer Science"
 msgstr "計算機科學"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
 msgid "The string of text that the original text should start with."
 msgstr "原始文字開頭的字元"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:229
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
 msgid "Calculates the standard deviation of the column."
 msgstr "計算此欄位的標準差"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:230
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
 msgid "Population"
 msgstr "人口"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
 msgid "A numeric column."
 msgstr "數字欄位"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
 msgid "Returns a portion of the supplied text."
 msgstr "返回部分提供的文字"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:241
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:313
 msgid "The text to return a portion of."
 msgstr "此文字返回某部分的"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
 msgid "The position to start copying characters."
 msgstr "開始複製字元的位置"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:245
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
 msgid "The number of characters to return."
 msgstr "欲返回字元的數目"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
 msgid "Adds up all the values of the column."
-msgstr "將列的所有值相加"
+msgstr "將列的所有值相加。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:253
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
 msgid "The numeric column to sum."
 msgstr "數字欄位加總"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
 msgstr "匯總行匹配條件的列中的值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
 msgid "Order Status"
 msgstr "訂單狀態"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
 msgid "Valid"
 msgstr "有效"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "刪除文字開頭及結尾空白"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
 msgid "Returns the string of text in all upper case."
 msgstr "返回大寫文字"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
 msgid "The column with values to convert to upper case."
 msgstr "欄位資料轉換成大寫"
 
@@ -14209,7 +14232,7 @@ msgstr[0] "{0} 數字umbe"
 #: frontend/src/metabase/lib/settings.js:239
 msgid "{0} special character"
 msgid_plural "{0} special characters"
-msgstr[0] "{0} special character"
+msgstr[0] "{0} 特殊的角色"
 
 #: frontend/src/metabase/lib/validate.js:8
 msgid "must be a valid email address"
@@ -14225,41 +14248,41 @@ msgstr "感謝使用 Metabase ！"
 
 #: frontend/src/metabase/public/components/LogoBadge.jsx:20
 msgid "Powered by {0}"
-msgstr "由{0}提供支持"
+msgstr "Powered by {0}"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:191
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
 msgid "To:"
 msgstr "至:"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:40
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
 msgstr "這個提問無法使用，因為它是基於另一個資料庫。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:44
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:43
 msgid "Couldn't find a saved question with that ID number."
 msgstr "無法找到以此ID number儲存的問題(查詢)"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:55
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:54
 msgid "Pick a saved question"
 msgstr "請挑選一個儲存的問題(查詢)"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:57
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:56
 msgid "Pick a different question"
 msgstr "請挑選一個不同的問題(查詢)"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:62
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:61
 msgid "Loading…"
 msgstr "載入中..."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:79
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:78
 msgid "Question #…"
-msgstr "題 ＃…"
+msgstr "題 #…"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:81
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
-msgstr "問題＃{0}"
+msgstr "題 #{0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:115
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
 msgstr "最後編輯 {0}"
 
@@ -14272,11 +14295,11 @@ msgid "Giving a variable the \"Field Filter\" type allows you to link questions 
 msgstr "設定過濾篩選變數來連結到展示板上的相關SQL提問(查詢)的篩選元件。\n"
 "當加入欲篩選欄位時，欄位篩選變數會插入一段SQL語法到視覺查詢建構器所產生的查詢語句"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:131
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
 msgstr "變數名稱"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:217
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:218
 msgid "Filter widget label"
 msgstr "篩選元件標籤"
 
@@ -14308,17 +14331,17 @@ msgstr "欄位開頭"
 msgid "In every table cell"
 msgstr "每一資料表單元格"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:351
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:341
 msgid "Value formatting"
 msgstr "資料格式"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:361
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
 msgid "Full"
 msgstr "充分"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
 msgid "No change from last {0}"
-msgstr "與上一個{0}相比沒有變化"
+msgstr "從上沒有變化 {0}"
 
 #: src/metabase/api/database.clj
 msgid "Connection to ''{0}:{1}'' successful, but could not connect to DB."
@@ -14342,7 +14365,7 @@ msgstr "無法連線至資料庫"
 
 #: src/metabase/api/embed.clj
 msgid "You''re not allowed to specify a value for {0}."
-msgstr "You''re not allowed to specify a value for {0}"
+msgstr "您不允許為 {0}"
 
 #: src/metabase/api/embed.clj
 msgid "You can''t specify a value for {0} if it''s already set in the JWT."
@@ -14362,7 +14385,7 @@ msgstr "搜尋欄位資料錯誤"
 
 #: src/metabase/api/field.clj
 msgid "Error searching for remapping"
-msgstr "Error searching for remapping"
+msgstr "搜索重新映射時出錯"
 
 #: src/metabase/api/session.clj
 msgid "Google Auth token appears to be incorrect. "
@@ -14370,7 +14393,7 @@ msgstr "Google Auth token似乎是錯誤的"
 
 #: src/metabase/api/session.clj
 msgid "Double check that it matches in Google and Metabase."
-msgstr "Double check that it matches in Google and Metabase"
+msgstr "仔細檢查它在Google和Metabase中是否匹配"
 
 #: src/metabase/api/table.clj
 msgid "Everything else"
@@ -14403,7 +14426,7 @@ msgstr "資料庫需要手動更新"
 #. Tell transaction to automatically `.rollback` instead of `.commit` when the transaction finishes
 #: src/metabase/db.clj
 msgid "Set transaction to automatically roll back..."
-msgstr "Set transaction to automatically roll back..."
+msgstr "將交易設置為自動回滾..."
 
 #. Disable auto-commit. This should already be off but set it just to be safe
 #: src/metabase/db.clj
@@ -14416,16 +14439,16 @@ msgstr "以 connection pool 設定預設資料庫連線"
 
 #: src/metabase/db.clj
 msgid "Successfully verified {0} {1} application database connection."
-msgstr "Successfully verified {0} {1} application database connection"
+msgstr "成功驗證 {0} {1} 應用程序數據庫連接"
 
 #. if both of the decoders above fail, then the date string is invalid
 #: src/metabase/driver/common/parameters/dates.clj
 msgid "Don''t know how to parse date param ''{0}'' — invalid format"
-msgstr "Don''t know how to parse date param ''{0}'' — invalid format"
+msgstr "不知道如何解析日期參數 ''{0}'' — 無效的格式"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "The sub-query from referenced question #{0} failed with the following error: {1}"
-msgstr "The sub-query from referenced question #{0} failed with the following error: {1}"
+msgstr "引用問題的子查詢 #{0} 失敗，出現以下錯誤： {1}"
 
 #: src/metabase/driver/mysql.clj
 msgid "WARNING: Metabase only officially supports MySQL {0}/MariaDB {1} and above."
@@ -14505,23 +14528,23 @@ msgstr "設定 {0} 是內部的"
 
 #: src/metabase/plugins.clj
 msgid "Loading local plugin manifest at {0}"
-msgstr "正在{0}加載本地插件清單"
+msgstr "正在加載本地插件清單 {0}"
 
 #: src/metabase/public_settings.clj
 msgid "Google Analytics tracking code."
-msgstr "Google Analytics tracking code."
+msgstr "Google Analytics（分析）跟踪代碼."
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) with {2} Cards via email"
-msgstr "Sending Pulse ({0}: {1}) with {2} Cards via email"
+msgstr "發送脈衝 ({0}: {1}) 與 {2} 通過電子郵件卡"
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) with {2} Cards via Slack"
-msgstr "Sending Pulse ({0}: {1}) with {2} Cards via Slack"
+msgstr "發送脈衝 ({0}: {1}) 與 {2} 通過鬆弛卡"
 
 #: src/metabase/pulse/render.clj
 msgid "Rendering pulse card with chart-type {0} and render-type {1}"
-msgstr "Rendering pulse card with chart-type {0} and render-type {1}"
+msgstr "圖表類型的渲染脈衝卡 {0} 和渲染類型 {1}"
 
 #. TODO  - there is code that calls this in `render.body` regardless of the types of values
 #: src/metabase/pulse/render/datetime.clj
@@ -14558,7 +14581,7 @@ msgstr "清除舊查詢結果快取錯誤"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Caching results for next time for query with hash {0}."
-msgstr "Caching results for next time for query with hash {0}."
+msgstr "下次緩存結果以進行哈希查詢 {0}."
 
 #: src/metabase/query_processor/middleware/cache.clj
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
@@ -14639,4 +14662,483 @@ msgstr "從欄位產生 insights 錯誤"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandonment email!"
-msgstr "發送遺棄電子郵件！"
+msgstr "送出 abandonment email ！"
+
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
+msgstr "您可以創建保存的指標以添加命名指標選項。保存的指標包括聚合類型，聚合字段以及您添加的任何過濾器（可選）。例如，您可以使用它來創建類似於為Orders表計算“平均價格”的官方方法。"
+
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:105
+msgid "Select and add filters to create your new segment."
+msgstr "選擇並添加過濾器以創建新的細分。"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+msgid "Alphabetical"
+msgstr "按字母順序"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+msgid "Smart"
+msgstr "聰明"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+msgid "Column order: {0}"
+msgstr "列順序：{0}"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
+msgid "Unhide all"
+msgstr "全部取消隱藏"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:204
+msgid "Hide all"
+msgstr "全部藏起來"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:206
+msgid "Unhide"
+msgstr "取消隱藏"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:22
+msgid "New metric"
+msgstr "新指標"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:45
+msgid "Create metrics to add them to the Summarize dropdown in the query builder"
+msgstr "創建指標以將其添加到查詢構建器的“匯總”下拉列表中"
+
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:22
+msgid "New segment"
+msgstr "新細分"
+
+#: frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx:71
+msgid "Filter by table"
+msgstr "依表格篩選"
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:64
+msgid "Checking HTTPS..."
+msgstr "正在檢查HTTPS ..."
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:66
+msgid "It looks like HTTPS is not properly configured"
+msgstr "看來HTTPS配置不正確"
+
+#: frontend/src/metabase/admin/settings/selectors.js:57
+msgid "Redirect to HTTPS"
+msgstr "重定向到HTTPS"
+
+#: frontend/src/metabase/admin/settings/selectors.js:219
+msgid "Localization"
+msgstr "本土化"
+
+#: frontend/src/metabase/admin/settings/selectors.js:222
+msgid "Instance language"
+msgstr "實例語言"
+
+#: frontend/src/metabase/admin/settings/selectors.js:237
+msgid "Localization options"
+msgstr "本地化選項"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:51
+msgid "This database doesn't have any tables."
+msgstr "該數據庫沒有任何表。"
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
+msgid "This field only accepts a single value because it's used in a SQL query."
+msgstr "該字段僅接受一個值，因為它在SQL查詢中使用。"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:17
+msgid "Service Accounts"
+msgstr "服務帳號"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:26
+msgid "Metabase connects to Big Query via {0}."
+msgstr "配置數據庫通過{0}連接到Big Query。"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:29
+msgid "Continue using an OAuth application to connect"
+msgstr "繼續使用OAuth應用程序進行連接"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:43
+msgid "We recommend switching to use {0} instead of an OAuth application to connect to BigQuery"
+msgstr "我們建議切換為使用{0}而不是OAuth應用程序來連接到BigQuery"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:48
+msgid "Connect to a Service Account instead"
+msgstr "改為連接到服務帳戶"
+
+#: frontend/src/metabase/entities/databases/forms.js:44
+msgid "invalid JSON"
+msgstr "無效的JSON"
+
+#: frontend/src/metabase/entities/databases/forms.js:50
+msgid "SSH private key"
+msgstr "SSH私鑰"
+
+#: frontend/src/metabase/entities/databases/forms.js:51
+msgid "Paste the contents of your ssh private key here"
+msgstr "將ssh私鑰的內容粘貼到此處"
+
+#: frontend/src/metabase/entities/databases/forms.js:55
+msgid "Passphrase for the SSH private key"
+msgstr "SSH私鑰的密碼"
+
+#: frontend/src/metabase/entities/databases/forms.js:58
+msgid "SSH Authentication"
+msgstr "SSH驗證"
+
+#: frontend/src/metabase/entities/databases/forms.js:60
+msgid "SSH Key"
+msgstr "SSH密鑰"
+
+#: frontend/src/metabase/entities/databases/forms.js:65
+msgid "Server SSL certificate chain"
+msgstr "服務器SSL證書鏈"
+
+#: frontend/src/metabase/entities/databases/forms.js:66
+msgid "Paste the contents of the server's SSL certificate chain here"
+msgstr "在此處粘貼服務器的SSL證書鏈的內容"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:11
+msgid "Paste a connection string"
+msgstr "粘貼連接字符串"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:12
+msgid "Fill out individual fields"
+msgstr "填寫各個字段"
+
+#: frontend/src/metabase/entities/snippets.js:14
+msgid "Enter some SQL here so you can reuse it later"
+msgstr "在此處輸入一些SQL，以便稍後使用"
+
+#: frontend/src/metabase/entities/snippets.js:24
+msgid "Give your snippet a name"
+msgstr "給您的代碼片段起個名字"
+
+#: frontend/src/metabase/entities/snippets.js:25
+msgid "Current Customers"
+msgstr "現有客戶"
+
+#: frontend/src/metabase/entities/snippets.js:30
+msgid "Add a description"
+msgstr "增加一個說明"
+
+#: frontend/src/metabase/entities/users/forms.js:37
+msgid "Use site default"
+msgstr "使用網站默認"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+msgid "find"
+msgstr "找"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+msgid "replace"
+msgstr "更換"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+msgid "The text to find."
+msgstr "要查找的文字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "The text to use as the replacement."
+msgstr "用作替代的文本。"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+msgid "Editing {0}"
+msgstr "編輯{0}"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+msgid "Create your new snippet"
+msgstr "創建您的新片段"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+msgid "Archived snippets"
+msgstr "存檔片段"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+msgid "Snippets are reusable bits of SQL"
+msgstr "片段是SQL的可重用位"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+msgid "Create a snippet"
+msgstr "創建一個片段"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+msgid "Snippets"
+msgstr "片段"
+
+#: frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx:15
+msgid "SQL Snippets"
+msgstr "SQL片段"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:38
+msgid "Your language is set to {0}"
+msgstr "您的語言設置為{0}"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:50
+msgid "What's your preferred language?"
+msgstr "您首選的語言是什麼？"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:54
+msgid "This language will be used throughout Metabase and will be the default for new users."
+msgstr "該語言將在整個Metabase中使用，並將成為新用戶的默認語言。"
+
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:159
+msgid "We filtered out {0} row(s) containing null values."
+msgstr "我們過濾掉包含空值的{0}行。"
+
+#: frontend/src/metabase/visualizations/lib/settings/series.js:133
+msgid "Show values for this series"
+msgstr "顯示該系列的值"
+
+#: src/metabase/api/card.clj
+msgid "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
+msgstr "問題的平均執行持續時間為{0}；使用{1}的“魔術” TTL"
+
+#: src/metabase/api/native_query_snippet.clj
+msgid "A snippet with that name already exists. Please pick a different name."
+msgstr "具有該名稱的代碼段已存在。請選擇其他名稱。"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Metric]"
+msgstr "[未知指標]"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Segment]"
+msgstr "[未知細分]"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error writing error to output stream"
+msgstr "將錯誤寫入輸出流時出錯"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Caught unexpected Exception in streaming response body"
+msgstr "流式響應正文中捕獲了意外的異常"
+
+#: src/metabase/async/streaming_response.clj
+msgid "bound-fn caught unexpected Exception"
+msgstr "bound-fn捕獲了意外的異常"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error determining whether HTTP request was canceled"
+msgstr "確定HTTP請求是否已取消時出錯"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Check cancelation status timed out after {0}"
+msgstr "{0}後檢查取消狀態超時"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Unexpected exception in do-f-async"
+msgstr "do-f-async中發生意外的異常"
+
+#: src/metabase/async/streaming_response.clj src/metabase/server.clj
+msgid "Unexpected exception writing error response"
+msgstr "意外的異常寫入錯誤響應"
+
+#: src/metabase/driver/common.clj
+msgid "Server certificate not trusted - did you specify the correct SSL certificate chain?"
+msgstr "服務器證書不受信任-您是否指定了正確的SSL證書鏈？"
+
+#: src/metabase/driver/common.clj
+msgid "Server appears to require SSL - please enable SSL above"
+msgstr "服務器似乎需要SSL-請在上面啟用SSL"
+
+#: src/metabase/driver/common.clj
+msgid "Username"
+msgstr "用戶名"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Don''t know how to parse parameter of type {0}"
+msgstr "不知道如何解析類型為{0}的參數"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Invalid :card parameter: missing `:card-id`"
+msgstr "：card參數無效：缺少`：card-id`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Unable to resolve Snippet: missing `:snippet-id`"
+msgstr "無法解析代碼段：缺少`：snippet-id`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Snippet {0} {1} not found."
+msgstr "找不到代碼段{0} {1}。"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error determining value for parameter"
+msgstr "確定參數值時出錯"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error building query parameter map"
+msgstr "建立查詢參數圖時出錯"
+
+#: src/metabase/middleware/log.clj
+msgid "ASYNC"
+msgstr "異步"
+
+#: src/metabase/middleware/log.clj
+msgid "{0} ({1} DB calls)"
+msgstr "{0}（{1}個數據庫調用）"
+
+#: src/metabase/middleware/log.clj
+msgid "App DB connections: {0}/{1}"
+msgstr "應用數據庫連接：{0} / {1}"
+
+#: src/metabase/middleware/log.clj
+msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
+msgstr "碼頭線程：{0} / {1}（{2}空閒，{3}排隊）"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} total active threads)"
+msgstr "（{0}個活動線程總數）"
+
+#: src/metabase/middleware/log.clj
+msgid "Queries in flight: {0}"
+msgstr "進行中的查詢：{0}"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} queued)"
+msgstr "（{0}已排隊）"
+
+#: src/metabase/models/collection.clj
+msgid "Collection must be in the same namespace as its parent"
+msgstr "集合必須與其父集合位於同一名稱空間中"
+
+#: src/metabase/models/collection.clj
+msgid "Personal Collections must be in the default namespace"
+msgstr "個人收藏集必須位於默認名稱空間中"
+
+#: src/metabase/models/collection.clj
+msgid "You cannot move a Collection to a different namespace once it has been created."
+msgstr "創建集合後，您無法將其移動到其他名稱空間。"
+
+#: src/metabase/models/collection.clj src/metabase/models/permissions.clj
+msgid "Collection does not exist."
+msgstr "集合不存在。"
+
+#: src/metabase/models/collection.clj
+msgid "A {0} can only go in Collections in the {1} namespace."
+msgstr "{0}只能進入{1}名稱空間的Collections中。"
+
+#: src/metabase/models/database.clj
+msgid "Error sending database deletion notification"
+msgstr "發送數據庫刪除通知時出錯"
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "You cannot update the creator_id of a NativeQuerySnippet."
+msgstr "您無法更新NativeQuerySnippet的creator_id。"
+
+#: src/metabase/models/setting.clj
+msgid "Error fetching value of Setting"
+msgstr "獲取設置值時出錯"
+
+#: src/metabase/public_settings.clj
+msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
+msgstr "Metabase的UI，系統電子郵件，脈沖和警報應使用的語言。"
+
+#: src/metabase/public_settings.clj
+msgid "This is also the default language for all users, which they can change from their own account settings."
+msgstr "這也是所有用戶的默認語言，他們可以從自己的帳戶設置中更改。"
+
+#: src/metabase/public_settings.clj
+msgid "Invalid locale {0}"
+msgstr "無效的語言環境{0}"
+
+#: src/metabase/public_settings.clj
+msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
+msgstr "如果站點URL為HTTPS，則強制所有流量通過重定向使用HTTPS"
+
+#: src/metabase/public_settings.clj
+msgid "Cannot redirect requests to HTTPS unless `site-url` is HTTPS."
+msgstr "除非`site-url`是HTTPS，否則不能將請求重定向到HTTPS。"
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error registering fonts: Metabase will not be able to send Pulses."
+msgstr "註冊字體時出錯：Metabase無法發送Pulse。"
+
+#: src/metabase/pulse/render/png.clj
+msgid "This is a known issue with certain JVMs. See {0} and for more details."
+msgstr "這是某些JVM的已知問題。有關更多詳細信息，請參見{0}。"
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error rendering Pulse"
+msgstr "錯誤呈現脈衝"
+
+#: src/metabase/query_processor/context/default.clj
+msgid "Query timed out after {0}, raising timeout exception."
+msgstr "查詢在{0}之後超時，引發超時異常。"
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "No fields found for table {0}."
+msgstr "找不到表{0}的字段。"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Case"
+msgstr "案件"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Variance of {0}"
+msgstr "{0}的方差"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Median of {0}"
+msgstr "{0}的中位數"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "{0}th percentile of {1}"
+msgstr "{1}的第{0}個百分點"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Not caching results: results are larger than {0} KB"
+msgstr "不緩存結果：結果大於{0} KB"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Cannot cache results: expected byte array, got {0}"
+msgstr "無法緩存結果：預期的字節數組，得到了{0}"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Request is closed; no one to return cached results to"
+msgstr "請求已關閉；沒有人將緩存的結果返回給"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Error attempting to fetch cached results for query with hash {0}"
+msgstr "嘗試獲取哈希值為{0}的查詢的緩存結果時出錯"
+
+#: src/metabase/query_processor/middleware/cache_backend/db.clj
+msgid "Error preparing statement to fetch cached query results"
+msgstr "錯誤準備語句以獲取緩存的查詢結果"
+
+#: src/metabase/query_processor/middleware/catch_exceptions.clj
+msgid "Error processing query: {0}"
+msgstr "處理查詢時出錯：{0}"
+
+#: src/metabase/server.clj
+msgid "Unexpected exception in endpoint"
+msgstr "端點中的意外異常"
+
+#: src/metabase/server.clj
+msgid "Unexpected Exception in API request handler"
+msgstr "API請求處理程序中的異常"
+
+#: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+msgid "Error reducing {0}"
+msgstr "減少{0}時出錯"
+
+#: src/metabase/sync/analyze/fingerprint/insights.clj
+msgid "Error generating timeseries insight keyed by: {0}"
+msgstr "生成時間序列洞察力時出錯，輸入鍵為：{0}"
+
+#: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
+msgstr "{0}的數據庫位置已從“ {1}”更改為“ {2}”。"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Unscheduling task for Database {0}: trigger: {1}"
+msgstr "數據庫{0}的未調度任務：觸發器：{1}"
+
+#: src/metabase/util/schema.clj
+msgid "value must be a keyword or string."
+msgstr "值必須是關鍵字或字符串。"
+
+#: src/metabase/util/schema.clj
+msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
+msgstr "字符串必須是有效的兩個字母的ISO語言或語言國家/地區代碼，例如“ en”或“ en_US”。"

--- a/locales/zh.po
+++ b/locales/zh.po
@@ -14,6 +14,7 @@ msgid "Your database has been added!"
 msgstr "数据库添加成功！"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:28
+#, fuzzy
 msgid "We took a look at your data, and we have some automated explorations that we can show you!"
 msgstr "我们查看了你的数据，有一些自动化的探索，我们可以告诉你！"
 
@@ -30,13 +31,14 @@ msgid "Select a database type"
 msgstr "选择数据库类型"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:411
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:154
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -49,7 +51,7 @@ msgstr "保存"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "为了做一些神奇的事情，Metabase 需要扫描你的数据库。我们将会定期扫描，来保持源数据是最新的。你也可以在周期的扫描之前，手工来控制扫描。"
 
-#: frontend/src/metabase/entities/databases/forms.js:221
+#: frontend/src/metabase/entities/databases/forms.js:290
 msgid "Database syncing"
 msgstr "数据库同步中"
 
@@ -64,7 +66,7 @@ msgstr "这是一个检查数据库模式变化的轻量级的过程，大部分
 msgid "Scan"
 msgstr "扫描"
 
-#: frontend/src/metabase/entities/databases/forms.js:228
+#: frontend/src/metabase/entities/databases/forms.js:297
 msgid "Scanning for Filter Values"
 msgstr "扫描过滤器值"
 
@@ -75,7 +77,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase 可以扫描数据库中每个字段的值, 用以启用查询或仪表板中的选择框过滤器. 当您的数据库较大时, 这可能是一个资源密集型的过程."
 
-#: frontend/src/metabase/entities/databases/forms.js:232
+#: frontend/src/metabase/entities/databases/forms.js:301
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Metabase 应该在什么时候自动扫描缓存的字段值"
 
@@ -97,6 +99,7 @@ msgid "Never, I'll do this manually if I need to"
 msgstr "不用，如果需要我会手动执行"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 msgid "Saving..."
@@ -133,9 +136,9 @@ msgid "in this box:"
 msgstr "在这个框里:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:75
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
@@ -152,18 +155,18 @@ msgstr "在这个框里:"
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:301
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:39
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:90
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:99
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:311
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:328
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "取消"
@@ -180,7 +183,7 @@ msgstr "删除"
 #: frontend/src/metabase/admin/permissions/selectors.js:323
 #: frontend/src/metabase/admin/permissions/selectors.js:330
 #: frontend/src/metabase/admin/permissions/selectors.js:441
-#: frontend/src/metabase/admin/routes.jsx:57
+#: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
@@ -200,9 +203,10 @@ msgid "Scheduling"
 msgstr "调度"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:71
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
@@ -210,8 +214,8 @@ msgid "Save changes"
 msgstr "保存修改"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:203
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:35
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
 msgstr "动作"
 
@@ -223,8 +227,8 @@ msgstr "开始同步数据库模式"
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:90
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:98
 msgid "Starting…"
 msgstr "开始..."
 
@@ -242,13 +246,13 @@ msgstr "现在重新扫描字段值"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
 msgstr "无法开始扫描"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:92
 msgid "Scan triggered!"
 msgstr "扫描已触发！"
 
@@ -271,15 +275,15 @@ msgid "Add database"
 msgstr "添加数据库"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:28
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:28
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
 #: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:195
+#: frontend/src/metabase/entities/databases/forms.js:264
 #: frontend/src/metabase/entities/questions.js:86
 #: frontend/src/metabase/entities/questions.js:102
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
@@ -319,6 +323,7 @@ msgstr "保存成功！"
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:285
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "编辑"
@@ -361,44 +366,43 @@ msgstr "失败"
 msgid "Success"
 msgstr "成功"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:86
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:185
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "预览"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:93
 msgid "No column description yet"
 msgstr "暂无列描述"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:127
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:126
 msgid "Select a field visibility"
 msgstr "选择字段可见性"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:187
 msgid "No special type"
 msgstr "无指定类型"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
 #: frontend/src/metabase/lib/core.js:275
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:44
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:37
 msgid "Other"
 msgstr "其他"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:221
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "选择指定类型"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:255
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:262
 #: frontend/src/metabase/reference/components/Field.jsx:99
 msgid "Select a target"
 msgstr "选择目标"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
@@ -406,18 +410,18 @@ msgstr "选择目标"
 msgid "Columns"
 msgstr "字段"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "字段"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:144
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:288
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
 msgid "Visibility"
 msgstr "可见性"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
 msgid "Type"
 msgstr "类型"
 
@@ -425,7 +429,7 @@ msgstr "类型"
 msgid "Current database:"
 msgstr "当前数据库"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
 msgid "Show original schema"
 msgstr "查看原始格式"
 
@@ -446,27 +450,27 @@ msgid "{0} schema"
 msgid_plural "{0} schemas"
 msgstr[0] "{0} 结构"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:99
 msgid "Why Hide?"
 msgstr "为什么隐藏？"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:100
 msgid "Technical Data"
 msgstr "技术数据"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
 msgstr "不相关"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 msgid "Queryable"
 msgstr "可查询"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:108
 msgid "Hidden"
 msgstr "已隐藏"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136
 msgid "No table description yet"
 msgstr "暂无表格描述"
 
@@ -474,30 +478,31 @@ msgstr "暂无表格描述"
 msgid "Metadata Strength"
 msgstr "元数据完整度"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0}可查询表格"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:91
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0}隐藏表格"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:115
 msgid "Find a table"
 msgstr "查找表格"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:128
 msgid "Schemas"
 msgstr "表结构"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:838
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:21
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:43
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:62
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 msgid "Metrics"
 msgstr "指标"
@@ -506,8 +511,8 @@ msgstr "指标"
 msgid "Add a Metric"
 msgstr "添加指标"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "定义"
@@ -516,12 +521,12 @@ msgstr "定义"
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "创建指标并添加到查询设计器的视图下拉列表"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:21
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
 #: frontend/src/metabase/home/containers/SearchApp.jsx:72
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:961
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:61
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "过滤器"
@@ -530,35 +535,35 @@ msgstr "过滤器"
 msgid "Add a Segment"
 msgstr "添加过滤器"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:51
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:45
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "创建过滤器并添加到查询设计器的筛选下拉列表"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:21
 msgid "created"
 msgstr "已创建"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "reverted to a previous version"
 msgstr "恢复到前一个版本"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:30
 msgid "edited the title"
 msgstr "编辑标题"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:32
 msgid "edited the description"
 msgstr "编辑描述"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:34
 msgid "edited the "
 msgstr "编辑 "
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:40
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "made some changes"
 msgstr "做了一些改动"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
 #: frontend/src/metabase/home/components/Activity.jsx:83
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
@@ -568,84 +573,84 @@ msgstr "您"
 msgid "Datamodel"
 msgstr "数据模型"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:41
 msgid " History"
 msgstr " 历史"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
 msgstr "历史版本"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:228
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
 msgid "{0} – Field Settings"
 msgstr "{0} - 字段设置"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:289
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
 msgid "Where this field will appear throughout Metabase"
 msgstr "这些字段将在哪里显示？"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:311
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
 msgid "Filtering on this field"
 msgstr "字段过滤"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:312
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "当在过滤器中使用此字段时，人们应该使用什么形式输入他们想要过滤的值?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:437
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
 msgid "No description for this field yet"
 msgstr "暂无筛选条件描述"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
 msgid "Original value"
 msgstr "原始值"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:390
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
 msgid "Mapped value"
 msgstr "映射值"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
 msgid "Enter value"
 msgstr "输入值"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:25
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use original value"
 msgstr "使用原始值"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Use foreign key"
 msgstr "使用外键"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 msgid "Custom mapping"
 msgstr "自定义映射"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
 msgid "Unrecognized mapping type"
 msgstr "无法识别的映射类型"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:89
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "当前字段不是外键或者缺少外键关联表元数据"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
 msgid "The selected field isn't a foreign key"
 msgstr "选中的字段不是外键"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:327
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
 msgid "Display values"
 msgstr "显示值"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:328
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "选择显示数据库中的原始值，或者显示此字段的关联或自定义信息。"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:278
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
 msgid "Choose a field"
 msgstr "选择字段"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:299
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
 msgid "Please select a column to use for display."
 msgstr "请选择显示字段"
 
@@ -653,16 +658,16 @@ msgstr "请选择显示字段"
 msgid "Tip:"
 msgstr "提示："
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:443
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "你可能想要更新这个字段的名称来确保它基于你的重新映射选择时仍然有意义"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:344
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "缓存字段值"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:345
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase 通过扫描该字段，以启用仪表盘和问题的多选框筛选。"
 
@@ -671,53 +676,53 @@ msgid "Re-scan this field"
 msgstr "重新扫描该字段"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
 msgstr "丢弃字段缓存"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
 msgstr "丢弃字段值失败"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 msgid "Discard triggered!"
 msgstr "丢弃处理已经触发！"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "选择任意表单来显示它的所有模式并且添加或删除元数据"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:36
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "名称必填"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:39
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "描述必填"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:43
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "调整信息必填"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
 msgid "Aggregation is required"
 msgstr "聚合信息必填"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Edit Your Metric"
 msgstr "编辑指标"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:142
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
 msgid "Create Your Metric"
 msgstr "创建指标"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "修改指标并留下简要说明。"
 
@@ -725,62 +730,62 @@ msgstr "修改指标并留下简要说明。"
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "你能够创造已存储的指标来添加一个已经命名的指标选项到这个表单。存储刻度包括你添加的聚合类型，聚合字段和可选的任何筛选项。举个例子，你可能使用这个来为一个订单表单创造一些像是“平均价”的官方计算方法，"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:180
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
 msgid "Result: "
 msgstr "结果： "
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:189
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
 msgid "Name Your Metric"
 msgstr "命名你的指标"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:190
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Give your metric a name to help others find it."
 msgstr "为指标命名，方便其他人查找。"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:194
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:152
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "简短的描述"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:198
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
 msgid "Describe Your Metric"
 msgstr "描述你的指标"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:199
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "描述指标，方便其他人理解。"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:203
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "在这里详细描述指标，比如不太明显的规则"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:207
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:165
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "变更的原因"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:209
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "留言以说明您所做的更改以及为何需要这些更改。"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:213
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "这将显示在此指标的修订历史记录中，以帮助每个人记住事情发生变化的原因"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
 msgstr "至少需要一个筛选条件"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
 msgstr "编辑划分"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
 msgstr "创建划分"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "更改划分，并描述变动内容。"
 
@@ -788,33 +793,33 @@ msgstr "更改划分，并描述变动内容。"
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "选择并添加筛选条件以为{0}表创建新段"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
 msgstr "命名划分"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:148
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
 msgstr "命名划分方便其他人查找"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:156
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
 msgstr "描述划分"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "描述划分，方便其他人理解。"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "在这里详细描述划分，比如不太明显的规则"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "这将显示在过滤器的修订历史记录中，以帮助每个人记住事情发生变化的原因"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
-#: frontend/src/metabase/admin/routes.jsx:132
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:215
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
+#: frontend/src/metabase/admin/routes.jsx:137
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
@@ -822,11 +827,11 @@ msgstr "这将显示在过滤器的修订历史记录中，以帮助每个人记
 msgid "Settings"
 msgstr "设置"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase扫描此表中的值以启用仪表板和问题中的复选框过滤器。"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
 msgstr "刷新表格"
 
@@ -840,11 +845,11 @@ msgstr "添加"
 msgid "Not a valid formatted email address"
 msgstr "非法的email地址"
 
-#: frontend/src/metabase/entities/users/forms.js:12
+#: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
 msgstr "名"
 
-#: frontend/src/metabase/entities/users/forms.js:18
+#: frontend/src/metabase/entities/users/forms.js:20
 msgid "Last name"
 msgstr "姓"
 
@@ -883,10 +888,10 @@ msgstr "组员"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
-#: frontend/src/metabase/admin/settings/selectors.js:120
-#: frontend/src/metabase/entities/users/forms.js:24
+#: frontend/src/metabase/admin/settings/selectors.js:121
+#: frontend/src/metabase/entities/users/forms.js:26
 #: frontend/src/metabase/lib/core.js:146
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:294
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:298
 msgid "Email"
 msgstr "邮箱"
 
@@ -895,14 +900,14 @@ msgid "A group is only as good as its members."
 msgstr "组内成员权限一致"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
-#: frontend/src/metabase/admin/routes.jsx:52
+#: frontend/src/metabase/admin/routes.jsx:55
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Admin"
 msgstr "管理员"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:241
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:299
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:288
 msgid "and"
 msgstr "和"
 
@@ -953,12 +958,12 @@ msgstr "移除分组"
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:42
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:294
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:397
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:317
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:334
 msgid "Done"
 msgstr "完成"
 
@@ -969,8 +974,9 @@ msgstr "分组名称"
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
-#: frontend/src/metabase/admin/routes.jsx:92
+#: frontend/src/metabase/admin/routes.jsx:97
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "分组"
 
@@ -1000,7 +1006,7 @@ msgstr "停用"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:21
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
-#: frontend/src/metabase/admin/routes.jsx:88
+#: frontend/src/metabase/admin/routes.jsx:93
 #: frontend/src/metabase/nav/containers/Navbar.jsx:235
 msgid "People"
 msgstr "人员"
@@ -1311,25 +1317,25 @@ msgstr "查看集合"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:542
+#: frontend/src/metabase/admin/permissions/selectors.js:558
 msgid "Data Access"
 msgstr "允许访问数据"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:667
-#: frontend/src/metabase/admin/permissions/selectors.js:672
+#: frontend/src/metabase/admin/permissions/selectors.js:665
+#: frontend/src/metabase/admin/permissions/selectors.js:670
 msgid "View tables"
 msgstr "查看表格"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:608
+#: frontend/src/metabase/admin/permissions/selectors.js:606
 msgid "SQL Queries"
 msgstr "SQL查询"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:678
+#: frontend/src/metabase/admin/permissions/selectors.js:676
 msgid "View schemas"
 msgstr "查看架构"
 
-#: frontend/src/metabase/admin/routes.jsx:63
+#: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
 msgstr "数据模型"
@@ -1359,20 +1365,24 @@ msgid "Allows users within your LDAP directory to log in to Metabase with their 
 msgstr "允许LDAP目录中的用户使用他们的LDAP凭证登录到Metabase，并且允许自动同步LDAP组的数据到Metabase中来。"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:19
-#: frontend/src/metabase/admin/settings/selectors.js:167
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
+#: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
 msgstr "这不是有效的电子邮件地址"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
 msgstr "那不是一个有效的整数"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
 msgstr "更改已保存！"
 
-#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:178
+#: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
 msgid "Looks like we ran into some problems"
 msgstr "看起来我们遇到了一些问题"
 
@@ -1394,7 +1404,7 @@ msgstr "完成"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:195
+#: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "认证"
 
@@ -1446,15 +1456,15 @@ msgstr "你的Google客户端ID"
 msgid "Allow users to sign up on their own if their Google account email address is from:"
 msgstr "允许用户用他们自己的邮箱注册，如果他们的Google账户地址来自："
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:242
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:249
 msgid "Answers sent right to your Slack #channels"
 msgstr "答案发送到您的Slack #channels"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:251
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:258
 msgid "Create a Slack Bot User for MetaBot"
 msgstr "为MetaBot创建一个Slack Bot用户"
 
-#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:261
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:268
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "进入后，请为其命名并单击{0}。然后将Bot API令牌复制并粘贴到下面的字段中。完成后，在Slack中创建“metabase_files”通道。Metabase需要这个来上传图表。"
 
@@ -1467,8 +1477,8 @@ msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Metabase {0}可更新。你正在运行是{1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:41
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 msgid "Update"
 msgstr "更新"
 
@@ -1495,16 +1505,16 @@ msgstr "删除自定义地图"
 #: frontend/src/metabase/containers/Overworld.jsx:293
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
 #: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:115
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "删除"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:165
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:141
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
 msgstr "选择"
 
@@ -1687,48 +1697,46 @@ msgid "Generate Key"
 msgstr "生成秘钥"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:87
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:18
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enabled"
 msgstr "生效"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:92
-#: frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx:19
+#: frontend/src/metabase/admin/settings/selectors.js:93
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "取消"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:112
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:113
 msgid "Unknown setting {0}"
 msgstr "未知设置{0}"
 
-#: frontend/src/metabase/admin/settings/selectors.js:34
+#: frontend/src/metabase/admin/settings/selectors.js:37
 msgid "Setup"
 msgstr "初始化"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:207
-#: frontend/src/metabase/admin/settings/selectors.js:39
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:214
+#: frontend/src/metabase/admin/settings/selectors.js:42
 msgid "General"
 msgstr "基本设置"
 
-#: frontend/src/metabase/admin/settings/selectors.js:43
+#: frontend/src/metabase/admin/settings/selectors.js:46
 msgid "Site Name"
 msgstr "网站名称"
 
-#: frontend/src/metabase/admin/settings/selectors.js:48
+#: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Site URL"
 msgstr "网站地址"
 
-#: frontend/src/metabase/admin/settings/selectors.js:53
+#: frontend/src/metabase/admin/settings/selectors.js:64
 msgid "Email Address for Help Requests"
 msgstr "客服邮箱"
 
-#: frontend/src/metabase/admin/settings/selectors.js:58
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
 msgstr "报表时区"
 
-#: frontend/src/metabase/admin/settings/selectors.js:61
+#: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
 msgstr "数据源默认时区"
 
@@ -1736,11 +1744,11 @@ msgstr "数据源默认时区"
 msgid "Select a timezone"
 msgstr "选择时区"
 
-#: frontend/src/metabase/admin/settings/selectors.js:64
+#: frontend/src/metabase/admin/settings/selectors.js:75
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "并非所有数据库支持时区，部分设置无法生效。"
 
-#: frontend/src/metabase/admin/settings/selectors.js:69
+#: frontend/src/metabase/entities/users/forms.js:34
 msgid "Language"
 msgstr "语言"
 
@@ -1748,64 +1756,64 @@ msgstr "语言"
 msgid "Select a language"
 msgstr "选择语言"
 
-#: frontend/src/metabase/admin/settings/selectors.js:79
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
 msgstr "匿名跟踪"
 
-#: frontend/src/metabase/admin/settings/selectors.js:84
+#: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
 msgstr "友好的表单和字段名称"
 
-#: frontend/src/metabase/admin/settings/selectors.js:90
+#: frontend/src/metabase/admin/settings/selectors.js:91
 msgid "Only replace underscores and dashes with spaces"
 msgstr "仅用空格替换下划线和短划线"
 
-#: frontend/src/metabase/admin/settings/selectors.js:98
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Enable Nested Queries"
 msgstr "启用网状查询"
 
-#: frontend/src/metabase/admin/settings/selectors.js:109
+#: frontend/src/metabase/admin/settings/selectors.js:110
 msgid "Updates"
 msgstr "更新"
 
-#: frontend/src/metabase/admin/settings/selectors.js:114
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
 msgstr "检查更新"
 
-#: frontend/src/metabase/admin/settings/selectors.js:125
+#: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
 msgstr "SMTP地址"
 
-#: frontend/src/metabase/admin/settings/selectors.js:133
+#: frontend/src/metabase/admin/settings/selectors.js:134
 msgid "SMTP Port"
 msgstr "SMTP端口"
 
-#: frontend/src/metabase/admin/settings/selectors.js:137
+#: frontend/src/metabase/admin/settings/selectors.js:138
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:47
 msgid "That's not a valid port number"
 msgstr "不是有效的端口"
 
-#: frontend/src/metabase/admin/settings/selectors.js:141
+#: frontend/src/metabase/admin/settings/selectors.js:142
 msgid "SMTP Security"
 msgstr "SMTP安全"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:150
 msgid "SMTP Username"
 msgstr "SMTP用户名"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "SMTP Password"
 msgstr "SMTP密码"
 
-#: frontend/src/metabase/admin/settings/selectors.js:163
+#: frontend/src/metabase/admin/settings/selectors.js:164
 msgid "From Address"
 msgstr "选择地址"
 
-#: frontend/src/metabase/admin/settings/selectors.js:176
+#: frontend/src/metabase/admin/settings/selectors.js:178
 msgid "Slack API Token"
 msgstr "Slack API令牌"
 
-#: frontend/src/metabase/admin/settings/selectors.js:178
+#: frontend/src/metabase/admin/settings/selectors.js:180
 msgid "Enter the token you received from Slack"
 msgstr "输入您从Slack收到的令牌"
 
@@ -1834,8 +1842,10 @@ msgid "Username or DN"
 msgstr "用户名或DN"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:43
+#: frontend/src/metabase/entities/databases/forms.js:61
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:64
-#: frontend/src/metabase/user/components/UserSettings.jsx:65
+#: frontend/src/metabase/user/components/UserSettings.jsx:66
+#: src/metabase/driver/common.clj
 msgid "Password"
 msgstr "密码"
 
@@ -1871,79 +1881,79 @@ msgstr "同步组成员"
 msgid "Group search base"
 msgstr "用户组搜索库"
 
-#: frontend/src/metabase/admin/settings/selectors.js:199
+#: frontend/src/metabase/admin/settings/selectors.js:201
 msgid "Maps"
 msgstr "地图"
 
-#: frontend/src/metabase/admin/settings/selectors.js:203
+#: frontend/src/metabase/admin/settings/selectors.js:205
 msgid "Map tile server URL"
 msgstr "地图贴片服务器URL"
 
-#: frontend/src/metabase/admin/settings/selectors.js:204
+#: frontend/src/metabase/admin/settings/selectors.js:206
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Metabase默认使用PoenStreet地图"
 
-#: frontend/src/metabase/admin/settings/selectors.js:209
+#: frontend/src/metabase/admin/settings/selectors.js:211
 msgid "Custom Maps"
 msgstr "自定义地图"
 
-#: frontend/src/metabase/admin/settings/selectors.js:210
+#: frontend/src/metabase/admin/settings/selectors.js:212
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "添加您自己的GeoJSON文件以启用不同的区域地图可视化"
 
-#: frontend/src/metabase/admin/settings/selectors.js:228
+#: frontend/src/metabase/admin/settings/selectors.js:245
 msgid "Public Sharing"
 msgstr "公开分享"
 
-#: frontend/src/metabase/admin/settings/selectors.js:232
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "Enable Public Sharing"
 msgstr "开启公开共享"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:254
 msgid "Shared Dashboards"
 msgstr "已共享仪表盘"
 
-#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Shared Questions"
 msgstr "已共享提问"
 
-#: frontend/src/metabase/admin/settings/selectors.js:250
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Embedding in other Applications"
 msgstr "嵌入在其他的应用中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:276
+#: frontend/src/metabase/admin/settings/selectors.js:293
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "启用将Metabase嵌入到其他应用中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:286
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Embedding secret key"
 msgstr "嵌入秘钥"
 
-#: frontend/src/metabase/admin/settings/selectors.js:292
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Embedded Dashboards"
 msgstr "嵌入的仪表板"
 
-#: frontend/src/metabase/admin/settings/selectors.js:298
+#: frontend/src/metabase/admin/settings/selectors.js:315
 msgid "Embedded Questions"
 msgstr "嵌入的问题"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:322
 msgid "Caching"
 msgstr "缓存中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:326
 msgid "Enable Caching"
 msgstr "启用缓存"
 
-#: frontend/src/metabase/admin/settings/selectors.js:314
+#: frontend/src/metabase/admin/settings/selectors.js:331
 msgid "Minimum Query Duration"
 msgstr "最小查询周期"
 
-#: frontend/src/metabase/admin/settings/selectors.js:321
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "缓存生存时间（TTL）乘数"
 
-#: frontend/src/metabase/admin/settings/selectors.js:328
+#: frontend/src/metabase/admin/settings/selectors.js:345
 msgid "Max Cache Entry Size"
 msgstr "最大缓存允许大小"
 
@@ -2110,7 +2120,8 @@ msgstr "此集合中的仪表板，集合和定时通知也将被归档。"
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/routes.jsx:205
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
+#: frontend/src/metabase/routes.jsx:196
 msgid "Archive"
 msgstr "归档"
 
@@ -2126,21 +2137,21 @@ msgstr "查看归档"
 msgid "Unarchive this {0}"
 msgstr "取消归档此{0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:39
-#: frontend/src/metabase/components/BrowseApp.jsx:102
-#: frontend/src/metabase/components/BrowseApp.jsx:194
+#: frontend/src/metabase/components/BrowseApp.jsx:46
+#: frontend/src/metabase/components/BrowseApp.jsx:112
+#: frontend/src/metabase/components/BrowseApp.jsx:204
 #: frontend/src/metabase/containers/Overworld.jsx:270
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
 msgstr "我们的数据"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:146
+#: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
 msgid "X-ray this table"
 msgstr "透视这个数据表单"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:161
+#: frontend/src/metabase/components/BrowseApp.jsx:171
 msgid "Learn about this table"
 msgstr "了解这张数据表"
 
@@ -2235,7 +2246,7 @@ msgstr "固定"
 msgid "Drag something here to pin it to the top"
 msgstr "把东西拖到这里将它固定在顶部"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:755
+#: frontend/src/metabase/admin/permissions/selectors.js:753
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2288,7 +2299,7 @@ msgstr "新建集合"
 msgid "Copied!"
 msgstr "已复制！"
 
-#: frontend/src/metabase/entities/databases/forms.js:12
+#: frontend/src/metabase/entities/databases/forms.js:14
 msgid "Use an SSH-tunnel for database connections"
 msgstr "为Metabse连接使用SSH通道"
 
@@ -2300,7 +2311,7 @@ msgstr "一些数据库安装只有通过SSH通道访问的服务器有权访问
 "当VPN不可用时，这个选项也提供了一个额外的安全层。\n"
 "启用这个选项，通常比直接连接速度更慢。"
 
-#: frontend/src/metabase/entities/databases/forms.js:212
+#: frontend/src/metabase/entities/databases/forms.js:281
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "这是一个大型数据库，让我选择Metabase同步和扫描的时间"
 
@@ -2310,17 +2321,17 @@ msgid "By default, Metabase does a lightweight hourly sync and an intensive dail
 msgstr "默认情况下，Metabase每小时执行一次轻量级同步，每天执行一次密集扫描。\n"
 "如果您有一个大型数据库，我们建议启用此功能并查看字段值扫描的发生时间和频率。"
 
-#: frontend/src/metabase/entities/databases/forms.js:78
+#: frontend/src/metabase/entities/databases/forms.js:113
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0}为您的项目生成客户端ID和客户端密钥。"
 
-#: frontend/src/metabase/entities/databases/forms.js:80
-#: frontend/src/metabase/entities/databases/forms.js:95
-#: frontend/src/metabase/entities/databases/forms.js:131
+#: frontend/src/metabase/entities/databases/forms.js:115
+#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:166
 msgid "Click here"
 msgstr "点击这里"
 
-#: frontend/src/metabase/entities/databases/forms.js:83
+#: frontend/src/metabase/entities/databases/forms.js:118
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "选择“其他”作为应用程序类型。把它命名为你想要的任何东西。"
 
@@ -2328,19 +2339,19 @@ msgstr "选择“其他”作为应用程序类型。把它命名为你想要的
 msgid "{0} to get an auth code"
 msgstr "{0}获取身份验证代码"
 
-#: frontend/src/metabase/entities/databases/forms.js:107
+#: frontend/src/metabase/entities/databases/forms.js:142
 msgid "with Google Drive permissions"
 msgstr "使用Google Driver权限"
 
-#: frontend/src/metabase/entities/databases/forms.js:129
+#: frontend/src/metabase/entities/databases/forms.js:164
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "要将Metabase用于此数据，您必须在Google Developers Console中启用API访问权限。"
 
-#: frontend/src/metabase/entities/databases/forms.js:130
+#: frontend/src/metabase/entities/databases/forms.js:165
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "如果您还没有这样做，请转到控制台{0}。"
 
-#: frontend/src/metabase/entities/databases/forms.js:196
+#: frontend/src/metabase/entities/databases/forms.js:265
 msgid "How would you like to refer to this database?"
 msgstr "您想如何使用这个数据库？"
 
@@ -2349,10 +2360,11 @@ msgstr "您想如何使用这个数据库？"
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:143
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:70
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:123
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:96
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:126
 #: frontend/src/metabase/setup/components/UserStep.jsx:93
 msgid "Next"
-msgstr "下一步"
+msgstr "下一个"
 
 #: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
@@ -2532,7 +2544,7 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "回滚到一个更早的调整并且{0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:290
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "调整记录"
@@ -2578,7 +2590,7 @@ msgid "Questions"
 msgstr "问题"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:320
+#: frontend/src/metabase/routes.jsx:311
 msgid "Pulses"
 msgstr "定时任务"
 
@@ -2623,15 +2635,16 @@ msgstr "我们有点失落......"
 msgid "Temporary Password"
 msgstr "临时密码"
 
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:207
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:481
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
 msgid "Hide"
 msgstr "隐藏"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:467
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:482
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:471
 msgid "Show"
 msgstr "显示"
 
@@ -2741,7 +2754,7 @@ msgstr "对不起，你没有权限看那些东西"
 msgid "Unknown error encountered"
 msgstr "未知错误发生了"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:17
+#: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/nav/containers/Navbar.jsx:373
 msgid "Create"
 msgstr "创建"
@@ -2754,7 +2767,7 @@ msgstr "创建仪表盘"
 msgid "Table"
 msgstr "表格"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:42
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
 msgid "Database"
 msgstr "数据库"
 
@@ -2774,7 +2787,7 @@ msgstr "尝试调整过滤器以找到您要查找的内容。"
 msgid "View by"
 msgstr "查看方式"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:122
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:121
 msgid "of"
 msgstr "的"
 
@@ -2801,33 +2814,33 @@ msgstr "分析"
 msgid "Browse all items"
 msgstr "浏览所有"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:118
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:117
 msgid "Replace or save as new?"
 msgstr "替换还是保存为新的？"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:168
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace original question, \"{0}\""
 msgstr "替换原始问题“{0}”"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:172
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:171
 msgid "Save as new question"
 msgstr "保存为新问题"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:92
 msgid "First, save your question"
 msgstr "首先，保存您的问题"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:94
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
 msgid "Save question"
 msgstr "保存问题"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:133
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
 msgid "What is the name of your card?"
 msgstr "这个卡片叫什么名字？"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
 #: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/entities/questions.js:89
@@ -2843,15 +2856,16 @@ msgstr "这个卡片叫什么名字？"
 msgid "Description"
 msgstr "描述"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
 #: frontend/src/metabase/entities/dashboards.js:150
 #: frontend/src/metabase/entities/questions.js:91
 #: frontend/src/metabase/entities/questions.js:107
+#: frontend/src/metabase/entities/snippets.js:31
 msgid "It's optional but oh, so helpful"
 msgstr "这是可选的，但非常有帮助"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:148
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "将这个放到哪个集合中？"
@@ -2868,19 +2882,19 @@ msgstr "项"
 msgid "Undo"
 msgstr "撤销"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:266
 msgid "Applying Question"
 msgstr "正在使用的图表"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:286
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "That question isn't compatible"
 msgstr "那个问题不兼容"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:322
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:309
 msgid "Search for a question"
 msgstr "查找问题"
 
-#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:351
+#: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:343
 msgid "We're not sure if this question is compatible"
 msgstr "我们不确定这个提问是否兼容"
 
@@ -2929,25 +2943,23 @@ msgstr "添加一个问题"
 msgid "Add a question to this dashboard"
 msgstr "添加报表到仪表盘"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
 msgid "Add a filter"
 msgstr "添加筛选"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:256
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "参数"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:276
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:280
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
 msgid "Add a text box"
 msgstr "添加文本框"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:320
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:314
 msgid "Move dashboard"
 msgstr "移动仪表盘"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:303
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
 msgid "Edit dashboard"
 msgstr "编辑仪表盘"
 
@@ -2955,11 +2967,11 @@ msgstr "编辑仪表盘"
 msgid "Edit Dashboard Layout"
 msgstr "编辑仪表盘展示"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:371
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:365
 msgid "You are editing a dashboard"
 msgstr "正在编辑仪表盘"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:376
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:370
 msgid "Select the field that should be filtered for each card"
 msgstr "选择应该在每个卡片中都应该被过滤的字段"
 
@@ -3047,7 +3059,7 @@ msgstr "此卡没有可以映射到此参数类型的任何字段或参数。"
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "此字段中的值不会与您选择的任何其他字段的值重叠。"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:162
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "无可用字段"
@@ -3115,7 +3127,7 @@ msgstr "接收最新的数据来自"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:329
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
 msgid "Unknown"
 msgstr "未知"
 
@@ -3242,6 +3254,7 @@ msgstr "{0}项已选择"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
 msgid "Unarchive"
 msgstr "取消归档"
 
@@ -3334,7 +3347,7 @@ msgid "Longitude"
 msgstr "经度"
 
 #: frontend/src/metabase/lib/core.js:43
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:45
 msgid "Number"
 msgstr "数字"
@@ -3391,7 +3404,7 @@ msgid "User"
 msgstr "用户"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:211
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
 msgid "Source"
 msgstr "来源"
 
@@ -3432,16 +3445,17 @@ msgid "Score"
 msgstr "分数"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "标题"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
 msgid "Comment"
 msgstr "评论"
 
@@ -3493,9 +3507,9 @@ msgstr "不要包括"
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
 msgstr "Metabase永远不会获取此字段。将此用于敏感或不相关的信息。"
 
-#: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:300
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/query/description.js:77
+#: frontend/src/metabase/lib/query/description.js:262
+#: frontend/src/metabase/lib/schema_metadata.js:476
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
@@ -3510,8 +3524,7 @@ msgstr "计数"
 msgid "CumulativeCount"
 msgstr "累积计数"
 
-#: frontend/src/metabase/lib/expressions/config.js:9
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:485
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3521,7 +3534,6 @@ msgstr "求和"
 msgid "CumulativeSum"
 msgstr "累积求和"
 
-#: frontend/src/metabase/lib/expressions/config.js:11
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Distinct"
 msgstr "不重复"
@@ -3530,25 +3542,22 @@ msgstr "不重复"
 msgid "StandardDeviation"
 msgstr "标准差"
 
-#: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:494
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "平均"
 
-#: frontend/src/metabase/lib/expressions/config.js:14
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:539
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "最小"
 
-#: frontend/src/metabase/lib/expressions/config.js:15
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:548
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:503
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:492
 msgid "Max"
 msgstr "最大"
 
@@ -3599,54 +3608,66 @@ msgstr "你在想什么？"
 msgid "What do you want to find out?"
 msgstr "你想找出什么？"
 
-#: frontend/src/metabase/lib/query.js:298
-#: frontend/src/metabase/lib/schema_metadata.js:466
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:250
+#: frontend/src/metabase/lib/query/description.js:75
+#: frontend/src/metabase/lib/query/description.js:260
+#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "原始数据"
 
-#: frontend/src/metabase/lib/query.js:302
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/query/description.js:79
+#: frontend/src/metabase/lib/query/description.js:264
+#: frontend/src/metabase/lib/schema_metadata.js:521
 msgid "Cumulative count"
 msgstr "累积计数"
 
-#: frontend/src/metabase/lib/query.js:305
+#: frontend/src/metabase/lib/query/description.js:82
+#: frontend/src/metabase/lib/query/description.js:266
 msgid "Average of "
 msgstr "平均"
 
-#: frontend/src/metabase/lib/query.js:310
+#: frontend/src/metabase/lib/query/description.js:87
+#: frontend/src/metabase/lib/query/description.js:268
 msgid "Distinct values of "
 msgstr "去重值"
 
-#: frontend/src/metabase/lib/query.js:315
+#: frontend/src/metabase/lib/query/description.js:92
+#: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
 msgstr "标准差"
 
-#: frontend/src/metabase/lib/query.js:320
+#: frontend/src/metabase/lib/query/description.js:97
+#: frontend/src/metabase/lib/query/description.js:272
 msgid "Sum of "
 msgstr "总计"
 
-#: frontend/src/metabase/lib/query.js:325
+#: frontend/src/metabase/lib/query/description.js:102
+#: frontend/src/metabase/lib/query/description.js:274
 msgid "Cumulative sum of "
 msgstr "累积和"
 
-#: frontend/src/metabase/lib/query.js:330
+#: frontend/src/metabase/lib/query/description.js:107
+#: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
 msgstr "最大"
 
-#: frontend/src/metabase/lib/query.js:335
+#: frontend/src/metabase/lib/query/description.js:112
+#: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
 msgstr "最小"
 
-#: frontend/src/metabase/lib/query.js:349
+#: frontend/src/metabase/lib/query/description.js:126
+#: frontend/src/metabase/lib/query/description.js:286
 msgid "Grouped by "
 msgstr "以……聚合"
 
-#: frontend/src/metabase/lib/query.js:363
+#: frontend/src/metabase/lib/query/description.js:140
+#: frontend/src/metabase/lib/query/description.js:295
 msgid "Filtered by "
 msgstr "以……筛选"
 
-#: frontend/src/metabase/lib/query.js:392
+#: frontend/src/metabase/lib/query/description.js:169
+#: frontend/src/metabase/lib/query/description.js:320
 msgid "Sorted by "
 msgstr "以……分类"
 
@@ -3658,55 +3679,45 @@ msgstr "真"
 msgid "False"
 msgstr "假"
 
-#: frontend/src/metabase/lib/schema_metadata.js:321
+#: frontend/src/metabase/lib/schema_metadata.js:322
 msgid "Select longitude field"
 msgstr "选择经度字段"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:323
 msgid "Enter upper latitude"
 msgstr "输入纬度上边届"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:324
 msgid "Enter left longitude"
 msgstr "输入经度左边界"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:325
 msgid "Enter lower latitude"
 msgstr "输入纬度下边界"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:326
 msgid "Enter right longitude"
 msgstr "输入经度右边界"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:539
 #: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:397
-#: frontend/src/metabase/lib/schema_metadata.js:405
-#: frontend/src/metabase/lib/schema_metadata.js:411
-#: frontend/src/metabase/lib/schema_metadata.js:416
-msgid "Is"
-msgstr "是"
-
 #: frontend/src/metabase/lib/schema_metadata.js:362
 #: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:398
 #: frontend/src/metabase/lib/schema_metadata.js:406
 #: frontend/src/metabase/lib/schema_metadata.js:412
-msgid "Is not"
-msgstr "不是"
+#: frontend/src/metabase/lib/schema_metadata.js:417
+msgid "Is"
+msgstr "是"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:417
-msgid "Is empty"
-msgstr "为空"
+#: frontend/src/metabase/lib/schema_metadata.js:413
+msgid "Is not"
+msgstr "不是"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:378
@@ -3715,109 +3726,119 @@ msgstr "为空"
 #: frontend/src/metabase/lib/schema_metadata.js:402
 #: frontend/src/metabase/lib/schema_metadata.js:408
 #: frontend/src/metabase/lib/schema_metadata.js:418
+msgid "Is empty"
+msgstr "为空"
+
+#: frontend/src/metabase/lib/schema_metadata.js:365
+#: frontend/src/metabase/lib/schema_metadata.js:379
+#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:395
+#: frontend/src/metabase/lib/schema_metadata.js:403
+#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:419
 msgid "Not empty"
 msgstr "不为空"
 
-#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:371
 msgid "Equal to"
 msgstr "等于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:372
 msgid "Not equal to"
 msgstr "不等于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Greater than"
 msgstr "大于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Less than"
 msgstr "小于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "介于之间"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:376
 msgid "Greater than or equal to"
 msgstr "大于或等于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Less than or equal to"
 msgstr "小于或等于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
+#: frontend/src/metabase/lib/schema_metadata.js:384
 msgid "Contains"
 msgstr "包含"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:385
 msgid "Does not contain"
 msgstr "不包含"
 
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:388
 msgid "Starts with"
 msgstr "以…开始"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:389
 msgid "Ends with"
 msgstr "以…结束"
 
-#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:399
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "早于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:400
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "晚于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:414
 msgid "Inside"
 msgstr "介于中间"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "只是一个包含数据行的表格，没有其他操作。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:474
+#: frontend/src/metabase/lib/schema_metadata.js:475
 msgid "Count of rows"
 msgstr "总行数"
 
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:477
 msgid "Total number of rows in the answer."
 msgstr "总的数据行数。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Sum of ..."
 msgstr "总和"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:486
 msgid "Sum of all the values of a column."
 msgstr "一个字段所有数值的总和。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:492
+#: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Average of ..."
 msgstr "平均值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:495
 msgid "Average of all the values of a column"
 msgstr "一个字段所有数值的平均值。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:501
+#: frontend/src/metabase/lib/schema_metadata.js:502
 msgid "Number of distinct values of ..."
 msgstr "不重复值的总数"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:504
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "一个字段所有互不重复的值的总数"
 
-#: frontend/src/metabase/lib/schema_metadata.js:510
+#: frontend/src/metabase/lib/schema_metadata.js:511
 msgid "Cumulative sum of ..."
 msgstr "累积求和"
 
@@ -3825,7 +3846,7 @@ msgstr "累积求和"
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "一个字段所有数值的累积加和。\\\\n比如：随着时间推移的总收入。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:519
+#: frontend/src/metabase/lib/schema_metadata.js:520
 msgid "Cumulative count of rows"
 msgstr "累积行数"
 
@@ -3833,27 +3854,27 @@ msgstr "累积行数"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "累积的数据行数。\\\\ n比如：随着时间的推移销售数量。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:528
+#: frontend/src/metabase/lib/schema_metadata.js:529
 msgid "Standard deviation of ..."
 msgstr "标准差"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:531
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "一个字段所有数值的标准差。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:537
+#: frontend/src/metabase/lib/schema_metadata.js:538
 msgid "Minimum of ..."
 msgstr "最小值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Minimum value of a column"
 msgstr "一个字段的最小值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:546
+#: frontend/src/metabase/lib/schema_metadata.js:547
 msgid "Maximum of ..."
 msgstr "最大值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:549
 msgid "Maximum value of a column"
 msgstr "一个字段的最大值"
 
@@ -4029,7 +4050,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "类别、类型、模型、评分等"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:43
-#: frontend/src/metabase/user/components/UserSettings.jsx:55
+#: frontend/src/metabase/user/components/UserSettings.jsx:56
 msgid "Account settings"
 msgstr "账户设置"
 
@@ -4041,7 +4062,7 @@ msgstr "退出管理员"
 msgid "Logs"
 msgstr "日志"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:103
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:104
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:22
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:65
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:100
@@ -4081,9 +4102,9 @@ msgid "Metabase Admin"
 msgstr "Metabase管理员"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:36
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:36
 msgid "Ask a question"
 msgstr "创建问题"
 
@@ -4104,7 +4125,7 @@ msgstr "参考"
 msgid "Which metric?"
 msgstr "哪个指标？"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "为你的团队定义共同指标，让它甚至简单到可以轻松的提问"
 
@@ -4116,7 +4137,7 @@ msgstr "如何创建指标"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "按地图、趋势查看时间维度的数据，方便了解趋势变化"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:149
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
 msgid "Custom"
 msgstr "自定义"
 
@@ -4129,13 +4150,13 @@ msgstr "新的疑问"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "使用简单的疑问创建器来查看趋势、列表或者事物，或者创建你自己的指标。"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:107
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:110
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "原生查询"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:108
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:111
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "为了回答更多复杂的疑问，你可以写下你自己的SQL语句或者原生查询。"
 
@@ -4237,6 +4258,7 @@ msgid "Enter a default value..."
 msgstr "输入一个默认值……"
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
+#: frontend/src/metabase/containers/Form.jsx:307
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "发生了一个错误"
@@ -4484,7 +4506,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "推荐精简定时任务，方便整个团队理解和使用。"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:161
-#: frontend/src/metabase/query_builder/components/view/View.jsx:131
+#: frontend/src/metabase/query_builder/components/view/View.jsx:133
 msgid "Pick your data"
 msgstr "选择你的数据"
 
@@ -4500,47 +4522,47 @@ msgstr "电子邮箱"
 msgid "Slack messages"
 msgstr "Slack消息"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:216
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "发送"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:217
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0}将会在……被发送"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:219
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "信息"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:235
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "现在发送邮件"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:236
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "现在发送邮件给{0}"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:238
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "发送中……"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "发送失败"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "未发送，因为定时任务没有结果。"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "定时任务已发送。"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:282
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0}需要被设置成管理员"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:295
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:299
 msgid "Slack"
 msgstr "Slack"
 
@@ -4693,7 +4715,7 @@ msgstr "平均"
 msgid "Distincts"
 msgstr "不重复"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:55
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "查看这个{0}\n"
@@ -4704,11 +4726,12 @@ msgstr[0] "查看这个{0}\n"
 msgid "Zoom in"
 msgstr "放大"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "自定义表达方式"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Common Metrics"
 msgstr "共同指标"
 
@@ -4905,34 +4928,34 @@ msgstr "通常"
 msgid "Pick a segment or table"
 msgstr "选择一个区间或者表单"
 
-#: frontend/src/metabase/entities/databases/forms.js:191
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
+#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "选择一个数据库"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:94
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:85
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:31
 msgid "Select..."
 msgstr "选择……"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:134
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
 msgid "Select a table"
 msgstr "选择一个表单"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:819
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:926
 msgid "No tables found in this database."
 msgstr "该数据库未发现表"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:856
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:901
 msgid "Is a question missing?"
 msgstr "图表缺失？"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:863
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:909
 msgid "Learn more about nested queries"
 msgstr "了解更多关于嵌套查询"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:898
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:951
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:40
 msgid "Fields"
 msgstr "字段"
 
@@ -4966,11 +4989,11 @@ msgstr "排序"
 msgid "Row limit"
 msgstr "行限制"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
 msgid "Unknown Field"
 msgstr "未知字段"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:75
 msgid "field"
 msgstr "字段"
 
@@ -4978,19 +5001,20 @@ msgstr "字段"
 msgid "Matches"
 msgstr "匹配"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:148
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:156
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:135
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "添加筛选条件来缩小你的答案范围"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:293
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
 msgstr "添加一个聚合"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:37
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:313
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
-#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:66
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:67
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:89
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:131
@@ -5006,16 +5030,16 @@ msgstr "添加一个聚合"
 msgid "Data"
 msgstr "数据"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:340
 msgid "Filtered by"
 msgstr "筛选条件"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:376
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:357
 msgid "View"
 msgstr "查看"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:393
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:374
 msgid "Grouped By"
 msgstr "分组条件"
 
@@ -5023,7 +5047,7 @@ msgstr "分组条件"
 msgid "None"
 msgstr "没有"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:471
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
 msgid "This question is written in {0}."
 msgstr "这个疑问已经被写入{0}"
 
@@ -5035,7 +5059,7 @@ msgstr "隐藏编辑器"
 msgid "Hide Query"
 msgstr "隐藏查询"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:481
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
 msgid "Open Editor"
 msgstr "打开编辑器"
 
@@ -5275,7 +5299,7 @@ msgstr "{0}的去重值"
 msgid "Number of {0} grouped by {1}"
 msgstr "按{1}分组的{0}计数"
 
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:77
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5334,32 +5358,33 @@ msgstr "查看{0}的所有原始数据"
 msgid "More"
 msgstr "更多"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:194
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:216
 msgid "Invalid expression"
 msgstr "不可用的表达式"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:269
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:282
 msgid "unknown error"
 msgstr "未知错误"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:47
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:53
 msgid "Field formula"
 msgstr "字段公式"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:60
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:64
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "这有点像在EXCEL表中编写公式，你可以使用数字，字段，数学符号和一些函数，例如 Subtotal - Cost。"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:69
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:208
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
 msgid "Learn more"
 msgstr "了解更多"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:77
 msgid "Give it a name"
 msgstr "给它一个名字吧"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:79
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
 msgid "Something nice and descriptive"
 msgstr "一些超棒的、值得记录的东西"
 
@@ -5439,11 +5464,11 @@ msgid "Enter desired number"
 msgstr "输入期望值"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:154
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:161
 msgid "Empty"
 msgstr "空的"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:119
 msgid "Find a value"
 msgstr "寻找一个值"
 
@@ -5511,35 +5536,35 @@ msgstr "阅读完整文档"
 msgid "Filter label"
 msgstr "过滤标签"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:135
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:134
 msgid "Variable type"
 msgstr "多种类型"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:143
 msgid "Text"
 msgstr "文本"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
 msgid "Date"
 msgstr "日期"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:147
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
 msgid "Field Filter"
 msgstr "字段筛选条件"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Field to map to"
 msgstr "字段映射到"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:180
 msgid "Filter widget type"
 msgstr "过滤器样式"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:230
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
 msgid "Required?"
 msgstr "必填项？"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:240
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
 msgid "Default filter widget value"
 msgstr "过滤器默认值"
 
@@ -5551,7 +5576,7 @@ msgstr "归档图表？"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "这个图表会从已引用的仪表盘或定时任务中移除"
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:158
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
 msgid "Question"
 msgstr "疑问"
 
@@ -5721,7 +5746,7 @@ msgid "Details"
 msgstr "细节"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
-#: frontend/src/metabase/reference/databases/TableList.jsx:116
+#: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
 msgstr "{0}中的报表"
 
@@ -5802,24 +5827,24 @@ msgstr "为什么这个表单有趣"
 msgid "Things to be aware of about this table"
 msgstr "关于这个表单需要知道的事情"
 
-#: frontend/src/metabase/reference/databases/TableList.jsx:30
+#: frontend/src/metabase/reference/databases/TableList.jsx:29
 msgid "Tables in this database will appear here as they're added"
 msgstr "当在这个数据库中添加表单时，它们将会出现在这里"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:34
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:33
 msgid "Questions about this table will appear here as they're added"
 msgstr "当关于这个表单的疑问被添加时，它们将会出现在这里"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:73
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:77
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:37
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:76
 msgid "Questions about {0}"
 msgstr "关于{0}的疑问"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
 msgid "Created {0} by {1}"
 msgstr "根据{1}创建{0}"
 
@@ -6008,19 +6033,19 @@ msgstr "你可以通过聚合这个指标形成的其他领域"
 msgid "Fields you can group this metric by"
 msgstr "你可以通过聚合这个指标得到的领域"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "指标是你的团队关心的官方数字"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Metrics will appear here once your admins have created some"
 msgstr "一但你的管理员创建了一些指标的话，它们将会出现在这里"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:28
 msgid "Learn how to create metrics"
 msgstr "了解如何创建指标"
 
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:35
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:34
 msgid "Questions about this metric will appear here as they're added"
 msgstr "添加这个指标的图表会在这里显示。"
 
@@ -6046,23 +6071,23 @@ msgstr "为什么这个区段很有意思"
 msgid "Things to be aware of about this Segment"
 msgstr "关于这个区段的注意事项"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
 msgid "Segments are interesting subsets of tables"
 msgstr "区段是表格的子集"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "为你的团队定义公共区段，让它用来提问也十分容易"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Segments will appear here once your admins have created some"
 msgstr "你的管理员添加后，区段将会出现在这里，"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
 msgid "Learn how to create segments"
 msgstr "学习如何创建区段"
 
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:35
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:34
 msgid "Questions about this segment will appear here as they're added"
 msgstr "当它们被添加时，关于这个区段的疑问将会出现在这里"
 
@@ -6082,22 +6107,22 @@ msgstr "有关这个区段的疑问"
 msgid "X-ray this segment"
 msgstr "透视这个区段"
 
-#: frontend/src/metabase/routes.jsx:178 frontend/src/metabase/routes.jsx:179
+#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
 msgid "Login"
 msgstr "登录"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:303
 #: frontend/src/metabase/containers/ItemPicker.jsx:115
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:204
+#: frontend/src/metabase/routes.jsx:195
 msgid "Search"
 msgstr "查询"
 
-#: frontend/src/metabase/routes.jsx:223
+#: frontend/src/metabase/routes.jsx:214
 msgid "Dashboard"
 msgstr "仪表盘"
 
-#: frontend/src/metabase/routes.jsx:236
+#: frontend/src/metabase/routes.jsx:227
 msgid "New Question"
 msgstr "新疑问"
 
@@ -6141,63 +6166,63 @@ msgstr "感谢帮助我们提升"
 msgid "We won't collect any usage events"
 msgstr "我们不会收集任何使用事件信息"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:88
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "为了提升Metabase的用户体验，可能需要通过Google Analytics收集特定的使用数据。"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:90
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Here's a full list of everything we track and why."
 msgstr "这个我们所有我们要收集的清单，以及为什么要收集"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "允许Metabase匿名收集使用事件"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:113
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase{0}收集任何事情关于你的数据或者提问结果"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:114
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
 msgid "never"
 msgstr "永不"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:119
 msgid "All collection is completely anonymous."
 msgstr "所有的收集都是匿名的。"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "您随时可以在管理设置中关闭信息收集。"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:44
+#: frontend/src/metabase/setup/components/Setup.jsx:59
 msgid "If you feel stuck"
 msgstr "如果你不知从何下手"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:49
+#: frontend/src/metabase/setup/components/Setup.jsx:64
 msgid "our getting started guide"
 msgstr "初始化文档"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:50
+#: frontend/src/metabase/setup/components/Setup.jsx:65
 msgid "is just a click away."
 msgstr "点击一下"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:92
+#: frontend/src/metabase/setup/components/Setup.jsx:111
 msgid "Welcome to Metabase"
 msgstr "欢迎来到Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:93
+#: frontend/src/metabase/setup/components/Setup.jsx:112
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "看起来一切都在正常工作，现在让我们了解你吧，连接到你的数据，并且开始寻找一些属于你的答案！"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:97
+#: frontend/src/metabase/setup/components/Setup.jsx:116
 msgid "Let's get started"
 msgstr "让我们开始吧"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:142
+#: frontend/src/metabase/setup/components/Setup.jsx:166
 msgid "You're all set up!"
 msgstr "你已经设置完毕了！"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:153
+#: frontend/src/metabase/setup/components/Setup.jsx:177
 msgid "Take me to Metabase"
 msgstr "带我去Metabase"
 
@@ -6209,13 +6234,13 @@ msgstr "我们应该怎么称呼你？"
 msgid "Hi, {0}. nice to meet you!"
 msgstr "你好，{0}很高兴见到你！"
 
-#: frontend/src/metabase/entities/users/forms.js:33
+#: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
 msgstr "创建一个密码"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:44
-#: frontend/src/metabase/entities/users/forms.js:35
-#: frontend/src/metabase/entities/users/forms.js:82
+#: frontend/src/metabase/entities/users/forms.js:50
+#: frontend/src/metabase/entities/users/forms.js:97
 msgid "Shhh..."
 msgstr "嘘……"
 
@@ -6223,11 +6248,11 @@ msgstr "嘘……"
 msgid "Confirm password"
 msgstr "确认密码"
 
-#: frontend/src/metabase/entities/users/forms.js:42
+#: frontend/src/metabase/entities/users/forms.js:57
 msgid "Shhh... but one more time so we get it right"
 msgstr "嘘……再输入一次让我们确保它是对的"
 
-#: frontend/src/metabase/entities/users/forms.js:70
+#: frontend/src/metabase/entities/users/forms.js:85
 msgid "Your company or team name"
 msgstr "你的公司或者团队名称"
 
@@ -6396,7 +6421,7 @@ msgstr "密码成功更新！"
 msgid "Account updated successfully!"
 msgstr "账户成功更新！"
 
-#: frontend/src/metabase/entities/users/forms.js:81
+#: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
 msgstr "当前密码"
 
@@ -6408,7 +6433,7 @@ msgstr "用Google邮箱地址登录"
 msgid "User Details"
 msgstr "用户详情"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:327
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:344
 msgid "Reset to defaults"
 msgstr "恢复默认值"
 
@@ -6433,15 +6458,15 @@ msgstr "横坐标和纵坐标想使用那些字段?"
 msgid "Choose fields"
 msgstr "选择字段"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:217
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:234
 msgid "Save as default view"
 msgstr "作为默认视图存储"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Draw box to filter"
 msgstr "添加过滤器"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:239
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Cancel filter"
 msgstr "取消过滤器"
 
@@ -6469,19 +6494,19 @@ msgstr "找不到可视化"
 msgid "Could not display this chart with this data."
 msgstr "无法显示这个图表显示这些数据"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:526
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
 msgid "No results!"
 msgstr "没有结果！"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:547
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
 msgid "Still Waiting..."
 msgstr "仍然在等待……"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:550
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
 msgid "This usually takes an average of {0}."
 msgstr "这将通常取一个{0}的平均数。"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:556
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
 msgid "(This is a bit long for a dashboard)"
 msgstr "（这对于仪表盘来说有点太长了）"
 
@@ -6640,19 +6665,19 @@ msgstr "添加规则"
 msgid "Update rule"
 msgstr "更新规则"
 
-#: frontend/src/metabase/visualizations/index.js:32
+#: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
 msgstr "可视化是空的"
 
-#: frontend/src/metabase/visualizations/index.js:37
+#: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
 msgstr "可视化图标必须定义一个作为“标识符”的静态变量：␣"
 
-#: frontend/src/metabase/visualizations/index.js:43
+#: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
 msgstr "具有该标识符的可视化图表已经注册：␣"
 
-#: frontend/src/metabase/visualizations/index.js:71
+#: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
 msgstr "没有{0}的可视化"
 
@@ -6678,23 +6703,23 @@ msgid "Doh! The data from your query doesn't fit the chosen display choice. This
 msgstr "正在……噢！从你的查询中获得的数去并不适合所选的展示选项，这个可视化需要最少数据中的{0}{1}。"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:9
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:117
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:120
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:161
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:169
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:249
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:267
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "列"
@@ -6804,83 +6829,83 @@ msgstr "什么也没有"
 msgid "Linear Interpolated"
 msgstr "线性插值平滑"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
 msgstr "X轴比例"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
 msgstr "时间系列"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:454
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
 msgid "Linear"
 msgstr "线性"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:455
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
 msgid "Power"
 msgstr "势"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:456
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:428
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:445
 msgid "Log"
 msgstr "日志"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:441
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:430
 msgid "Histogram"
 msgstr "柱状图"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
 msgstr "序数"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
 msgstr "Y轴比例"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:462
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
 msgstr "显示X轴线和标记"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:360
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:468
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:349
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
 msgid "Compact"
 msgstr "压缩"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:469
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
 msgid "Rotate 45°"
 msgstr "旋转45°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:470
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:459
 msgid "Rotate 90°"
 msgstr "旋转90°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:466
 msgid "Show y-axis line and marks"
 msgstr "显示Y轴线段和标记"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:489
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Auto y-axis range"
 msgstr "自动Y轴范围"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:533
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:522
 msgid "Use a split y-axis when necessary"
 msgstr "当需要时使用一个分离的Y轴"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:540
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:529
 msgid "Show label on x-axis"
 msgstr "展示标签在X轴上"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:546
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:535
 msgid "X-axis label"
 msgstr "X轴标签"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:555
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:544
 msgid "Show label on y-axis"
 msgstr "展示标签在Y轴上"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:561
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:550
 msgid "Y-axis label"
 msgstr "Y轴标签"
 
@@ -7006,23 +7031,23 @@ msgstr "最小不透明度"
 msgid "Max Zoom"
 msgstr "放到最大"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:231
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:234
 msgid "No relationships found."
 msgstr "没有发现关联。"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:269
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:272
 msgid "via {0}"
 msgstr "通过{0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:347
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
 msgid "This {0} is connected to:"
 msgstr "这个{0}连接到"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "Object Detail"
 msgstr "对象细节"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:93
 msgid "object"
 msgstr "对象"
 
@@ -7410,7 +7435,7 @@ msgstr "在{0}中有很多已保存的问题？创建集合以帮助管理它们
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:149 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -8924,19 +8949,19 @@ msgstr "允许修改集合及其内容"
 msgid "Can view items in this collection"
 msgstr "允许查看该集合的内容"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:767
+#: frontend/src/metabase/admin/permissions/selectors.js:765
 msgid "Collection Access"
 msgstr "集合的权限"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:841
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "该组有权查看此集合的至少一个子集合。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:848
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "该组有权编辑此集合的至少一个子集合。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:861
+#: frontend/src/metabase/admin/permissions/selectors.js:859
 msgid "View sub-collections"
 msgstr "查看子集合"
 
@@ -8944,7 +8969,7 @@ msgstr "查看子集合"
 msgid "Remember Me"
 msgstr "记住我"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:63
+#: frontend/src/metabase/components/BrowseApp.jsx:73
 msgid "X-ray this schema"
 msgstr "透视这个图表"
 
@@ -9005,15 +9030,15 @@ msgstr "Metabase无法找到您的搜索结果。"
 msgid "No metrics"
 msgstr "没有指标"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:31
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:41
 msgid "Aggregations"
 msgstr "聚合"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:32
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:42
 msgid "Operators"
 msgstr "运算符"
 
-#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:30
+#: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:35
 msgid "Custom fields"
 msgstr "自定义字段"
 
@@ -9179,7 +9204,7 @@ msgstr "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
 msgid "toucan_sightings"
 msgstr "toucan_sightings"
 
-#: src/metabase/driver/sparksql.clj
+#: src/metabase/models/collection.clj
 msgid "default"
 msgstr "默认"
 
@@ -9207,10 +9232,10 @@ msgstr "不适用"
 msgid "Windows domain"
 msgstr "Windows域名"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:539
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:545
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:554
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:560
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:528
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:534
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:543
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
 msgstr "标签"
 
@@ -9245,9 +9270,9 @@ msgstr "分享"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:286
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:294
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:302
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:319
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:324
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
@@ -9262,19 +9287,18 @@ msgstr "分享"
 msgid "Display"
 msgstr "显示"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:461
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:476
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:502
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:532
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:402
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:465
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:483
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:521
 msgid "Axes"
 msgstr "坐标轴"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:212
-#: frontend/src/metabase/admin/settings/selectors.js:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:219
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:62
 msgid "Formatting"
@@ -9308,7 +9332,7 @@ msgstr "透视"
 msgid "Compare to the rest"
 msgstr "和其余的比较"
 
-#: frontend/src/metabase/entities/databases/forms.js:16
+#: frontend/src/metabase/entities/databases/forms.js:18
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "使用Java虚拟机时区"
 
@@ -9337,24 +9361,24 @@ msgstr "使用Java虚拟机时区"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "我们现在正在分析数据表和字段来帮助你探索数据"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
 msgid "Tip: "
 msgstr "提示："
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:237
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
 msgstr "选择一个统用的类型"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:300
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
 msgid "Field Type"
 msgstr "字段类型"
 
-#: frontend/src/metabase/admin/routes.jsx:113
+#: frontend/src/metabase/admin/routes.jsx:118
 #: frontend/src/metabase/nav/containers/Navbar.jsx:267
 msgid "Troubleshooting"
 msgstr "错误排查"
 
-#: frontend/src/metabase/admin/settings/selectors.js:103
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Enable X-ray features"
 msgstr "开启透视(X-ray) 功能"
 
@@ -9399,7 +9423,7 @@ msgstr "用时"
 msgid "Currency"
 msgstr "货币"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
 msgstr "选择一个用户或频道"
 
@@ -9547,7 +9571,7 @@ msgstr "线条样式"
 msgid "Show dots on lines"
 msgstr "在线上显示圆圈"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:348
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
@@ -9561,7 +9585,7 @@ msgstr "哪个轴？"
 msgid "Line + Bar"
 msgstr "线状图+条行图"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
 msgid "line and bar chart"
 msgstr "线状图和条型图"
 
@@ -11008,7 +11032,7 @@ msgstr "该指标如何分布在不同的数字上"
 msgid "Sessions by page where the session began"
 msgstr "会话开始时的页面会话"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:503
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -11377,7 +11401,7 @@ msgstr "复制该项目"
 msgid "Archive this item"
 msgstr "归档该项目"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:331
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:325
 msgid "Duplicate dashboard"
 msgstr "复制仪表板"
 
@@ -11406,11 +11430,11 @@ msgstr "下一个{0}"
 #: frontend/src/metabase/lib/query_time.js:135
 #: src/metabase/pulse/render/datetime.clj
 msgid "Previous {0}"
-msgstr "上一页{0}"
+msgstr "上一个{0}"
 
 #: frontend/src/metabase/lib/query_time.js:139
 msgid "Previous {0} {1}"
-msgstr "上一页{0} {1}"
+msgstr "上一个{0} {1}"
 
 #: frontend/src/metabase/lib/query_time.js:141
 msgid "Next {0} {1}"
@@ -11473,7 +11497,7 @@ msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] "季度"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
@@ -11488,8 +11512,8 @@ msgstr "新的[[this.short-name]]随着时间的推移"
 msgid "This"
 msgstr "这个"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:97
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:137
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:136
 msgid "Invalid"
 msgstr "无效"
 
@@ -11651,7 +11675,7 @@ msgstr "加入[[this.short-name]]的几个月"
 
 #: src/metabase/models/interface.clj
 msgid "Unable to normalize:"
-msgstr "上一页{0} {1}"
+msgstr "上一个{0} {1}"
 
 #: src/metabase/models/params.clj
 msgid "Could not find matching Field ID for target:"
@@ -12252,6 +12276,7 @@ msgstr "[[CreateTimestamp]]按小时计算"
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
 msgstr "您可以更详细一点，或者使用ID？ 我找到了这些名字匹配的卡片："
 
+#: src/metabase/driver/common/parameters/values.clj
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
 msgstr "卡片 {0} 未找到."
@@ -12360,11 +12385,11 @@ msgstr "失火指令"
 msgid "Archive this?"
 msgstr "将这个归档?"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:243
+#: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
 msgstr "了解我们的数据"
 
-#: frontend/src/metabase/entities/databases/forms.js:20
+#: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
 msgstr "连接时使用DNS SRV（域名服务器）"
 
@@ -12374,7 +12399,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "使用此选项要求提供的主机是一个FQDN。 如果连接到一个Atlas集群，您可能需要启用此选项。 如果你不知道这意味着什么，请保持禁用该选项。"
 
-#: frontend/src/metabase/entities/databases/forms.js:204
+#: frontend/src/metabase/entities/databases/forms.js:273
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "在进行简单的过滤和汇总时自动运行查询"
 
@@ -12398,11 +12423,11 @@ msgstr "所有结果"
 msgid "Our Analytics"
 msgstr "我们的分析"
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:513
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
 msgstr "这里仔细看看[[this]]"
 
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
 msgstr "行数的附加计数。\\ ne.x。总销售额随着时间的推移。"
 
@@ -12412,7 +12437,7 @@ msgstr "行数的附加计数。\\ ne.x。总销售额随着时间的推移。"
 msgid "Filter"
 msgstr "过滤器"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:50
 msgid "record"
 msgid_plural "records"
 msgstr[0] "记录"
@@ -12425,27 +12450,27 @@ msgstr "浏览数据"
 msgid "Write SQL"
 msgstr "写SQL"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:83
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
 msgstr "简单查询"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:84
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:87
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
 msgstr "挑选并浏览数据, 添加简单的过滤或聚合, 然后将数据可视化."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:95
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:98
 msgid "Custom question"
 msgstr "自定义查询"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:96
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:99
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "使用高级查询编辑器完成关联, 创建自定义列, 实现数学计算等更多高级功能."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Basic Metrics"
 msgstr "基础指标"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:322
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
 msgid "Custom…"
 msgstr "自定义"
 
@@ -12514,15 +12539,15 @@ msgstr "选择分组的列"
 msgid "Pick your starting data"
 msgstr "选择您的起始数据"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select None"
 msgstr "全不选"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select All"
 msgstr "全选"
 
-#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:151
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:152
 msgid "Pick a table..."
 msgstr "选择数据表…"
 
@@ -12643,15 +12668,15 @@ msgstr "添加指标"
 #: frontend/src/metabase/lib/core.js:137 frontend/src/metabase/lib/core.js:142
 #: frontend/src/metabase/lib/core.js:147 frontend/src/metabase/lib/core.js:152
 #: frontend/src/metabase/lib/core.js:157 frontend/src/metabase/lib/core.js:162
-#: frontend/src/metabase/user/components/UserSettings.jsx:63
+#: frontend/src/metabase/user/components/UserSettings.jsx:64
 msgid "Profile"
 msgstr "主页"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:560
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "这通常很快，但现在似乎需要一段时间。"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
 msgid "Combo"
 msgstr "组合"
 
@@ -12667,11 +12692,11 @@ msgstr "趋势"
 msgid "Boolean"
 msgstr "布尔值"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:62
 msgid "Unknown Segment"
 msgstr "未知的划分"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:73
 msgid "Unknown Filter"
 msgstr "未知过滤器"
 
@@ -12801,6 +12826,7 @@ msgstr "使用NEWLY CREATED类加载器作为共享上下文类加载器：{0}"
 msgid "Failed to copy file"
 msgstr "复制文件失败"
 
+#. check that the URL is valid
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
 msgstr "无效的站点URL: {0}"
@@ -13075,7 +13101,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "选择需要包含的列"
 
-#: frontend/src/metabase/entities/databases/forms.js:205
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "这个选项开启时，当用户在查看表格或图表时使用“汇总”和“过滤”按钮进行简单数据探索时，Metabase将自动运行查询。 如果查询此数据库的速度很慢，可以将该选项关闭。 此设置不会影响数据钻探或SQL查询。"
 
@@ -13113,7 +13139,7 @@ msgstr "确定查询的预期列时出错"
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "无法处理的异常,  希望`catch-exceptions`能够处理它."
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:125
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
 msgid "Diagnostic Info"
 msgstr "诊断信息"
 
@@ -13137,11 +13163,11 @@ msgstr "使用Google登录时出现问题。 请与管理员联系。"
 msgid "Sign in with email"
 msgstr "邮箱登录"
 
-#: frontend/src/metabase/entities/databases/forms.js:21
+#: frontend/src/metabase/entities/databases/forms.js:23
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "使用此选项要求提供的主机是FQDN。 如果连接到Atlas群集，则可能需要启用此选项。 如果您不知道这意味着什么，请禁用此功能。"
 
-#: frontend/src/metabase/entities/databases/forms.js:213
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "默认情况下，Metabase每小时执行一次轻量级同步，每天执行一次密集扫描。 如果您有一个大型数据库，我们建议启用此功能并查看字段值扫描的发生时间和频率。"
 
@@ -13209,11 +13235,11 @@ msgstr "不包含"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "在使用GUI界面创建的问题中，该字段将不可见或不可选择。 在SQL /本地查询中仍然可以访问。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:512
 msgid "Cumulative sum"
 msgstr "累积和"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Standard deviation"
 msgstr "标准偏差"
 
@@ -13225,23 +13251,23 @@ msgstr "必须至少为{0}个字符"
 msgid "Must be at least {0} characters long"
 msgstr "必须至少为{0}个字符"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:389
+#: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:82
 msgid "Name (required)"
 msgstr "名称（必填）"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:556
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
 msgid "Run selected text"
 msgstr "运行选中文本"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:557
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
 msgid "Run query"
 msgstr "运行查询"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(⌘ + enter)"
 msgstr "（command + 回车）"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:559
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
 msgid "(Ctrl + enter)"
 msgstr "（Ctrl + 回车）"
 
@@ -13253,7 +13279,7 @@ msgstr "您的结果将会在这出现"
 msgid "You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question."
 msgstr "除非您单击“保存”并选择替换原始问题，否则您不会对已保存的问题进行任何更改。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:199
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:200
 msgid "There aren't any filter widgets for this type of field yet."
 msgstr "尚无此类型字段的过滤组件。"
 
@@ -13289,19 +13315,19 @@ msgstr "目标线"
 msgid "Trend line"
 msgstr "趋势线"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:320
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:317
 msgid "Show values on data points"
 msgstr "在数据点上显示值"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:334
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:325
 msgid "Values to show"
 msgstr "值显示"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:342
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:332
 msgid "As many as can fit nicely"
 msgstr "尽可能多地适合"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:343
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:333
 msgid "All"
 msgstr "全部"
 
@@ -13593,31 +13619,31 @@ msgstr "数字"
 msgid "No mappable groups"
 msgstr "无匹配集合"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:107
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
 msgstr "Metabase档案"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
 msgstr "包括故障排除指南"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:112
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
 msgid "Post on the Metabase support forum"
 msgstr "在元数据库支持论坛上发布"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:114
 msgid "A community forum for all things Metabase"
 msgstr "有关万物数据库的社区论坛"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:117
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
 msgid "File a bug report"
 msgstr "提交错误报告"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:119
 msgid "Create a GitHub issue (includes the diagnostic info below)"
 msgstr "建立一个Github问题 （包括下面的诊断信息）"
 
-#: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
+#: frontend/src/metabase/admin/tasks/containers/Help.jsx:127
 msgid "Please include these details in support requests. Thank you!"
 msgstr "请在支持请求中包括这些详细信息。谢谢！"
 
@@ -13645,38 +13671,40 @@ msgstr "无匹配结果"
 msgid "Submit"
 msgstr "提交"
 
-#: frontend/src/metabase/entities/databases/forms.js:13
+#: frontend/src/metabase/entities/databases/forms.js:15
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host. This option also provides an extra layer of security when a VPN is not available. Enabling this is usually slower than a direct connection."
 msgstr "某些数据库安装只能通过SSH堡垒主机进行连接才能访问。当VPN不可用时，此选项还提供了额外的安全层。启用它通常比直接连接要慢。"
 
-#: frontend/src/metabase/entities/databases/forms.js:17
+#: frontend/src/metabase/entities/databases/forms.js:19
 msgid "We suggest you leave this off unless you're doing manual timezone casting in many or most of your queries with this data."
 msgstr "我们建议您不要选择此项，除非您要对许多或大多数查询中的数据进行手动时区转换。"
 
-#: frontend/src/metabase/entities/databases/forms.js:93
+#: frontend/src/metabase/entities/databases/forms.js:128
 msgid "{0} to get an auth code."
 msgstr "{0}获取验证码。"
 
-#: frontend/src/metabase/entities/databases/forms.js:101
+#: frontend/src/metabase/entities/databases/forms.js:136
+#: src/metabase/models/collection.clj
 msgid "or"
 msgstr "或"
 
-#: frontend/src/metabase/entities/databases/forms.js:159
-#: frontend/src/metabase/entities/databases/forms.js:197
-#: frontend/src/metabase/entities/users/forms.js:44
+#: frontend/src/metabase/entities/databases/forms.js:39
+#: frontend/src/metabase/entities/databases/forms.js:226
+#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "需要"
 
-#: frontend/src/metabase/entities/databases/forms.js:188
+#: frontend/src/metabase/entities/databases/forms.js:257
 msgid "Database type"
 msgstr "数据库类型"
 
-#: frontend/src/metabase/entities/databases/forms.js:222
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "这是一个轻量级的过程，用于检查对该数据库架构的更新。在大多数情况下，最好将此设置保持为每小时同步。"
 
-#: frontend/src/metabase/entities/databases/forms.js:230
+#: frontend/src/metabase/entities/databases/forms.js:299
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase可以扫描此数据库中每个字段中存在的值，以启用仪表板和问题中的复选框过滤器。这可能会占用一些资源，特别是如果您的数据库很大。"
 
@@ -13684,15 +13712,15 @@ msgstr "Metabase可以扫描此数据库中每个字段中存在的值，以启�
 msgid "Collection"
 msgstr "集合"
 
-#: frontend/src/metabase/entities/users/forms.js:40
+#: frontend/src/metabase/entities/users/forms.js:55
 msgid "Confirm your password"
 msgstr "确认你的密码"
 
-#: frontend/src/metabase/entities/users/forms.js:45
+#: frontend/src/metabase/entities/users/forms.js:60
 msgid "passwords do not match"
 msgstr "密码不匹配"
 
-#: frontend/src/metabase/entities/users/forms.js:71
+#: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
 msgstr "真棒系"
 
@@ -13732,328 +13760,324 @@ msgid "Returns the average of the values in the column."
 msgstr "返回列中值的平均值。"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:18
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
 msgid "The column whose values to average."
 msgstr "要取其平均值的列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "start"
 msgstr "开始"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
 msgid "end"
 msgstr "结束"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
 msgid "Checks a date or numeric column's values to see if they're within the specified range."
 msgstr "通过检查数字列的值来看它们是否在特定范围内"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
 msgstr "评价"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:24
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:98
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
 msgid "condition"
 msgstr "状况"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
 msgid "output"
 msgstr "输出"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "测试案例列表，并返回第一个真实案例的对应值，如果不满足其他条件，则返回可选的默认值。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
 msgid "Weight"
 msgstr "重量"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
 msgid "Large"
 msgstr "大"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
 msgid "Medium"
 msgstr "中"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
 msgid "Small"
 msgstr "小"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
 msgid "Something that should evaluate to true or false."
 msgstr "应该评估为真或假的东西。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:54
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "如果前面的条件为true，则将返回的值。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:62
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "value1"
 msgstr "值1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:69
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:74
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
 msgid "value2"
 msgstr "值2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "按顺序查看每个参数中的值，并为每行返回第一个非空值。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:56
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
 msgid "Comments"
 msgstr "评论"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
 msgid "Notes"
 msgstr "笔记"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
 msgid "No comments"
 msgstr "无评论"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
 msgid "A column or value."
 msgstr "列或值。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:65
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:77
 msgid "If value1 is empty, value2 gets returned if it's not empty, and so on."
 msgstr "如果value1为空，则如果value2不为空，则返回value2，依此类推。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 msgid "Combines two or more strings of text together."
 msgstr "将两个或多个文本字符串组合在一起。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
 msgid "Last Name"
 msgstr "姓"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
 msgid "First Name"
 msgstr "名"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
 msgstr "将value2添加到此末尾。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
 msgstr "这将被添加到value1的末尾。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
 msgid "string1"
 msgstr "字符串1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:79
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
 msgid "string2"
 msgstr "字符串2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:80
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "检查string1中是否包含string2。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:284
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
 msgid "Status"
 msgstr "状态"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:81
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
 msgid "Pass"
 msgstr "通过"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
 msgstr "该字符串的内容将被检查。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
 msgid "The string of text to look for."
 msgstr "要查找的文本字符串。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:90
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:116
 msgid "Returns the count of rows in the source data."
 msgstr "返回源数据中的行数。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Only counts rows where the condition is true."
 msgstr "仅计算条件为真的行。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:97
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:261
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
 msgid "Subtotal"
 msgstr "小计"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
 msgid "The additive total of rows across a breakout."
 msgstr "突破中行的总和。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:110
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
 msgid "The rolling sum of a column across a breakout."
 msgstr "突破中列的滚动总和。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:113
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:268
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
 msgstr "要汇总的列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
 msgid "The number of distinct values in this column."
 msgstr "此列中不同值的数量。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "The column whose distinct values to count."
 msgstr "要计数其不同值的列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:128
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:145
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:153
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:201
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:274
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
 msgid "text"
 msgstr "文本"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:125
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:130
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:217
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:223
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
 msgid "comparison"
 msgstr "比较"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "如果文本的结尾与比较文本匹配，则返回真正。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "Appetite"
 msgstr "食欲"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
 msgid "hungry"
 msgstr "饥饿"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 msgid "A column or string of text to check."
 msgstr "要检查的一列或一串文本。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
 msgid "The string of text that the original text should end with."
 msgstr "原始文本应以其结尾的文本字符串。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:135
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 msgid "regular_expression"
 msgstr "正则表达式"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:136
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "根据正则表达式提取匹配的子字符串。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:137
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
 msgid "Address"
 msgstr "地址"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 msgid "The column or string of text to search though."
 msgstr "但是，要搜索的文本列或字符串。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
 msgid "The regular expression to match."
 msgstr "要匹配的正则表达式。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the string of text in all lowercase."
 msgstr "返回所有小写字母的文本字符串。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:149
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to lowercase."
 msgstr "具有要转换为小写字母的值的列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:154
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 msgid "Removes leading whitespace from a string of text."
 msgstr "从文本字符串中删除前导空格。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:157
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column with values you want to trim."
 msgstr "具有要修剪的值的列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "Returns the largest value found in the column."
 msgstr "返回在该列中找到的最大值。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
 msgid "Age"
 msgstr "年龄"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:165
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
 msgid "The numeric column whose maximum you want to find."
 msgstr "要查找其最大值的数字列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:170
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "Returns the smallest value found in the column."
 msgstr "返回在列中找到的最小值。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
 msgid "Salary"
 msgstr "薪水"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:173
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
 msgid "The numeric column whose minimum you want to find."
 msgstr "要查找其最小值的数字列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:181
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:242
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
 msgid "position"
 msgstr "位置"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:194
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
 msgid "length"
 msgstr "长度"
 
@@ -14062,7 +14086,7 @@ msgstr "长度"
 msgid "new_text"
 msgstr "new_text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:187
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
 msgid "Replaces a part of the input text with new text."
 msgstr "用新文本替换输入文本的一部分。"
 
@@ -14074,7 +14098,7 @@ msgstr "订单 ID"
 msgid "Updated Part of ID"
 msgstr "ID的更新部分"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
 msgid "The text that will be modified."
 msgstr "将被修改的文本。"
 
@@ -14090,87 +14114,87 @@ msgstr "要替换的字符数。"
 msgid "The text to use in the replacement."
 msgstr "用于替换的文本。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "Removes trailing whitespace from a string of text."
 msgstr "从文本字符串中删除结尾的空格。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:210
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "以十进制形式返回数据中符合条件的行的百分比。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:218
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "如果文本的开头与比较文本匹配，则返回true。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Course Name"
 msgstr "课程名称"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
 msgid "Computer Science"
 msgstr "计算机科学"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
 msgid "The string of text that the original text should start with."
 msgstr "原始文本应以其开头的文本字符串。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:229
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
 msgid "Calculates the standard deviation of the column."
 msgstr "计算列的标准偏差。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:230
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
 msgid "Population"
 msgstr "人口"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
 msgid "A numeric column."
 msgstr "一个数字列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
 msgid "Returns a portion of the supplied text."
 msgstr "返回提供的文本的一部分。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:241
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:313
 msgid "The text to return a portion of."
 msgstr "要返回的文本的一部分。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
 msgid "The position to start copying characters."
 msgstr "开始复制字符的位置。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:245
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
 msgid "The number of characters to return."
 msgstr "要返回的字符数。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
 msgid "Adds up all the values of the column."
 msgstr "将列的所有值相加。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:253
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
 msgid "The numeric column to sum."
 msgstr "要求和的数字列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
 msgstr "汇总行匹配条件的列中的值。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
 msgid "Order Status"
 msgstr "订单状态"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
 msgid "Valid"
 msgstr "有效的"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "从文本字符串中删除开头和结尾的空格。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
 msgid "Returns the string of text in all upper case."
 msgstr "以大写形式返回文本字符串。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
 msgid "The column with values to convert to upper case."
 msgstr "具有要转换为大写字母的值的列。"
 
@@ -14227,39 +14251,39 @@ msgstr "感谢您使用元数据库！"
 msgid "Powered by {0}"
 msgstr "由{0}提供支持"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:191
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
 msgid "To:"
 msgstr "至："
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:40
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
 msgstr "由于该问题基于其他数据库，因此无法使用。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:44
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:43
 msgid "Couldn't find a saved question with that ID number."
 msgstr "找不到具有该ID号的已保存问题。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:55
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:54
 msgid "Pick a saved question"
 msgstr "选择一个已保存的问题"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:57
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:56
 msgid "Pick a different question"
 msgstr "选择一个不同的问题"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:62
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:61
 msgid "Loading…"
 msgstr "载入中..."
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:79
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:78
 msgid "Question #…"
 msgstr "题 ＃…"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:81
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
 msgstr "问题＃{0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:115
+#: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
 msgstr "上次编辑的{0}"
 
@@ -14271,11 +14295,11 @@ msgstr "{0}在此查询模板中创建一个名为“ variable_name”的变量�
 msgid "Giving a variable the \"Field Filter\" type allows you to link questions to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "通过为变量指定“字段过滤器”类型，您可以将问题链接到仪表板过滤器小部件，或在SQL问题上使用更多类型的过滤器小部件。在现有列上添加过滤器时，“字段过滤器”变量将插入与GUI查询构建器生成的SQL相似的SQL。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:131
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
 msgstr "变量名"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:217
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:218
 msgid "Filter widget label"
 msgstr "过滤器小部件标签"
 
@@ -14307,11 +14331,11 @@ msgstr "在列标题中"
 msgid "In every table cell"
 msgstr "在每个表格单元格中"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:351
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:341
 msgid "Value formatting"
 msgstr "值格式"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:361
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:350
 msgid "Full"
 msgstr "充分"
 
@@ -14639,4 +14663,483 @@ msgstr "生成列的见解时出错："
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandonment email!"
 msgstr "发送遗弃电子邮件！"
+
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
+msgstr "您可以创建保存的指标以添加命名指标选项。保存的指标包括聚合类型，聚合字段以及您添加的任何过滤器（可选）。例如，您可以使用它来创建类似于为Orders表计算“平均价格”的官方方法。"
+
+#: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:105
+msgid "Select and add filters to create your new segment."
+msgstr "选择并添加过滤器以创建新的细分。"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+msgid "Alphabetical"
+msgstr "按字母顺序"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+msgid "Smart"
+msgstr "聪明"
+
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+msgid "Column order: {0}"
+msgstr "列顺序：{0}"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
+msgid "Unhide all"
+msgstr "全部取消隐藏"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:204
+msgid "Hide all"
+msgstr "全部藏起来"
+
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:206
+msgid "Unhide"
+msgstr "取消隐藏"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:22
+msgid "New metric"
+msgstr "新指标"
+
+#: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:45
+msgid "Create metrics to add them to the Summarize dropdown in the query builder"
+msgstr "创建指标以将其添加到查询构建器的“汇总”下拉列表中"
+
+#: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:22
+msgid "New segment"
+msgstr "新细分"
+
+#: frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx:71
+msgid "Filter by table"
+msgstr "依表格筛选"
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:64
+msgid "Checking HTTPS..."
+msgstr "正在检查HTTPS ..."
+
+#: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:66
+msgid "It looks like HTTPS is not properly configured"
+msgstr "看来HTTPS配置不正确"
+
+#: frontend/src/metabase/admin/settings/selectors.js:57
+msgid "Redirect to HTTPS"
+msgstr "重定向到HTTPS"
+
+#: frontend/src/metabase/admin/settings/selectors.js:219
+msgid "Localization"
+msgstr "本土化"
+
+#: frontend/src/metabase/admin/settings/selectors.js:222
+msgid "Instance language"
+msgstr "实例语言"
+
+#: frontend/src/metabase/admin/settings/selectors.js:237
+msgid "Localization options"
+msgstr "本地化选项"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:51
+msgid "This database doesn't have any tables."
+msgstr "该数据库没有任何表。"
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
+msgid "This field only accepts a single value because it's used in a SQL query."
+msgstr "该字段仅接受一个值，因为它在SQL查询中使用。"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:17
+msgid "Service Accounts"
+msgstr "服务帐号"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:26
+msgid "Metabase connects to Big Query via {0}."
+msgstr "配置数据库通过{0}连接到Big Query。"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:29
+msgid "Continue using an OAuth application to connect"
+msgstr "继续使用OAuth应用程序进行连接"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:43
+msgid "We recommend switching to use {0} instead of an OAuth application to connect to BigQuery"
+msgstr "我们建议切换到使用{0}而不是OAuth应用程序来连接到BigQuery"
+
+#: frontend/src/metabase/entities/databases/big-query-fields.js:48
+msgid "Connect to a Service Account instead"
+msgstr "改为连接到服务帐户"
+
+#: frontend/src/metabase/entities/databases/forms.js:44
+msgid "invalid JSON"
+msgstr "无效的JSON"
+
+#: frontend/src/metabase/entities/databases/forms.js:50
+msgid "SSH private key"
+msgstr "SSH私钥"
+
+#: frontend/src/metabase/entities/databases/forms.js:51
+msgid "Paste the contents of your ssh private key here"
+msgstr "将ssh私钥的内容粘贴到此处"
+
+#: frontend/src/metabase/entities/databases/forms.js:55
+msgid "Passphrase for the SSH private key"
+msgstr "SSH私钥的密码"
+
+#: frontend/src/metabase/entities/databases/forms.js:58
+msgid "SSH Authentication"
+msgstr "SSH验证"
+
+#: frontend/src/metabase/entities/databases/forms.js:60
+msgid "SSH Key"
+msgstr "SSH密钥"
+
+#: frontend/src/metabase/entities/databases/forms.js:65
+msgid "Server SSL certificate chain"
+msgstr "服务器SSL证书链"
+
+#: frontend/src/metabase/entities/databases/forms.js:66
+msgid "Paste the contents of the server's SSL certificate chain here"
+msgstr "在此处粘贴服务器的SSL证书链的内容"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:11
+msgid "Paste a connection string"
+msgstr "粘贴连接字符串"
+
+#: frontend/src/metabase/entities/databases/mongo-fields.js:12
+msgid "Fill out individual fields"
+msgstr "填写各个字段"
+
+#: frontend/src/metabase/entities/snippets.js:14
+msgid "Enter some SQL here so you can reuse it later"
+msgstr "在此处输入一些SQL，以便稍后使用"
+
+#: frontend/src/metabase/entities/snippets.js:24
+msgid "Give your snippet a name"
+msgstr "给您的代码片段起个名字"
+
+#: frontend/src/metabase/entities/snippets.js:25
+msgid "Current Customers"
+msgstr "现有客户"
+
+#: frontend/src/metabase/entities/snippets.js:30
+msgid "Add a description"
+msgstr "增加一个说明"
+
+#: frontend/src/metabase/entities/users/forms.js:37
+msgid "Use site default"
+msgstr "使用网站默认"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+msgid "find"
+msgstr "找"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+msgid "replace"
+msgstr "更换"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+msgid "The text to find."
+msgstr "要查找的文字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "The text to use as the replacement."
+msgstr "用作替代的文本。"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+msgid "Editing {0}"
+msgstr "编辑{0}"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+msgid "Create your new snippet"
+msgstr "创建您的新片段"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+msgid "Archived snippets"
+msgstr "存档片段"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+msgid "Snippets are reusable bits of SQL"
+msgstr "片段是SQL的可重用位"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+msgid "Create a snippet"
+msgstr "创建一个片段"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+msgid "Snippets"
+msgstr "片段"
+
+#: frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx:15
+msgid "SQL Snippets"
+msgstr "SQL片段"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:38
+msgid "Your language is set to {0}"
+msgstr "您的语言设置为{0}"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:50
+msgid "What's your preferred language?"
+msgstr "您首选的语言是什么？"
+
+#: frontend/src/metabase/setup/components/LanguageStep.jsx:54
+msgid "This language will be used throughout Metabase and will be the default for new users."
+msgstr "该语言将在整个Metabase中使用，并将成为新用户的默认语言。"
+
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:159
+msgid "We filtered out {0} row(s) containing null values."
+msgstr "我们过滤掉包含空值的{0}行。"
+
+#: frontend/src/metabase/visualizations/lib/settings/series.js:133
+msgid "Show values for this series"
+msgstr "显示该系列的值"
+
+#: src/metabase/api/card.clj
+msgid "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
+msgstr "问题的平均执行持续时间为{0}；使用{1}的“魔术” TTL"
+
+#: src/metabase/api/native_query_snippet.clj
+msgid "A snippet with that name already exists. Please pick a different name."
+msgstr "具有该名称的代码段已存在。请选择其他名称。"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Metric]"
+msgstr "[未知指标]"
+
+#: src/metabase/api/query_description.clj
+msgid "[Unknown Segment]"
+msgstr "[未知细分]"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error writing error to output stream"
+msgstr "将错误写入输出流时出错"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Caught unexpected Exception in streaming response body"
+msgstr "流式响应正文中捕获了意外的异常"
+
+#: src/metabase/async/streaming_response.clj
+msgid "bound-fn caught unexpected Exception"
+msgstr "bound-fn捕获了意外的异常"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Error determining whether HTTP request was canceled"
+msgstr "确定HTTP请求是否已取消时出错"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Check cancelation status timed out after {0}"
+msgstr "{0}后检查取消状态超时"
+
+#: src/metabase/async/streaming_response.clj
+msgid "Unexpected exception in do-f-async"
+msgstr "do-f-async中发生意外的异常"
+
+#: src/metabase/async/streaming_response.clj src/metabase/server.clj
+msgid "Unexpected exception writing error response"
+msgstr "意外的异常写入错误响应"
+
+#: src/metabase/driver/common.clj
+msgid "Server certificate not trusted - did you specify the correct SSL certificate chain?"
+msgstr "服务器证书不受信任-您是否指定了正确的SSL证书链？"
+
+#: src/metabase/driver/common.clj
+msgid "Server appears to require SSL - please enable SSL above"
+msgstr "服务器似乎需要SSL-请在上面启用SSL"
+
+#: src/metabase/driver/common.clj
+msgid "Username"
+msgstr "用户名"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Don''t know how to parse parameter of type {0}"
+msgstr "不知道如何解析类型为{0}的参数"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Invalid :card parameter: missing `:card-id`"
+msgstr "：card参数无效：缺少`：card-id`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Unable to resolve Snippet: missing `:snippet-id`"
+msgstr "无法解析代码段：缺少`：snippet-id`"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Snippet {0} {1} not found."
+msgstr "找不到代码段{0} {1}。"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error determining value for parameter"
+msgstr "确定参数值时出错"
+
+#: src/metabase/driver/common/parameters/values.clj
+msgid "Error building query parameter map"
+msgstr "建立查询参数图时出错"
+
+#: src/metabase/middleware/log.clj
+msgid "ASYNC"
+msgstr "异步"
+
+#: src/metabase/middleware/log.clj
+msgid "{0} ({1} DB calls)"
+msgstr "{0}（{1}个数据库调用）"
+
+#: src/metabase/middleware/log.clj
+msgid "App DB connections: {0}/{1}"
+msgstr "应用数据库连接：{0} / {1}"
+
+#: src/metabase/middleware/log.clj
+msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
+msgstr "码头线程：{0} / {1}（{2}空闲，{3}排队）"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} total active threads)"
+msgstr "（{0}个活动线程总数）"
+
+#: src/metabase/middleware/log.clj
+msgid "Queries in flight: {0}"
+msgstr "进行中的查询：{0}"
+
+#: src/metabase/middleware/log.clj
+msgid "({0} queued)"
+msgstr "（{0}已排队）"
+
+#: src/metabase/models/collection.clj
+msgid "Collection must be in the same namespace as its parent"
+msgstr "集合必须与其父集合位于同一名称空间中"
+
+#: src/metabase/models/collection.clj
+msgid "Personal Collections must be in the default namespace"
+msgstr "个人收藏集必须位于默认名称空间中"
+
+#: src/metabase/models/collection.clj
+msgid "You cannot move a Collection to a different namespace once it has been created."
+msgstr "创建集合后，您无法将其移动到其他名称空间。"
+
+#: src/metabase/models/collection.clj src/metabase/models/permissions.clj
+msgid "Collection does not exist."
+msgstr "集合不存在。"
+
+#: src/metabase/models/collection.clj
+msgid "A {0} can only go in Collections in the {1} namespace."
+msgstr "{0}只能进入{1}名称空间的Collections中。"
+
+#: src/metabase/models/database.clj
+msgid "Error sending database deletion notification"
+msgstr "发送数据库删除通知时出错"
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "You cannot update the creator_id of a NativeQuerySnippet."
+msgstr "您无法更新NativeQuerySnippet的creator_id。"
+
+#: src/metabase/models/setting.clj
+msgid "Error fetching value of Setting"
+msgstr "获取设置值时出错"
+
+#: src/metabase/public_settings.clj
+msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
+msgstr "Metabase的UI，系统电子邮件，脉冲和警报应使用的语言。"
+
+#: src/metabase/public_settings.clj
+msgid "This is also the default language for all users, which they can change from their own account settings."
+msgstr "这也是所有用户的默认语言，他们可以从自己的帐户设置中更改。"
+
+#: src/metabase/public_settings.clj
+msgid "Invalid locale {0}"
+msgstr "无效的语言环境{0}"
+
+#: src/metabase/public_settings.clj
+msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
+msgstr "如果站点URL为HTTPS，则强制所有流量通过重定向使用HTTPS"
+
+#: src/metabase/public_settings.clj
+msgid "Cannot redirect requests to HTTPS unless `site-url` is HTTPS."
+msgstr "除非`site-url`是HTTPS，否则不能将请求重定向到HTTPS。"
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error registering fonts: Metabase will not be able to send Pulses."
+msgstr "注册字体时出错：Metabase无法发送Pulse。"
+
+#: src/metabase/pulse/render/png.clj
+msgid "This is a known issue with certain JVMs. See {0} and for more details."
+msgstr "这是某些JVM的已知问题。有关更多详细信息，请参见{0}。"
+
+#: src/metabase/pulse/render/png.clj
+msgid "Error rendering Pulse"
+msgstr "错误呈现脉冲"
+
+#: src/metabase/query_processor/context/default.clj
+msgid "Query timed out after {0}, raising timeout exception."
+msgstr "查询在{0}之后超时，引发超时异常。"
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "No fields found for table {0}."
+msgstr "找不到表{0}的字段。"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Case"
+msgstr "案件"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Variance of {0}"
+msgstr "{0}的方差"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Median of {0}"
+msgstr "{0}的中位数"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "{0}th percentile of {1}"
+msgstr "{1}的第{0}个百分点"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Not caching results: results are larger than {0} KB"
+msgstr "不缓存结果：结果大于{0} KB"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Cannot cache results: expected byte array, got {0}"
+msgstr "无法缓存结果：预期的字节数组，得到了{0}"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Request is closed; no one to return cached results to"
+msgstr "请求已关闭；没有人将缓存的结果返回给"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Error attempting to fetch cached results for query with hash {0}"
+msgstr "尝试获取哈希值为{0}的查询的缓存结果时出错"
+
+#: src/metabase/query_processor/middleware/cache_backend/db.clj
+msgid "Error preparing statement to fetch cached query results"
+msgstr "错误准备语句以获取缓存的查询结果"
+
+#: src/metabase/query_processor/middleware/catch_exceptions.clj
+msgid "Error processing query: {0}"
+msgstr "处理查询时出错：{0}"
+
+#: src/metabase/server.clj
+msgid "Unexpected exception in endpoint"
+msgstr "端点中的意外异常"
+
+#: src/metabase/server.clj
+msgid "Unexpected Exception in API request handler"
+msgstr "API请求处理程序中的异常"
+
+#: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+msgid "Error reducing {0}"
+msgstr "减少{0}时出错"
+
+#: src/metabase/sync/analyze/fingerprint/insights.clj
+msgid "Error generating timeseries insight keyed by: {0}"
+msgstr "生成时间序列洞察力时出错，输入键为：{0}"
+
+#: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
+msgstr "{0}的数据库位置已从“ {1}”更改为“ {2}”。"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Unscheduling task for Database {0}: trigger: {1}"
+msgstr "数据库{0}的未调度任务：触发器：{1}"
+
+#: src/metabase/util/schema.clj
+msgid "value must be a keyword or string."
+msgstr "值必须是关键字或字符串。"
+
+#: src/metabase/util/schema.clj
+msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
+msgstr "字符串必须是有效的两个字母的ISO语言或语言国家/地区代码，例如“ en”或“ en_US”。"
 


### PR DESCRIPTION
These PRs aren't really reviewable, but marking pinging @camsaul for a green checkmark. I updated the strings with the `import-po-from-poeditor` script, and verified translations and corrected `\n` errors via `build-translation-resources`.

Updates the following languages:

![image](https://user-images.githubusercontent.com/2223916/87974604-2b0ab200-ca7f-11ea-9be9-59498cc335d4.png)
