### PR TITLE
Slack tweaks for orgs with large numbers of channels/users

### DIFF
--- a/test/metabase/integrations/slack_test.clj
+++ b/test/metabase/integrations/slack_test.clj
@@ -49,7 +49,7 @@
     (testing "should return nil if no Slack token has been configured"
       (tu/with-temporary-setting-values [slack-token nil]
         (is (= nil
-               (thunk)))))))
+               (not-empty (thunk))))))))
 
 (defn- test-invalid-auth-token
   "Test that a Slack API endpoint function throws an Exception if an invalid Slack API token is set."


### PR DESCRIPTION
Fixes #11735 by increasing the timeout we use for HTTP requests to the Slack API
Fixes #12978 by increasing the limit to the number of channels we fetch from 1,000 to 10,000 while increasing the page size for each request made to the Slack API from 100 to 1000. Filters out deleted and bot users from the Slack API response.