### PR TITLE
Fix build breakage in Cloverage

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -367,8 +367,8 @@
 
    :cloverage
    [:test-common
-    {:dependencies [[cloverage "1.1.3-SNAPSHOT" :exclusions [riddley]]]
-     :plugins      [[lein-cloverage  "1.1.3-SNAPSHOT"]]
+    {:dependencies [[cloverage "1.2.0" :exclusions [riddley]]]
+     :plugins      [[lein-cloverage  "1.2.0"]]
      :source-paths ^:replace ["src" "backend/mbql/src"]
      :test-paths   ^:replace ["test" "backend/mbql/test"]
      :cloverage    {:fail-threshold 69


### PR DESCRIPTION
We were using a SNAPSHOT of Cloverage, which is broken.

Updating to 1.2.0, the latest, which includes a fix that
Cam had submitted to upstream.