### PR TITLE
Lift dimensions from nested queries

### DIFF
--- a/src/metabase/query_processor/middleware/add_dimension_projections.clj
+++ b/src/metabase/query_processor/middleware/add_dimension_projections.clj
@@ -23,10 +23,13 @@
   appropriate `:remapped_from` and `:remapped_to` attributes in the result `:cols` in post-processing.
   `:remapped_from` and `:remapped_to` are the names of the columns, e.g. `category_id` is `:remapped_to` `name`, and
   `name` is `:remapped_from` `:category_id`."
-  (:require [metabase.mbql
+  (:require [medley.core :as m]
+            [metabase.mbql
              [schema :as mbql.s]
              [util :as mbql.u]]
-            [metabase.models.dimension :refer [Dimension]]
+            [metabase.models
+             [dimension :refer [Dimension]]
+             [field :refer [Field]]]
             [metabase.util :as u]
             [metabase.util.schema :as su]
             [schema.core :as s]
@@ -37,9 +40,11 @@
 (def ^:private ExternalRemappingDimension
   "Schema for the info we fetch about `external` type Dimensions that will be used for remappings in this Query. Fetched
   by the pre-processing portion of the middleware, and passed along to the post-processing portion."
-  {:name                    su/NonBlankString       ; display name for the remapping
-   :field_id                su/IntGreaterThanZero   ; ID of the Field being remapped
-   :human_readable_field_id su/IntGreaterThanZero}) ; ID of the FK Field to remap values to
+  {:name                                       su/NonBlankString       ; display name for the remapping
+   :field_id                                   su/IntGreaterThanZero   ; ID of the Field being remapped
+   :human_readable_field_id                    su/IntGreaterThanZero   ; ID of the FK Field to remap values to
+   (s/optional-key :field_name)                s/Str
+   (s/optional-key :human_readable_field_name) s/Str})
 
 
 ;;; ----------------------------------------- add-fk-remaps (pre-processing) -----------------------------------------
@@ -71,7 +76,9 @@
        (let [dimension (field-id->remapping-dimension id)]
          [&match
           [:fk-> &match [:field-id (:human_readable_field_id dimension)]]
-          dimension])))))
+          (assoc dimension
+            :field_name                (-> dimension :field_id Field :name)
+            :human_readable_field_name (-> dimension :human_readable_field_id Field :name))])))))
 
 (s/defn ^:private update-remapped-order-by :- [mbql.s/OrderBy]
   "Order by clauses that include an external remapped column should be replace that original column in the order by with
@@ -88,22 +95,27 @@
                                     (s/one mbql.s/Query "query")]
   "Add any Fields needed for `:external` remappings to the `:fields` clause of the query, and update `:order-by`
   clause as needed. Returns a pair like `[external-remapping-dimensions updated-query]`."
-  [{{:keys [fields order-by]} :query, :as query} :- mbql.s/Query]
-  ;; TODO - I think we need to handle Fields in `:breakout` here as well...
-  ;; fetch remapping column pairs if any exist...
-  (if-let [remap-col-tuples (seq (create-remap-col-tuples fields))]
-    ;; if they do, update `:fields` and `:order-by` clauses accordingly and add to the query
-    (let [new-fields   (vec (concat fields (map second remap-col-tuples)))
-          ;; make a map of field-id-clause -> fk-clause from the tuples
-          new-order-by (update-remapped-order-by (into {} (for [[field-clause fk-clause] remap-col-tuples]
-                                                            [field-clause fk-clause]))
-                                                 order-by)]
-      ;; return the Dimensions we are using and the query
-      [(map last remap-col-tuples)
-       (cond-> (assoc-in query [:query :fields] new-fields)
-         (seq new-order-by) (assoc-in [:query :order-by] new-order-by))])
-    ;; otherwise return query as-is
-    [nil query]))
+  [{{:keys [fields order-by source-query]} :query, :as query} :- mbql.s/Query]
+  (let [[source-query-remappings query]
+        (if source-query
+          (let [[source-query-remappings source-query] (add-fk-remaps (assoc query :query source-query))]
+            [source-query-remappings (assoc-in query [:query :source-query] (:query source-query))])
+          [nil query])]
+    ;; TODO - I think we need to handle Fields in `:breakout` here as well...
+    ;; fetch remapping column pairs if any exist...
+    (if-let [remap-col-tuples (seq (create-remap-col-tuples fields))]
+      ;; if they do, update `:fields` and `:order-by` clauses accordingly and add to the query
+      (let [new-fields   (vec (concat fields (map second remap-col-tuples)))
+            ;; make a map of field-id-clause -> fk-clause from the tuples
+            new-order-by (update-remapped-order-by (into {} (for [[field-clause fk-clause] remap-col-tuples]
+                                                              [field-clause fk-clause]))
+                                                   order-by)]
+        ;; return the Dimensions we are using and the query
+        [(concat source-query-remappings (map last remap-col-tuples))
+         (cond-> (assoc-in query [:query :fields] new-fields)
+           (seq new-order-by) (assoc-in [:query :order-by] new-order-by))])
+      ;; otherwise return query as-is
+      [source-query-remappings query])))
 
 
 ;;; ---------------------------------------- remap-results (post-processing) -----------------------------------------
