### PR TITLE
Make jetty client SSL auth configurable

### DIFF
--- a/docs/operations-guide/environment-variables.md
+++ b/docs/operations-guide/environment-variables.md
@@ -487,6 +487,13 @@ When set to `true`, will enable HTTPS with the options configured in the `MB_JET
 
 Also see the [Customizing Jetty web server](customizing-jetty-webserver.md) documentation page.
 
+#### `MB_JETTY_SSL_CLIENT_AUTH`
+
+Type: boolean<br>
+Default: `null`
+
+Configure Java SSL client authentication. When set to `true`, client certificates are required and verified by the certificate authority in the TrustStore.
+
 #### `MB_JETTY_SSL_KEYSTORE`
 
 Type: string<br>

--- a/src/metabase/server.clj
+++ b/src/metabase/server.clj
@@ -22,7 +22,9 @@
     :keystore       (config/config-str :mb-jetty-ssl-keystore)
     :key-password   (config/config-str :mb-jetty-ssl-keystore-password)
     :truststore     (config/config-str :mb-jetty-ssl-truststore)
-    :trust-password (config/config-str :mb-jetty-ssl-truststore-password)}))
+    :trust-password (config/config-str :mb-jetty-ssl-truststore-password)
+    :client-auth    (when (config/config-bool :mb-jetty-ssl-client-auth)
+                      :need)}))
 
 (defn- jetty-config []
   (cond-> (m/filter-vals


### PR DESCRIPTION
Add :mb-jetty-ssl-client-auth boolean config key to require ssl client auth when set.


Hi there! My use-case for this configuration is to improve security when running metabase on a public IP. Required client SSL certs add a second layer of authentication on top of username/password credentials. Jetty's `TrustStore` is already configurable, but an included CA cert isn't used to validate client certs unless the `SslContextFactory$Server#setNeedClientAuth` flag is set too.

I added this configuration as a boolean, instead of passing `:need` or `:want` through to ring, since there's nothing the server will do with an available, but optional, valid client cert in the case of `:want`. If anyone ever needed the `:want` option, it'd be pretty straightforward to relax the config from boolean to keyword though.
(See also: http://ring-clojure.github.io/ring/ring.adapter.jetty.html)

FWIW, Google Cloud's Identity Aware Proxy (see https://github.com/metabase/metabase/issues/6709) would address my particular use-case too, and I'd be happy to contribute that as well, but this change seems useful nonetheless.


###### Before submitting the PR, please make sure you do the following
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
