### PR TITLE
Don't parse unix date query params, fix field value loading

### DIFF
--- a/frontend/src/metabase/parameters/components/Parameters.jsx
+++ b/frontend/src/metabase/parameters/components/Parameters.jsx
@@ -268,7 +268,8 @@ export function parseQueryParam(
   }
   // [].every is always true, so only check if there are some fields
   if (fields.length > 0) {
-    if (fields.every(f => f.isNumeric())) {
+    // unix dates fields are numeric but query params shouldn't be parsed as numbers
+    if (fields.every(f => f.isNumeric() && !f.isDate())) {
       return parseFloat(value);
     }
     if (fields.every(f => f.isBoolean())) {

--- a/frontend/test/metabase/parameters/components/Parameters.unit.spec.js
+++ b/frontend/test/metabase/parameters/components/Parameters.unit.spec.js
@@ -1,3 +1,5 @@
+import Field from "metabase-lib/lib/metadata/Field";
+
 import { ORDERS, PRODUCTS } from "__support__/sample_dataset_fixture";
 
 import { parseQueryParam } from "metabase/parameters/components/Parameters";
@@ -23,6 +25,14 @@ describe("Parameters", () => {
     it("should not parse if there are no fields", () => {
       const result = parseQueryParam("123", []);
       expect(result).toBe("123");
+    });
+    it("should not parse date/numeric fields", () => {
+      const dateField = new Field({
+        ...ORDERS.QUANTITY, // some numeric field
+        special_type: "type/UNIXTimestampSeconds", // make it a date
+      });
+      const result = parseQueryParam("past30days", [dateField]);
+      expect(result).toBe("past30days");
     });
   });
 });


### PR DESCRIPTION
Fixes #12362 

The direct fix was to check that numeric fields don't have a date special_type before parsing them. I also updated how we fetch field values since @flamber suspected that it might be part of a worse bug. This avoids inserting a field with `undefined` id into redux state.