### PR TITLE
Add an error msg for disabled accounts via Google Auth

### DIFF
--- a/frontend/src/metabase/auth/components/GoogleButton.jsx
+++ b/frontend/src/metabase/auth/components/GoogleButton.jsx
@@ -40,15 +40,38 @@ export default class GoogleButton extends Component {
           auth2.attachClickHandler(
             element,
             {},
-            googleUser => {
+            async googleUser => {
               this.setState({ errorMessage: null });
-              loginGoogle(googleUser, location.query.redirect);
+              const result = await loginGoogle(
+                googleUser,
+                location.query.redirect,
+              );
+
+              if (
+                result.payload["status"] &&
+                result.payload["status"] === 400 &&
+                result.payload.data &&
+                result.payload.data.errors
+              ) {
+                let errorMessage = "";
+                for (const [, value] of Object.entries(
+                  result.payload.data.errors,
+                )) {
+                  if (errorMessage !== "") {
+                    errorMessage = errorMessage + "<br/>";
+                  }
+                  errorMessage = errorMessage + value;
+                }
+                this.setState({
+                  errorMessage: errorMessage,
+                });
+              }
             },
             error => {
               this.setState({
                 errorMessage:
                   GOOGLE_AUTH_ERRORS[error.error] ||
-                  t`There was an issue signing in with Google. Pleast contact an administrator.`,
+                  t`There was an issue signing in with Google. Please contact an administrator.`,
               });
             },
           );

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -20,7 +20,8 @@
             [metabase.test.integrations.ldap :as ldap.test]
             [schema.core :as s]
             [toucan.db :as db])
-  (:import java.util.UUID))
+  (:import clojure.lang.ExceptionInfo
+           java.util.UUID))
 
 ;; one of the tests below compares the way properties for the H2 driver are translated, so we need to make sure it's
 ;; loaded
@@ -405,6 +406,32 @@
                                      token-1
                                      token-2)}
                     token-1)))))))
+
+(deftest google-auth-tests
+  (mt/with-temporary-setting-values [google-auth-client-id "PRETEND-GOOD-GOOGLE-CLIENT-ID"]
+    (testing "with an active account"
+      (mt/with-temp User [user {:email "test@metabase.com" :is_active true}]
+        (with-redefs [http/post (fn [url] {:status 200
+                                           :body   (str "{\"aud\":\"PRETEND-GOOD-GOOGLE-CLIENT-ID\","
+                                                        "\"email_verified\":\"true\","
+                                                        "\"first_name\":\"test\","
+                                                        "\"last_name\":\"user\","
+                                                        "\"email\":\"test@metabase.com\"}")})]
+
+          (let [result (session-api/do-google-auth {:body {:token "foo"}})]
+            (is (= 200 (:status result)))))))
+    (testing "with a disabled account"
+      (mt/with-temp User [user {:email "test@metabase.com" :is_active false}]
+        (with-redefs [http/post (fn [url] {:status 200
+                                           :body   (str "{\"aud\":\"PRETEND-GOOD-GOOGLE-CLIENT-ID\","
+                                                        "\"email_verified\":\"true\","
+                                                        "\"first_name\":\"test\","
+                                                        "\"last_name\":\"user\","
+                                                        "\"email\":\"test@metabase.com\"}")})]
+          (is (thrown-with-msg?
+               ExceptionInfo
+               #"Your account is disabled. Please contact your administrator."
+               (session-api/do-google-auth {:body {:token "foo"}}))))))))
 
 ;;; --------------------------------------- google-auth-fetch-or-create-user! ----------------------------------------
 


### PR DESCRIPTION
Previously, if your Metabase account for a Google login was disabled,
you would be returned to the login box with no indication as to what was
wrong. Now we return to the page with a red error that says "Your
account is disabled."

Resolves #3245
