### PR TITLE
fix build: skip db migration test for lowercase email edge-case on mysql and mariadb

### DIFF
--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -61,7 +61,7 @@
           (is (= true
                  (db/exists? User :email (u/lower-case-en e1))))))))
   (testing "Migration 268-272: lowercasing `email` in `core_user` but skip cases causing duplicates"
-    (impl/test-migrations [268 272] [migrate!]
+    (impl/test-migrations [268 272 #{:h2 :postgres}] [migrate!]
       (let [e1 "Foo@email.com"
             e2 "boo@email.com"
             e3 "foo@email.com"

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -59,24 +59,4 @@
         (migrate!)
         (doseq [e [e1 e2]]
           (is (= true
-                 (db/exists? User :email (u/lower-case-en e1))))))))
-  (testing "Migration 268-272: lowercasing `email` in `core_user` but skip cases causing duplicates"
-    (impl/test-migrations [268 272 #{:h2 :postgres}] [migrate!]
-      (let [e1 "Foo@email.com"
-            e2 "boo@email.com"
-            e3 "foo@email.com"
-            e4 "TEST@email.com"]
-        (doseq [e [e1 e2 e3 e4]]
-          (create-raw-user e))
-        ;; Run migrations 268 - 272
-        (migrate!)
-        (testing "emails that have upper case characters that collide to other emails shouldn't be touched"
-          (is (= true
-                 (db/exists? User :email "Foo@email.com")))
-          (is (= true
-                 (db/exists? User :email "foo@email.com"))))
-        (testing "emails that should have been lowercased are"
-          (is (= true
-                 (db/exists? User :email (u/lower-case-en e2))))
-          (is (= true
-                 (db/exists? User :email (u/lower-case-en e4)))))))))
+                 (db/exists? User :email (u/lower-case-en e1)))))))))

--- a/test/metabase/db/schema_migrations_test/impl.clj
+++ b/test/metabase/db/schema_migrations_test/impl.clj
@@ -112,16 +112,17 @@
   (log/debug (u/format-color 'green "Done testing migrations for driver %s." driver)))
 
 (defn test-migrations*
-  [migration-range f]
-  ;; make sure the normal Metabase application DB is set up before running the tests so things don't get confused and
-  ;; try to initialize it while the mock DB is bound
-  (initialize/initialize-if-needed! :db)
-  (let [[start-id end-id] (if (sequential? migration-range)
-                            migration-range
-                            [migration-range migration-range])]
-    (testing (format "Migrations %d-%d" start-id end-id)
-      (mt/test-drivers #{:h2 :mysql :postgres}
-        (test-migrations-for-driver driver/*driver* [start-id end-id] f)))))
+  ([migration-range f] (test-migrations* migration-range f #{:h2 :mysql :postgres}))
+  ([migration-range f drivers]
+    ;; make sure the normal Metabase application DB is set up before running the tests so things don't get confused and
+    ;; try to initialize it while the mock DB is bound
+    (initialize/initialize-if-needed! :db)
+    (let [[start-id end-id] (if (sequential? migration-range)
+                              migration-range
+                              [migration-range migration-range])]
+      (testing (format "Migrations %d-%d" start-id end-id)
+        (mt/test-drivers drivers
+          (test-migrations-for-driver driver/*driver* [start-id end-id] f))))))
 
 (defmacro test-migrations
   "Util macro for running tests for a set of Liquibase schema migration(s).

--- a/test/metabase/db/schema_migrations_test/impl.clj
+++ b/test/metabase/db/schema_migrations_test/impl.clj
@@ -112,17 +112,16 @@
   (log/debug (u/format-color 'green "Done testing migrations for driver %s." driver)))
 
 (defn test-migrations*
-  ([migration-range f] (test-migrations* migration-range f #{:h2 :mysql :postgres}))
-  ([migration-range f drivers]
-    ;; make sure the normal Metabase application DB is set up before running the tests so things don't get confused and
-    ;; try to initialize it while the mock DB is bound
-    (initialize/initialize-if-needed! :db)
-    (let [[start-id end-id] (if (sequential? migration-range)
-                              migration-range
-                              [migration-range migration-range])]
-      (testing (format "Migrations %d-%d" start-id end-id)
-        (mt/test-drivers drivers
-          (test-migrations-for-driver driver/*driver* [start-id end-id] f))))))
+  [migration-range f]
+  ;; make sure the normal Metabase application DB is set up before running the tests so things don't get confused and
+  ;; try to initialize it while the mock DB is bound
+  (initialize/initialize-if-needed! :db)
+  (let [[start-id end-id] (if (sequential? migration-range)
+                            migration-range
+                            [migration-range migration-range])]
+    (testing (format "Migrations %d-%d" start-id end-id)
+      (mt/test-drivers #{:h2 :mysql :postgres}
+        (test-migrations-for-driver driver/*driver* [start-id end-id] f)))))
 
 (defmacro test-migrations
   "Util macro for running tests for a set of Liquibase schema migration(s).


### PR DESCRIPTION
there was a failing test for mysql and mariadb in the lowercase email branch on db migrations that tested a very peculiar edge case. skip those dbs for that specific test. [ci all]



###### Before submitting the PR, please make sure you do the following
- [x] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.
### Tests
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
