### PR TITLE
Guard against undefined sections when formatting description

### DIFF
--- a/frontend/src/metabase/lib/query/description.js
+++ b/frontend/src/metabase/lib/query/description.js
@@ -345,7 +345,6 @@ export function formatQueryDescription(parts, options = {}) {
   if (!parts) {
     return "";
   }
-  console.log("formatQueryDescription", { parts, options });
 
   options = {
     jsx: false,
@@ -370,7 +369,7 @@ export function formatQueryDescription(parts, options = {}) {
   };
 
   // these array gymnastics are needed to support JSX formatting
-  const sections = options.sections
+  const sections = (options.sections || [])
     .map(section =>
       _.flatten(sectionFns[section](parts, options)).filter(s => !!s),
     )


### PR DESCRIPTION
Maybe fixes #12982

I'm not sure why `options.sections` would be undefined, but this guard will hopefully address the error seen in #12982. It will avoid the crash and instead result in blank descriptions for any problematic metrics.