### PR TITLE
Adds dev/src/dev/nocommit to ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ profiles.clj
 target/checksum.txt
 xcshareddata
 xcuserdata
+dev/src/dev/nocommit/


### PR DESCRIPTION
now you can create a folder nocommit/ under the dev classpath root so
you can keep some namespaces around as you work on features.

Ex:

```clojure
(ns dev.nocommit.oom
  (:require [metabase.models
             [database :refer [Database]]
             [field :refer [Field]]
             [table :refer [Table]]]
            [metabase.sync.analyze
             [fingerprint :as analyze.fingerprint]]
            [metabase.sync :as sync]
            [metabase.sync
             [field-values :as sync.field-values]]
            [metabase.models.field-values :as field-values]
            [metabase.sync.analyze.fingerprint.fingerprinters :as fingerprinters]
            [metabase
             [util :as u]]
            [metabase.sync.sync-metadata.fields :as metadata.fields]
            [metabase.sync.sync-metadata.fields.fetch-metadata :as fetch-metadata]
            [metabase.query-processor :as qp]
            [toucan.db :as db]
            [metabase.db
             [metadata-queries :as metadata-queries]]))

(def pg (Database 4))

(comment
  (fetch-metadata/db-metadata pg emails-table)
  (metadata.fields/sync-fields! pg)

  (sync/sync-database! pg))

(clojure.test/run-tests 'whatever-namespace)

```

I ended up with lots of `(comment ...)` blocks in lots of different
namespaces and this has helped keep my worktree clean.



###### Before submitting the PR, please make sure you do the following
- [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.
### Tests
-  [ ] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

-  [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
