### PR TITLE
Add repro for #13061 [ci skip]

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -34,6 +34,18 @@ describe("scenarios > admin > settings", () => {
     cy.findByText("Save changes");
   });
 
+  it.skip("shouldn't automatically save settings on page load (metabase#13061)", () => {
+    cy.server();
+    cy.route("PUT", "api/setting/site-url").as("save");
+
+    cy.visit("/admin/settings/general");
+    cy.wait("@save");
+    cy.log("**Bug noticed in v0.36.2**");
+    // Overriding default timeout of 4000ms
+    // We want to make sure the element doesn't already disappear when Cypress tries to assert
+    cy.get(".SaveStatus", { timeout: 1000 }).should("not.exist");
+  });
+
   it("should save a setting", () => {
     cy.server();
     cy.route("PUT", "**/admin-email").as("saveSettings");


### PR DESCRIPTION
### Status
NEEDS REVIEW

### What does this PR accomplish?
- reproduces #13061 

### How to test this manually?
- `yarn test-cypress-open`
- open `frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js`
- replace it.skip() with it.only()
- test should fail until the underlying issue is resolved

### Additional notes:
- unskip and merge with the fix for this issue
- skipped CI until the question below is answered/resolved

--- 
- Although this is fairly simple test, there are a few different ways to make assertion. The problem with
`cy.findByText("Saved").should("not.exist")` (for example) is that Cypress will wait for that element to go away, and then pass - giving us false positive. That's why I asserted on the wrapper for status message (".SaveStatus"). With `cy.get()` I could shorten the default timeout to 1s, making sure the test finds that element and fails.

Alternative to this would be to assert on the XHR itself. However, I couldn't find reliable way online to do that, and it seems that [it's not encouraged to assert that things didn't happen](https://stackoverflow.com/a/51082050/8815185). I could try some of the [solutions from this SO answer](https://stackoverflow.com/questions/47354360/is-there-a-way-to-assert-that-a-route-has-not-been-called-in-cypress).

Afaic, asserting on the appearance of status update message is good enough, but please let me know if you think we should do it differently (XHR assertion, or some other way). Thanks.