### PR TITLE
Handle ARRAY return types in BigQuery

### DIFF
--- a/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
@@ -189,8 +189,9 @@
           (doall
            (for [^TableFieldSchema field (.getFields schema)
                  :let                    [column-type (.getType field)
+                                          column-mode (.getMode field)
                                           method (get-method bigquery.qp/parse-result-of-type column-type)]]
-             (partial method column-type bigquery.common/*bigquery-timezone-id*)))
+             (partial method column-type column-mode bigquery.common/*bigquery-timezone-id*)))
 
           columns
           (for [column (table-schema->metabase-field-info schema)]

--- a/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
@@ -55,28 +55,38 @@
 
 (defmulti parse-result-of-type
   "Parse the values that come back in results of a BigQuery query based on their column type."
-  {:arglists '([column-type timezone-id v])}
-  (fn [column-type _ _] column-type))
+  {:arglists '([column-type column-mode timezone-id v])}
+  (fn [column-type _ _ _] column-type))
+
+(defn- parse-value
+  [column-mode v parse-fn]
+  ;; For results from a query like `SELECT [1,2]`, BigQuery sets the column-mode to `REPEATED` and wraps the column in an ArrayList,
+  ;; with ArrayMap entries, like: `ArrayList(ArrayMap("v", 1), ArrayMap("v", 2))`
+  (if (= "REPEATED" column-mode)
+    (for [result v
+          ^java.util.Map$Entry entry result]
+      (parse-fn (.getValue entry)))
+    (parse-fn v)))
 
 (defmethod parse-result-of-type :default
-  [_ _ v]
-  v)
+  [_ column-mode _ v]
+  (parse-value column-mode v identity))
 
 (defmethod parse-result-of-type "BOOLEAN"
-  [_ _ v]
-  (Boolean/parseBoolean v))
+  [_ column-mode _ v]
+  (parse-value column-mode v #(Boolean/parseBoolean %)))
 
 (defmethod parse-result-of-type "FLOAT"
-  [_ _ v]
-  (Double/parseDouble v))
+  [_ column-mode _ v]
+  (parse-value column-mode v #(Double/parseDouble %)))
 
 (defmethod parse-result-of-type "INTEGER"
-  [_ _ v]
-  (Long/parseLong v))
+  [_ column-mode _ v]
+  (parse-value column-mode v #(Long/parseLong %)))
 
 (defmethod parse-result-of-type "NUMERIC"
-  [_ _ v]
-  (bigdec v))
+  [_ column-mode _ v]
+  (parse-value column-mode v bigdec))
 
 (defn- parse-timestamp-str [timezone-id s]
   ;; Timestamp strings either come back as ISO-8601 strings or Unix timestamps in µs, e.g. "1.3963104E9"
@@ -86,20 +96,20 @@
     (u.date/parse s timezone-id)))
 
 (defmethod parse-result-of-type "DATE"
-  [_ timezone-id s]
-  (parse-timestamp-str timezone-id s))
+  [_ column-mode timezone-id v]
+  (parse-value column-mode v (partial parse-timestamp-str timezone-id)))
 
 (defmethod parse-result-of-type "DATETIME"
-  [_ timezone-id s]
-  (parse-timestamp-str timezone-id s))
+  [_ column-mode timezone-id v]
+  (parse-value column-mode v (partial parse-timestamp-str timezone-id)))
 
 (defmethod parse-result-of-type "TIMESTAMP"
-  [_ timezone-id s]
-  (parse-timestamp-str timezone-id s))
+  [_ column-mode timezone-id v]
+  (parse-value column-mode v (partial parse-timestamp-str timezone-id)))
 
 (defmethod parse-result-of-type "TIME"
-  [_ timezone-id s]
-  (u.date/parse s timezone-id))
+  [_ column-mode timezone-id v]
+  (parse-value column-mode v (fn [v] (u.date/parse v timezone-id))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
@@ -59,6 +59,30 @@
                                         "FROM `v2_test_data.checkins` "
                                         "LIMIT 2")}
                  :type     :native
+                 :database (mt/id)})))))
+
+    (testing "queries with array result columns deserialize properly (issue #10275)"
+      (is (= [[["foo" "bar"]
+               [1 2]
+               [3.14159265359 0.5772156649]
+               [1234M 5678M]
+               [#t "2018-01-01T00:00Z[UTC]" #t "2018-12-31T00:00Z[UTC]"]
+               [#t "12:34" #t "20:01:13.230"]
+               [#t "1957-05-17T03:35Z[UTC]" #t "2018-06-01T01:15:34.120Z[UTC]"]
+               [#t "2014-09-27T20:30:00.450Z[UTC]" #t "2020-09-27T14:57:00.450Z[UTC]"]
+               []]]
+             (mt/rows
+              (qp/process-query
+               {:native   {:query (str "SELECT ['foo', 'bar'], "
+                                       "[1, 2], "
+                                       "[3.14159265359, 0.5772156649], "
+                                       "[NUMERIC '1234', NUMERIC '5678'], "
+                                       "[DATE '2018-01-01', DATE '2018-12-31'], "
+                                       "[TIME '12:34:00.00', TIME '20:01:13.23'], "
+                                       "[DATETIME '1957-05-17 03:35:00.00', DATETIME '2018-06-01 01:15:34.12'], "
+                                       "[TIMESTAMP '2014-09-27 12:30:00.45-08', TIMESTAMP '2020-09-27 09:57:00.45-05'], "
+                                       "[]")}
+                 :type     :native
                  :database (mt/id)})))))))
 
 (deftest aggregations-test


### PR DESCRIPTION
BigQuery returns arrays in a result with a type of: {:mode "REPEATED" :type "NUMERIC"}

Handle these REPEATED values appropriately

Resolves #10275

[ci bigquery]
