### PR TITLE
Fix-12964: Set :format-rows false to export card results

### DIFF
--- a/backend/mbql/src/metabase/mbql/schema.clj
+++ b/backend/mbql/src/metabase/mbql/schema.clj
@@ -952,7 +952,7 @@
    s/Bool
 
    ;; should we skip converting datetime types to ISO-8601 strings with appropriate timezone when post-processing
-   ;; results? Used by `metabase.query-processor.middleware.format-rows`; default `false`
+   ;; results? Used by `metabase.query-processor.middleware.format-rows`; default `true`
    (s/optional-key :format-rows?)
    s/Bool
 

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -639,7 +639,7 @@
      :parameters  (json/parse-string parameters keyword)
      :constraints nil
      :context     (dataset-api/export-format->context export-format)
-     :middleware  {:skip-results-metadata? true 
+     :middleware  {:skip-results-metadata? true
                    :format-rows?           false})))
 
 

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -639,7 +639,8 @@
      :parameters  (json/parse-string parameters keyword)
      :constraints nil
      :context     (dataset-api/export-format->context export-format)
-     :middleware  {:skip-results-metadata? true :format-rows? false})))
+     :middleware  {:skip-results-metadata? true 
+                   :format-rows?           false})))
 
 
 ;;; ----------------------------------------------- Sharing is Caring ------------------------------------------------

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -639,7 +639,7 @@
      :parameters  (json/parse-string parameters keyword)
      :constraints nil
      :context     (dataset-api/export-format->context export-format)
-     :middleware  {:skip-results-metadata? true})))
+     :middleware  {:skip-results-metadata? true :format-rows? false})))
 
 
 ;;; ----------------------------------------------- Sharing is Caring ------------------------------------------------

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -1132,8 +1132,7 @@
         (is (= ["MAX(DATE)" 
                 "2015-12-29"]
                (str/split-lines
-                ((mt/user->client :rasta) :post 202 (format "card/%d/query/csv" (u/get-id card)) )))))))
-  )
+                ((mt/user->client :rasta) :post 202 (format "card/%d/query/csv" (u/get-id card)) ))))))))
                                                             
 
 (deftest json-download-test
@@ -1147,7 +1146,12 @@
       (with-cards-in-readable-collection card
         (is (= [{(keyword "COUNT(*)") 8}]
                ((mt/user->client :rasta) :post 202 (format "card/%d/query/json?parameters=%s"
-                                                                   (u/get-id card) encoded-params))))))))
+                                                                   (u/get-id card) encoded-params)))))))
+  (testing "no-fomatting-rows"
+    (with-temp-native-card [_ card "CHECKINS" "SELECT MAX(DATE) FROM CHECKINS;"]
+      (with-cards-in-readable-collection card
+        (is (= [{(keyword "MAX(DATE)") "2015-12-29"}]
+               ((mt/user->client :rasta) :post 202 (format "card/%d/query/json" (u/get-id card)))))))))
 
 (defn- parse-xlsx-results [results]
   (->> results
@@ -1171,7 +1175,14 @@
                (parse-xlsx-results
                 ((mt/user->client :rasta) :post 202 (format "card/%d/query/xlsx?parameters=%s"
                                                                     (u/get-id card) encoded-params)
-                 {:request-options {:as :byte-array}}))))))))
+                 {:request-options {:as :byte-array}})))))))
+  (testing "no-fomatting-rows"
+    (with-temp-native-card [_ card "CHECKINS" "SELECT MAX(DATE) FROM CHECKINS;"]
+      (with-cards-in-readable-collection card
+        (is (= [{:col "MAX(DATE)"} {:col "2015-12-29"}]
+               (parse-xlsx-results
+                ((mt/user->client :rasta) :post 202 (format "card/%d/query/xlsx" (u/get-id card))
+                                          {:request-options {:as :byte-array}}))))))))
 
 (deftest download-default-constraints-test
   (tt/with-temp Card [card {:dataset_query {:database   (data/id)

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -1129,7 +1129,7 @@
   (testing "no-fomatting-rows"
     (with-temp-native-card [_ card "CHECKINS" "SELECT MAX(DATE) FROM CHECKINS;"]
       (with-cards-in-readable-collection card
-        (is (= ["MAX(DATE)" 
+        (is (= ["MAX(DATE)"
                 "2015-12-29"]
                (str/split-lines
                 ((mt/user->client :rasta) :post 202 (format "card/%d/query/csv" (u/get-id card)) ))))))))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -1111,7 +1111,7 @@
 
 (deftest csv-download-test
   (testing "no parameters"
-    (with-temp-native-card [_ card "CATEGORIES" "SELECT COUNT(*) FROM CATEGORIES;"] 
+    (with-temp-native-card [_ card "CATEGORIES" "SELECT COUNT(*) FROM CATEGORIES;"]
       (with-cards-in-readable-collection card
         (is (= ["COUNT(*)"
                 "75"]
@@ -1133,7 +1133,6 @@
                 "2015-12-29"]
                (str/split-lines
                 ((mt/user->client :rasta) :post 202 (format "card/%d/query/csv" (u/get-id card)) ))))))))
-                                                            
 
 (deftest json-download-test
   (testing "no parameters"


### PR DESCRIPTION
Fixes #12964 

The issue is related to the default value of `:format-rows` option.
In the `/:card-id/query/:export-format` [endpoint](https://github.com/metabase/metabase/blob/b6ad9f508971017f92f552d90ca9e7787272acc9/src/metabase/api/card.clj#L642) (which is used to export saved questios) we dont pass `:format-rows? false` as we do in the `/api/dataset/:export-format` [endpoint](https://github.com/metabase/metabase/blob/b6ad9f508971017f92f552d90ca9e7787272acc9/src/metabase/api/dataset.clj#L91). Because we don't pass `false` to `:format-rows` in card export endpoint, it'll assume the default value in the `format_rows.clj`, which is defined as  `true` in the `format-rows` [method](https://github.com/metabase/metabase/blob/b6ad9f508971017f92f552d90ca9e7787272acc9/src/metabase/query_processor/middleware/format_rows.clj#L77).
[Following the MBQL schema](https://github.com/metabase/metabase/blob/b6ad9f508971017f92f552d90ca9e7787272acc9/backend/mbql/src/metabase/mbql/schema.clj#L955), the default value of this parameter should be `false`. We prefer to change only the endpoint, because the consequences is more predictable. We also changed the docstring in MBQL schema to maintain the default value documentation consistent with the code.
