### PR TITLE
MBQL: make mbql.u/field-clause->id-or-field work with expressions

### DIFF
--- a/backend/mbql/src/metabase/mbql/util.clj
+++ b/backend/mbql/src/metabase/mbql/util.clj
@@ -442,7 +442,7 @@
   "Unwrap a Field `clause`, if it's something that can be unwrapped (i.e. something that is, or wraps, a `:field-id` or
   `:field-literal`). Otherwise return `clause` as-is."
   [clause]
-  (if (is-clause? #{:field-id :fk-> :field-literal :datetime-field :binning-strategy} clause)
+  (if (is-clause? #{:field-id :fk-> :field-literal :datetime-field :binning-strategy :joined-field} clause)
     (unwrap-field-clause clause)
     clause))
 
@@ -456,7 +456,7 @@
   For expressions (or any other clauses) this returns the clause as-is, so as to facilitate the primary use case of
   comparing Field clauses."
   [clause :- mbql.s/Field]
-  (second (unwrap-field-clause clause)))
+  (second (maybe-unwrap-field-clause clause)))
 
 (s/defn add-order-by-clause :- mbql.s/MBQLQuery
   "Add a new `:order-by` clause to an MBQL `inner-query`. If the new order-by clause references a Field that is

--- a/backend/mbql/src/metabase/mbql/util.clj
+++ b/backend/mbql/src/metabase/mbql/util.clj
@@ -453,8 +453,7 @@
     (field-clause->id-or-literal [:datetime-field [:field-id 100] ...]) ; -> 100
     (field-clause->id-or-literal [:field-id 100])                       ; -> 100
 
-  For expressions (or any other clauses) this returns the clause as-is, so as to facilitate the primary use case of
-  comparing Field clauses."
+  For expressions returns the expression name."
   [clause :- mbql.s/Field]
   (second (maybe-unwrap-field-clause clause)))
 

--- a/backend/mbql/test/metabase/mbql/util_test.clj
+++ b/backend/mbql/test/metabase/mbql/util_test.clj
@@ -1066,7 +1066,7 @@
 
 (expect
   "foo"
-  (mbql.u/field-clause->id-or-literal [:field-value "foo"]))
+  (mbql.u/field-clause->id-or-literal [:field-literal "foo"]))
 
 (expect
   "foo"

--- a/backend/mbql/test/metabase/mbql/util_test.clj
+++ b/backend/mbql/test/metabase/mbql/util_test.clj
@@ -1059,3 +1059,15 @@
                                 :query    {:source-query {:expressions  {:two [:+ 1 1]}
                                                           :source-table 1}}}
                                "two"))
+
+(expect
+  1
+  (mbql.u/field-clause->id-or-literal [:field-id 1]))
+
+(expect
+  "foo"
+  (mbql.u/field-clause->id-or-literal [:field-value "foo"]))
+
+(expect
+  "foo"
+  (mbql.u/field-clause->id-or-literal [:expression "foo"]))

--- a/backend/mbql/test/metabase/mbql/util_test.clj
+++ b/backend/mbql/test/metabase/mbql/util_test.clj
@@ -1066,7 +1066,7 @@
 
 (expect
   "foo"
-  (mbql.u/field-clause->id-or-literal [:field-literal "foo"]))
+  (mbql.u/field-clause->id-or-literal [:field-literal "foo" :type/Integer]))
 
 (expect
   "foo"


### PR DESCRIPTION
Fixes a bug where ` mbql.u/field-clause->id-or-field` did not gracefully handle expressions, despite the doc string saying it did.

Fixes #13241 
