### PR TITLE
Fix `snippet` Cypress error

### DIFF
--- a/frontend/test/metabase/scenarios/question/snippets.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/snippets.cy.spec.js
@@ -1,11 +1,8 @@
 import { signInAsNormalUser, restore, modal } from "__support__/cypress";
 
-function _clearAndRecursivelyTypeUsingLabel(label, string) {
-  // Cypress throws an error when trying to type an empty string
-  if (!string) {
-    return;
-  }
-
+// HACK which lets us type (even very long words) without losing focus
+// this is needed for fields where autocomplete suggestions are enabled
+function _clearAndIterativelyTypeUsingLabel(label, string) {
   cy.findByLabelText(label).clear();
 
   for (const char of string) {
@@ -18,21 +15,13 @@ describe("scenarios > question > snippets", () => {
   beforeEach(signInAsNormalUser);
 
   it("should let you create and use a snippet", () => {
-    const snippet = {
-      name: "stuff-snippet",
-      sql: "stuff",
-    };
-    // Single quotes are easy to miss here, but are very important!
-    // We're not using SQL keywords or actual tables, so our string must be escaped.
-    const escapedSQL = `'${snippet.sql}'`;
-
     cy.visit("/question/new");
     cy.contains("Native query").click();
 
     // type a query and highlight some of the text
     cy.get(".ace_content").as("ace");
     cy.get("@ace").type(
-      `select ${escapedSQL}` + `{shift}{leftarrow}`.repeat(escapedSQL.length),
+      "select 'stuff'" + "{shift}{leftarrow}".repeat("'stuff'".length),
     );
 
     // add a snippet of that text
@@ -41,56 +30,42 @@ describe("scenarios > question > snippets", () => {
 
     modal()
       .find("input[name=name]")
-      .type(snippet.name);
+      .type("stuff-snippet");
     modal()
       .contains("Save")
       .click();
 
     // SQL editor should get updated automatically
-    cy.get("@ace").contains(`select {{snippet: ${snippet.name}}}`);
+    cy.get("@ace").contains("select {{snippet: stuff-snippet}}");
 
     // run the query and check the displayed scalar
     cy.get(".NativeQueryEditor .Icon-play").click();
-    cy.get(".ScalarValue").contains(snippet.sql);
+    cy.get(".ScalarValue").contains("stuff");
   });
 
   it("should let you edit snippet", () => {
-    const snippet = {
-      name: "foo-snippet",
-      sql: "some extremely very very loooong snippet",
-    };
-    const escapedSQL = `'${snippet.sql}'`;
-
     // open the snippet edit modal
     cy.get(".Icon-chevrondown").click({ force: true });
     cy.findByText("Edit").click();
-
-    cy.server();
-    cy.route("put", "/api/native-query-snippet/*").as("update-snippet");
 
     // update the name and content
     modal().within(() => {
       cy.findByText("Editing stuff-snippet");
 
-      _clearAndRecursivelyTypeUsingLabel(
+      _clearAndIterativelyTypeUsingLabel(
         "Enter some SQL here so you can reuse it later",
-        escapedSQL,
+        "1+1",
       );
-      _clearAndRecursivelyTypeUsingLabel(
-        "Give your snippet a name",
-        snippet.name,
-      );
+      _clearAndIterativelyTypeUsingLabel("Give your snippet a name", "Math");
 
       cy.findByText("Save").click();
     });
 
-    cy.wait("@update-snippet");
-
     // SQL editor should get updated automatically
-    cy.get(".ace_content").contains(`select {{snippet: ${snippet.name}}}`);
+    cy.get(".ace_content").contains("select {{snippet: Math}}");
 
     // run the query and check the displayed scalar
     cy.get(".NativeQueryEditor .Icon-play").click();
-    cy.get(".ScalarValue").contains(snippet.sql);
+    cy.get(".ScalarValue").contains("2");
   });
 });

--- a/frontend/test/metabase/scenarios/question/snippets.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/snippets.cy.spec.js
@@ -1,59 +1,96 @@
 import { signInAsNormalUser, restore, modal } from "__support__/cypress";
 
+function _clearAndRecursivelyTypeUsingLabel(label, string) {
+  // Cypress throws an error when trying to type an empty string
+  if (!string) {
+    return;
+  }
+
+  cy.findByLabelText(label).clear();
+
+  for (const char of string) {
+    cy.findByLabelText(label).type(char);
+  }
+}
+
 describe("scenarios > question > snippets", () => {
   before(restore);
   beforeEach(signInAsNormalUser);
 
   it("should let you create and use a snippet", () => {
+    const snippet = {
+      name: "stuff-snippet",
+      sql: "stuff",
+    };
+    // Single quotes are easy to miss here, but are very important!
+    // We're not using SQL keywords or actual tables, so our string must be escaped.
+    const escapedSQL = `'${snippet.sql}'`;
+
     cy.visit("/question/new");
     cy.contains("Native query").click();
 
     // type a query and highlight some of the text
     cy.get(".ace_content").as("ace");
     cy.get("@ace").type(
-      "select 'stuff'" + "{shift}{leftarrow}".repeat("'stuff'".length),
+      `select ${escapedSQL}` + `{shift}{leftarrow}`.repeat(escapedSQL.length),
     );
 
     // add a snippet of that text
     cy.get(".Icon-snippet").click();
     cy.contains("Create a snippet").click();
+
     modal()
       .find("input[name=name]")
-      .type("stuff-snippet");
+      .type(snippet.name);
     modal()
       .contains("Save")
       .click();
 
     // SQL editor should get updated automatically
-    cy.get("@ace").contains("select {{snippet: stuff-snippet}}");
+    cy.get("@ace").contains(`select {{snippet: ${snippet.name}}}`);
 
     // run the query and check the displayed scalar
     cy.get(".NativeQueryEditor .Icon-play").click();
-    cy.get(".ScalarValue").contains("stuff");
+    cy.get(".ScalarValue").contains(snippet.sql);
   });
 
   it("should let you edit snippet", () => {
+    const snippet = {
+      name: "foo-snippet",
+      sql: "some extremely very very loooong snippet",
+    };
+    const escapedSQL = `'${snippet.sql}'`;
+
     // open the snippet edit modal
     cy.get(".Icon-chevrondown").click({ force: true });
     cy.findByText("Edit").click();
 
+    cy.server();
+    cy.route("put", "/api/native-query-snippet/*").as("update-snippet");
+
     // update the name and content
     modal().within(() => {
       cy.findByText("Editing stuff-snippet");
-      cy.findByLabelText("Enter some SQL here so you can reuse it later").type(
-        "{selectall}{del}'foo'",
+
+      _clearAndRecursivelyTypeUsingLabel(
+        "Enter some SQL here so you can reuse it later",
+        escapedSQL,
       );
-      cy.findByLabelText("Give your snippet a name").type(
-        "{selectall}{del}foo",
+      _clearAndRecursivelyTypeUsingLabel(
+        "Give your snippet a name",
+        snippet.name,
       );
+
       cy.findByText("Save").click();
     });
 
+    cy.wait("@update-snippet");
+
     // SQL editor should get updated automatically
-    cy.get(".ace_content").contains("select {{snippet: foo}}");
+    cy.get(".ace_content").contains(`select {{snippet: ${snippet.name}}}`);
 
     // run the query and check the displayed scalar
     cy.get(".NativeQueryEditor .Icon-play").click();
-    cy.get(".ScalarValue").contains("foo");
+    cy.get(".ScalarValue").contains(snippet.sql);
   });
 });


### PR DESCRIPTION
### Status
WIP (ready, but probably needs refactoring)

### What does this PR accomplish?
- It solves Cypress flake that was breaking our CI very often

### Additional notes:
- Error was happening because of autocomplete_suggestion.
- This "solution" is ugly and requires typing letter by letter, but it should solve this flake for good.
- The input field loses focus because of autocomplete, and I even caught it continue typing in the first next field that has focus (a fall-through effect that you can see in this video):
https://share.getcloudapp.com/04uOb4ZN
- This is what is probably happening with the rest of our flakes that are related to typing. The only difference being that when there is no input field or text area below the modal that lost focus, we don't see it typing. That's most likely the explanation for "cut" or completely missing words.