### PR TITLE
Fix Redshift field filters regression

### DIFF
--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -175,32 +175,27 @@
  [::legacy/use-legacy-classes-for-read-and-set OffsetTime]
  [:postgres OffsetTime])
 
-(defn query->field-values
-  "Convert a MBQL query to a map of field->value"
-  [query]
+(defn- field->parameter-value
+  "Map fields used in parameters to parameter `:value`s."
+  [{:keys [user-parameters]}]
   (into {}
-        (filter identity
-                (map
-                 (fn [param]
-                   (if (contains? param :name)
-                     [(:name param) (:value param)]
+        (keep (fn [param]
+                (if (contains? param :name)
+                  [(:name param) (:value param)]
 
-                     (when-let [field-id (mbql.u/match-one
-                                          param
-                                          [:dimension field]
-                                          (let [field-id-or-name (mbql.u/field-clause->id-or-literal field)]
-                                            (when (integer? field-id-or-name)
-                                              field-id-or-name)))]
-                       [(:name (qp.store/field field-id)) (:value param)])))
-                 (:user-parameters query)))))
+                  (when-let [field-id (mbql.u/match-one param
+                                        [:field-id field-id] (when (contains? (set &parents) :dimension)
+                                                               field-id))]
+                    [(:name (qp.store/field field-id)) (:value param)]))))
+        user-parameters))
 
 (defmethod qputil/query->remark :redshift
-  [_ {{:keys [executed-by query-hash card-id], :as info} :info, query-type :type :as query}]
+  [_ {{:keys [executed-by query-hash card-id]} :info, :as query}]
   (str "/* partner: \"metabase\", "
-       (json/generate-string {:dashboard_id nil ;; requires metabase/metabase#11909
-                              :chart_id card-id
-                              :optional_user_id executed-by
+       (json/generate-string {:dashboard_id        nil ;; requires metabase/metabase#11909
+                              :chart_id            card-id
+                              :optional_user_id    executed-by
                               :optional_account_id (pubset/site-uuid)
-                              :filter_values (query->field-values query)})
+                              :filter_values       (field->parameter-value query)})
        " */ "
        (qputil/default-query->remark query)))

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -60,3 +60,19 @@
                       :nested? false
                       :query-hash (byte-array [-53, -125, -44, -10, -18, -36, 37, 14, -37, 15, 44, 22, -8, -39, -94, 30, 93, 66, -13, 34, -52, -20, -31, 73, 76, -114, -13, -42, 52, 88, 31, -30])})))
           "if I run a Redshift query, does it get a remark added to it?")))))
+
+(deftest parameters-test
+  (testing "Native query parameters should work with filters."
+    (is (= [[693 "2015-12-29T00:00:00Z" 10 90]]
+           (mt/rows
+             (qp/process-query
+              {:database   (mt/id)
+               :type       :native
+               :native     {:query         "select * from checkins where {{date}} order by date desc limit 1;"
+                            :template-tags {"date" {:name         "date"
+                                                    :display-name "date"
+                                                    :type         :dimension
+                                                    :dimension    [:field-id (mt/id :checkins :date)]}}}
+               :parameters [{:type :date/all-options
+                             :target [:dimension [:template-tag "date"]]
+                             :value "past30years"}]}))))))


### PR DESCRIPTION
`mbql.u/field-clause->id-or-literal` is picky in what it accepts. This reworks the code to directly extract the ID (as only the case where we have field ID is needed). 

Fixes #12984