### PR TITLE
Add e2e test for adding/connecting PostgreSQL database

### DIFF
--- a/frontend/test/metabase-db/postgres/add.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/add.cy.spec.js
@@ -1,0 +1,56 @@
+import {
+  signInAsAdmin,
+  restore,
+  modal,
+  typeAndBlurUsingLabel,
+} from "__support__/cypress";
+
+function addPostgresDatabase() {
+  cy.visit("/admin/databases/create");
+  cy.contains("Database type")
+    .closest(".Form-field")
+    .find("a")
+    .click();
+  cy.contains("PostgreSQL").click({ force: true });
+  cy.contains("Additional JDBC connection string options");
+
+  typeAndBlurUsingLabel("Name", "QA Postgres12");
+  typeAndBlurUsingLabel("Host", "localhost");
+  // TODO: "Port" label and input field are misconfigured (input field is missing `aria-labeledby` attribute)
+  // typeAndBlurUsingLabel("Port", "5432") => this will not work (switching to placeholder temporarily)
+  cy.findByPlaceholderText("5432")
+    .click()
+    .type("5432");
+  typeAndBlurUsingLabel("Database name", "sample");
+  typeAndBlurUsingLabel("Username", "metabase");
+  typeAndBlurUsingLabel("Password", "metasample123");
+
+  cy.findByText("Save")
+    .should("not.be.disabled")
+    .click();
+}
+
+describe("postgres > admin > add", () => {
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+    cy.server();
+  });
+
+  it("should add a database and redirect to listing", () => {
+    cy.route({
+      method: "POST",
+      url: "/api/database",
+    }).as("createDatabase");
+
+    addPostgresDatabase();
+
+    cy.wait("@createDatabase");
+
+    cy.url().should("match", /\/admin\/databases\?created=\d+$/);
+    cy.contains("Your database has been added!");
+    modal()
+      .contains("I'm good thanks")
+      .click();
+  });
+});


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- adds first e2e test for PostreSQL integration
- makes sure we can connect to a [postres-sample-12](https://hub.docker.com/layers/metabase/qa-databases/postgres-sample-12/images/sha256-5216844b59abebef95dbac5d1b9e683baafe0530a718c9d642cbd1f29cef0dc3?context=explore) database running on Docker
- exposes a new found bug (misconfigured "Port" label and input field)

### Additional context
``` bash
docker run --rm -p 5432:5432 --name meta-postgres12-sample  metabase/qa-databases:postgres-sample-12
```