### PR TITLE
i18n(App) grammarly suggetions while translating

### DIFF
--- a/frontend/src/metabase/lib/expressions/helper_text_strings.js
+++ b/frontend/src/metabase/lib/expressions/helper_text_strings.js
@@ -49,7 +49,7 @@ const helperTextStrings = [
     args: [
       {
         name: t`column`,
-        description: t`The numeric column to get standard deviation of.`,
+        description: t`The numeric column to get the standard deviation of.`,
       },
     ],
   },
@@ -262,7 +262,7 @@ const helperTextStrings = [
   {
     name: "length",
     structure: "length(" + t`text` + ")",
-    description: t`Returns the number of characters in text.`,
+    description: t`Returns the number of characters in a text.`,
     example: "length([" + t`Comment` + "])",
     args: [
       {
@@ -336,7 +336,7 @@ const helperTextStrings = [
     args: [
       {
         name: t`column`,
-        description: t`The column or number to round to nearest integer.`,
+        description: t`The column or number to round to the nearest integer.`,
       },
     ],
   },
@@ -348,7 +348,7 @@ const helperTextStrings = [
     args: [
       {
         name: t`column`,
-        description: t`The column or number to return square root value of.`,
+        description: t`The column or number to return the square root value of.`,
       },
     ],
   },
@@ -477,7 +477,7 @@ const helperTextStrings = [
       { name: t`value1`, description: t`The column or value to return.` },
       {
         name: t`value2`,
-        description: t`If value1 is empty, value2 gets returned if its not empty, and so on.`,
+        description: t`If value1 is empty, value2 gets returned if it's not empty, and so on.`,
       },
     ],
   },

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -345,7 +345,7 @@
     (match [native schemas]
       [:write :all]  :ok
       [:write _]     (log/warn "Invalid DB permissions: if you have write access for native queries, you must have full data access.")
-      [:read  :none] (log/warn "Invalid DB permissions: if you have readonly native query access, you must also have data access.")
+      [:read  :none] (log/warn "Invalid DB permissions: if you have read-only native query access, you must also have data access.")
       [_      _]     :ok)))
 
 (def ^:private StrictDBPermissionsGraph

--- a/src/metabase/public_settings/metastore.clj
+++ b/src/metabase/public_settings/metastore.clj
@@ -65,7 +65,7 @@
           ;; slurp will throw a FileNotFoundException for 404s, so in that case just return an appropriate
           ;; 'Not Found' message
           (catch java.io.FileNotFoundException e
-            {:valid false, :status (tru "Unable to validate token: 404 not found.")})
+            {:valid false, :status (tru "Unable to validate the token: 404 not found.")})
           ;; if there was any other error fetching the token, log it and return a generic message about the
           ;; token being invalid. This message will get displayed in the Settings page in the admin panel so
           ;; we do not want something complicated
@@ -118,7 +118,7 @@
     (try
       (when (seq new-value)
         (when (s/check ValidToken new-value)
-          (throw (ex-info (tru "Token format is invalid. Token should be 64 hexadecimal characters.")
+          (throw (ex-info (tru "The token format is invalid. Token should be 64 hexadecimal characters.")
                    {:status-code 400})))
         (valid-token->features new-value)
         (log/info (trs "Token is valid.")))


### PR DESCRIPTION
I also found these syntax errors for Enterprise files in case you want to fix those in your internal code.

=> Reference: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
```
- Provide easy login that works with your exisiting authentication infrastructure.
+ Provide easy login that works with your existing authentication infrastructure.
```
=>Reference: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
```
- Enter the token you recieved from the store
+ Enter the token you received from the store
```
=>Reference: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
```
- All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization
+ All the tools you need to quickly and easily provide reports for your customers or to help you run and monitor Metabase in a large organization
```

HTH