### PR TITLE
Test for null BSON ObjectId properly

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -226,7 +226,10 @@
 
 (defmethod ->rvalue :value
   [[_ value {base-type :base_type}]]
-  (if (isa? base-type :type/MongoBSONID)
+  (if (and (isa? base-type :type/MongoBSONID)
+           (some? value))
+    ;; Passing a nil to the ObjectId constructor throws an exception
+    ;; "invalid hexadecimal representation of an ObjectId: []" so, just treat it as nil
     (ObjectId. (str value))
     value))
 

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -219,15 +219,23 @@
      [{:field-name "name", :base-type :type/Text}
       {:field-name "bird_id", :base-type :type/MongoBSONID}]
      [["Rasta Toucan" (ObjectId. "012345678901234567890123")]
-      ["Lucky Pigeon" (ObjectId. "abcdefabcdefabcdefabcdef")]]]])
+      ["Lucky Pigeon" (ObjectId. "abcdefabcdefabcdefabcdef")]
+      ["Unlucky Raven" nil]]]])
 
 (deftest bson-ids-test
   (mt/test-driver :mongo
-    (is (= [[2 "Lucky Pigeon" (ObjectId. "abcdefabcdefabcdefabcdef")]]
-           (rows (mt/dataset with-bson-ids
-                   (mt/run-mbql-query birds
-                     {:filter [:= $bird_id "abcdefabcdefabcdefabcdef"]}))))
-        "Check that we support Mongo BSON ID and can filter by it (#1367)")))
+    (testing "BSON IDs"
+     (is (= [[2 "Lucky Pigeon" (ObjectId. "abcdefabcdefabcdefabcdef")]]
+            (rows (mt/dataset with-bson-ids
+                    (mt/run-mbql-query birds
+                      {:filter [:= $bird_id "abcdefabcdefabcdefabcdef"]}))))
+         "Check that we support Mongo BSON ID and can filter by it (#1367)")
+
+     (is (= [[3 "Unlucky Raven" nil]]
+            (rows (mt/dataset with-bson-ids
+                    (mt/run-mbql-query birds
+                      {:filter [:is-null $bird_id]}))))
+         "handle null ObjectId queries properly (#11134)"))))
 
 (deftest bson-fn-call-forms-test
   (mt/test-driver :mongo


### PR DESCRIPTION
The check for a null ObjectId is {"$eq" nil} - not using the ObjectId class.

Resolves #11134

[ci mongo]