### PR TITLE
Fix "editor-sorting-columns" Cypress error

### DIFF
--- a/frontend/test/metabase/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/editor.cy.spec.js
@@ -157,6 +157,8 @@ describe("scenarios > admin > datamodel > editor", () => {
       .contains("Alphabetical")
       .click({ force: true });
 
+    cy.wait("@tableUpdate");
+
     // move product_id to the top
     cy.get(".Grabber")
       .eq(3)

--- a/frontend/test/metabase/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/editor.cy.spec.js
@@ -12,12 +12,12 @@ describe("scenarios > admin > datamodel > editor", () => {
   beforeEach(() => {
     restore();
     signInAsAdmin();
-    withSampleDataset(({ ORDERS_ID }) => {
-      cy.wrap(`${SAMPLE_DB_URL}/table/${ORDERS_ID}`).as(`ORDERS_URL`);
-    });
     cy.server();
     cy.route("PUT", "/api/table/*").as("tableUpdate");
     cy.route("PUT", "/api/field/*").as("fieldUpdate");
+    withSampleDataset(({ ORDERS_ID }) => {
+      cy.wrap(`${SAMPLE_DB_URL}/table/${ORDERS_ID}`).as(`ORDERS_URL`);
+    });
   });
 
   it("should allow editing of the name and description", () => {
@@ -147,6 +147,8 @@ describe("scenarios > admin > datamodel > editor", () => {
   });
 
   it("should allow sorting columns", () => {
+    cy.route("PUT", "/api/table/2/fields/order").as("fieldReorder");
+
     visitAlias("@ORDERS_URL");
     cy.contains("Column order:").click();
 
@@ -156,7 +158,6 @@ describe("scenarios > admin > datamodel > editor", () => {
       .click({ force: true });
 
     // move product_id to the top
-    cy.route("PUT", "/api/table/2/fields/order").as("fieldReorder");
     cy.get(".Grabber")
       .eq(3)
       .trigger("mousedown", 0, 0);


### PR DESCRIPTION
### Status
READY

### What does this PR acoomplish?
- fixes failing Cypress test where editor "should allow sorting columns", which was causing a lot of breaks in CI

### How to test this manually?
- `yarn test-cypress-open`
- run `editor.cy.spec.js`
- either run all tests in that file or run failing test in isolation: `it.only("should allow sorting columns", () => {...})`

### Additional notes:
- `cy.server()` and `cy.routes()` should always be defined before `cy.visit()` as per [this comment](https://github.com/cypress-io/cypress/issues/3427#issuecomment-504938130),
- I couldn't pinpoint the exact issue here, but my best assumption is that table never finished updating before we start reordering fields
- alternatively, check the code and the comments below

```javascript
// Should this test continue to fail even after proposed changes,
// we can use different logic when trying to get "Product ID"'s handle.
// find Product ID, then go to its parent and find the "grabber" inside

cy.get(".Grabber")
  .eq(3) // there was no guarantee that the fourth field was indeed "Product ID"
  .trigger("mousedown", 0, 0);
```
