### PR TITLE
Improve querying icons in tests

### DIFF
--- a/frontend/src/metabase/components/Icon.jsx
+++ b/frontend/src/metabase/components/Icon.jsx
@@ -62,10 +62,6 @@ class BaseIcon extends Component {
       return <span />;
     }
 
-    const { ariaLabel } = icon.attrs;
-    // must be removed to avoid "Unknown prop" warning
-    delete icon.attrs.ariaLabel;
-
     const props = {
       ...icon.attrs,
       ...stripLayoutProps(rest),
@@ -88,24 +84,17 @@ class BaseIcon extends Component {
     delete props.size, props.scale;
 
     if (icon.img) {
+      // avoid passing `role="img"` to an actual image file
+      // eslint-disable-next-line no-unused-vars
+      const { role, ...rest } = props;
       return (
-        <RetinaImage
-          forceOriginalDimensions={false}
-          src={icon.img}
-          {...props}
-        />
+        <RetinaImage forceOriginalDimensions={false} src={icon.img} {...rest} />
       );
     } else if (icon.svg) {
-      return (
-        <svg
-          {...props}
-          aria-label={ariaLabel}
-          dangerouslySetInnerHTML={{ __html: icon.svg }}
-        />
-      );
+      return <svg {...props} dangerouslySetInnerHTML={{ __html: icon.svg }} />;
     } else if (icon.path) {
       return (
-        <svg {...props} aria-label={ariaLabel}>
+        <svg {...props}>
           <path d={icon.path} />
         </svg>
       );

--- a/frontend/src/metabase/components/Icon.jsx
+++ b/frontend/src/metabase/components/Icon.jsx
@@ -62,6 +62,10 @@ class BaseIcon extends Component {
       return <span />;
     }
 
+    const { ariaLabel } = icon.attrs;
+    // must be removed to avoid "Unknown prop" warning
+    delete icon.attrs.ariaLabel;
+
     const props = {
       ...icon.attrs,
       ...stripLayoutProps(rest),
@@ -92,10 +96,16 @@ class BaseIcon extends Component {
         />
       );
     } else if (icon.svg) {
-      return <svg {...props} dangerouslySetInnerHTML={{ __html: icon.svg }} />;
+      return (
+        <svg
+          {...props}
+          aria-label={ariaLabel}
+          dangerouslySetInnerHTML={{ __html: icon.svg }}
+        />
+      );
     } else if (icon.path) {
       return (
-        <svg {...props}>
+        <svg {...props} aria-label={ariaLabel}>
           <path d={icon.path} />
         </svg>
       );

--- a/frontend/src/metabase/icon_paths.js
+++ b/frontend/src/metabase/icon_paths.js
@@ -441,7 +441,7 @@ export function loadIcon(name: string) {
       height: 16,
       fill: "currentcolor",
       role: "img",
-      ariaLabel: name + " icon",
+      "aria-label": name + " icon",
     },
     svg: undefined,
     path: undefined,

--- a/frontend/src/metabase/icon_paths.js
+++ b/frontend/src/metabase/icon_paths.js
@@ -414,7 +414,7 @@ ICON_PATHS["scalar"] = ICON_PATHS["number"];
 export function parseViewBox(viewBox: string): Array<number> {
   // a viewBox is a string that takes the form 'min-x, min-y, width, height'
   // grab the values and return just width and height since we currently don't
-  // tend to card about min-x or min-y
+  // tend to care about min-x or min-y
 
   // we cast to numbers so we can do math-y stuff with the width and height
   return viewBox
@@ -440,6 +440,8 @@ export function loadIcon(name: string) {
       width: 16,
       height: 16,
       fill: "currentcolor",
+      role: "img",
+      ariaLabel: name + " icon",
     },
     svg: undefined,
     path: undefined,

--- a/frontend/test/metabase/components/Icon.unit.spec.js
+++ b/frontend/test/metabase/components/Icon.unit.spec.js
@@ -1,4 +1,9 @@
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render, screen } from "@testing-library/react";
+
 import { ICON_PATHS, loadIcon, parseViewBox } from "metabase/icon_paths";
+import Icon from "metabase/components/Icon";
 
 // find the first icon with a non standard viewBox
 const NON_STANDARD_VIEWBOX_ICON = Object.keys(ICON_PATHS).filter(key => {
@@ -25,6 +30,35 @@ describe("Icon", () => {
 
       expect(width).toEqual(parsedWidth / 2);
       expect(height).toEqual(parsedHeight / 2);
+    });
+  });
+
+  describe("component", () => {
+    it("should render correct icon for the valid `name`", () => {
+      // used "google" to cover the use of `dangerouslySetInnerHTML`
+      render(<Icon name="google" />);
+      const icon = screen.getByRole("img", { name: /google icon/i });
+
+      expect(icon).toHaveClass("Icon-google");
+    });
+
+    it("should render `unknown` icon given non-existing `name`", () => {
+      render(<Icon name="404-icon-not-found" />);
+      const icon = screen.getByRole("img", { name: /unknown icon/i });
+
+      expect(icon).toHaveClass("Icon-unknown");
+    });
+
+    it("should render `unknown` icon when `name` is not provided", () => {
+      render(<Icon />);
+      const icon = screen.getByRole("img", { name: /unknown icon/i });
+
+      expect(icon).toHaveClass("Icon-unknown");
+    });
+
+    it("should render an image if `img` attribute is present in `ICON_PATHS`", () => {
+      render(<Icon name="slack" />);
+      expect(screen.getByRole("img")).toHaveAttribute("src");
     });
   });
 });

--- a/frontend/test/metabase/components/Icon.unit.spec.js
+++ b/frontend/test/metabase/components/Icon.unit.spec.js
@@ -6,11 +6,9 @@ import { ICON_PATHS, loadIcon, parseViewBox } from "metabase/icon_paths";
 import Icon from "metabase/components/Icon";
 
 // find the first icon with a non standard viewBox
-const NON_STANDARD_VIEWBOX_ICON = Object.keys(ICON_PATHS).filter(key => {
-  if (ICON_PATHS[key].attrs && ICON_PATHS[key].attrs.viewBox) {
-    return ICON_PATHS[key];
-  }
-})[0];
+const NON_STANDARD_VIEWBOX_ICON = Object.keys(ICON_PATHS).find(key => {
+  return ICON_PATHS[key].attrs && ICON_PATHS[key].attrs.viewBox;
+});
 
 describe("Icon", () => {
   describe("parseViewBox", () => {

--- a/frontend/test/metabase/components/__snapshots__/Button.unit.spec.js.snap
+++ b/frontend/test/metabase/components/__snapshots__/Button.unit.spec.js.snap
@@ -26,9 +26,11 @@ exports[`Button should render correctly with an icon 1`] = `
     style={null}
   >
     <svg
+      aria-label="star icon"
       className="Icon Icon-star Icon-sc-1x67v3y-1 hFNRPZ"
       fill="currentcolor"
       height={14}
+      role="img"
       viewBox="0 0 32 32"
       width={14}
     >

--- a/frontend/test/metabase/components/__snapshots__/Calendar.unit.spec.js.snap
+++ b/frontend/test/metabase/components/__snapshots__/Calendar.unit.spec.js.snap
@@ -12,9 +12,11 @@ exports[`Calendar should render correctly 1`] = `
       onClick={[Function]}
     >
       <svg
+        aria-label="chevronleft icon"
         className="Icon Icon-chevronleft Icon-sc-1x67v3y-1 hFNRPZ"
         fill="currentcolor"
         height={10}
+        role="img"
         viewBox="0 0 32 32"
         width={10}
       >
@@ -37,9 +39,11 @@ exports[`Calendar should render correctly 1`] = `
       onClick={[Function]}
     >
       <svg
+        aria-label="chevronright icon"
         className="Icon Icon-chevronright Icon-sc-1x67v3y-1 hFNRPZ"
         fill="currentcolor"
         height={10}
+        role="img"
         viewBox="0 0 32 32"
         width={10}
       >

--- a/frontend/test/metabase/internal/__snapshots__/components.unit.spec.js.snap
+++ b/frontend/test/metabase/internal/__snapshots__/components.unit.spec.js.snap
@@ -43,9 +43,11 @@ exports[`Button should render "with an icon" correctly 1`] = `
     style={null}
   >
     <svg
+      aria-label="star icon"
       className="Icon Icon-star Icon-sc-1x67v3y-1 hFNRPZ"
       fill="currentcolor"
       height={14}
+      role="img"
       viewBox="0 0 32 32"
       width={14}
     >
@@ -259,9 +261,11 @@ exports[`CheckBox should render "Green" correctly 1`] = `
   }
 >
   <svg
+    aria-label="check icon"
     className="Icon Icon-check Icon-sc-1x67v3y-1 hFNRPZ"
     fill="currentcolor"
     height={12}
+    role="img"
     style={
       Object {
         "color": "white",
@@ -291,9 +295,11 @@ exports[`CheckBox should render "On - Default blue" correctly 1`] = `
   }
 >
   <svg
+    aria-label="check icon"
     className="Icon Icon-check Icon-sc-1x67v3y-1 hFNRPZ"
     fill="currentcolor"
     height={12}
+    role="img"
     style={
       Object {
         "color": "white",
@@ -323,9 +329,11 @@ exports[`CheckBox should render "Purple" correctly 1`] = `
   }
 >
   <svg
+    aria-label="check icon"
     className="Icon Icon-check Icon-sc-1x67v3y-1 hFNRPZ"
     fill="currentcolor"
     height={12}
+    role="img"
     style={
       Object {
         "color": "white",
@@ -355,9 +363,11 @@ exports[`CheckBox should render "Red" correctly 1`] = `
   }
 >
   <svg
+    aria-label="check icon"
     className="Icon Icon-check Icon-sc-1x67v3y-1 hFNRPZ"
     fill="currentcolor"
     height={12}
+    role="img"
     style={
       Object {
         "color": "white",
@@ -387,9 +397,11 @@ exports[`CheckBox should render "Yellow" correctly 1`] = `
   }
 >
   <svg
+    aria-label="check icon"
     className="Icon Icon-check Icon-sc-1x67v3y-1 hFNRPZ"
     fill="currentcolor"
     height={12}
+    role="img"
     style={
       Object {
         "color": "white",
@@ -420,9 +432,11 @@ exports[`EntityMenu should render "Edit menu" correctly 1`] = `
         onClick={[Function]}
       >
         <svg
+          aria-label="pencil icon"
           className="Icon Icon-pencil Icon-sc-1x67v3y-1 bcaYRA"
           fill="currentcolor"
           height={18}
+          role="img"
           viewBox="0 0 32 32"
           width={18}
         >
@@ -454,9 +468,11 @@ exports[`EntityMenu should render "More menu" correctly 1`] = `
         onClick={[Function]}
       >
         <svg
+          aria-label="burger icon"
           className="Icon Icon-burger Icon-sc-1x67v3y-1 bcaYRA"
           fill="currentcolor"
           height={18}
+          role="img"
           viewBox="0 0 32 32"
           width={18}
         >
@@ -488,9 +504,11 @@ exports[`EntityMenu should render "Multiple menus" correctly 1`] = `
         onClick={[Function]}
       >
         <svg
+          aria-label="pencil icon"
           className="Icon Icon-pencil Icon-sc-1x67v3y-1 bcaYRA"
           fill="currentcolor"
           height={18}
+          role="img"
           viewBox="0 0 32 32"
           width={18}
         >
@@ -511,10 +529,12 @@ exports[`EntityMenu should render "Multiple menus" correctly 1`] = `
         onClick={[Function]}
       >
         <svg
+          aria-label="share icon"
           className="Icon Icon-share Icon-sc-1x67v3y-1 bcaYRA"
           fill="currentcolor"
           fillRule="evenodd"
           height={18}
+          role="img"
           viewBox="0 0 32 41"
           width={18}
         >
@@ -535,9 +555,11 @@ exports[`EntityMenu should render "Multiple menus" correctly 1`] = `
         onClick={[Function]}
       >
         <svg
+          aria-label="burger icon"
           className="Icon Icon-burger Icon-sc-1x67v3y-1 bcaYRA"
           fill="currentcolor"
           height={18}
+          role="img"
           viewBox="0 0 32 32"
           width={18}
         >
@@ -569,10 +591,12 @@ exports[`EntityMenu should render "Share menu" correctly 1`] = `
         onClick={[Function]}
       >
         <svg
+          aria-label="share icon"
           className="Icon Icon-share Icon-sc-1x67v3y-1 bcaYRA"
           fill="currentcolor"
           fillRule="evenodd"
           height={18}
+          role="img"
           viewBox="0 0 32 41"
           width={18}
         >
@@ -598,10 +622,12 @@ exports[`ModalContent should render "default" correctly 1`] = `
     id={undefined}
   >
     <svg
+      aria-label="close icon"
       className="Icon Icon-close text-light text-medium-hover cursor-pointer absolute z2 m2 p2 top right Icon-sc-1x67v3y-1 hFNRPZ"
       fill="currentcolor"
       height={16}
       onClick={[Function]}
+      role="img"
       viewBox="0 0 32 32"
       width={16}
     >
@@ -987,9 +1013,11 @@ exports[`Select should render "default" correctly 1`] = `
       </span>
     </span>
     <svg
+      aria-label="chevrondown icon"
       className="Icon Icon-chevrondown AdminSelect-chevron flex-align-right Icon-sc-1x67v3y-1 hFNRPZ"
       fill="currentcolor"
       height={12}
+      role="img"
       viewBox="0 0 32 32"
       width={12}
     >
@@ -1028,9 +1056,11 @@ exports[`Select should render "kitchen_sink" correctly 1`] = `
       </span>
     </span>
     <svg
+      aria-label="chevrondown icon"
       className="Icon Icon-chevrondown AdminSelect-chevron flex-align-right Icon-sc-1x67v3y-1 hFNRPZ"
       fill="currentcolor"
       height={12}
+      role="img"
       viewBox="0 0 32 32"
       width={12}
     >
@@ -1069,9 +1099,11 @@ exports[`Select should render "multiple" correctly 1`] = `
       </span>
     </span>
     <svg
+      aria-label="chevrondown icon"
       className="Icon Icon-chevrondown AdminSelect-chevron flex-align-right Icon-sc-1x67v3y-1 hFNRPZ"
       fill="currentcolor"
       height={12}
+      role="img"
       viewBox="0 0 32 32"
       width={12}
     >
@@ -1106,9 +1138,11 @@ exports[`Select should render "search" correctly 1`] = `
       </span>
     </span>
     <svg
+      aria-label="chevrondown icon"
       className="Icon Icon-chevrondown AdminSelect-chevron flex-align-right Icon-sc-1x67v3y-1 hFNRPZ"
       fill="currentcolor"
       height={12}
+      role="img"
       viewBox="0 0 32 32"
       width={12}
     >
@@ -1143,9 +1177,11 @@ exports[`Select should render "sections" correctly 1`] = `
       </span>
     </span>
     <svg
+      aria-label="chevrondown icon"
       className="Icon Icon-chevrondown AdminSelect-chevron flex-align-right Icon-sc-1x67v3y-1 hFNRPZ"
       fill="currentcolor"
       height={12}
+      role="img"
       viewBox="0 0 32 32"
       width={12}
     >
@@ -1182,9 +1218,11 @@ exports[`StackedCheckBox should render "Checked with color" correctly 1`] = `
     }
   >
     <svg
+      aria-label="check icon"
       className="Icon Icon-check Icon-sc-1x67v3y-1 hFNRPZ"
       fill="currentcolor"
       height={12}
+      role="img"
       style={
         Object {
           "color": "white",
@@ -1238,9 +1276,11 @@ exports[`StackedCheckBox should render "Checked" correctly 1`] = `
     }
   >
     <svg
+      aria-label="check icon"
       className="Icon Icon-check Icon-sc-1x67v3y-1 hFNRPZ"
       fill="currentcolor"
       height={12}
+      role="img"
       style={
         Object {
           "color": "white",


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- introduces a new and improved way to query icons and make assertions on them in tests
- slightly improves icons' accessibility by adding `role` and `aria-label` attributes
- adds new unit tests for `Icon.jsx` component
- closes #13224 

### How should this be manually tested?
`yarn test-unit-watch` and then isolate `Icon.unit.spec.js`

### Additional notes
- I was using `screen.someQuery()` instead of destructuring that query from the render method ([read more](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#not-using-screen))
- [React uses `aria-label`](https://www.aditus.io/aria/aria-label/#react-and-aria-label) (with hypen), but to be able to achieve that I needed a bit of gymnastics. Please check code comments.