### PR TITLE
cypress flake fix: use `popover().within` to retry getting popover

### DIFF
--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -117,12 +117,8 @@ describe("scenarios > question > notebook", () => {
       });
 
       // select the join columns
-      popover()
-        .findByText("A_COLUMN")
-        .click();
-      popover()
-        .findByText("B_COLUMN")
-        .click();
+      popover().within(() => cy.findByText("A_COLUMN").click());
+      popover().within(() => cy.findByText("B_COLUMN").click());
 
       cy.findByText("Visualize").click();
       cy.queryByText("Visualize").then($el => cy.wrap($el).should("not.exist")); // wait for that screen to disappear to avoid "multiple elements" errors


### PR DESCRIPTION
I'm going to rebuild this a few times before merging since it always seems to pass locally but I saw it fail twice in CI.