### PR TITLE
Migrate `EntityMenuItem` test from enzyme to react-testing-library

### DIFF
--- a/frontend/test/metabase/components/EntityMenuItem.unit.spec.js
+++ b/frontend/test/metabase/components/EntityMenuItem.unit.spec.js
@@ -1,24 +1,20 @@
 import React from "react";
-import { shallow, mount } from "enzyme";
-import { Link } from "react-router";
+import "@testing-library/jest-dom/extend-expect";
+import { fireEvent, render, screen } from "@testing-library/react";
 
-import Icon from "metabase/components/Icon";
 import EntityMenuItem from "metabase/components/EntityMenuItem";
 
 describe("EntityMenuItem", () => {
   it("should display the proper title and icon", () => {
-    const wrapper = shallow(
+    render(
       <EntityMenuItem
         title="A pencil icon"
         icon="pencil"
         action={() => ({})}
       />,
     );
-
-    const icon = wrapper.find(Icon);
-
-    expect(icon.length).toBe(1);
-    expect(icon.props().name).toEqual("pencil");
+    screen.getByRole("img", { name: /pencil icon/i });
+    screen.getByText("A pencil icon");
   });
 
   describe("actions and links", () => {
@@ -26,22 +22,22 @@ describe("EntityMenuItem", () => {
       it("should call an action function if an action is provided", () => {
         const spy = jest.fn();
 
-        const wrapper = mount(
+        render(
           <EntityMenuItem title="A pencil icon" icon="pencil" action={spy} />,
         );
 
-        wrapper.simulate("click");
-        expect(spy).toHaveBeenCalled();
+        fireEvent.click(screen.getByRole("img", { name: /pencil icon/i }));
+        expect(spy).toHaveBeenCalledTimes(1);
       });
     });
 
     describe("links", () => {
       it("should be a link if a link is provided", () => {
-        const wrapper = mount(
+        const { container } = render(
           <EntityMenuItem title="A pencil icon" icon="pencil" link="/derp" />,
         );
 
-        expect(wrapper.find(Link).length).toBe(1);
+        expect(container.querySelector("a")).toBeInTheDocument();
       });
     });
   });


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- it migrates `EntityMenuItem` test from Enzyme to React Testing Library