### PR TITLE
Don't duplicate fields when doing remappings

### DIFF
--- a/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
+++ b/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
@@ -50,8 +50,19 @@
      (testing "make sure FK remaps add an entry for the FK field to `:fields`, and returns a pair of [dimension-info updated-query]"
        (is (= [[remapped-field]
                (update-in example-query [:query :fields]
-                          conj [:fk-> [:field-id (mt/id :venues :category_id)] [:field-id (mt/id :categories :name)]])]
+                          conj [:fk-> [:field-id (mt/id :venues :category_id)]
+                                [:field-id (mt/id :categories :name)]])]
               (#'add-dim-projections/add-fk-remaps example-query))))
+
+     (testing "make sure we don't duplicate remappings"
+       (is (= [[remapped-field]
+               (update-in example-query [:query :fields]
+                          conj [:fk-> [:field-id (mt/id :venues :category_id)]
+                                [:field-id (mt/id :categories :name)]])]
+              (#'add-dim-projections/add-fk-remaps
+               (update-in example-query [:query :fields]
+                          conj [:fk-> [:field-id (mt/id :venues :category_id)]
+                                [:field-id (mt/id :categories :name)]])))))
 
      (testing "adding FK remaps should replace any existing order-bys for a field with order bys for the FK remapping Field"
        (is (= [[remapped-field]


### PR DESCRIPTION
Having FK remappings defined could cause us to generate invalid queries if the user for some reason or other also added the same `:fk->` expression.

I am however not sure this is the right approach. Currently and middleware that adds to fields has to be mindful of this restriction. Perhaps it would be better to loosen the schema to allow duplicates in intermittent results and have a final cleanup step where we dedup (I think _use-first_ is a good enough strategy that it can be used as one size fits all). 