### PR TITLE
Remove fs dep

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -105,7 +105,6 @@
                  javax.jms/jms
                  com.sun.jdmk/jmxtools
                  com.sun.jmx/jmxri]]
-   [me.raynes/fs "1.4.6"]                                             ; Filesystem tools
    [medley "1.3.0"]                                                   ; lightweight lib of useful functions
    [metabase/connection-pool "1.1.1"]                                 ; simple wrapper around C3P0. JDBC connection pools
    [metabase/throttle "1.0.2"]                                        ; Tools for throttling access to API endpoints and other code pathways

--- a/src/metabase/cmd/dump_to_h2.clj
+++ b/src/metabase/cmd/dump_to_h2.clj
@@ -106,17 +106,17 @@
 
     (println "Dumping from configured Metabase db to H2 file" h2-filename)
 
-    (mdb/setup-db!* (get-target-db-conn h2-filename) true)
-    (mdb/setup-db!)
-
     (if (= :h2 (mdb/db-type))
       (println (u/format-color 'yellow (trs "Don't need to migrate, just use the existing H2 file")))
-      (jdbc/with-db-transaction [target-db-conn (get-target-db-conn h2-filename)]
-        (println "Conn of target: " target-db-conn)
-        (println-ok)
-        (println (u/format-color 'blue "Loading data..."))
-        (load-data! target-db-conn)
-        (println-ok)
-        (jdbc/db-unset-rollback-only! target-db-conn)))
+      (do
+        (mdb/setup-db!* (get-target-db-conn h2-filename) true)
+        (mdb/setup-db!)
+        (jdbc/with-db-transaction [target-db-conn (get-target-db-conn h2-filename)]
+          (println "Conn of target: " target-db-conn)
+          (println-ok)
+          (println (u/format-color 'blue "Loading data..."))
+          (load-data! target-db-conn)
+          (println-ok)
+          (jdbc/db-unset-rollback-only! target-db-conn))))
 
     (println "Dump complete")))

--- a/src/metabase/cmd/dump_to_h2.clj
+++ b/src/metabase/cmd/dump_to_h2.clj
@@ -12,7 +12,6 @@
              [jdbc :as jdbc]]
             [clojure.string :as str]
             [colorize.core :as color]
-            [me.raynes.fs :as fs]
             [metabase
              [db :as mdb]
              [util :as u]]
@@ -99,11 +98,10 @@
   Defaults to using `@metabase.db/db-file` as the connection string."
   [h2-filename]
   (let [h2-filename (or h2-filename "metabase_dump.h2")]
-    (println "Dumping to " h2-filename)
-    (doseq [filename [h2-filename
-                    (str h2-filename ".mv.db")]]
+    (println "Dumping to" h2-filename)
+    (doseq [filename [h2-filename (str h2-filename ".mv.db")]]
       (when (.exists (io/file filename))
-        (fs/delete filename)
+        (io/delete-file filename)
         (println (u/format-color 'red (trs "Output H2 database already exists: %s, removing.") filename))))
 
     (println "Dumping from configured Metabase db to H2 file" h2-filename)

--- a/src/metabase/cmd/dump_to_h2.clj
+++ b/src/metabase/cmd/dump_to_h2.clj
@@ -106,17 +106,17 @@
 
     (println "Dumping from configured Metabase db to H2 file" h2-filename)
 
+    (mdb/setup-db!* (get-target-db-conn h2-filename) true)
+    (mdb/setup-db!)
+
     (if (= :h2 (mdb/db-type))
       (println (u/format-color 'yellow (trs "Don't need to migrate, just use the existing H2 file")))
-      (do
-        (mdb/setup-db!* (get-target-db-conn h2-filename) true)
-        (mdb/setup-db!)
-        (jdbc/with-db-transaction [target-db-conn (get-target-db-conn h2-filename)]
-          (println "Conn of target: " target-db-conn)
-          (println-ok)
-          (println (u/format-color 'blue "Loading data..."))
-          (load-data! target-db-conn)
-          (println-ok)
-          (jdbc/db-unset-rollback-only! target-db-conn))))
+      (jdbc/with-db-transaction [target-db-conn (get-target-db-conn h2-filename)]
+        (println "Conn of target: " target-db-conn)
+        (println-ok)
+        (println (u/format-color 'blue "Loading data..."))
+        (load-data! target-db-conn)
+        (println-ok)
+        (jdbc/db-unset-rollback-only! target-db-conn)))
 
     (println "Dump complete")))

--- a/test/metabase/cmd/dump_to_h2_test.clj
+++ b/test/metabase/cmd/dump_to_h2_test.clj
@@ -1,7 +1,9 @@
 (ns metabase.cmd.dump-to-h2-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer :all]
             [flatland.ordered.map :as ordered-map]
             [metabase.cmd.dump-to-h2 :as dump-to-h2]
+            [metabase.util.files :as u.files]
             [toucan.db :as db]))
 
 (deftest path-test
@@ -33,3 +35,23 @@
       (is (= {:cols ["\"id\"" "\"row\"" "\"sizeX\"" "\"sizeY\""]
               :vals [[281 0 18 9]]}
              cols+vals)))))
+
+(deftest dump-deletes-target-db-files-tests
+  (let [tmp-h2-db     (str (u.files/get-path (System/getProperty "java.io.tmpdir") "mbtest_dump.h2"))
+        tmp-h2-db-mv  (str tmp-h2-db ".mv.db")
+        file-contents {tmp-h2-db    "Not really an H2 DB"
+                       tmp-h2-db-mv "Not really another H2 DB"}]
+    (try
+      (doseq [[filename contents] file-contents]
+        (spit filename contents))
+      (dump-to-h2/dump-to-h2! tmp-h2-db)
+
+      (doseq [filename (keys file-contents)]
+        (testing (str filename " was deleted")
+          (is (false? (.exists (io/file filename))))))
+
+      (finally
+        (doseq [filename (keys file-contents)
+                :let [file (io/file filename)]]
+          (when (.exists file)
+            (io/delete-file file)))))))

--- a/test/metabase/cmd/dump_to_h2_test.clj
+++ b/test/metabase/cmd/dump_to_h2_test.clj
@@ -1,0 +1,35 @@
+(ns metabase.cmd.dump-to-h2-test
+  (:require [clojure.test :refer :all]
+            [flatland.ordered.map :as ordered-map]
+            [metabase.cmd.dump-to-h2 :as dump-to-h2]
+            [toucan.db :as db]))
+
+(deftest path-test
+  (testing "works without file: schema"
+    (is (= {:classname   "org.h2.Driver"
+            :subprotocol "h2"
+            :subname     "file:/path/to/metabase.db"
+            :type        :h2}
+           (#'dump-to-h2/h2-details "/path/to/metabase.db"))))
+
+  (testing "works with file: schema"
+    (is (= {:classname "org.h2.Driver"
+            :subprotocol "h2"
+            :subname     "file:/path/to/metabase.db"
+            :type        :h2}
+           (#'dump-to-h2/h2-details "file:/path/to/metabase.db")))))
+
+(deftest casing-corner-cases-test
+  (testing "objects->colums+values property handles columns with weird casing: `sizeX` and `sizeY`"
+    (let [cols+vals (binding [db/*quoting-style* :ansi]
+                      (-> (#'dump-to-h2/objects->colums+values
+                           ;; using ordered-map so the results will be in a predictable order
+                           [(ordered-map/ordered-map
+                             :id    281
+                             :row   0
+                             :sizex 18
+                             :sizey 9)])
+                          (update :cols vec)))]
+      (is (= {:cols ["\"id\"" "\"row\"" "\"sizeX\"" "\"sizeY\""]
+              :vals [[281 0 18 9]]}
+             cols+vals)))))


### PR DESCRIPTION
I was about to switch it to the maintained fork at clj-commons/fs, but found that it's only used once, and where `io/delete-file` would serve just as well.

The code path to the `io/delete-file` call was tested manually.