### PR TITLE
Data model heading spacing

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx
@@ -67,11 +67,13 @@ export default class MetadataHeader extends Component {
 
   render() {
     return (
-      <div className="MetadataEditor-header flex align-center flex-no-shrink">
-        <div className="MetadataEditor-headerSection py2 h2">
+      <div className="MetadataEditor-header flex align-center flex-no-shrink pb2">
+        <Icon className="flex align-center flex-no-shrink text-medium" name="database" />
+        <div className="MetadataEditor-headerSection h2">
           <DatabaseDataSelector
             selectedDatabaseId={this.props.databaseId}
             setDatabaseFn={id => this.props.selectDatabase({ id })}
+            style={{padding: 0, paddingLeft: 8}}
           />
         </div>
         <div className="MetadataEditor-headerSection flex flex-align-right align-center flex-no-shrink">

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx
@@ -68,12 +68,15 @@ export default class MetadataHeader extends Component {
   render() {
     return (
       <div className="MetadataEditor-header flex align-center flex-no-shrink pb2">
-        <Icon className="flex align-center flex-no-shrink text-medium" name="database" />
+        <Icon
+          className="flex align-center flex-no-shrink text-medium"
+          name="database"
+        />
         <div className="MetadataEditor-headerSection h2">
           <DatabaseDataSelector
             selectedDatabaseId={this.props.databaseId}
             setDatabaseFn={id => this.props.selectDatabase({ id })}
-            style={{padding: 0, paddingLeft: 8}}
+            style={{ padding: 0, paddingLeft: 8 }}
           />
         </div>
         <div className="MetadataEditor-headerSection flex flex-align-right align-center flex-no-shrink">

--- a/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
@@ -77,7 +77,7 @@ export default class MetadataEditor extends Component {
   render() {
     const { databaseId, tableId } = this.props;
     return (
-      <div className="p3">
+      <div className="p4">
         <MetadataHeader
           ref="header"
           databaseId={databaseId}


### PR DESCRIPTION
We let the height o(or VerticalWidth™) of the datababase selector and original schema toggle get a bit out of control in 0.36, so this PR reins that back in. We also cut the text that used to read "current database," so I've added in a database icon to help contextualize the selector.

## Before

![Screen Shot 2020-08-18 at 1 49 09 PM](https://user-images.githubusercontent.com/2223916/90569997-bac97c00-e163-11ea-90a7-2601971ab4ad.png)

## After

![Screen Shot 2020-08-18 at 2 55 22 PM](https://user-images.githubusercontent.com/2223916/90570017-c7e66b00-e163-11ea-9f52-9085bfdaf096.png)

![Screen Shot 2020-08-18 at 2 55 31 PM](https://user-images.githubusercontent.com/2223916/90570353-58bd4680-e164-11ea-8082-ec62ab7f5d69.png)

![Screen Shot 2020-08-18 at 2 55 39 PM](https://user-images.githubusercontent.com/2223916/90570364-5c50cd80-e164-11ea-8b27-0ca3f26bb478.png)
