### PR TITLE
Add repro for #13306

### DIFF
--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -74,6 +74,9 @@ describe("scenarios > question > new", () => {
     });
 
     it.skip("should keep manually entered parenthesis intact (metabase#13306)", () => {
+      const FORMULA =
+        "Sum([Total]) / (Sum([Product → Price]) * Average([Quantity]))";
+
       cy.visit("/question/new?database=1&table=2&mode=notebook");
       cy.findByText("Summarize").click();
       popover()
@@ -81,44 +84,13 @@ describe("scenarios > question > new", () => {
         .click();
       popover().within(() => {
         cy.get("[contentEditable=true]")
-          .type("Sum([Total]) / (Sum([Product → Price]) * Average([Quantity]))")
+          .type(FORMULA)
           .blur();
 
         cy.log("**Fails after blur in v0.36.6**");
-        cy.get("[contentEditable=true]").contains(
-          "Sum([Total]) / (Sum([Product → Price]) * Average([Quantity]))",
-        );
-
-        cy.findByPlaceholderText("Name (required)").type("Incorrect");
-        cy.findByText("Done").click();
+        // Implicit assertion
+        cy.get("[contentEditable=true]").contains(FORMULA);
       });
-
-      cy.get(".Icon-add")
-        .last()
-        .click();
-
-      popover()
-        .contains("Custom Expression")
-        .click();
-      popover().within(() => {
-        cy.get("[contentEditable=true]")
-          .type(
-            "Sum([Total]) / (0 + Sum([Product → Price]) * Average([Quantity]))",
-          )
-          .blur();
-
-        cy.get("[contentEditable=true]").contains(
-          "Sum([Total]) / (0 + Sum([Product → Price]) * Average([Quantity]))",
-        );
-
-        cy.findByPlaceholderText("Name (required)").type("Correct - hack");
-        cy.findByText("Done").click();
-      });
-
-      cy.contains("Visualize").click();
-
-      // Both results should be the same
-      cy.findAllByText("0.51").should("have.length", 2);
     });
   });
 });


### PR DESCRIPTION
### Status
NEEDS REVIEW

### What does this PR accomplish?
- reproduces #13306 

### How should this be manually tested?
- replace `it.skip()` with `it.only()` and run the test

### Additional notes:
- test should pass once the issue is resolved (remove `.skip`)

@flamber 
- this test correctly fails because parenthesis are indeed being removed on blur, however
- if I comment out this part...
```javascript
// cy.log("**Fails after blur in v0.36.6**");
// cy.get("[contentEditable=true]").contains(
//   "Sum([Total]) / (Sum([Product → Price]) * Average([Quantity]))",
// );
```
... and let the test run until the end, I still see that both results are `0.51`, regardless of the fact parenthesis have been removed. o.O