### PR TITLE
Email Case Insensitive Handling for User Account

### DIFF
--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -4,7 +4,7 @@ describe("scenarios > admin > people", () => {
   before(restore);
   beforeEach(signInAsAdmin);
 
-  var email = `testy${Math.round(Math.random() * 100000)}@metabase.com`;
+  const email = `testy${Math.round(Math.random() * 100000)}@metabase.com`;
 
   describe("user management", () => {
     it("should render", () => {
@@ -43,7 +43,6 @@ describe("scenarios > admin > people", () => {
       cy.findByLabelText("Email").type(email.toUpperCase());
       cy.findByText("Create").click();
       cy.contains("Email address already in use.");
-
     });
   });
 });

--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -4,6 +4,8 @@ describe("scenarios > admin > people", () => {
   before(restore);
   beforeEach(signInAsAdmin);
 
+  var email = `testy${Math.round(Math.random() * 100000)}@metabase.com`;
+
   describe("user management", () => {
     it("should render", () => {
       cy.visit("/admin/people");
@@ -20,9 +22,7 @@ describe("scenarios > admin > people", () => {
       cy.findByLabelText("First name").type("Testy");
       cy.findByLabelText("Last name").type("McTestface");
       // bit of a hack since there are multiple "Email" nodes
-      cy.findByLabelText("Email").type(
-        `testy${Math.round(Math.random() * 100000)}@metabase.com`,
-      );
+      cy.findByLabelText("Email").type(email);
       cy.findByText("Create").click();
 
       // second modal
@@ -31,6 +31,19 @@ describe("scenarios > admin > people", () => {
       cy.findByText("Done").click();
 
       cy.findByText("Testy McTestface");
+    });
+    it("should disallow admin to create new users with case mutation of existing user", () => {
+      cy.visit("/admin/people");
+      cy.findByText("Add someone").click();
+
+      // first modal
+      cy.findByLabelText("First name").type("TestyNew");
+      cy.findByLabelText("Last name").type("McTestfaceNew");
+      // bit of a hack since there are multiple "Email" nodes
+      cy.findByLabelText("Email").type(email.toUpperCase());
+      cy.findByText("Create").click();
+      cy.contains("Email address already in use.");
+
     });
   });
 });

--- a/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
@@ -34,7 +34,7 @@ describe("scenarios > auth > signin", () => {
     cy.findByText("Sign in").click();
     cy.contains(/[a-z ]+, Bob/i);
   });
-  
+
   it("should allow login regardless of login email case", () => {
     cy.visit("/auth/login");
     cy.findByLabelText("Email address").type(USERS.admin.username.toUpperCase());

--- a/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
@@ -34,6 +34,14 @@ describe("scenarios > auth > signin", () => {
     cy.findByText("Sign in").click();
     cy.contains(/[a-z ]+, Bob/i);
   });
+  
+  it("should allow login regardless of login email case", () => {
+    cy.visit("/auth/login");
+    cy.findByLabelText("Email address").type(USERS.admin.username.toUpperCase());
+    cy.findByLabelText("Password").type(USERS.admin.password);
+    cy.findByText("Sign in").click();
+    cy.contains(/[a-z ]+, Bob/i);
+  });
 
   it("should redirect to a unsaved question after login", () => {
     signIn();

--- a/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
@@ -37,7 +37,9 @@ describe("scenarios > auth > signin", () => {
 
   it("should allow login regardless of login email case", () => {
     cy.visit("/auth/login");
-    cy.findByLabelText("Email address").type(USERS.admin.username.toUpperCase());
+    cy.findByLabelText("Email address").type(
+      USERS.admin.username.toUpperCase(),
+    );
     cy.findByLabelText("Password").type(USERS.admin.password);
     cy.findByText("Sign in").click();
     cy.contains(/[a-z ]+, Bob/i);

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -7654,7 +7654,7 @@ databaseChangeLog:
             constraintName: fk_view_log_ref_user_id
             onDelete: CASCADE
 
-# changesets 268-272 allow for handling user account emails in lowercase (GH issue 3047)
+# changesets 268-274 allow for handling user account emails in lowercase (GH issue 3047)
   - property:
       name: email_constraint_name
       value: constraint_4

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -7679,7 +7679,7 @@ databaseChangeLog:
       comment: Added 0.37.0  # set email values to lower(email) but do so defensively and in a way that works on postgres and mysql - skip over those that would introduce duplicates (e.g. Reza@email.com and reza@email.com)
       changes:
         - sql :
-            sql : UPDATE core_user SET email = lower(email) WHERE lower(email) NOT IN (SELECT * FROM (SELECT lower(email) FROM core_user GROUP BY lower(email) HAVING count(email) > 1) as e);
+            sql : UPDATE core_user SET email = lower(email) WHERE lower(email) NOT IN (SELECT * FROM (SELECT lower(email) FROM core_user GROUP BY lower(email) HAVING count(email) > 1) as e)
   - changeSet:
       id: 270
       author: rlotun

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -7653,3 +7653,72 @@ databaseChangeLog:
             referencedColumnNames: id
             constraintName: fk_view_log_ref_user_id
             onDelete: CASCADE
+
+# these group of changesets allow for the use of lowercasing emails (GH issue 3047) 
+#  - changeSet:
+#      id: 268
+#      author: rlotun
+#      comment: Added 0.37.0   # drop unique constraint on email
+#      changes:
+#        - dropUniqueConstraint:
+#            columnDataType: varchar(254)
+#            constraintName: email
+#            tableName: core_user
+
+#   - changeSet:
+#      id: 269
+#      author: rlotun
+#      comment: Added 0.37.0 # drop index on email
+#      changes:
+#        - dropIndex:
+#          columnDataType: varchar(254)
+#          indexName: email
+#          columnName: lower(email)
+#          tableName: metabase_user
+
+  - changeSet:
+      id: 270
+      author: rlotun
+      comment: Added 0.37.0  # set email to lower email
+      changes:
+        - sql :
+          sql : update core_user set email = lower(email)
+
+  - changeSet:
+      id: 271
+      author: rlotun
+      comment: Added 0.37.0 # PG and H2 only - convert column to citext / VARCHAR IGNORECASE=TRUE (?)
+      changes:
+        - modifyDataType:
+            dbms: h2
+            tableName: core_user
+            columnName: email
+            newDataType: VARCHAR_IGNORECASE(254)
+
+#        - modifyDataType:
+#            dbms: postgresql
+#            tableName: core_user
+#            columnName: email
+#            newDataType: CITEXT
+#- changeSet:
+#      id: 272
+#      author: rlotun
+#      comment: Added 0.37.0  # create index on lower(email)
+#      changes:
+#        - createIndex:
+#            columns:
+#              - column:
+#                name: lower(email)
+#                type: varchar(254)
+#            tableName: metabase_user
+#            indexName: email
+
+  - changeSet:
+      id: 273
+      author: rlotun
+      comment: Added 0.37.0  # add unique constraint on lower(email)
+      changes:
+        - addUniqueConstraint:
+            columnNames: email
+            constraintName: idx_unique_email
+            tableName: core_user

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -7670,7 +7670,7 @@ databaseChangeLog:
       comment: Added 0.37.0  # set email to lower email
       changes:
         - sql :
-          sql : update core_user set email = lower(email)
+            sql : update core_user set email = lower(email)
   - property:
       name: email_c_type
       value: varchar_ignorecase(254)

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -7672,15 +7672,15 @@ databaseChangeLog:
       author: rlotun
       comment: Added 0.37.0   # drop unique constraint on email - this will also remove supporting indexes
       preConditions:
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-              - dbms:
-                    type: postgresql
-              - dbms:
-                    type: h2
+        - or:
+            - dbms:
+                type: mysql
+            - dbms:
+                type: mariadb
+            - dbms:
+                type: postgresql
+            - dbms:
+                type: h2
       changes:
         - dropUniqueConstraint:
             columnDataType: varchar(254)
@@ -7689,30 +7689,57 @@ databaseChangeLog:
   - changeSet:
       id: 269
       author: rlotun
-      comment: Added 0.37.0  # set email to lower email
+      comment: Added 0.37.0  # set email values to lower email
       changes:
         - sql :
-            sql : update core_user set email = lower(email)
-  - property:
-      name: email_c_type
-      value: varchar_ignorecase(254)
-      dbms: h2
+            sql : UPDATE core_user SET email = lower(email)
   - changeSet:
       id: 270
       author: rlotun
-      comment: Added 0.37.0 # for H2 convert column to VARCHAR IGNORECASE=TRUE (PG needs citext extension installed)
+      comment: Added 0.37.0 # try to install citext extension on psql (user requires privileges on postgres)
       failOnError: false
       preConditions:
-          - or:
-              - dbms:
-                    type: h2
+        - onFail: MARK_RAN
+        - or:
+            - dbms:
+                type: postgresql
+      changes:
+        - sql :
+            sql : CREATE EXTENSION IF NOT EXISTS citext
+  - changeSet:
+      id: 271
+      author: rlotun
+      comment: Added 0.37.0 # try to convert email column to citext on postgres, if citext extension installed
+      failOnError: false
+      preConditions:
+        - onFail: MARK_RAN
+        - and:
+            - dbms:
+                type: postgresql
+            - sqlCheck:
+                expectedResult: 1
+                sql: SELECT count(*) FROM pg_extension WHERE extname = 'citext'
       changes:
         - modifyDataType:
             tableName: core_user
             columnName: email
-            newDataType: ${email_c_type}
+            newDataType: citext
   - changeSet:
-      id: 271
+      id: 272
+      author: rlotun
+      comment: Added 0.37.0 # for H2 convert column to VARCHAR_IGNORECASE
+      failOnError: false
+      preConditions:
+         - or:
+             - dbms:
+                   type: h2
+      changes:
+        - modifyDataType:
+            tableName: core_user
+            columnName: email
+            newDataType: varchar_ignorecase(254)
+  - changeSet:
+      id: 273
       author: rlotun
       comment: Added 0.37.0  # add unique constraint on lower(email)
       changes:
@@ -7721,7 +7748,7 @@ databaseChangeLog:
             constraintName: constraint_email_unique
             tableName: core_user
   - changeSet:
-      id: 272
+      id: 274
       author: rlotun
       comment: Added 0.37.0  # create index on lower(email)
       failOnError: false
@@ -7731,7 +7758,7 @@ databaseChangeLog:
         - createIndex:
             columns:
              - column:
-                 name: email
+                 name: lower(email)
                  type: varchar(254)
             tableName: core_user
-            indexName: idx_constraint_email_unique
+            indexName: idx_constraint_lower_email_unique

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -7655,14 +7655,36 @@ databaseChangeLog:
             onDelete: CASCADE
 
 # changesets 268-272 allow for handling user account emails in lowercase (GH issue 3047)
+  - property:
+      name: email_constraint_name
+      value: constraint_4
+      dbms: h2
+  - property:
+      name: email_constraint_name
+      value: core_user_email_key
+      dbms: postgresql
+  - property:
+      name: email_constraint_name
+      value: email
+      dbms: mysql,mariadb
   - changeSet:
       id: 268
       author: rlotun
       comment: Added 0.37.0   # drop unique constraint on email - this will also remove supporting indexes
+      preConditions:
+          - or:
+              - dbms:
+                    type: mysql
+              - dbms:
+                    type: mariadb
+              - dbms:
+                    type: postgresql
+              - dbms:
+                    type: h2
       changes:
         - dropUniqueConstraint:
             columnDataType: varchar(254)
-            constraintName: constraint_4
+            constraintName: ${email_constraint_name}
             tableName: core_user
   - changeSet:
       id: 269
@@ -7675,14 +7697,15 @@ databaseChangeLog:
       name: email_c_type
       value: varchar_ignorecase(254)
       dbms: h2
-  - property:
-      name: email_c_type
-      value: citext
-      dbms: postgresql
   - changeSet:
       id: 270
       author: rlotun
-      comment: Added 0.37.0 # PG and H2 only - convert column to citext / VARCHAR IGNORECASE=TRUE
+      comment: Added 0.37.0 # for H2 convert column to VARCHAR IGNORECASE=TRUE (PG needs citext extension installed)
+      failOnError: false
+      preConditions:
+          - or:
+              - dbms:
+                    type: h2
       changes:
         - modifyDataType:
             tableName: core_user
@@ -7701,6 +7724,7 @@ databaseChangeLog:
       id: 272
       author: rlotun
       comment: Added 0.37.0  # create index on lower(email)
+      failOnError: false
       preConditions:
         - onFail: MARK_RAN
       changes:

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -7654,71 +7654,60 @@ databaseChangeLog:
             constraintName: fk_view_log_ref_user_id
             onDelete: CASCADE
 
-# these group of changesets allow for the use of lowercasing emails (GH issue 3047) 
-#  - changeSet:
-#      id: 268
-#      author: rlotun
-#      comment: Added 0.37.0   # drop unique constraint on email
-#      changes:
-#        - dropUniqueConstraint:
-#            columnDataType: varchar(254)
-#            constraintName: email
-#            tableName: core_user
-
-#   - changeSet:
-#      id: 269
-#      author: rlotun
-#      comment: Added 0.37.0 # drop index on email
-#      changes:
-#        - dropIndex:
-#          columnDataType: varchar(254)
-#          indexName: email
-#          columnName: lower(email)
-#          tableName: metabase_user
-
+# changesets 268-272 allow for handling user account emails in lowercase (GH issue 3047)
   - changeSet:
-      id: 270
+      id: 268
+      author: rlotun
+      comment: Added 0.37.0   # drop unique constraint on email - this will also remove supporting indexes
+      changes:
+        - dropUniqueConstraint:
+            columnDataType: varchar(254)
+            constraintName: constraint_4
+            tableName: core_user
+  - changeSet:
+      id: 269
       author: rlotun
       comment: Added 0.37.0  # set email to lower email
       changes:
         - sql :
           sql : update core_user set email = lower(email)
-
+  - property:
+      name: email_c_type
+      value: varchar_ignorecase(254)
+      dbms: h2
+  - property:
+      name: email_c_type
+      value: citext
+      dbms: postgresql
   - changeSet:
-      id: 271
+      id: 270
       author: rlotun
-      comment: Added 0.37.0 # PG and H2 only - convert column to citext / VARCHAR IGNORECASE=TRUE (?)
+      comment: Added 0.37.0 # PG and H2 only - convert column to citext / VARCHAR IGNORECASE=TRUE
       changes:
         - modifyDataType:
-            dbms: h2
             tableName: core_user
             columnName: email
-            newDataType: VARCHAR_IGNORECASE(254)
-
-#        - modifyDataType:
-#            dbms: postgresql
-#            tableName: core_user
-#            columnName: email
-#            newDataType: CITEXT
-#- changeSet:
-#      id: 272
-#      author: rlotun
-#      comment: Added 0.37.0  # create index on lower(email)
-#      changes:
-#        - createIndex:
-#            columns:
-#              - column:
-#                name: lower(email)
-#                type: varchar(254)
-#            tableName: metabase_user
-#            indexName: email
-
+            newDataType: ${email_c_type}
   - changeSet:
-      id: 273
+      id: 271
       author: rlotun
       comment: Added 0.37.0  # add unique constraint on lower(email)
       changes:
         - addUniqueConstraint:
             columnNames: email
-            constraintName: idx_unique_email
+            constraintName: constraint_email_unique
             tableName: core_user
+  - changeSet:
+      id: 272
+      author: rlotun
+      comment: Added 0.37.0  # create index on lower(email)
+      preConditions:
+        - onFail: MARK_RAN
+      changes:
+        - createIndex:
+            columns:
+             - column:
+                 name: email
+                 type: varchar(254)
+            tableName: core_user
+            indexName: idx_constraint_email_unique

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -7654,49 +7654,36 @@ databaseChangeLog:
             constraintName: fk_view_log_ref_user_id
             onDelete: CASCADE
 
-# changesets 268-274 allow for handling user account emails in lowercase (GH issue 3047)
-  - property:
-      name: email_constraint_name
-      value: constraint_4
-      dbms: h2
-  - property:
-      name: email_constraint_name
-      value: core_user_email_key
-      dbms: postgresql
-  - property:
-      name: email_constraint_name
-      value: email
-      dbms: mysql,mariadb
+# changesets 268-272 allow for handling user account emails in lowercase (GH issue 3047)
   - changeSet:
       id: 268
       author: rlotun
-      comment: Added 0.37.0   # drop unique constraint on email - this will also remove supporting indexes
+      comment: Added 0.37.0  # create index on lower(email), for performance reasons (not availble on h2 and only on more recent versions of mysql)
+      failOnError: false
       preConditions:
-        - or:
+        - onFail: MARK_RAN
+        - and:
             - dbms:
-                type: mysql
-            - dbms:
-                type: mariadb
-            - dbms:
-                type: postgresql
-            - dbms:
-                type: h2
+                type: postgresql,mysql,mariadb
       changes:
-        - dropUniqueConstraint:
-            columnDataType: varchar(254)
-            constraintName: ${email_constraint_name}
+        - createIndex:
+            columns:
+             - column:
+                 name: lower(email)
+                 type: varchar(254)
             tableName: core_user
+            indexName: idx_lower_email
   - changeSet:
       id: 269
       author: rlotun
-      comment: Added 0.37.0  # set email values to lower email
+      comment: Added 0.37.0  # set email values to lower(email) but do so defensively - skip over those that would introduce duplicates (e.g. Reza@email.com and reza@email.com)
       changes:
         - sql :
-            sql : UPDATE core_user SET email = lower(email)
+            sql : UPDATE core_user SET email = lower(email) WHERE lower(email) IN (SELECT lower(email) from core_user GROUP BY lower(email) HAVING COUNT(email) = 1) AND email <> lower(email)
   - changeSet:
       id: 270
       author: rlotun
-      comment: Added 0.37.0 # try to install citext extension on psql (user requires privileges on postgres)
+      comment: Added 0.37.0 # try to install citext extension on posgres (user requires privileges on postgres)
       failOnError: false
       preConditions:
         - onFail: MARK_RAN
@@ -7738,27 +7725,3 @@ databaseChangeLog:
             tableName: core_user
             columnName: email
             newDataType: varchar_ignorecase(254)
-  - changeSet:
-      id: 273
-      author: rlotun
-      comment: Added 0.37.0  # add unique constraint on lower(email)
-      changes:
-        - addUniqueConstraint:
-            columnNames: email
-            constraintName: constraint_email_unique
-            tableName: core_user
-  - changeSet:
-      id: 274
-      author: rlotun
-      comment: Added 0.37.0  # create index on lower(email)
-      failOnError: false
-      preConditions:
-        - onFail: MARK_RAN
-      changes:
-        - createIndex:
-            columns:
-             - column:
-                 name: lower(email)
-                 type: varchar(254)
-            tableName: core_user
-            indexName: idx_constraint_lower_email_unique

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -7676,10 +7676,10 @@ databaseChangeLog:
   - changeSet:
       id: 269
       author: rlotun
-      comment: Added 0.37.0  # set email values to lower(email) but do so defensively - skip over those that would introduce duplicates (e.g. Reza@email.com and reza@email.com)
+      comment: Added 0.37.0  # set email values to lower(email) but do so defensively and in a way that works on postgres and mysql - skip over those that would introduce duplicates (e.g. Reza@email.com and reza@email.com)
       changes:
         - sql :
-            sql : UPDATE core_user SET email = lower(email) WHERE lower(email) IN (SELECT lower(email) from core_user GROUP BY lower(email) HAVING COUNT(email) = 1) AND email <> lower(email)
+            sql : UPDATE core_user SET email = lower(email) WHERE lower(email) NOT IN (SELECT * FROM (SELECT lower(email) FROM core_user GROUP BY lower(email) HAVING count(email) > 1) as e);
   - changeSet:
       id: 270
       author: rlotun

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -112,7 +112,7 @@
    group_ids        (s/maybe [su/IntGreaterThanZero])
    login_attributes (s/maybe user/LoginAttributes)}
   (api/check-superuser)
-  (api/checkp (not (db/exists? User :email email))
+  (api/checkp (not (db/exists? User :%lower.email (u/lower-case-en email)))
     "email" (tru "Email address already in use."))
   (db/transaction
     (let [new-user-id (u/get-id (user/create-and-invite-user!
@@ -157,7 +157,7 @@
     ;; Google/LDAP non-admin users can't change their email to prevent account hijacking
     (api/check-403 (valid-email-update? user-before-update email))
     ;; can't change email if it's already taken BY ANOTHER ACCOUNT
-    (api/checkp (not (db/exists? User, :email email, :id [:not= id]))
+    (api/checkp (not (db/exists? User, :%lower.email (u/lower-case-en email), :id [:not= id]))
       "email" (tru "Email address already associated to another user."))
     (db/transaction
       (api/check-500

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -157,7 +157,7 @@
     ;; Google/LDAP non-admin users can't change their email to prevent account hijacking
     (api/check-403 (valid-email-update? user-before-update email))
     ;; can't change email if it's already taken BY ANOTHER ACCOUNT
-    (api/checkp (not (db/exists? User, :%lower.email (u/lower-case-en email), :id [:not= id]))
+    (api/checkp (not (db/exists? User, :%lower.email (if email (u/lower-case-en email) email), :id [:not= id]))
       "email" (tru "Email address already associated to another user."))
     (db/transaction
       (api/check-500

--- a/src/metabase/cmd/reset_password.clj
+++ b/src/metabase/cmd/reset_password.clj
@@ -1,13 +1,14 @@
 (ns metabase.cmd.reset-password
   (:require [metabase.db :as mdb]
             [metabase.models.user :as user :refer [User]]
+            [metabase.util :as u]
             [metabase.util.i18n :refer [deferred-trs trs]]
             [toucan.db :as db]))
 
 (defn- set-reset-token!
   "Set and return a new `reset_token` for the user with EMAIL-ADDRESS."
   [email-address]
-  (let [user-id (or (db/select-one-id User, :email email-address)
+  (let [user-id (or (db/select-one-id User, :%lower.email (u/lower-case-en email-address))
                     (throw (Exception. (str (deferred-trs "No user found with email address ''{0}''. " email-address)
                                             (deferred-trs "Please check the spelling and try again.")))))]
     (user/set-password-reset-token! user-id)))

--- a/src/metabase/cmd/reset_password.clj
+++ b/src/metabase/cmd/reset_password.clj
@@ -1,7 +1,8 @@
 (ns metabase.cmd.reset-password
-  (:require [metabase.db :as mdb]
+  (:require [metabase
+             [db :as mdb]
+             [util :as u]]
             [metabase.models.user :as user :refer [User]]
-            [metabase.util :as u]
             [metabase.util.i18n :refer [deferred-trs trs]]
             [toucan.db :as db]))
 

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -47,6 +47,8 @@
      user
      {:password_salt salt
       :password      (creds/hash-bcrypt (str salt password))}
+     ;; lower-case the email before saving
+     {:email (u/lower-case-en email)}
      ;; if there's a reset token encrypt that as well
      (when reset_token
        {:reset_token (creds/hash-bcrypt reset_token)})
@@ -96,7 +98,8 @@
   ;; If we're setting the reset_token then encrypt it before it goes into the DB
   (cond-> user
     reset_token (update :reset_token creds/hash-bcrypt)
-    locale      (update :locale i18n/normalized-locale-string)))
+    locale      (update :locale i18n/normalized-locale-string)
+    email       (update :email u/lower-case-en)))
 
 (defn add-common-name
   "Add a `:common_name` key to `user` by combining their first and last names."

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -2,9 +2,7 @@
   "Tests for /api/session"
   (:require [cheshire.core :as json]
             [clj-http.client :as http]
-            [clojure
-             [string :as str]
-             [test :refer :all]]
+            [clojure.test :refer :all]
             [metabase
              [email-test :as et]
              [http-client :as http-client]

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -41,7 +41,11 @@
   (testing "POST /api/session"
     (testing "Test that we can login"
       (is (schema= SessionResponse
-                   (mt/client :post 200 "session" (mt/user->credentials :rasta)))))))
+                   (mt/client :post 200 "session" (mt/user->credentials :rasta)))))
+    (testing "Test that we can login with email of mixed case"
+      (let [creds (update (mt/user->credentials :rasta) :username clojure.string/capitalize)]
+        (is (schema= SessionResponse
+                     (mt/client :post 200 "session" creds)))))))
 
 (deftest login-validation-test
   (testing "POST /api/session"

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -2,7 +2,9 @@
   "Tests for /api/session"
   (:require [cheshire.core :as json]
             [clj-http.client :as http]
-            [clojure.test :refer :all]
+            [clojure
+             [string :as str]
+             [test :refer :all]]
             [metabase
              [email-test :as et]
              [http-client :as http-client]
@@ -43,7 +45,7 @@
       (is (schema= SessionResponse
                    (mt/client :post 200 "session" (mt/user->credentials :rasta)))))
     (testing "Test that we can login with email of mixed case"
-      (let [creds (update (mt/user->credentials :rasta) :username clojure.string/capitalize)]
+      (let [creds (update (mt/user->credentials :rasta) :username u/upper-case-en)]
         (is (schema= SessionResponse
                      (mt/client :post 200 "session" creds)))))))
 

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -354,20 +354,20 @@
             email     (tu/random-email)]
         (is (= email
               (:email (et/with-fake-inbox
-                   (try
-                     (tu/boolean-ids-and-timestamps
-                      ((mt/user->client :crowberto) :post 200 "user"
-                       {:first_name       user-name
-                        :last_name        user-name
-                        :email            (u/upper-case-en email)
-                        :login_attributes {:test "value"}}))
-                     (finally
-                       ;; clean up after ourselves
-                       (db/delete! User :email email)))))))))
+                        (try
+                          (tu/boolean-ids-and-timestamps
+                            ((mt/user->client :crowberto) :post 200 "user"
+                             {:first_name       user-name
+                              :last_name        user-name
+                              :email            (u/upper-case-en email)
+                              :login_attributes {:test "value"}}))
+                          (finally
+                             ;; clean up after ourselves
+                             (db/delete! User :email email)))))))))
 
     (testing "attempting to create a new user with an email with case mutations of an existing email should fail"
       (is (= {:errors {:email "Email address already in use."}}
-            ((mt/user->client :crowberto) :post 400 "user"
+             ((mt/user->client :crowberto) :post 400 "user"
                {:first_name "Something"
                 :last_name  "Random"
                 :email      (u/upper-case-en (:email (mt/fetch-user :rasta)))}))))))

--- a/test/metabase/cmd/reset_password_test.clj
+++ b/test/metabase/cmd/reset_password_test.clj
@@ -1,0 +1,19 @@
+(ns metabase.cmd.reset-password-test
+  (:require [clojure.test :refer :all]
+            [metabase.cmd.reset-password :as reset-password]
+            [metabase
+             [test :as mt]
+             [util :as u]]
+            [metabase.models.user :refer [User]]))
+
+(deftest reset-password-test
+  (testing "set reset token throws exception on unknown email"
+    (is (thrown? Exception
+         (#'reset-password/set-reset-token! "some.random.email.to.reset@metabase.com"))))
+
+  (testing "reset token generated for known email in differing case"
+    (let [email "some.valid.user.to.reset@metabase.com"]
+      (mt/with-temp User [user {:email (u/upper-case-en email)}]
+        (is (instance?
+              String
+              (#'reset-password/set-reset-token! email)))))))

--- a/test/metabase/cmd/reset_password_test.clj
+++ b/test/metabase/cmd/reset_password_test.clj
@@ -1,9 +1,9 @@
 (ns metabase.cmd.reset-password-test
   (:require [clojure.test :refer :all]
-            [metabase.cmd.reset-password :as reset-password]
             [metabase
              [test :as mt]
              [util :as u]]
+            [metabase.cmd.reset-password :as reset-password]
             [metabase.models.user :refer [User]]))
 
 (deftest reset-password-test

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -9,11 +9,12 @@
 
   See `metabase.db.schema-migrations-test.impl` for the implementation of this functionality."
   (:require [clojure.test :refer :all]
+            [metabase
+             [models :refer [Database Field Table]]
+             [util :as u]]
             [metabase.db.schema-migrations-test.impl :as impl]
-            [metabase.models :refer [Database Field Table]]
             [metabase.models.user :refer [User]]
-            [metabase.test.util :as tu :refer [random-name]]
-            [metabase.util :as u]
+            [metabase.test.util :as tu]
             [toucan.db :as db])
   (:import java.util.UUID))
 

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -11,7 +11,11 @@
   (:require [clojure.test :refer :all]
             [metabase.db.schema-migrations-test.impl :as impl]
             [metabase.models :refer [Database Field Table]]
-            [toucan.db :as db]))
+            [metabase.models.user :refer [User]]
+            [metabase.test.util :as tu :refer [random-name]]
+            [metabase.util :as u]
+            [toucan.db :as db])
+  (:import java.util.UUID))
 
 (deftest database-position-test
   (testing "Migration 165: add `database_position` to Field"
@@ -31,3 +35,47 @@
           (testing (format "Field %d" id)
             (is (= id
                    (db/select-one-field :database_position Field :id id)))))))))
+
+(defn- create-raw-user [email]
+  "create a user but skip pre and post insert steps"
+  (db/simple-insert! User
+    :email        email
+    :first_name   (tu/random-name)
+    :last_name    (tu/random-name)
+    :password     (str (UUID/randomUUID))
+    :date_joined  :%now
+    :is_active    true
+    :is_superuser false))
+
+(deftest email-lowercasing-test
+  (testing "Migration 268-272: basic lowercasing `email` in `core_user`"
+    (impl/test-migrations [268 272] [migrate!]
+      (let [e1 "Foo@email.com"
+            e2 "boo@email.com"]
+        (doseq [e [e1 e2]]
+          (create-raw-user e))
+        ;; Run migrations 268 - 272
+        (migrate!)
+        (doseq [e [e1 e2]]
+          (is (= true
+                 (db/exists? User :email (u/lower-case-en e1))))))))
+  (testing "Migration 268-272: lowercasing `email` in `core_user` but skip cases causing duplicates"
+    (impl/test-migrations [268 272] [migrate!]
+      (let [e1 "Foo@email.com"
+            e2 "boo@email.com"
+            e3 "foo@email.com"
+            e4 "TEST@email.com"]
+        (doseq [e [e1 e2 e3 e4]]
+          (create-raw-user e))
+        ;; Run migrations 268 - 272
+        (migrate!)
+        (testing "emails that have upper case characters that collide to other emails shouldn't be touched"
+          (is (= true
+                 (db/exists? User :email "Foo@email.com")))
+          (is (= true
+                 (db/exists? User :email "foo@email.com"))))
+        (testing "emails that should have been lowercased are"
+          (is (= true
+                 (db/exists? User :email (u/lower-case-en e2))))
+          (is (= true
+                 (db/exists? User :email (u/lower-case-en e4)))))))))

--- a/test/metabase/models/session_test.clj
+++ b/test/metabase/models/session_test.clj
@@ -9,7 +9,7 @@
 (deftest first-session-for-user-test
   (tt/with-temp User [{user-id :id} {:first_name (tu/random-name)
                                      :last_name  (tu/random-name)
-                                     :email      (str (tu/random-name) "@metabase.com")
+                                     :email      (tu/random-email)
                                      :password   "nada"}]
     (db/simple-insert-many! Session
       [{:id         "the-greatest-day-ever"

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -84,7 +84,7 @@
 (defn random-email
   "Generate a random email address."
   []
-  (str (random-name) "@metabase.com"))
+  (str (u/lower-case-en (random-name)) "@metabase.com"))
 
 (defn boolean-ids-and-timestamps
   "Useful for unit test comparisons. Converts map keys found in `DATA`


### PR DESCRIPTION
Allow for email case insensitive handling on user operations - primarily login.

Unit tests and cypress tests added and pass. Need some help on fully validating DB migration changesets on postgres.

Resolves #3047 