### PR TITLE
Add --keep-existing flag to dump-to-h2 command

### DIFF
--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -38,10 +38,11 @@
 
 (defn ^:command dump-to-h2
   "Transfer data from existing database to newly created H2 DB."
-  [h2-filename]
+  [h2-filename & opts]
   (classloader/require 'metabase.cmd.dump-to-h2)
   (binding [mdb/*disable-data-migrations* true]
-    (let [return-code ((resolve 'metabase.cmd.dump-to-h2/dump-to-h2!) h2-filename)]
+    (let [keep-existing (boolean (some #{"--keep-existing"} opts))
+          return-code   ((resolve 'metabase.cmd.dump-to-h2/dump-to-h2!) h2-filename keep-existing)]
       (when (pos-int? return-code)
         (System/exit return-code)))))
 

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -37,7 +37,9 @@
      ((resolve 'metabase.cmd.load-from-h2/load-from-h2!) h2-connection-string))))
 
 (defn ^:command dump-to-h2
-  "Transfer data from existing database to newly created H2 DB."
+  "Transfer data from existing database to newly created H2 DB with specified filename.
+
+  Target H2 file is deleted before dump, unless the --keep-existing flag is given."
   [h2-filename & opts]
   (classloader/require 'metabase.cmd.dump-to-h2)
   (binding [mdb/*disable-data-migrations* true]

--- a/src/metabase/cmd/dump_to_h2.clj
+++ b/src/metabase/cmd/dump_to_h2.clj
@@ -97,12 +97,13 @@
   from one instance to another using H2 as serialization target.
 
   Defaults to using `@metabase.db/db-file` as the connection string."
-  [h2-filename]
+  [h2-filename keep-existing]
   (let [h2-filename (or h2-filename "metabase_dump.h2")]
     (println "Dumping to " h2-filename)
     (doseq [filename [h2-filename
                     (str h2-filename ".mv.db")]]
-      (when (.exists (io/file filename))
+      (when (and (.exists (io/file filename))
+                 (not keep-existing))
         (fs/delete filename)
         (println (u/format-color 'red (trs "Output H2 database already exists: %s, removing.") filename))))
 

--- a/src/metabase/cmd/dump_to_h2.clj
+++ b/src/metabase/cmd/dump_to_h2.clj
@@ -92,11 +92,12 @@
 ;;; --------------------------------------------------- Public Fns ---------------------------------------------------
 
 (defn dump-to-h2!
-  "Transfer data from existing database specified by connection string
-  to the H2 DB specified by env vars.  Intended as a tool for migrating
-  from one instance to another using H2 as serialization target.
+  "Transfer data from existing database specified by connection string to the H2 DB specified by env vars. Intended as a
+  tool for migrating from one instance to another using H2 as serialization target.
 
-  Defaults to using `@metabase.db/db-file` as the connection string."
+  Defaults to using `@metabase.db/db-file` as the connection string.
+
+  Target H2 DB will be deleted if it exists, unless `keep-existing` is truthy."
   [h2-filename keep-existing]
   (let [h2-filename (or h2-filename "metabase_dump.h2")]
     (println "Dumping to " h2-filename)

--- a/src/metabase/cmd/dump_to_h2.clj
+++ b/src/metabase/cmd/dump_to_h2.clj
@@ -79,7 +79,7 @@
   (println-ok))
 
 (defn- load-data! [target-db-conn]
-  (println "Source db:" (mdb/jdbc-spec))
+  (println "Source db:" (dissoc (mdb/jdbc-spec) :password))
   (jdbc/with-db-connection [db-conn (mdb/jdbc-spec)]
     (doseq [{table-name :table, :as e} entities
             :let [rows (jdbc/query db-conn [(str "SELECT * FROM " (name table-name))])]


### PR DESCRIPTION
Looks like the `dump-to-h2` command is also affected by #10087, dumping a PostgreSQL db to H2, and it's tripping up a hosting customer. This PR adds a flag to the `dump-to-h2` command to prevent it from deleting the target H2 database when starting. This is so that we can work around the constraints issue by dumping to a pre-prepared H2 db with the relevant constraints dropped.

There could be all manner of similar corner cases that could be worked around by uses a pre-prepared H2 db, so this seems like a practical (non-default) option to have.

This is based on the `release-0.36.x` branch to keep changes from 0.36.6 (which the customer is using) to a minimum.