### PR TITLE
Slightly rework error handling for site URL

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -55,7 +55,8 @@
             s
             (str "http://" s))]
     ;; check that the URL is valid
-    (assert (u/url? s) (tru "Invalid site URL: {0}" (pr-str s)))
+    (when-not (u/url? s)
+      (throw (ex-info (tru "Invalid site URL: {0}" (pr-str s)) {:url (pr-str s)})))
     s))
 
 (declare redirect-all-requests-to-https)
@@ -68,7 +69,7 @@
   :getter (fn []
             (try
               (some-> (setting/get-string :site-url) normalize-site-url)
-              (catch AssertionError e
+              (catch clojure.lang.ExceptionInfo e
                 (log/error e (trs "site-url is invalid; returning nil for now. Will be reset on next request.")))))
   :setter (fn [new-value]
             (let [new-value (some-> new-value normalize-site-url)

--- a/test/metabase/public_settings_test.clj
+++ b/test/metabase/public_settings_test.clj
@@ -41,7 +41,7 @@
   (testing "we should not be allowed to set an invalid `site-url` (#9850)"
     (mt/discard-setting-changes [site-url]
       (is (thrown?
-           AssertionError
+           clojure.lang.ExceptionInfo
            (public-settings/site-url "http://https://www.camsaul.com"))))))
 
 (deftest site-url-settings-set-valid-domain-name


### PR DESCRIPTION
Instead of using assert, which throws an exception with confusing detail
for the users, use a more user-friendly error.

Old error:

    Error: Assert failed: Invalid site URL: "https://localhost:3000!" (u/url? s)

New error:

    Error: Invalid site URL: "http://localhost:3000!"

Resolves #4506
