### PR TITLE
Remove deleted entities from state

### DIFF
--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -488,9 +488,9 @@ export function createEntity(def: EntityDefinition): Entity {
     // delegate to getObject
     (state, entityIds) =>
       entityIds &&
-      entityIds.map(entityId =>
-        entity.selectors.getObject(state, { entityId }),
-      ),
+      entityIds
+        .map(entityId => entity.selectors.getObject(state, { entityId }))
+        .filter(e => e != null), // deleted entities might remain in lists
   );
 
   // REQUEST STATE SELECTORS

--- a/frontend/src/metabase/lib/redux.js
+++ b/frontend/src/metabase/lib/redux.js
@@ -134,10 +134,10 @@ export const updateData = async ({
 export function mergeEntities(entities, newEntities) {
   entities = { ...entities };
   for (const id in newEntities) {
-    if (id in entities) {
-      entities[id] = { ...entities[id], ...newEntities[id] };
+    if (newEntities[id] === null) {
+      delete entities[id];
     } else {
-      entities[id] = newEntities[id];
+      entities[id] = { ...entities[id], ...newEntities[id] };
     }
   }
   return entities;

--- a/frontend/test/metabase/lib/redux.unit.spec.js
+++ b/frontend/test/metabase/lib/redux.unit.spec.js
@@ -1,4 +1,4 @@
-import { fetchData, updateData } from "metabase/lib/redux";
+import { fetchData, updateData, mergeEntities } from "metabase/lib/redux";
 
 import { delay } from "metabase/lib/promise";
 
@@ -139,6 +139,30 @@ describe("Metadata", () => {
       await delay(10);
       expect(argsFail.dispatch.calls.count()).toEqual(2);
       expect(data).toEqual(args.existingData);
+    });
+  });
+
+  describe("mergeEntities", () => {
+    it("add an entity", () => {
+      expect(
+        mergeEntities(
+          { 1: { id: 1, name: "foo" } },
+          { 2: { id: 2, name: "bar" } },
+        ),
+      ).toEqual({ 1: { id: 1, name: "foo" }, 2: { id: 2, name: "bar" } });
+    });
+    it("merge entity keys", () => {
+      expect(
+        mergeEntities(
+          { 1: { id: 1, name: "foo", prop1: 123 } },
+          { 1: { id: 1, name: "bar", prop2: 456 } },
+        ),
+      ).toEqual({ 1: { id: 1, name: "bar", prop1: 123, prop2: 456 } });
+    });
+    it("delete an entity", () => {
+      expect(
+        mergeEntities({ 1: { id: 1 }, 2: { id: 2 } }, { 2: null }),
+      ).toEqual({ 1: { id: 1 } });
     });
   });
 });


### PR DESCRIPTION
Fixes #11653

Deleting entities was broken. The action dispatched correctly set the entity's value to `null`, but our code to merge keys rather than replacing existing entities didn't account for this. The null was merged with the entity's keys resulting in not removing it. I'm guessing this didn't cause more issues because we frequently re-list entities and we usually mark as archived rather than deleting.