### PR TITLE
Half of fix for OOM in sync (#13288) (2.1)

### DIFF
--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -89,12 +89,17 @@
   inferring special types and what-not; we don't want to scan millions of values at any rate."
   10000)
 
+(def table-rows-sample-options
+  "Schema for `table-rows-sample` options"
+  (s/maybe {(s/optional-key :truncation-size) s/Int}))
+
 (s/defn table-rows-sample :- (s/maybe si/TableSample)
   "Run a basic MBQL query to fetch a sample of rows belonging to a Table."
   {:style/indent 1}
   ([table :- si/TableInstance, fields :- [si/FieldInstance]]
    (table-rows-sample table fields nil))
-  ([table :- si/TableInstance, fields :- [si/FieldInstance] truncation-size :- (s/maybe s/Int)]
+  ([table :- si/TableInstance, fields :- [si/FieldInstance]
+    {:keys [truncation-size] :as _opts} :- table-rows-sample-options]
    (let [text-fields        (filter (comp #{:type/Text} :base_type) fields)
          field->expressions (when truncation-size
                               (into {} (for [field text-fields]

--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -99,7 +99,7 @@
   "Run a basic MBQL query to fetch a sample of rows belonging to a Table."
   {:style/indent 1}
   [table :- si/TableInstance, fields :- [si/FieldInstance]]
-  (let [text-fields        (filter (comp #{:type/Text} :base_type) fields)
+  (let [text-fields        (filter (comp #{"text"} :database_type) fields)
         field->expressions (into {} (for [field text-fields]
                                       [field [(str (gensym "substring"))
                                               [:substring [:field-id (u/get-id field)] 0 truncation-size]]]))

--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -89,17 +89,30 @@
   inferring special types and what-not; we don't want to scan millions of values at any rate."
   10000)
 
+(def truncation-size
+  "The maximum size of :type/Text to be selected from the database in `table-rows-sample`. In practice we see large
+  text blobs and want to balance taking enough for distinct counts and but not so much that we risk out of memory
+  issues when syncing."
+  1234)
+
 (s/defn table-rows-sample :- (s/maybe si/TableSample)
   "Run a basic MBQL query to fetch a sample of rows belonging to a Table."
   {:style/indent 1}
   [table :- si/TableInstance, fields :- [si/FieldInstance]]
-  (let [results ((resolve 'metabase.query-processor/process-query)
-                 {:database   (:db_id table)
-                  :type       :query
-                  :query      {:source-table (u/get-id table)
-                               :fields       (vec (for [field fields]
-                                                    [:field-id (u/get-id field)]))
-                               :limit        max-sample-rows}
-                  :middleware {:format-rows?           false
-                               :skip-results-metadata? true}})]
+  (let [text-fields        (filter (comp #{:type/Text} :base_type) fields)
+        field->expressions (into {} (for [field text-fields]
+                                      [field [(str (gensym "substring"))
+                                              [:substring [:field-id (u/get-id field)] 0 truncation-size]]]))
+        results            ((resolve 'metabase.query-processor/process-query)
+                            {:database   (:db_id table)
+                             :type       :query
+                             :query      {:source-table (u/get-id table)
+                                          :expressions  (into {} (vals field->expressions))
+                                          :fields       (vec (for [field fields]
+                                                               (if-let [[expression-name _] (field->expressions field)]
+                                                                 [:expression expression-name]
+                                                                 [:field-id (u/get-id field)])))
+                                          :limit        max-sample-rows}
+                             :middleware {:format-rows?           false
+                                          :skip-results-metadata? true}})]
     (get-in results [:data :rows])))

--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -99,10 +99,10 @@
   "Run a basic MBQL query to fetch a sample of rows belonging to a Table."
   {:style/indent 1}
   [table :- si/TableInstance, fields :- [si/FieldInstance]]
-  (let [text-fields        (filter (comp #{"text"} :database_type) fields)
+  (let [text-fields        (filter (comp #{:type/Text} :base_type) fields)
         field->expressions (into {} (for [field text-fields]
                                       [field [(str (gensym "substring"))
-                                              [:substring [:field-id (u/get-id field)] 0 truncation-size]]]))
+                                              [:substring [:field-id (u/get-id field)] 1 truncation-size]]]))
         results            ((resolve 'metabase.query-processor/process-query)
                             {:database   (:db_id table)
                              :type       :query

--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -89,7 +89,7 @@
   inferring special types and what-not; we don't want to scan millions of values at any rate."
   10000)
 
-(def table-rows-sample-options
+(def TableRowsSampleOptions
   "Schema for `table-rows-sample` options"
   (s/maybe {(s/optional-key :truncation-size) s/Int}))
 
@@ -99,7 +99,7 @@
   ([table :- si/TableInstance, fields :- [si/FieldInstance]]
    (table-rows-sample table fields nil))
   ([table :- si/TableInstance, fields :- [si/FieldInstance]
-    {:keys [truncation-size] :as _opts} :- table-rows-sample-options]
+    {:keys [truncation-size] :as _opts} :- TableRowsSampleOptions]
    (let [text-fields        (filter (comp #{:type/Text} :base_type) fields)
          field->expressions (when truncation-size
                               (into {} (for [field text-fields]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -220,7 +220,7 @@
    :box           :type/*
    :bpchar        :type/Text ; "blank-padded char" is the internal name of "character"
    :bytea         :type/*    ; byte array
-   :cidr          :type/Text ; IPv4/IPv6 network address
+   :cidr          :type/Structured ; IPv4/IPv6 network address
    :circle        :type/*
    :citext        :type/Text ; case-insensitive text
    :date          :type/Date
@@ -234,11 +234,11 @@
    :int4          :type/Integer
    :int8          :type/BigInteger
    :interval      :type/*               ; time span
-   :json          :type/Text
-   :jsonb         :type/Text
+   :json          :type/Structured
+   :jsonb         :type/Structured
    :line          :type/*
    :lseg          :type/*
-   :macaddr       :type/Text
+   :macaddr       :type/Structured
    :money         :type/Decimal
    :numeric       :type/Decimal
    :path          :type/*
@@ -262,7 +262,7 @@
    :uuid          :type/UUID
    :varbit        :type/*
    :varchar       :type/Text
-   :xml           :type/Text
+   :xml           :type/Structured
    (keyword "bit varying")                :type/*
    (keyword "character varying")          :type/Text
    (keyword "double precision")           :type/Float

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -281,8 +281,10 @@
   [_ database-type _]
   ;; this is really, really simple right now.  if its postgres :json type then it's :type/SerializedJSON special-type
   (case database-type
-    "json" :type/SerializedJSON
-    "inet" :type/IPAddress
+    "json"  :type/SerializedJSON
+    "jsonb" :type/SerializedJSON
+    "xml"   :type/XML
+    "inet"  :type/IPAddress
     nil))
 
 (def ^:private ssl-params

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -138,6 +138,7 @@
              [:not (mdb/isa :special_type :type/PK)]
              [:= :special_type nil]]
             [:not-in :visibility_type ["retired" "sensitive"]]
+            [:not= :base_type "type/Structured"]
             (cons :or (versions-clauses))]})
 
   ([table :- i/TableInstance]

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -40,6 +40,12 @@
    :updated-fingerprints   0
    :fingerprints-attempted fields-count})
 
+(def truncation-size
+  "The maximum size of :type/Text to be selected from the database in `table-rows-sample`. In practice we see large
+  text blobs and want to balance taking enough for distinct counts and but not so much that we risk out of memory
+  issues when syncing."
+  1234)
+
 (s/defn ^:private fingerprint-table!
   [table :- i/TableInstance, fields :- [i/FieldInstance]]
   (transduce identity
@@ -60,7 +66,7 @@
                               (update count-info :updated-fingerprints inc))))
                         (empty-stats-map (count fingerprints))
                         (map vector fields fingerprints))))
-             (metadata-queries/table-rows-sample table fields {:truncation-size f/truncation-size})))
+             (metadata-queries/table-rows-sample table fields {:truncation-size truncation-size})))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                    WHICH FIELDS NEED UPDATED FINGERPRINTS?                                     |

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -60,7 +60,7 @@
                               (update count-info :updated-fingerprints inc))))
                         (empty-stats-map (count fingerprints))
                         (map vector fields fingerprints))))
-             (metadata-queries/table-rows-sample table fields f/truncation-size)))
+             (metadata-queries/table-rows-sample table fields {:truncation-size f/truncation-size})))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                    WHICH FIELDS NEED UPDATED FINGERPRINTS?                                     |

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -60,7 +60,7 @@
                               (update count-info :updated-fingerprints inc))))
                         (empty-stats-map (count fingerprints))
                         (map vector fields fingerprints))))
-             (metadata-queries/table-rows-sample table fields)))
+             (metadata-queries/table-rows-sample table fields f/truncation-size)))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                    WHICH FIELDS NEED UPDATED FINGERPRINTS?                                     |

--- a/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
@@ -231,21 +231,13 @@
   issues when syncing."
   1234)
 
-(defn- snif-json
-  "If we suspect we have a partial string then we attempt heuristics to determine if we might have json. Its not
-  important to be exact here so good approximation is fine."
-  [s]
-  (let [json-starts ["[" "{"]]
-    (some #(str/starts-with? s %) json-starts)))
-
 (defn- valid-serialized-json?
-  "Is x a serialized JSON dictionary or array."
+  "Is x a serialized JSON dictionary or array. Uses a regex to search for a leading [ or {. In the case of a leading [,
+  expects not a alpha character after to prevent matching tokens like [prod] as json."
   [x]
   (u/ignore-exceptions
     (when (and x (string? x))
-      (if (= (.length ^String x) truncation-size)
-        (snif-json x)
-        ((some-fn map? sequential?) (json/parse-string x))))))
+      (re-matches #"^(?:\[[^a-zA-Z]|\{).*" x))))
 
 (deffingerprinter :type/Text
   ((map str) ; we cast to str to support `field-literal` type overwriting:

--- a/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
@@ -223,12 +223,6 @@
         :q1  q1
         :q3  q3)))))
 
-(def truncation-size
-  "The maximum size of :type/Text to be selected from the database in `table-rows-sample`. In practice we see large
-  text blobs and want to balance taking enough for distinct counts and but not so much that we risk out of memory
-  issues when syncing."
-  1234)
-
 (defn- valid-serialized-json?
   "Is x a serialized JSON dictionary or array. Hueristically recognize maps and arrays. Uses the following strategies:
   - leading character {: assume valid JSON

--- a/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
@@ -1,8 +1,6 @@
 (ns metabase.sync.analyze.fingerprint.fingerprinters
   "Non-identifying fingerprinters for various field types."
   (:require [bigml.histogram.core :as hist]
-            [cheshire.core :as json]
-            [clojure.string :as str]
             [java-time :as t]
             [kixi.stats
              [core :as stats]

--- a/src/metabase/types.clj
+++ b/src/metabase/types.clj
@@ -158,6 +158,10 @@
 (derive :type/Country :type/Address)
 (derive :type/ZipCode :type/Address)
 
+;;; Structured
+
+(derive :type/Structured :type/*)
+
 
 ;;; Legacy Special Types. These will hopefully be going away in the future when we add columns like `:is_pk` and
 ;;; `:cardinality`

--- a/src/metabase/types.clj
+++ b/src/metabase/types.clj
@@ -161,6 +161,8 @@
 ;;; Structured
 
 (derive :type/Structured :type/*)
+(derive :type/SerializedJSON :type/Structured)
+(derive :type/XML :type/Structured)
 
 
 ;;; Legacy Special Types. These will hopefully be going away in the future when we add columns like `:is_pk` and

--- a/test/metabase/db/metadata_queries_test.clj
+++ b/test/metabase/db/metadata_queries_test.clj
@@ -41,7 +41,7 @@
                   ["BCD Tofu House"]]
         table (Table (mt/id :venues))
         fields [(Field (mt/id :venues :name))]
-        fetch! #(->> (metadata-queries/table-rows-sample table fields {:truncation-size %})
+        fetch! #(->> (metadata-queries/table-rows-sample table fields (when % {:truncation-size %}))
                      ;; since order is not guaranteed do some sorting here so we always get the same results
                      (sort-by first)
                      (take 5))]

--- a/test/metabase/db/metadata_queries_test.clj
+++ b/test/metabase/db/metadata_queries_test.clj
@@ -3,7 +3,8 @@
             [metabase
              [models :refer [Field Table]]
              [test :as mt]]
-            [metabase.db.metadata-queries :as metadata-queries]))
+            [metabase.db.metadata-queries :as metadata-queries]
+            [metabase.driver.sql-jdbc.test-util :as sql-jdbc.tu]))
 
 ;; Redshift tests are randomly failing -- see https://github.com/metabase/metabase/issues/2767
 (defn- metadata-queries-test-drivers []
@@ -31,3 +32,26 @@
   (mt/test-drivers (metadata-queries-test-drivers)
     (is (= [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]
            (map int (metadata-queries/field-distinct-values (Field (mt/id :checkins :user_id))))))))
+
+(deftest table-rows-sample-test
+  (let [expected [["20th Century Cafe"]
+                  ["25°"]
+                  ["33 Taps"]
+                  ["800 Degrees Neapolitan Pizzeria"]
+                  ["BCD Tofu House"]]
+        table (Table (mt/id :venues))
+        fields [(Field (mt/id :venues :name))]
+        fetch! #(->> (metadata-queries/table-rows-sample table fields)
+                     ;; since order is not guaranteed do some sorting here so we always get the same results
+                     (sort-by first)
+                     (take 5))]
+    (is (= :type/Text (-> fields first :base_type)))
+    (mt/test-drivers (sql-jdbc.tu/sql-jdbc-drivers)
+      (is (= expected (fetch!)))
+      (testing "truncates text fields (see #13288)"
+        (doseq [size [1 4 80]]
+          (with-redefs [metadata-queries/truncation-size size]
+            (is (= (mapv (fn [[s]] [(subs (or s "") 0 (min size (count s)))])
+                         expected)
+                   (fetch!))
+                "Did not truncate a text field")))))))

--- a/test/metabase/db/metadata_queries_test.clj
+++ b/test/metabase/db/metadata_queries_test.clj
@@ -41,7 +41,7 @@
                   ["BCD Tofu House"]]
         table (Table (mt/id :venues))
         fields [(Field (mt/id :venues :name))]
-        fetch! #(->> (metadata-queries/table-rows-sample table fields %)
+        fetch! #(->> (metadata-queries/table-rows-sample table fields {:truncation-size %})
                      ;; since order is not guaranteed do some sorting here so we always get the same results
                      (sort-by first)
                      (take 5))]

--- a/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
@@ -115,7 +115,7 @@
          (transduce identity
                     (f/fingerprinter (field/map->FieldInstance {:base_type :type/Text}))
                     ["metabase" "more" "like" "metabae" "[1, 2, 3]"])))
-  (let [truncated-json (subs (json/generate-string (vec (range 1234))) 0 f/truncation-size)]
+  (let [truncated-json (subs (json/generate-string (vec (range 50))) 0 30)]
     (is (= {:global {:distinct-count 5
                      :nil%           0.0}
             :type   {:type/Text {:percent-json   0.2

--- a/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
@@ -1,7 +1,8 @@
 (ns metabase.sync.analyze.fingerprint.fingerprinters-test
-  (:require [clojure.test :refer :all]
+  (:require [cheshire.core :as json]
+            [clojure.test :refer :all]
             [metabase.models.field :as field :refer [Field]]
-            [metabase.sync.analyze.fingerprint.fingerprinters :refer :all]
+            [metabase.sync.analyze.fingerprint.fingerprinters :as f]
             [metabase.test :as mt]
             [schema.core :as s]
             [toucan.db :as db]))
@@ -19,7 +20,7 @@
                     :type   {:type/DateTime {:earliest "2013-01-01"
                                              :latest   "2018-01-01"}}}
                   (transduce identity
-                             (fingerprinter (field/map->FieldInstance {:base_type :type/DateTime}))
+                             (f/fingerprinter (field/map->FieldInstance {:base_type :type/DateTime}))
                              [#t "2013" nil #t "2018" nil nil #t "2015"])))
            (testing "handle ChronoLocalDateTime"
              (is (= {:global {:distinct-count 2
@@ -27,7 +28,7 @@
                      :type   {:type/DateTime {:earliest "2013-01-01T20:04:00Z"
                                               :latest   "2018-01-01T04:04:00Z"}}}
                     (transduce identity
-                               (fingerprinter (field/map->FieldInstance {:base_type :type/Temporal}))
+                               (f/fingerprinter (field/map->FieldInstance {:base_type :type/Temporal}))
                                [(java.time.LocalDateTime/of 2013 01 01 20 04 0 0)
                                 (java.time.LocalDateTime/of 2018 01 01 04 04 0 0)]))))
            (testing "handle comparing explicit Instant with ChronoLocalDateTime"
@@ -36,7 +37,7 @@
                      :type   {:type/DateTime {:earliest "2007-12-03T10:15:30Z"
                                               :latest   "2018-01-01T04:04:00Z"}}}
                     (transduce identity
-                               (fingerprinter (field/map->FieldInstance {:base_type :type/Temporal}))
+                               (f/fingerprinter (field/map->FieldInstance {:base_type :type/Temporal}))
                                [(java.time.Instant/parse "2007-12-03T10:15:30.00Z")
                                 (java.time.LocalDateTime/of 2018 01 01 04 04 0 0)]))))
            (testing "mixing numbers and strings"
@@ -45,7 +46,7 @@
                      :type   {:type/DateTime {:earliest "1970-01-01T00:00:01.234Z"
                                               :latest   "2007-12-03T10:15:30Z"}}}
                     (transduce identity
-                               (fingerprinter (field/map->FieldInstance {:base_type :type/Temporal}))
+                               (f/fingerprinter (field/map->FieldInstance {:base_type :type/Temporal}))
                                ["2007-12-03T10:15:30.00Z" 1234]))))
            (testing "nil temporal values"
              (is (= {:global {:distinct-count 1
@@ -53,7 +54,7 @@
                      :type   {:type/DateTime {:earliest nil
                                               :latest   nil}}}
                     (transduce identity
-                               (fingerprinter (field/map->FieldInstance {:base_type :type/DateTime}))
+                               (f/fingerprinter (field/map->FieldInstance {:base_type :type/DateTime}))
                                (repeat 10 nil)))))
             (testing "handle all supported types"
               (is (= {:global {:distinct-count 5
@@ -61,7 +62,7 @@
                       :type   {:type/DateTime {:earliest "1970-01-01T00:00:01.234Z"
                                                :latest   "2020-07-06T20:25:33.36Z"}}}
                      (transduce identity
-                                (fingerprinter (field/map->FieldInstance {:base_type :type/Temporal}))
+                                (f/fingerprinter (field/map->FieldInstance {:base_type :type/Temporal}))
                                 [(java.time.LocalDateTime/of 2013 01 01 20 04 0 0) ; LocalDateTime
                                  1234 ; int
                                  1594067133360 ; long
@@ -75,8 +76,8 @@
             :type   {:type/DateTime {:earliest "2013-01-01"
                                      :latest   "2018-01-01"}}}
            (transduce identity
-                      (fingerprinter (field/map->FieldInstance {:base_type    :type/DateTime
-                                                                :special_type :type/FK}))
+                      (f/fingerprinter (field/map->FieldInstance {:base_type    :type/DateTime
+                                                                  :special_type :type/FK}))
                       [#t "2013" #t "2018" #t "2015"])))))
 
 (deftest fingerprint-numeric-values-test
@@ -89,7 +90,7 @@
                                  :q3  2.75
                                  :sd  1.0}}}
          (transduce identity
-                    (fingerprinter (field/map->FieldInstance {:base_type :type/Number}))
+                    (f/fingerprinter (field/map->FieldInstance {:base_type :type/Number}))
                     [1.0 2.0 3.0])))
   (testing "We should robustly survive weird values such as NaN, Infinity, and nil"
     (is (= {:global {:distinct-count 7
@@ -101,7 +102,7 @@
                                    :q3  2.75
                                    :sd  1.0}}}
            (transduce identity
-                      (fingerprinter (field/map->FieldInstance {:base_type :type/Number}))
+                      (f/fingerprinter (field/map->FieldInstance {:base_type :type/Number}))
                       [1.0 2.0 3.0 Double/NaN Double/POSITIVE_INFINITY Double/NEGATIVE_INFINITY nil nil])))))
 
 (deftest fingerprint-string-values-test
@@ -112,8 +113,18 @@
                                :percent-email  0.0
                                :average-length 6.4}}}
          (transduce identity
-                    (fingerprinter (field/map->FieldInstance {:base_type :type/Text}))
-                    ["metabase" "more" "like" "metabae" "[1, 2, 3]"]))))
+                    (f/fingerprinter (field/map->FieldInstance {:base_type :type/Text}))
+                    ["metabase" "more" "like" "metabae" "[1, 2, 3]"])))
+  (let [truncated-json (subs (json/generate-string (vec (range 1234))) 0 f/truncation-size)]
+    (is (= {:global {:distinct-count 5
+                     :nil%           0.0}
+            :type   {:type/Text {:percent-json   0.2
+                                 :percent-url    0.0
+                                 :percent-email  0.0
+                                 :average-length 251.4}}}
+           (transduce identity
+                      (f/fingerprinter (field/map->FieldInstance {:base_type :type/Text}))
+                      ["metabase" "more" "like" "metabae" truncated-json])))))
 
 (deftest fingerprints-in-db-test
   (mt/test-drivers (mt/normal-drivers)
@@ -142,3 +153,13 @@
                                              :sd  (s/pred #(< 0.76 % 0.78) "between 0.76 and 0.78")
                                              :avg (s/eq 2.03)}}}
                      (db/select-one-field :fingerprint Field :id (mt/id :venues :price))))))))
+
+(deftest snif-json-test
+  (testing "recognizes substrings of json"
+    (let [partial-json (fn [x]
+                         (let [json (json/generate-string x)]
+                           (subs json 0 (/ (count json) 2))))]
+      (is (#'f/snif-json (partial-json [1 2 3])))
+      (is (#'f/snif-json (partial-json {:a 1 :b 2})))
+      (is (#'f/snif-json (partial-json [{:a 2}])))
+      (is (not (#'f/snif-json "bob"))))))

--- a/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
@@ -121,7 +121,7 @@
             :type   {:type/Text {:percent-json   0.2
                                  :percent-url    0.0
                                  :percent-email  0.0
-                                 :average-length 251.4}}}
+                                 :average-length 10.6}}}
            (transduce identity
                       (f/fingerprinter (field/map->FieldInstance {:base_type :type/Text}))
                       ["metabase" "more" "like" "metabae" truncated-json])))))

--- a/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
@@ -162,5 +162,6 @@
       (is (#'f/valid-serialized-json? (partial-json [1 2 3])))
       (is (#'f/valid-serialized-json? (partial-json {:a 1 :b 2})))
       (is (#'f/valid-serialized-json? (partial-json [{:a 2}])))
+      (is (#'f/valid-serialized-json? (partial-json [true true])))
       (is (not (#'f/valid-serialized-json? "bob")))
       (is (not (#'f/valid-serialized-json? "[bob]"))))))

--- a/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
@@ -154,12 +154,13 @@
                                              :avg (s/eq 2.03)}}}
                      (db/select-one-field :fingerprint Field :id (mt/id :venues :price))))))))
 
-(deftest snif-json-test
+(deftest valid-serialized-json?-test
   (testing "recognizes substrings of json"
     (let [partial-json (fn [x]
                          (let [json (json/generate-string x)]
                            (subs json 0 (/ (count json) 2))))]
-      (is (#'f/snif-json (partial-json [1 2 3])))
-      (is (#'f/snif-json (partial-json {:a 1 :b 2})))
-      (is (#'f/snif-json (partial-json [{:a 2}])))
-      (is (not (#'f/snif-json "bob"))))))
+      (is (#'f/valid-serialized-json? (partial-json [1 2 3])))
+      (is (#'f/valid-serialized-json? (partial-json {:a 1 :b 2})))
+      (is (#'f/valid-serialized-json? (partial-json [{:a 2}])))
+      (is (not (#'f/valid-serialized-json? "bob")))
+      (is (not (#'f/valid-serialized-json? "[bob]"))))))

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -41,6 +41,7 @@
      [:not (mdb/isa :special_type :type/PK)]
      [:= :special_type nil]]
     [:not-in :visibility_type ["retired" "sensitive"]]
+    [:not= :base_type "type/Structured"]
     [:or
      [:and
       [:< :fingerprint_version 1]
@@ -56,6 +57,7 @@
      [:not (mdb/isa :special_type :type/PK)]
      [:= :special_type nil]]
     [:not-in :visibility_type ["retired" "sensitive"]]
+    [:not= :base_type "type/Structured"]
     [:or
      [:and
       [:< :fingerprint_version 2]
@@ -78,6 +80,7 @@
      [:not (mdb/isa :special_type :type/PK)]
      [:= :special_type nil]]
     [:not-in :visibility_type ["retired" "sensitive"]]
+    [:not= :base_type "type/Structured"]
     [:or
      [:and
       [:< :fingerprint_version 2]
@@ -100,6 +103,7 @@
      [:not (mdb/isa :special_type :type/PK)]
      [:= :special_type nil]]
     [:not-in :visibility_type ["retired" "sensitive"]]
+    [:not= :base_type "type/Structured"]
     [:or
      [:and
       [:< :fingerprint_version 4]
@@ -246,7 +250,7 @@
     (doseq [size [4 8 10]]
       (let [table (Table (mt/id :categories))
             field (Field (mt/id :categories :name))]
-        (with-redefs [metadata-queries/truncation-size size]
+        (with-redefs [fingerprinters/truncation-size size]
           (#'fingerprint/fingerprint-table! table [field])
           (let [field' (db/select-one [Field :fingerprint] :id (u/id field))
                 fingerprinted-size (get-in field' [:fingerprint :type :type/Text :average-length])]

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -250,7 +250,7 @@
     (doseq [size [4 8 10]]
       (let [table (Table (mt/id :categories))
             field (Field (mt/id :categories :name))]
-        (with-redefs [fingerprinters/truncation-size size]
+        (with-redefs [fingerprint/truncation-size size]
           (#'fingerprint/fingerprint-table! table [field])
           (let [field' (db/select-one [Field :fingerprint] :id (u/id field))
                 fingerprinted-size (get-in field' [:fingerprint :type :type/Text :average-length])]


### PR DESCRIPTION
* truncate type/Text fields to 1234 (a distinct number we can use as a
heuristic for longer fields if desired)

* test truncation in metadata-queries-test

* test that fingerprints reflect these truncations in fingerprint-test



###### Before submitting the PR, please make sure you do the following
- [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.
### Tests
-  [ ] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [X] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

-  [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
