### PR TITLE
Remove deprecated X-XSS-Protection header

### DIFF
--- a/src/metabase/middleware/security.clj
+++ b/src/metabase/middleware/security.clj
@@ -102,9 +102,7 @@
    (when-not allow-iframes?
      ;; Tell browsers not to render our site as an iframe (prevent clickjacking)
      {"X-Frame-Options"                 "DENY"})
-   { ;; Tell browser to block suspected XSS attacks
-    "X-XSS-Protection"                  "1; mode=block"
-    ;; Prevent Flash / PDF files from including content from site.
+   { ;; Prevent Flash / PDF files from including content from site.
     "X-Permitted-Cross-Domain-Policies" "none"
     ;; Tell browser not to use MIME sniffing to guess types of files -- protect against MIME type confusion attacks
     "X-Content-Type-Options"            "nosniff"}))

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -23,8 +23,7 @@
              "Strict-Transport-Security"         "max-age=31536000"
              "X-Content-Type-Options"            "nosniff"
              "X-Frame-Options"                   "DENY"
-             "X-Permitted-Cross-Domain-Policies" "none"
-             "X-XSS-Protection"                  "1; mode=block"}})
+             "X-Permitted-Cross-Domain-Policies" "none"}})
 
 (defn- mock-api-fn [response-fn]
   ((-> (fn [request respond _]


### PR DESCRIPTION
Fixes #11444. Header is deprecated in all browsers supported by Metabase.

### Tests
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).