### PR TITLE
More i18n verification in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ commands:
       - run:
           name: << parameters.command-name >>
           command: yarn << parameters.command >>
-          no_output_timeout: 5m
+          no_output_timeout: 10m
 
   wait-for-port:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,7 +337,11 @@ jobs:
           name: Install gettext
           command: sudo apt-get install gettext
       - run:
-          name: Verify i18n .po files
+          name: Check i18n tags/make sure template can be built
+          command: ./bin/i18n/update-translation-template
+          no_output_timeout: 2m
+      - run:
+          name: Verify i18n translations (.po files)
           command: ./bin/i18n/build-translation-resources
           no_output_timeout: 2m
 

--- a/frontend/src/metabase/lib/settings.js
+++ b/frontend/src/metabase/lib/settings.js
@@ -190,7 +190,7 @@ class Settings {
     }
 
     const { total, ...rest } = descriptions;
-    const includes = Object.values(rest).join(t`, `);
+    const includes = Object.values(rest).join(", ");
     if (total && includes) {
       return t`must be ${total} and include ${includes}.`;
     } else if (total) {

--- a/frontend/src/metabase/query_builder/components/FieldWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/FieldWidget.jsx
@@ -8,7 +8,7 @@ import Popover from "metabase/components/Popover";
 import * as FieldRef from "metabase/lib/query/field_ref";
 
 import cx from "classnames";
-import t from "ttag";
+import { t } from "ttag";
 
 export default class FieldWidget extends React.Component {
   constructor(props, context) {


### PR DESCRIPTION
Make sure `./bin/i18n/update-translation-template` runs without errors in CI. When doing the 0.37.0-rc I had to fix a handful of strings with incorrect tags that had already been merged in. It's better to catch the bad tags before merging something in