### PR TITLE
Improve time-interval datetime comparison performance

### DIFF
--- a/backend/mbql/src/metabase/mbql/util.clj
+++ b/backend/mbql/src/metabase/mbql/util.clj
@@ -301,25 +301,25 @@
     [:time-interval field :next    unit options] (recur [:time-interval field  1 unit options])
 
     [:time-interval field (n :guard #{-1}) unit (_ :guard :include-current)]
-    [:between [:datetime-field field unit] [:relative-datetime n unit] [:relative-datetime 0 unit]]
+    [:and [:>= field [:relative-datetime n unit]] [:< field [:relative-datetime 1 unit]]]
 
     [:time-interval field (n :guard #{1}) unit (_ :guard :include-current)]
-    [:between [:datetime-field field unit] [:relative-datetime 0 unit] [:relative-datetime n unit]]
+    [:and [:>= field [:relative-datetime 0 unit]] [:< field [:relative-datetime (+' n 1) unit]]]
 
     [:time-interval field (n :guard #{-1 0 1}) unit _]
-    [:= [:datetime-field field unit] [:relative-datetime n unit]]
+    [:and [:>= field [:relative-datetime n unit]] [:< field [:relative-datetime (+' n 1) unit]]]
 
     [:time-interval field (n :guard neg?) unit (_ :guard :include-current)]
-    [:between [:datetime-field field unit] [:relative-datetime n unit] [:relative-datetime 0 unit]]
+    [:and [:>= field [:relative-datetime n unit]] [:< field [:relative-datetime 1 unit]]]
 
     [:time-interval field (n :guard neg?) unit _]
-    [:between [:datetime-field field unit] [:relative-datetime n unit] [:relative-datetime -1 unit]]
+    [:and [:>= field [:relative-datetime n unit]] [:< field [:relative-datetime 0 unit]]]
 
     [:time-interval field n unit (_ :guard :include-current)]
-    [:between [:datetime-field field unit] [:relative-datetime 0 unit] [:relative-datetime n unit]]
+    [:and [:>= field [:relative-datetime 0 unit]] [:< field [:relative-datetime n unit]]]
 
     [:time-interval field n unit _]
-    [:between [:datetime-field field unit] [:relative-datetime 1 unit] [:relative-datetime n unit]]))
+    [:and [:>= field [:relative-datetime 1 unit]] [:< field [:relative-datetime (+' n 1) unit]]]))
 
 (defn desugar-does-not-contain
   "Rewrite `:does-not-contain` filter clauses as simpler `:not` clauses."

--- a/backend/mbql/test/metabase/mbql/util_test.clj
+++ b/backend/mbql/test/metabase/mbql/util_test.clj
@@ -552,44 +552,40 @@
       "Should be able to add a filter clause to a query"))
 
 (deftest desugar-time-interval-test
-  (is (= [:between
-          [:datetime-field [:field-id 1] :month]
-          [:relative-datetime 1 :month]
-          [:relative-datetime 2 :month]]
+  (is (= [:and
+          [:>= [:field-id 1] [:relative-datetime 1 :month]]
+          [:< [:field-id 1] [:relative-datetime 3 :month]]]
          (mbql.u/desugar-filter-clause [:time-interval [:field-id 1] 2 :month]))
-      "`time-interval` with value > 1 or < -1 should generate a `between` clause")
-  (is (= [:between
-          [:datetime-field [:field-id 1] :month]
-          [:relative-datetime 0 :month]
-          [:relative-datetime 2 :month]]
+      "`time-interval` with value > 1 or < -1 should generate an `and` clause")
+  (is (= [:and
+          [:>= [:field-id 1] [:relative-datetime 0 :month]]
+          [:< [:field-id 1] [:relative-datetime 2 :month]]]
          (mbql.u/desugar-filter-clause [:time-interval [:field-id 1] 2 :month {:include-current true}]))
       "test the `include-current` option -- interval should start or end at `0` instead of `1`")
-  (is (= [:=
-          [:datetime-field [:field-id 1] :month]
-          [:relative-datetime 1 :month]]
+  (is (= [:and
+          [:>= [:field-id 1] [:relative-datetime 1 :month]]
+          [:< [:field-id 1] [:relative-datetime 2 :month]]]
          (mbql.u/desugar-filter-clause [:time-interval [:field-id 1] 1 :month]))
-      "`time-interval` with value = 1 should generate an `=` clause")
-  (is (= [:=
-          [:datetime-field [:field-id 1] :week]
-          [:relative-datetime -1 :week]]
+      "`time-interval` with value = 1 should generate an `and` clause")
+  (is (= [:and
+          [:>= [:field-id 1] [:relative-datetime -1 :week]]
+          [:< [:field-id 1] [:relative-datetime 0 :week]]]
          (mbql.u/desugar-filter-clause [:time-interval [:field-id 1] -1 :week]))
-      "`time-interval` with value = -1 should generate an `=` clause")
+      "`time-interval` with value = -1 should generate an `and` clause")
   (testing "`include-current` option"
-    (is (= [:between
-            [:datetime-field [:field-id 1] :month]
-            [:relative-datetime 0 :month]
-            [:relative-datetime 1 :month]]
+    (is (= [:and
+            [:>= [:field-id 1] [:relative-datetime 0 :month]]
+            [:< [:field-id 1] [:relative-datetime 2 :month]]]
            (mbql.u/desugar-filter-clause [:time-interval [:field-id 1] 1 :month {:include-current true}]))
-        "interval with value = 1 should generate a `between` clause")
-    (is (= [:between
-            [:datetime-field [:field-id 1] :day]
-            [:relative-datetime -1 :day]
-            [:relative-datetime 0 :day]]
+        "interval with value = 1 should generate an `and` clause")
+    (is (= [:and
+            [:>= [:field-id 1] [:relative-datetime -1 :day]]
+            [:< [:field-id 1] [:relative-datetime 1 :day]]]
            (mbql.u/desugar-filter-clause [:time-interval [:field-id 1] -1 :day {:include-current true}]))
-        "`include-current` option -- interval with value = 1 should generate a `between` clause"))
-  (is (= [:=
-          [:datetime-field [:field-id 1] :week]
-          [:relative-datetime 0 :week]]
+        "`include-current` option -- interval with value = 1 should generate a `and` clause"))
+  (is (= [:and
+          [:>= [:field-id 1] [:relative-datetime 0 :week]]
+          [:< [:field-id 1] [:relative-datetime 1 :week]]]
          (mbql.u/desugar-filter-clause [:time-interval [:field-id 1] :current :week]))
       "keywords like `:current` should work correctly"))
 
@@ -733,9 +729,9 @@
             [:= [:field-id 1] 30]]
            (mbql.u/negate-filter-clause [:!= [:field-id 1] 10 20 30]))))
   (testing :time-interval
-    (is (= [:!=
-            [:datetime-field [:field-id 1] :week]
-            [:relative-datetime 0 :week]]
+    (is (= [:or
+            [:< [:field-id 1] [:relative-datetime 0 :week]]
+            [:>= [:field-id 1] [:relative-datetime 1 :week]]]
            (mbql.u/negate-filter-clause [:time-interval [:field-id 1] :current :week]))))
   (testing :is-null
     (is (= [:!= [:field-id 1] nil]

--- a/test/metabase/query_processor/middleware/desugar_test.clj
+++ b/test/metabase/query_processor/middleware/desugar_test.clj
@@ -10,18 +10,14 @@
           :query    {:source-table 1
                      :filter       [:and
                                     [:= [:field-id 1] "Run Query"]
-                                    [:between
-                                     [:datetime-field [:field-id 2] :day]
-                                     [:relative-datetime -30 :day]
-                                     [:relative-datetime -1 :day]]
+                                    [:>= [:field-id 2] [:relative-datetime -30 :day]]
+                                    [:< [:field-id 2] [:relative-datetime 0 :day]]
                                     [:!= [:field-id 3] "(not set)"]
                                     [:!= [:field-id 3] "url"]]
                      :aggregation  [[:share [:and
                                              [:= [:field-id 1] "Run Query"]
-                                             [:between
-                                              [:datetime-field [:field-id 2] :day]
-                                              [:relative-datetime -30 :day]
-                                              [:relative-datetime -1 :day]]
+                                             [:>= [:field-id 2] [:relative-datetime -30 :day]]
+                                             [:< [:field-id 2] [:relative-datetime 0 :day]]
                                              [:!= [:field-id 3] "(not set)"]
                                              [:!= [:field-id 3] "url"]]]]}}
          (:pre


### PR DESCRIPTION
1. where created_at >= '2020-08-07 00:00:00' and created_at < '2020-08-08 00:00:00'
2. where date(created_at) >= '2020-08-07 00:00:00' and date(created_at) < '2020-08-08 00:00:00'

performance of 1 is better than 2 because of index, most of the
databases including mysql/postgres will do a full scan on table if there are
functions performed on table columns



###### Before submitting the PR, please make sure you do the following
- [x] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.
### Tests
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
