### PR TITLE
Migrate `EntityMenuTrigger` test from enzyme to react-testing-library

### DIFF
--- a/frontend/test/metabase/components/EntityMenuTrigger.unit.spec.js
+++ b/frontend/test/metabase/components/EntityMenuTrigger.unit.spec.js
@@ -1,20 +1,14 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { render, screen, fireEvent } from "@testing-library/react";
 
-import Icon from "metabase/components/Icon";
 import EntityMenuTrigger from "metabase/components/EntityMenuTrigger";
 
 describe("EntityMenuTrigger", () => {
   it("should render the desired icon and call its onClick fn", () => {
     const spy = jest.fn();
-    const wrapper = shallow(<EntityMenuTrigger icon="pencil" onClick={spy} />);
+    render(<EntityMenuTrigger icon="pencil" onClick={spy} />);
 
-    const icon = wrapper.find(Icon);
-
-    expect(icon.length).toBe(1);
-    expect(icon.props().name).toEqual("pencil");
-
-    wrapper.simulate("click");
-    expect(spy).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("img", { name: /pencil icon/i }));
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- it migrates `EntityMenuTrigger` test from Enzyme to React Testing Library, using newly added ability to query icons by their role and aria-label