### PR TITLE
Remove duplicate entries in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@
 /frontend/test/snapshots/*
 /lein-plugins/*/target
 /local/src
-/local/src
 /locales/metabase-*.pot
 /modules/drivers/*/resources/namespaces.edn
 /modules/drivers/*/target
@@ -45,7 +44,6 @@
 /process.yml
 /reset-password-artifacts
 /resources/frontend_client/app/dist/
-/resources/frontend_client/app/locales
 /resources/frontend_client/app/locales
 /resources/frontend_client/embed.html
 /resources/frontend_client/index.html


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish
While working on localization issues (13063, 13082 - not linking) I noticed a few duplicate entries in `.gitignore`.
**This PR removes them.**


