### PR TITLE
Include card's display to prevent marking as dirty

### DIFF
--- a/frontend/src/metabase/visualizations/components/TitleLegendHeader.jsx
+++ b/frontend/src/metabase/visualizations/components/TitleLegendHeader.jsx
@@ -23,6 +23,7 @@ export const TitleLegendHeader = ({
             : {
                 id: cardIds[0],
                 dataset_query: originalSeries[0].card.dataset_query,
+                display: originalSeries[0].card.display,
               }),
         },
       },

--- a/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
@@ -1,0 +1,44 @@
+import { signIn, restore, popover } from "__support__/cypress";
+
+describe("scenarios > dashboard > title drill", () => {
+  before(restore);
+  beforeEach(signIn);
+
+  it("should let you click through the title to the query builder", () => {
+    createDashboard(dashId => {
+      cy.visit(`/dashboard/${dashId}`);
+      // wait for qustion to load
+      cy.findByText("foo");
+      // drill through title
+      cy.findByText("Q1").click();
+      cy.findByText("This question is written in SQL."); // check that we're in the QB now
+      cy.findByText("foo");
+      cy.findByText("bar");
+    });
+  });
+});
+
+function createDashboard(callback) {
+  cy.request("POST", "/api/card", {
+    name: "Q1",
+    dataset_query: {
+      type: "native",
+      native: { query: 'SELECT 1 as "foo", 2 as "bar"', "template-tags": {} },
+      database: 1,
+    },
+    display: "bar",
+    visualization_settings: {
+      "graph.dimensions": ["foo"],
+      "graph.metrics": ["bar"],
+    },
+  }).then(({ body }) =>
+    cy
+      .request("POST", "/api/dashboard", { name: "dashing dashboard" })
+      .then(({ body: { id: dashId } }) => {
+        cy.request("POST", `/api/dashboard/${dashId}/cards`, {
+          cardId: body.id,
+        });
+        callback(dashId);
+      }),
+  );
+}

--- a/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
@@ -1,4 +1,4 @@
-import { signIn, restore, popover } from "__support__/cypress";
+import { signIn, restore } from "__support__/cypress";
 
 describe("scenarios > dashboard > title drill", () => {
   before(restore);


### PR DESCRIPTION
Fixes #13042

This broke with my change in #12960. Clicking through on the title was incorrectly detecting a changed card because the display was getting stripped. Prior to #12960 that didn't matter, but in that change we started removing the card id to display all the "unsaved" UI.