### PR TITLE
Change BigQuery driver to accept documented dataset name

### DIFF
--- a/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
@@ -36,7 +36,7 @@
   [s]
   (boolean
    (and (string? s)
-        (re-matches #"^[a-zA-Z_0-9]{1,1024}$" s))))
+        (re-matches #"^[a-zA-Z_0-9]{1,128}$" s))))
 
 (def ^:private BigQueryIdentifierString
   (s/pred valid-bigquery-identifier? "Valid BigQuery identifier"))

--- a/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
@@ -36,7 +36,7 @@
   [s]
   (boolean
    (and (string? s)
-        (re-matches #"^([a-zA-Z_][a-zA-Z_0-9]*){1,128}$" s))))
+        (re-matches #"^[a-zA-Z_0-9]{1,1024}$" s))))
 
 (def ^:private BigQueryIdentifierString
   (s/pred valid-bigquery-identifier? "Valid BigQuery identifier"))

--- a/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
@@ -622,3 +622,20 @@
                   (mt/native-query
                     {:query  "SELECT count(*) AS `count` FROM `v2_test_data.venues` WHERE `v2_test_data.venues`.`name` = ?"
                      :params ["x\\\\' OR 1 = 1 -- "]})))))))))
+
+(deftest acceptable-dataset-test
+  (mt/test-driver :bigquery
+    (testing "Make sure validation of dataset's name works correctly"
+      (testing "acceptable names"
+        (are [name] (= true (#'bigquery.qp/valid-bigquery-identifier?' name))
+              "0"
+              "a"
+              "apple"
+              (repeat 1024 "a")
+              "_"))
+      (testing "rejected names"
+        (are [name] (= false (#'bigquery.qp/valid-bigquery-identifier?' name))
+              "have-dataset"
+              "have:dataset"
+              ""
+              (repeat 1025 "a"))))))

--- a/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
@@ -627,14 +627,14 @@
   (mt/test-driver :bigquery
     (testing "Make sure validation of dataset's name works correctly"
       (testing "acceptable names"
-        (are [name] (= true (#'bigquery.qp/valid-bigquery-identifier?' name))
+        (are [name] (= true (#'bigquery.qp/valid-bigquery-identifier? name))
               "0"
               "a"
               "_"
               "apple"
               (repeat 128 "a")))
       (testing "rejected names"
-        (are [name] (= false (#'bigquery.qp/valid-bigquery-identifier?' name))
+        (are [name] (= false (#'bigquery.qp/valid-bigquery-identifier? name))
               "have-dataset"
               "have:dataset"
               ""

--- a/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
@@ -630,12 +630,12 @@
         (are [name] (= true (#'bigquery.qp/valid-bigquery-identifier?' name))
               "0"
               "a"
+              "_"
               "apple"
-              (repeat 1024 "a")
-              "_"))
+              (repeat 128 "a")))
       (testing "rejected names"
         (are [name] (= false (#'bigquery.qp/valid-bigquery-identifier?' name))
               "have-dataset"
               "have:dataset"
               ""
-              (repeat 1025 "a"))))))
+              (repeat 129 "a"))))))

--- a/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
@@ -632,10 +632,10 @@
               "a"
               "_"
               "apple"
-              (repeat 128 "a")))
+              (apply str (repeat 128 "a"))))
       (testing "rejected names"
         (are [name] (= false (#'bigquery.qp/valid-bigquery-identifier? name))
               "have-dataset"
               "have:dataset"
               ""
-              (repeat 129 "a"))))))
+              (apply str (repeat 129 "a")))))))


### PR DESCRIPTION
## Overview
This changes are aimed to close #9388 .

According to the specification, BigQuery's dataset and table are acceptable,
if their name are satisfying following conditions.

* Include only `a-z`, `A-Z`, underscore(`_`) or numbers(`0-9`).
* Contain up to 1024 chars.

Ref.

* https://cloud.google.com/bigquery/docs/datasets?hl=en
* https://cloud.google.com/bigquery/docs/tables?hl=en

[ci all]