### PR TITLE
Migrate `PasswordReveal` test from enzyme to react-testing-library

### DIFF
--- a/frontend/src/metabase/components/CopyButton.jsx
+++ b/frontend/src/metabase/components/CopyButton.jsx
@@ -35,7 +35,7 @@ export default class CopyWidget extends Component {
     return (
       <Tooltip tooltip={t`Copied!`} isOpen={this.state.copied}>
         <CopyToClipboard text={value} onCopy={this.onCopy}>
-          <div className={className} style={style}>
+          <div className={className} style={style} data-testid="copy-button">
             <Icon name="copy" {...props} />
           </div>
         </CopyToClipboard>

--- a/frontend/test/metabase/components/PasswordReveal.unit.spec.js
+++ b/frontend/test/metabase/components/PasswordReveal.unit.spec.js
@@ -1,25 +1,21 @@
-import { click } from "__support__/enzyme";
-
 import React from "react";
+import { render, fireEvent, cleanup } from "@testing-library/react";
 import PasswordReveal from "metabase/components/PasswordReveal";
-import CopyButton from "metabase/components/CopyButton";
 
-import { shallow } from "enzyme";
+// This shouldn't be needed from version 9.0.0 of react-testing-library (TODO: remove after update)
+afterEach(cleanup);
 
 describe("password reveal", () => {
-  let wrapper;
-
-  beforeEach(() => {
-    wrapper = shallow(<PasswordReveal />);
-  });
-
   it("should toggle the visibility state when hide / show are clicked", () => {
-    expect(wrapper.state().visible).toEqual(false);
-    click(wrapper.find("a"));
-    expect(wrapper.state().visible).toEqual(true);
+    const { getByText } = render(<PasswordReveal />);
+
+    fireEvent.click(getByText("Show"));
+    getByText("Hide");
   });
 
   it("should render a copy button", () => {
-    expect(wrapper.find(CopyButton).length).toEqual(1);
+    const { getByTestId } = render(<PasswordReveal />);
+    // implicit assertion => it will throw an error if element is not found
+    getByTestId("copy-button");
   });
 });


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- migrates existing enzyme test to React Testing Library
- hopefully serves as a place for constructive discussion about the current best practices in testing community that will facilitate and set the ground for similar test migrations

### The end goal (tl;dr)
Migrate **all** existing enzyme tests to React Testing Library and remove enzyme as a dependency which will:
1. encourage the best practices according to the [guiding principles](https://github.com/testing-library/react-testing-library#guiding-principles) of React Testing Library
2. increase the confidence in tests
3. open the gates for the possibility to upgrade React and start using hooks :)

### Context
In my talk with @paulrosenzweig we touched on a subject of upgrading React to be able to utilize the power of hooks. Paul then mentioned that one of the obstacles for the upgrade is currect React's dependency on enzyme (`enzyme-adapter-react-15`, to be precise). This was the push for me to start digging even deeper, as I was already devouring all the material (videos, articles, code examples) that I could get my hands on from Kent C. Dodds - the author of React Testing Library. Convinced that [shallow rendering should be avoided](https://kentcdodds.com/blog/why-i-never-use-shallow-rendering) I searched for all occurrences of it in the code base. My goal was to start the ball rolling with a relatively simple component test that was relying both on shallow rendering and on [testing implementation details](https://kentcdodds.com/blog/testing-implementation-details), and to try to tackle both.
> The more your tests resemble the way your software is used, the more confidence they can give you. - Kent C. Dodds

### Next steps
- if this PR looks good and I get the green light I'll prepare a few more
- if we agree on some ground rules (please check code comments) I can sum them all up (issue, wiki...?) and they can maybe be added to the documentation/guides later

### Question
Would you prefer that I open an issue with proposal to migrate tests from enzyme to RTL, or are you ok with simply pushing PRs?