### PR TITLE
Remove unused occurances-of-substring fn

### DIFF
--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -554,15 +554,6 @@
   "Increment `n` if it is non-`nil`, otherwise return `1` (e.g. as if incrementing `0`)."
   (fnil inc 0))
 
-(defn occurances-of-substring
-  "Return the number of times SUBSTR occurs in string S."
-  ^Long [^String s, ^String substr]
-  (when (and (seq s) (seq substr))
-    (loop [index 0, cnt 0]
-      (if-let [^long new-index (str/index-of s substr index)]
-        (recur (inc new-index) (inc cnt))
-        cnt))))
-
 (defn select-non-nil-keys
   "Like `select-keys`, but returns a map only containing keys in KS that are present *and non-nil* in M.
 

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -151,25 +151,6 @@
     "<<>>"          false
     "{\"a\": 10}"   false))
 
-(deftest occurances-of-substring-test
-  (testing "should return nil if one or both strings are nil or empty"
-    (are+ [s substr expected] (= expected
-                                 (u/occurances-of-substring s substr))
-      nil                                                                                 nil      nil
-      nil                                                                                 ""       nil
-      ""                                                                                  nil      nil
-      ""                                                                                  ""       nil
-      "ABC"                                                                               ""       nil
-      ""                                                                                  "  ABC"  nil
-      ;; non-empty strings
-      "ABC"                                                                               "A"      1
-      "ABA"                                                                               "A"      2
-      "AAA"                                                                               "A"      3
-      "ABC"                                                                               "{{id}}" 0
-      "WHERE ID = {{id}}"                                                                 "{{id}}" 1
-      "WHERE ID = {{id}} OR USER_ID = {{id}}"                                             "{{id}}" 2
-      "WHERE ID = {{id}} OR USER_ID = {{id}} OR TOUCAN_ID = {{id}} OR BIRD_ID = {{bird}}" "{{id}}" 3)))
-
 (deftest select-keys-test
   (testing "select-non-nil-keys"
     (is (= {:a 100}


### PR DESCRIPTION
This util function is not actually used anywhere in the codebase anymore