### PR TITLE
Fix various dashboard interactivity bugs

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -39,7 +39,7 @@ const fetchParameterPossibleValues = async (
 ) => {
   // build a map of parameter ID -> value for parameters that this parameter is filtered by
   const otherValues = _.chain(parameters)
-    .filter(p => filteringParameters.includes(p.id))
+    .filter(p => filteringParameters.includes(p.id) && p.value != null)
     .map(p => [p.id, p.value])
     .object()
     .value();

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
@@ -148,11 +148,11 @@ const Column = ({ column, clickBehavior, onClick }) => (
       <h4>
         {clickBehavior && clickBehavior.type === "crossfilter"
           ? (n =>
-              t`${ngettext(
+              ngettext(
                 msgid`${column.display_name} updates ${n} filter`,
                 `${column.display_name} updates ${n} filters`,
                 n,
-              )}`)(Object.keys(clickBehavior.parameterMapping).length)
+              ))(Object.keys(clickBehavior.parameterMapping).length)
           : clickBehavior && clickBehavior.type === "link"
           ? jt`${column.display_name} goes to ${(
               <LinkTargetName clickBehavior={clickBehavior} />

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -180,6 +180,7 @@ export default class DashCard extends Component {
             isEditing ? (
               <DashCardActionButtons
                 series={series}
+                hasError={!!errorMessage}
                 isVirtualDashCard={isVirtualDashCard(dashcard)}
                 onRemove={onRemove}
                 onAddSeries={onAddSeries}
@@ -250,45 +251,59 @@ export default class DashCard extends Component {
 const DashCardActionButtons = ({
   series,
   isVirtualDashCard,
+  hasError,
   onRemove,
   onAddSeries,
   onReplaceAllVisualizationSettings,
   showClickBehaviorSidebar,
-}) => (
-  <span
-    className="DashCard-actions flex align-center"
-    style={{ lineHeight: 1 }}
-  >
-    {onReplaceAllVisualizationSettings &&
-      !getVisualizationRaw(series).visualization.disableSettingsConfig && (
+}) => {
+  const buttons = [];
+  if (!hasError) {
+    if (
+      onReplaceAllVisualizationSettings &&
+      !getVisualizationRaw(series).visualization.disableSettingsConfig
+    ) {
+      buttons.push(
         <ChartSettingsButton
           series={series}
           onReplaceAllVisualizationSettings={onReplaceAllVisualizationSettings}
-        />
-      )}
+        />,
+      );
+    }
+    if (!isVirtualDashCard) {
+      buttons.push(
+        <Tooltip tooltip={t`Click behavior`}>
+          <a
+            className="text-light text-medium-hover drag-disabled mr1"
+            data-metabase-event="Dashboard;Open Click Behavior Sidebar"
+            onClick={showClickBehaviorSidebar}
+            style={HEADER_ACTION_STYLE}
+          >
+            <Icon name="click" />
+          </a>
+        </Tooltip>,
+      );
+    }
 
-    {!isVirtualDashCard && (
-      <Tooltip tooltip={t`Click behavior`}>
-        <a
-          className="text-light text-medium-hover drag-disabled mr1"
-          data-metabase-event="Dashboard;Open Click Behavior Sidebar"
-          onClick={showClickBehaviorSidebar}
-          style={HEADER_ACTION_STYLE}
-        >
-          <Icon name="click" />
-        </a>
+    if (getVisualizationRaw(series).visualization.supportsSeries) {
+      buttons.push(
+        <AddSeriesButton series={series} onAddSeries={onAddSeries} />,
+      );
+    }
+  }
+
+  return (
+    <span
+      className="DashCard-actions flex align-center"
+      style={{ lineHeight: 1 }}
+    >
+      {buttons}
+      <Tooltip tooltip={t`Remove`}>
+        <RemoveButton className="ml1" onRemove={onRemove} />
       </Tooltip>
-    )}
-
-    {getVisualizationRaw(series).visualization.supportsSeries && (
-      <AddSeriesButton series={series} onAddSeries={onAddSeries} />
-    )}
-
-    <Tooltip tooltip={t`Remove`}>
-      <RemoveButton className="ml1" onRemove={onRemove} />
-    </Tooltip>
-  </span>
-);
+    </span>
+  );
+};
 
 const ChartSettingsButton = ({ series, onReplaceAllVisualizationSettings }) => (
   <ModalWithTrigger

--- a/frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx
@@ -7,25 +7,40 @@ import { t } from "ttag";
 
 import Dashboard from "metabase/entities/dashboards";
 
+import { setDashboardAttributes } from "../dashboard";
 import { getDashboardComplete } from "../selectors";
 
-const mapStateToProps = (state, props) => {
-  return {
-    dashboard: getDashboardComplete(state, props),
-  };
-};
+const mapStateToProps = (state, props) => ({
+  dashboard: getDashboardComplete(state, props),
+});
+const mapDispatchToProps = { setDashboardAttributes };
 
 @withRouter
-@connect(mapStateToProps)
+@connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)
 class DashboardDetailsModal extends React.Component {
   render() {
-    const { onClose, onChangeLocation, dashboard, ...props } = this.props;
+    const {
+      onClose,
+      onChangeLocation,
+      setDashboardAttributes,
+      dashboard,
+      ...props
+    } = this.props;
     return (
       <Dashboard.ModalForm
         title={t`Change title and description`}
         dashboard={dashboard}
         onClose={onClose}
-        onSaved={dashboard => onChangeLocation(Urls.dashboard(dashboard.id))}
+        onSaved={dashboard => {
+          const { id, ...attributes } = dashboard;
+          // hack: dashboards are stored both in entities.dashboards and dashboard.dashboards
+          // calling setDashboardAttributes sync this change made using the entity form into dashboard.dashboards
+          setDashboardAttributes({ id, attributes });
+          onChangeLocation(Urls.dashboard(id));
+        }}
         {...props}
       />
     );

--- a/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
@@ -2,6 +2,8 @@
 import { getIn } from "icepick";
 import _ from "underscore";
 
+import { isDate } from "metabase/lib/schema_metadata";
+import { parseTimestamp } from "metabase/lib/time";
 import Question from "metabase-lib/lib/Question";
 import { setOrUnsetParameterValues } from "metabase/dashboard/dashboard";
 import { getDataFromClicked } from "metabase/lib/click-behavior";
@@ -35,8 +37,12 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
   if (type === "crossfilter") {
     const valuesToSet = _.chain(parameterMapping)
       .values()
-      .map(({ source, id }) => {
-        const { value } = data[source.type][source.id.toLowerCase()] || {};
+      .map(({ source, target, id }) => {
+        const value = formatSourceForTarget(source, target, {
+          data,
+          extraData,
+          clickBehavior,
+        });
         return [id, value];
       })
       .value();
@@ -50,16 +56,16 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
       };
     } else if (linkType === "dashboard") {
       const url = new URL(`/dashboard/${targetId}`, location.href);
-      Object.entries(getQueryParams(parameterMapping, data)).forEach(([k, v]) =>
-        url.searchParams.append(k, v),
-      );
+      Object.entries(
+        getQueryParams(parameterMapping, { data, extraData, clickBehavior }),
+      ).forEach(([k, v]) => url.searchParams.append(k, v));
 
       behavior = { url: () => url.toString() };
     } else if (linkType === "question" && extraData && extraData.questions) {
       let targetQuestion = new Question(
         extraData.questions[targetId],
         question.metadata(),
-        getQueryParams(parameterMapping, data),
+        getQueryParams(parameterMapping, { data, extraData, clickBehavior }),
       );
 
       if (targetQuestion.isStructured()) {
@@ -67,7 +73,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
           _.chain(parameterMapping)
             .values()
             .map(({ target, id, source }) => ({
-              target,
+              target: target.dimension,
               id,
               type: getTypeForSource(source, extraData),
             }))
@@ -89,14 +95,13 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
   ];
 };
 
-function getQueryParams(parameterMapping, data) {
+function getQueryParams(parameterMapping, { data, extraData, clickBehavior }) {
   return _.chain(parameterMapping)
     .values()
-    .map(({ source, target }) => {
-      const { value } = data[source.type][source.id.toLowerCase()] || [];
-      const key = typeof target === "string" ? target : JSON.stringify(target);
-      return [key, value];
-    })
+    .map(({ source, target }) => [
+      target.id,
+      formatSourceForTarget(source, target, { data, extraData, clickBehavior }),
+    ])
     .filter(([key, value]) => value != null)
     .object()
     .value();
@@ -109,4 +114,49 @@ function getTypeForSource(source, extraData) {
     return type;
   }
   return "text";
+}
+
+function formatSourceForTarget(
+  source,
+  target,
+  { data, extraData, clickBehavior },
+) {
+  const datum = data[source.type][source.id.toLowerCase()] || [];
+  if (datum.column && isDate(datum.column)) {
+    if (target.type === "parameter") {
+      // we should serialize differently based on the target parameter type
+      const parameterPath =
+        clickBehavior.type === "crossfilter"
+          ? ["dashboard", "parameters"]
+          : ["dashboards", clickBehavior.targetId, "parameters"];
+      const parameters = getIn(extraData, parameterPath) || [];
+      const parameter = parameters.find(p => p.id === target.id);
+      if (parameter) {
+        return formatDateForParameterType(datum.value, parameter.type);
+      }
+    } else {
+      // If the target is a dimension or variable,, we serialize as a date to remove the timestamp.
+      // TODO: provide better serialization for field filter widget types
+      return formatDateForParameterType(datum.value, "date/single");
+    }
+  }
+  return datum.value;
+}
+
+function formatDateForParameterType(value, parameterType) {
+  const m = parseTimestamp(value);
+  if (!m.isValid()) {
+    return String(value);
+  }
+  if (parameterType === "date/month-year") {
+    return m.format("YYYY-MM");
+  } else if (parameterType === "date/quarter-year") {
+    return m.format("[Q]Q-YYYY");
+  } else if (
+    parameterType === "date/single" ||
+    parameterType === "date/all-options"
+  ) {
+    return m.format("YYYY-MM-DD");
+  }
+  return value;
 }

--- a/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
@@ -1,6 +1,4 @@
 /* @flow weak */
-
-import { push } from "react-router-redux";
 import { getIn } from "icepick";
 import _ from "underscore";
 
@@ -51,9 +49,12 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
           renderLinkURLForClick(clickBehavior.linkTemplate || "", data),
       };
     } else if (linkType === "dashboard") {
-      const pathname = `/dashboard/${targetId}`;
-      const query = getQueryParams(parameterMapping, data);
-      behavior = { action: () => push({ pathname, query }) };
+      const url = new URL(`/dashboard/${targetId}`, location.href);
+      Object.entries(getQueryParams(parameterMapping, data)).forEach(([k, v]) =>
+        url.searchParams.append(k, v),
+      );
+
+      behavior = { url: () => url.toString() };
     } else if (linkType === "question" && extraData && extraData.questions) {
       let targetQuestion = new Question(
         extraData.questions[targetId],
@@ -75,7 +76,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
       }
 
       const url = targetQuestion.getUrlWithParameters();
-      behavior = { action: () => push(url) };
+      behavior = { url: () => url };
     }
   }
 

--- a/frontend/src/metabase/public/components/EmbedFrame.jsx
+++ b/frontend/src/metabase/public/components/EmbedFrame.jsx
@@ -95,7 +95,7 @@ export default class EmbedFrame extends Component {
               {parameters && parameters.length > 0 ? (
                 <div className="flex ml-auto">
                   <Parameters
-                    // dashboard={this.props.dashboard} TODO: uncomment this when embed param endpoints work
+                    dashboard={this.props.dashboard}
                     parameters={parameters.map(p => ({
                       ...p,
                       value: parameterValues && parameterValues[p.id],

--- a/frontend/src/metabase/public/components/EmbedFrame.jsx
+++ b/frontend/src/metabase/public/components/EmbedFrame.jsx
@@ -95,7 +95,7 @@ export default class EmbedFrame extends Component {
               {parameters && parameters.length > 0 ? (
                 <div className="flex ml-auto">
                   <Parameters
-                    dashboard={this.props.dashboard}
+                    // dashboard={this.props.dashboard} TODO: uncomment this when embed param endpoints work
                     parameters={parameters.map(p => ({
                       ...p,
                       value: parameterValues && parameterValues[p.id],

--- a/frontend/test/metabase/lib/click-behavior.unit.spec.js
+++ b/frontend/test/metabase/lib/click-behavior.unit.spec.js
@@ -66,7 +66,7 @@ describe("metabase/lib/click-behavior", () => {
       });
       expect(id).toEqual("foo123");
       expect(name).toEqual("My Param");
-      expect(target).toEqual("my_param");
+      expect(target).toEqual({ type: "parameter", id: "foo123" });
     });
 
     it("should produce a template tag target", () => {
@@ -92,7 +92,7 @@ describe("metabase/lib/click-behavior", () => {
       });
       expect(id).toEqual("foo123");
       expect(name).toEqual("My Variable");
-      expect(target).toEqual("my_variable");
+      expect(target).toEqual({ type: "variable", id: "my_variable" });
     });
 
     it("should produce a template tag dimension target", () => {
@@ -121,7 +121,11 @@ describe("metabase/lib/click-behavior", () => {
       });
       expect(id).toEqual("foo123");
       expect(name).toEqual("My Field Filter");
-      expect(target).toEqual("my_field_filter");
+      expect(target).toEqual({
+        type: "dimension",
+        id: `["field-id",${PRODUCTS.CATEGORY}]`,
+        dimension: ["field-id", PRODUCTS.CATEGORY],
+      });
     });
 
     describe("filtering sources", () => {

--- a/frontend/test/metabase/lib/click-behavior.unit.spec.js
+++ b/frontend/test/metabase/lib/click-behavior.unit.spec.js
@@ -106,7 +106,7 @@ describe("metabase/lib/click-behavior", () => {
               "template-tags": {
                 my_field_filter: {
                   default: null,
-                  dimension: ["field-id", PRODUCTS.CATEGORY],
+                  dimension: ["field-id", PRODUCTS.CATEGORY.id],
                   "display-name": "My Field Filter",
                   id: "foo123",
                   name: "my_field_filter",
@@ -122,9 +122,8 @@ describe("metabase/lib/click-behavior", () => {
       expect(id).toEqual("foo123");
       expect(name).toEqual("My Field Filter");
       expect(target).toEqual({
-        type: "dimension",
-        id: `["field-id",${PRODUCTS.CATEGORY}]`,
-        dimension: ["field-id", PRODUCTS.CATEGORY],
+        type: "variable",
+        id: "my_field_filter",
       });
     });
 


### PR DESCRIPTION
This PR is a grab bag of fixes for the dashboard interactivity features:
* Hides all action buttons besides remove on failed cards: Fixes #13369, Fixes #13370, Fixes #13372
* Updates the title, description, and collection without refresh: Fixes #13368
* Improves date serialization: Fixes #13377 (this needs more testing, but I don't want to hold up the RC)
* Opens drills in another tab with command click (I didn't see an issue for this)
* Fixes issue where linked filters were scoped by empty values (I noticed this while fixing other things, but didn't file an issue)