@@ -116,10 +128,22 @@
   [columns                :- [su/Map]
    remapping-dimensions   :- (s/maybe [ExternalRemappingDimension])
    internal-remap-columns :- (s/maybe [su/Map])]
-  (let [column-id->column              (u/key-by :id columns)
+  ;; We have to complicate our lives a bit and account for the possibility that dimensions might be
+  ;; used in an upstream `source-query`. If so, `columns` will treat them as `:field-value`s, erasing
+  ;; IDs. In that case reconstruct the mappings using names.
+  ;;
+  ;; TODO:
+  ;; Matching by name is brittle and might produce wrong results when there are name clashes
+  ;; in the source fields.
+  (let [column-id->column              (merge (u/key-by :id columns)
+                                              (u/key-by :name columns))
         name->internal-remapped-to-col (u/key-by :remapped_from internal-remap-columns)
-        id->remapped-to-dimension      (u/key-by :field_id                remapping-dimensions)
-        id->remapped-from-dimension    (u/key-by :human_readable_field_id remapping-dimensions)]
+        id->remapped-to-dimension      (merge (u/key-by :field_id remapping-dimensions)
+                                              (u/key-by :field_name remapping-dimensions))
+        id->remapped-from-dimension    (merge (u/key-by :human_readable_field_id remapping-dimensions)
+                                              (u/key-by :human_readable_field_name remapping-dimensions))
+        get-any-key                    (fn [m & ks]
+                                         (some-> (m/find-first m ks) m))]
     (for [{:keys [id], column-name :name, :as column} columns]
       (merge
        {:base_type :type/*}
@@ -130,14 +154,18 @@
          {:remapped_to remapped-to-name})
        ;; if the pre-processing remapping Dimension info contains an entry where this Field's ID is `:field_id`, add
        ;; an entry noting the name of the Field it gets remapped to
-       (when-let [{remapped-to-id :human_readable_field_id} (get id->remapped-to-dimension id)]
-         {:remapped_to (:name (get column-id->column remapped-to-id))})
+       (when-let [{remapped-to-id :human_readable_field_id
+                   remapped-to-name :human_readable_field_name}
+                  (get-any-key id->remapped-to-dimension id column-name)]
+         {:remapped_to (:name (get-any-key column-id->column remapped-to-id remapped-to-name))})
        ;; if the pre-processing remapping Dimension info contains an entry where this Field's ID is
        ;; `:human_readable_field_id`, add an entry noting the name of the Field it gets remapped from, and use the
        ;; `:display_name` of the Dimension
-       (when-let [{dimension-name :name, remapped-from-id :field_id} (get id->remapped-from-dimension id)]
+       (when-let [{dimension-name :name
+                   remapped-from-id :field_id
+                   remapped-from-name :field_name} (get-any-key id->remapped-from-dimension id column-name)]
          {:display_name  dimension-name
-          :remapped_from (:name (get column-id->column remapped-from-id))})))))
+          :remapped_from (:name (get-any-key column-id->column remapped-from-id remapped-from-name))})))))
 
 (defn- create-remapped-col [col-name remapped-from base-type]
   {:description   nil
@@ -155,14 +183,14 @@
   "Converts `values` to a type compatible with the base_type found for `col`. These values should be directly comparable
   with the values returned from the database for the given `col`."
   [{:keys [base_type] :as col} values]
-  (let [transform (condp #(isa? %2 %1) base_type
-                    :type/Decimal    bigdec
-                    :type/Float      double
-                    :type/BigInteger bigint
-                    :type/Integer    int
-                    :type/Text       str
-                    identity)]
-    (map #(some-> % transform) values)))
+  (map (condp #(isa? %2 %1) base_type
+         :type/Decimal    bigdec
+         :type/Float      double
+         :type/BigInteger bigint
+         :type/Integer    int
+         :type/Text       str
+         identity)
+       values))
 
 (def ^:private InternalDimensionInfo
   {;; index of original column
@@ -241,7 +269,7 @@
   added and each row flowing through needs to include the remapped data for the new column. For external remappings,
   the column information needs to be updated with what it's being remapped from and the user specified name for the
   remapped column."
-  [{:keys [cols], :as metadata} {:keys [internal-only-dims]} rf]
+  [{:keys [internal-only-dims]} rf]
   (if-let [remap-fn (make-row-map-fn internal-only-dims)]
     (fn
       ([]
@@ -258,7 +286,7 @@
   (fn [metadata]
     (let [internal-cols-info (internal-columns-info (:cols metadata))
           metadata           (add-remapped-cols metadata remapping-dimensions internal-cols-info)]
-      (remap-results-xform metadata internal-cols-info (rff metadata)))))
+      (remap-results-xform internal-cols-info (rff metadata)))))
 
 (defn add-remapping
   "Query processor middleware. `qp` is the query processor, returns a function that works on a `query` map. Delgates to

--- a/src/metabase/query_processor/middleware/add_dimension_projections.clj
+++ b/src/metabase/query_processor/middleware/add_dimension_projections.clj
@@ -67,6 +67,7 @@
   get hidden when displayed anyway?)"
   [fields :- [mbql.s/Field]]
   (when-let [field-id->remapping-dimension (fields->field-id->remapping-dimension fields)]
+    ;; Reconstruct how we uniquify names in `metabase.query-processor.middleware.annotate`
     (let [unique-name (comp (mbql.u/unique-name-generator) :name Field)]
       (vec
        (mbql.u/match fields

--- a/src/metabase/query_processor/middleware/add_dimension_projections.clj
+++ b/src/metabase/query_processor/middleware/add_dimension_projections.clj
@@ -43,8 +43,7 @@
    :field_id                                   su/IntGreaterThanZero   ; ID of the Field being remapped
    :human_readable_field_id                    su/IntGreaterThanZero   ; ID of the FK Field to remap values to
    (s/optional-key :field_name)                su/NonBlankString       ; Name of the Field being remapped
-   (s/optional-key :human_readable_field_name) su/NonBlankString       ; Name of the FK field to remap values to
-   })
+   (s/optional-key :human_readable_field_name) su/NonBlankString})     ; Name of the FK field to remap values to
 
 
 ;;; ----------------------------------------- add-fk-remaps (pre-processing) -----------------------------------------

--- a/src/metabase/query_processor/middleware/add_dimension_projections.clj
+++ b/src/metabase/query_processor/middleware/add_dimension_projections.clj
@@ -95,11 +95,11 @@
 
 (defn- update-remapped-breakout
   [field->remapped-col breakout-clause]
-  (mapcat (fn [field]
-            (if-let [remapped-col (get field->remapped-col field)]
-              [remapped-col field]
-              [field]))
-          breakout-clause))
+  (vec (mapcat (fn [field]
+                 (if-let [remapped-col (get field->remapped-col field)]
+                   [remapped-col field]
+                   [field]))
+               breakout-clause)))
 
 (s/defn ^:private add-fk-remaps :- [(s/one (s/maybe [ExternalRemappingDimension]) "external remapping dimensions")
                                     (s/one mbql.s/Query "query")]

--- a/src/metabase/query_processor/middleware/add_dimension_projections.clj
+++ b/src/metabase/query_processor/middleware/add_dimension_projections.clj
@@ -97,7 +97,7 @@
   clause as needed. Returns a pair like `[external-remapping-dimensions updated-query]`."
   [{{:keys [fields order-by source-query]} :query, :as query} :- mbql.s/Query]
   (let [[source-query-remappings query]
-        (if source-query
+        (if (:query source-query) ;; Only do lifting if source is MBQL query
           (let [[source-query-remappings source-query] (add-fk-remaps (assoc query :query source-query))]
             [source-query-remappings (assoc-in query [:query :source-query] (:query source-query))])
           [nil query])]

--- a/src/metabase/query_processor/middleware/add_dimension_projections.clj
+++ b/src/metabase/query_processor/middleware/add_dimension_projections.clj
@@ -23,7 +23,8 @@
   appropriate `:remapped_from` and `:remapped_to` attributes in the result `:cols` in post-processing.
   `:remapped_from` and `:remapped_to` are the names of the columns, e.g. `category_id` is `:remapped_to` `name`, and
   `name` is `:remapped_from` `:category_id`."
-  (:require [metabase.mbql
+  (:require [medley.core :as m]
+            [metabase.mbql
              [schema :as mbql.s]
              [util :as mbql.u]]
             [metabase.models

--- a/src/metabase/query_processor/middleware/add_dimension_projections.clj
+++ b/src/metabase/query_processor/middleware/add_dimension_projections.clj
@@ -140,7 +140,9 @@
         id->remapped-to-dimension      (merge (u/key-by :field_id remapping-dimensions)
                                               (u/key-by :field_name remapping-dimensions))
         id->remapped-from-dimension    (merge (u/key-by :human_readable_field_id remapping-dimensions)
-                                              (u/key-by :human_readable_field_name remapping-dimensions))]
+                                              (u/key-by :human_readable_field_name remapping-dimensions))
+        get-first-key                  (fn [m & ks]
+                                         (some-> (m/find-first m ks) m))]
     (for [{:keys [id], column-name :name, :as column} columns]
       (merge
        {:base_type :type/*}
@@ -154,7 +156,7 @@
        (when-let [{remapped-to-id :human_readable_field_id
                    remapped-to-name :human_readable_field_name}
                   (id->remapped-to-dimension (or id column-name))]
-         {:remapped_to (:name (column-id->column (or remapped-to-id remapped-to-name)))})
+         {:remapped_to (:name (get-first-key column-id->column remapped-to-id remapped-to-name))})
        ;; if the pre-processing remapping Dimension info contains an entry where this Field's ID is
        ;; `:human_readable_field_id`, add an entry noting the name of the Field it gets remapped from, and use the
        ;; `:display_name` of the Dimension
@@ -162,7 +164,7 @@
                    remapped-from-id :field_id
                    remapped-from-name :field_name} (id->remapped-from-dimension (or id column-name))]
          {:display_name  dimension-name
-          :remapped_from (:name (column-id->column (or remapped-from-id remapped-from-name)))})))))
+          :remapped_from (:name (get-first-key column-id->column remapped-from-id remapped-from-name))})))))
 
 (defn- create-remapped-col [col-name remapped-from base-type]
   {:description   nil

--- a/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
+++ b/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
@@ -63,7 +63,16 @@
                                     [:field-id (mt/id :categories :name)]]))]
               (-> example-query
                   (assoc-in [:query :order-by] [[:asc [:field-id (mt/id :venues :category_id)]]])
-                  (#'add-dim-projections/add-fk-remaps))))))))
+                  (#'add-dim-projections/add-fk-remaps)))))
+
+     (testing "make sure FK remaps work with nested queries"
+       (let [example-query (assoc example-query :query {:source-query (:query example-query)})]
+         (is (= [[remapped-field]
+                 (update-in example-query [:query :source-query :fields]
+                            conj [:fk-> [:field-id (mt/id :venues :category_id)] [:field-id (mt/id :categories :name)]])]
+                (#'add-dim-projections/add-fk-remaps example-query))))))))
+
+
 
 
 ;;; ---------------------------------------- remap-results (post-processing) -----------------------------------------

--- a/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
+++ b/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.query-processor.middleware.add-dimension-projections-test
   (:require [clojure.test :refer :all]
-            [metabase.models :refer [Field]]
             [metabase.query-processor.middleware.add-dimension-projections :as add-dim-projections]
             [metabase.test :as mt]
             [metabase.test.fixtures :as fixtures]
@@ -11,34 +10,38 @@
 ;;; ----------------------------------------- add-fk-remaps (pre-processing) -----------------------------------------
 
 (def ^:private example-query
-  {:database 1
+  {:database (mt/id)
    :type     :query
-   :query    {:source-table 1
-              :fields       [[:field-id 1]
-                             [:field-id 2]
-                             [:field-id 3]]}})
+   :query    {:source-table (mt/id :venues)
+              :fields       [[:field-id (mt/id :venues :price)]
+                             [:field-id (mt/id :venues :longitude)]
+                             [:field-id (mt/id :venues :category_id)]]}})
 
 (def ^:private remapped-field
   {:name                      "Product"
-   :field_id                  3
-   :human_readable_field_id   4
-   :field_name                (-> 3 Field :name)
-   :human_readable_field_name (-> 4 Field :name)})
+   :field_id                  (mt/id :venues :category_id)
+   :human_readable_field_id   (mt/id :categories :name)
+   :field_name                "CATEGORY_ID"
+   :human_readable_field_name "NAME"})
 
 (defn- do-with-fake-remappings-for-field-3 [f]
   (with-redefs [add-dim-projections/fields->field-id->remapping-dimension
                 (constantly
-                 {3 {:name "Product", :field_id 3, :human_readable_field_id 4}})]
+                 {(mt/id :venues :category_id) {:name                    "Product"
+                                                :field_id                (mt/id :venues :category_id)
+                                                :human_readable_field_id (mt/id :categories :name)}})]
     (f)))
 
 (deftest create-remap-col-tuples
   (testing "make sure we create the remap column tuples correctly"
     (do-with-fake-remappings-for-field-3
      (fn []
-       (is (= [[[:field-id 3]
-                [:fk-> [:field-id 3] [:field-id 4]]
+       (is (= [[[:field-id (mt/id :venues :category_id)]
+                [:fk-> [:field-id (mt/id :venues :category_id)] [:field-id (mt/id :categories :name)]]
                 remapped-field]]
-              (#'add-dim-projections/create-remap-col-tuples [[:field-id 1] [:field-id 2] [:field-id 3]])))))))
+              (#'add-dim-projections/create-remap-col-tuples [[:field-id (mt/id :venues :price)]
+                                                              [:field-id (mt/id :venues :longitude)]
+                                                              [:field-id (mt/id :venues :category_id)]])))))))
 
 (deftest add-fk-remaps-test
   (do-with-fake-remappings-for-field-3
@@ -46,16 +49,21 @@
      (testing "make sure FK remaps add an entry for the FK field to `:fields`, and returns a pair of [dimension-info updated-query]"
        (is (= [[remapped-field]
                (update-in example-query [:query :fields]
-                          conj [:fk-> [:field-id 3] [:field-id 4]])]
+                          conj [:fk-> [:field-id (mt/id :venues :category_id)] [:field-id (mt/id :categories :name)]])]
               (#'add-dim-projections/add-fk-remaps example-query))))
 
      (testing "adding FK remaps should replace any existing order-bys for a field with order bys for the FK remapping Field"
        (is (= [[remapped-field]
                (-> example-query
-                   (assoc-in [:query :order-by] [[:asc [:fk-> [:field-id 3] [:field-id 4]]]])
+                   (assoc-in [:query :order-by]
+                             [[:asc [:fk-> [:field-id (mt/id :venues :category_id)]
+                                     [:field-id (mt/id :categories :name)]]]])
                    (update-in [:query :fields]
-                              conj [:fk-> [:field-id 3] [:field-id 4]]))]
-              (#'add-dim-projections/add-fk-remaps (assoc-in example-query [:query :order-by] [[:asc [:field-id 3]]]))))))))
+                              conj [:fk-> [:field-id (mt/id :venues :category_id)]
+                                    [:field-id (mt/id :categories :name)]]))]
+              (-> example-query
+                  (assoc-in [:query :order-by] [[:asc [:field-id (mt/id :venues :category_id)]]])
+                  (#'add-dim-projections/add-fk-remaps))))))))
 
 
 ;;; ---------------------------------------- remap-results (post-processing) -----------------------------------------

--- a/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
+++ b/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
@@ -71,9 +71,9 @@
                (-> example-query
                    (assoc-in [:query :aggregation] [[:count]])
                    (assoc-in [:query :breakout]
-                             [[:field-id (mt/id :venues :category_id)]
-                              [:fk-> [:field-id (mt/id :venues :category_id)]
-                               [:field-id (mt/id :categories :name)]]])
+                             [[:fk-> [:field-id (mt/id :venues :category_id)]
+                               [:field-id (mt/id :categories :name)]]
+                              [:field-id (mt/id :venues :category_id)]])
                    (m/dissoc-in [:query :fields]))]
               (-> example-query
                   (m/dissoc-in [:query :fields])

--- a/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
+++ b/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
@@ -81,14 +81,13 @@
                   (assoc-in [:query :breakout] [[:field-id (mt/id :venues :category_id)]])
                   (#'add-dim-projections/add-fk-remaps)))))
 
-     (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries)
-       (testing "make sure FK remaps work with nested queries"
-         (let [example-query (assoc example-query :query {:source-query (:query example-query)})]
-           (is (= [[remapped-field]
-                   (update-in example-query [:query :source-query :fields]
-                              conj [:fk-> [:field-id (mt/id :venues :category_id)]
-                                    [:field-id (mt/id :categories :name)]])]
-                  (#'add-dim-projections/add-fk-remaps example-query)))))))))
+     (testing "make sure FK remaps work with nested queries"
+       (let [example-query (assoc example-query :query {:source-query (:query example-query)})]
+         (is (= [[remapped-field]
+                 (update-in example-query [:query :source-query :fields]
+                            conj [:fk-> [:field-id (mt/id :venues :category_id)]
+                                  [:field-id (mt/id :categories :name)]])]
+                (#'add-dim-projections/add-fk-remaps example-query))))))))
 
 
 ;;; ---------------------------------------- remap-results (post-processing) -----------------------------------------

--- a/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
+++ b/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
@@ -71,9 +71,10 @@
                (-> example-query
                    (assoc-in [:query :aggregation] [[:count]])
                    (assoc-in [:query :breakout]
-                             [[:fk-> [:field-id (mt/id :venues :category_id)]
+                             [[:field-id (mt/id :venues :category_id)]
+                              [:fk-> [:field-id (mt/id :venues :category_id)]
                                [:field-id (mt/id :categories :name)]]])
-                   (m/dissoc-in [:query :fields]) )]
+                   (m/dissoc-in [:query :fields]))]
               (-> example-query
                   (m/dissoc-in [:query :fields])
                   (assoc-in [:query :aggregation] [[:count]])

--- a/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
+++ b/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
@@ -261,28 +261,4 @@
                       example-result-cols-category-id
                       example-result-cols-price
                       example-result-cols-category]}
-              [])))))
-
-  (testing "test that external remappings in source query get the appropriate `:remapped_from`/`:remapped_to` info"
-    (is (= {:status    :completed
-            :row_count 0
-            :data      {:rows []
-                        :cols [example-result-cols-id
-                               example-result-cols-name
-                               (assoc example-result-cols-category-id
-                                      :remapped_to "CATEGORY")
-                               example-result-cols-price
-                               (assoc example-result-cols-category
-                                      :remapped_from "CATEGORY_ID"
-                                      :display_name  "My Venue Category")]}}
-           (with-redefs [add-dim-projections/add-fk-remaps (fn [query]
-                                                             [[{:name "My Venue Category", :field_id 11, :human_readable_field_id 27}]
-                                                              query])]
-             (add-remapping
-              {:source-query {:table-id }}
-              {:cols [example-result-cols-id
-                      example-result-cols-name
-                      example-result-cols-category-id
-                      example-result-cols-price
-                      example-result-cols-category]}
               []))))))

--- a/test/metabase/query_processor_test/remapping_test.clj
+++ b/test/metabase/query_processor_test/remapping_test.clj
@@ -34,8 +34,7 @@
       (data/create-venue-category-fk-remapping! "Name")
       (is (= {:rows [["American" 2 8]
                      ["Artisan"  3 2]
-                     ["Asian"    4 2]
-                     ["BBQ"      5 7]]
+                     ["Asian"    4 2]]
               :cols [(-> (qp.test/col :categories :name)
                          (assoc :remapped_from (mt/format-name "category_id"))
                          (assoc :field_ref [:fk-> [:field-id (mt/id :venues :category_id)]
@@ -54,7 +53,7 @@
                    (mt/run-mbql-query venues
                      {:aggregation [[:count]]
                       :breakout    [$category_id]
-                      :limit       4}))
+                      :limit       3}))
                  qp.test/rows-and-cols
                  (update :cols (fn [[c1 c2 agg]]
                                  [c1 c2 (dissoc agg :base_type)]))))))))

--- a/test/metabase/query_processor_test/remapping_test.clj
+++ b/test/metabase/query_processor_test/remapping_test.clj
@@ -118,7 +118,7 @@
            :order-by [[:asc $name]]
            :limit    4})))))
 
-;; Test that we can remap inside an MBQL nested query
+;; Test that we can remap inside an MBQL query
 (datasets/expect-with-drivers (mt/normal-drivers-with-feature :foreign-keys :nested-queries)
   ["Kinaree Thai Bistro" "Ruen Pair Thai Restaurant" "Yamashiro Hollywood" "Spitz Eagle Rock" "The Gumbo Pot"]
   (mt/with-temp-objects

--- a/test/metabase/query_processor_test/remapping_test.clj
+++ b/test/metabase/query_processor_test/remapping_test.clj
@@ -37,13 +37,13 @@
                      ["Asian"    4 2]
                      ["BBQ"      5 7]]
               :cols [(-> (qp.test/col :categories :name)
-                         (assoc :remapped_from (mt/format-name "CATEGORY_ID"))
+                         (assoc :remapped_from (mt/format-name "category_id"))
                          (assoc :field_ref [:fk-> [:field-id (mt/id :venues :category_id)]
                                             [:field-id (mt/id :categories :name)]])
                          (assoc :fk_field_id (mt/id :venues :category_id))
                          (assoc :source :breakout))
                      (-> (qp.test/col :venues :category_id)
-                         (assoc :remapped_to (mt/format-name "NAME"))
+                         (assoc :remapped_to (mt/format-name "name"))
                          (assoc :source :breakout))
                      {:field_ref    [:aggregation 0]
                       :source       :aggregation
@@ -68,21 +68,23 @@
                      ["33 Taps"                          7 "Bar"]
                      ["800 Degrees Neapolitan Pizzeria" 58 "Pizza"]]
               :cols [(-> (qp.test/col :venues :name)
-                         (assoc :field_ref [:field-literal (mt/format-name "NAME") :type/Text])
+                         (assoc :field_ref [:field-literal (mt/format-name "name") :type/Text])
                          (dissoc :description :parent_id :visibility_type))
                      (-> (qp.test/col :venues :category_id)
                          (assoc :remapped_to "Foo")
-                         (assoc :field_ref [:field-literal (mt/format-name"CATEGORY_ID") :type/Integer])
+                         (assoc :field_ref [:field-literal (mt/format-name"category_id")])
                          (dissoc :description :parent_id :visibility_type))
                      (#'add-dimension-projections/create-remapped-col "Foo" (mt/format-name "category_id") :type/Text)]}
-             (qp.test/rows-and-cols
-               (qp.test/format-rows-by [str int str]
-                 (mt/run-mbql-query venues
-                   {:source-query {:source-table (mt/id :venues)
-                                   :fields       [[:field-id (mt/id :venues :name)]
-                                                  [:field-id  (mt/id :venues :category_id)]]
-                                   :order-by     [[:asc [:field-id (mt/id :venues :name)]]]
-                                   :limit        4}}))))))))
+             (-> (qp.test/format-rows-by [str int str]
+                   (mt/run-mbql-query venues
+                     {:source-query {:source-table (mt/id :venues)
+                                     :fields       [[:field-id (mt/id :venues :name)]
+                                                    [:field-id  (mt/id :venues :category_id)]]
+                                     :order-by     [[:asc [:field-id (mt/id :venues :name)]]]
+                                     :limit        4}}))
+                 qp.test/rows-and-cols
+                 (update :cols (fn [[c1 c2 c3]]
+                                 [c1 (update c2 :field_ref (comp vec butlast)) c3]))))))))
 
 (defn- select-columns
   "Focuses the given resultset to columns that return true when passed to `columns-pred`. Typically this would be done


### PR DESCRIPTION
Fixes a bug where our middleware that added dimension remappings didn't recur into `source-query`s and applies remapping logic to `breakout` clause.

## Notes

* For breakout the code adds both the source and remapped cols to the breakout (analogous to how we do it in `:fields`). This shouldn't change the semantics of the group by and as far as I can tell the FE is happy with this and everything works as expected. 
* While this fixes the bug it strikes me that the overall approach where each piece of middleware that's part of the MBQL processing needs to correctly handle nested queries is quite error prone. It would be better if nested queries were handled recursively by the same code path. Where it potentially gets tricky -- and this is also the cause of some of the messiness in this PR -- is that due to our single pass QP we don't get entire metadata until the full pass which makes recursive combining tricky [but this is of course beyond the scope of this PR]. 
* When `:source-query` is MBQL, we needlessly revert to `:field-value`s in `:cols` loosing field IDs. Again a big change at least in the number of tests we'd need to fix, but would retain much more information and for instance allow this fix to be much more robust as we wouldn't have to mess around with name matching. 


Fixes #10474 and #5600