### PR TITLE
Fixes #8396 "Postgres sync not respecting SSH tunneling"

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -97,7 +97,7 @@
 (defn- enum-types [driver database]
   (set
    (map (comp keyword :typname)
-        (jdbc/query (sql-jdbc.conn/connection-details->spec driver (:details database))
+        (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
                     [(str "SELECT DISTINCT t.typname "
                           "FROM pg_enum e "
                           "LEFT JOIN pg_type t "

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -95,13 +95,17 @@
        :placeholder "prepareThreshold=0")]))
 
 (defn- enum-types [driver database]
-  (set
-   (map (comp keyword :typname)
-        (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
-                    [(str "SELECT DISTINCT t.typname "
-                          "FROM pg_enum e "
-                          "LEFT JOIN pg_type t "
-                          "  ON t.oid = e.enumtypid")]))))
+  (try
+    (set
+      (map (comp keyword :typname)
+           (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
+                       [(str "SELECT DISTINCT t.typname "
+                             "FROM pg_enum e "
+                             "LEFT JOIN pg_type t "
+                             "  ON t.oid = e.enumtypid")])))
+    (catch Throwable e
+      (log/error e "Error getting enum types in postgres")
+      #{})))
 
 (def ^:private ^:dynamic *enum-types* nil)
 

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -95,17 +95,13 @@
        :placeholder "prepareThreshold=0")]))
 
 (defn- enum-types [_driver database]
-  (try
-    (set
-      (map (comp keyword :typname)
-           (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
-                       [(str "SELECT DISTINCT t.typname "
-                             "FROM pg_enum e "
-                             "LEFT JOIN pg_type t "
-                             "  ON t.oid = e.enumtypid")])))
-    (catch Throwable e
-      (log/error e "Error getting enum types in postgres")
-      #{})))
+  (set
+    (map (comp keyword :typname)
+         (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
+                     [(str "SELECT DISTINCT t.typname "
+                           "FROM pg_enum e "
+                           "LEFT JOIN pg_type t "
+                           "  ON t.oid = e.enumtypid")]))))
 
 (def ^:private ^:dynamic *enum-types* nil)
 

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -94,7 +94,7 @@
      (assoc driver.common/default-additional-options-details
        :placeholder "prepareThreshold=0")]))
 
-(defn- enum-types [driver database]
+(defn- enum-types [_driver database]
   (try
     (set
       (map (comp keyword :typname)

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -87,7 +87,9 @@
   (let [details-with-tunnel (ssh/include-ssh-tunnel details) ;; If the tunnel is disabled this returned unchanged
         spec                (connection-details->spec driver details-with-tunnel)
         properties          (data-warehouse-connection-pool-properties driver)]
-    (connection-pool/connection-pool-spec spec properties)))
+    (connection-pool/connection-pool-spec spec (merge properties
+                                                      (when (ssh/use-ssh-tunnel? details)
+                                                        {"idleConnectionTestPeriod" 120})))))
 
 (defn- destroy-pool! [database-id pool-spec]
   (log/debug (u/format-color 'red (trs "Closing old connection pool for database {0} ..." database-id)))

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -106,7 +106,9 @@
   more than one pool is ever open for a single database."
   [database-id pool-spec-or-nil]
   {:pre [(integer? database-id)]}
-  (let [[old-id->pool] (swap-vals! database-id->connection-pool assoc database-id pool-spec-or-nil)]
+  (let [[old-id->pool] (if pool-spec-or-nil
+                         (swap-vals! database-id->connection-pool assoc database-id pool-spec-or-nil)
+                         (swap-vals! database-id->connection-pool dissoc database-id))]
     ;; if we replaced a different pool with the new pool that is different from the old one, destroy the old pool
     (when-let [old-pool-spec (get old-id->pool database-id)]
       (when-not (identical? old-pool-spec pool-spec-or-nil)

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -87,9 +87,7 @@
   (let [details-with-tunnel (ssh/include-ssh-tunnel details) ;; If the tunnel is disabled this returned unchanged
         spec                (connection-details->spec driver details-with-tunnel)
         properties          (data-warehouse-connection-pool-properties driver)]
-    (connection-pool/connection-pool-spec spec (merge properties
-                                                      (when (ssh/use-ssh-tunnel? details)
-                                                        {"idleConnectionTestPeriod" 120})))))
+    (connection-pool/connection-pool-spec spec properties)))
 
 (defn- destroy-pool! [database-id pool-spec]
   (log/debug (u/format-color 'red (trs "Closing old connection pool for database {0} ..." database-id)))

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -370,7 +370,8 @@
   (create-enums-db!)
   (mt/with-temp Database [database {:engine :postgres, :details (enums-test-db-details)}]
     (sync-metadata/sync-db-metadata! database)
-    (f database)))
+    (f database)
+    (#'sql-jdbc.conn/set-pool! (u/id database) nil)))
 
 (deftest enums-test
   (mt/test-driver :postgres

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -6,8 +6,8 @@
              [db :as mdb]
              [test :as mt]
              [util :as u]]
-            [metabase.driver.util :as driver.u]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+            [metabase.driver.util :as driver.u]
             [metabase.models.database :refer [Database]]
             [metabase.test.data :as data]
             [metabase.test.util.log :as tu.log]))

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -1,6 +1,14 @@
 (ns metabase.driver.sql-jdbc.connection-test
-  (:require [expectations :refer [expect]]
+  (:require [clojure.java.jdbc :as jdbc]
+            [clojure.test :refer :all]
+            [expectations :refer [expect]]
+            [metabase
+             [db :as mdb]
+             [test :as mt]
+             [util :as u]]
             [metabase.driver.util :as driver.u]
+            [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+            [metabase.models.database :refer [Database]]
             [metabase.test.data :as data]
             [metabase.test.util.log :as tu.log]))
 
@@ -28,3 +36,37 @@
   false
   (tu.log/suppress-output
     (driver.u/can-connect-with-details? :postgres {:host "google.com", :port 80})))
+
+(deftest db->pooled-connection-spec-test
+  (mt/test-driver :h2
+    (testing "creating and removing specs works"
+      ;; need to create a new, nonexistent h2 db
+      (binding [mdb/*allow-potentailly-unsafe-connections* true]
+        (let [destroyed?       (atom false)
+              original-destroy @#'sql-jdbc.conn/destroy-pool!
+              spec             (sql-jdbc.conn/connection-details->spec
+                                   :h2
+                                 (mt/dbdef->connection-details :h2 :server {:database-name "connection_test"}))]
+          (with-redefs [sql-jdbc.conn/destroy-pool! (fn [id destroyed-spec]
+                                                      (original-destroy id destroyed-spec)
+                                                      (reset! destroyed? true))]
+            (jdbc/with-db-connection [conn spec]
+              (jdbc/execute! spec ["CREATE TABLE birds (name varchar)"])
+              (jdbc/execute! spec ["INSERT INTO birds values ('rasta'),('lucky')"])
+              (mt/with-temp Database [database {:engine :h2 :details spec}]
+                (testing "database id is not in our connection map initially"
+                  ;; deref'ing a var to get the atom. looks weird
+                  (is (not (contains? @@#'sql-jdbc.conn/database-id->connection-pool
+                                      (u/id database)))))
+                (testing "when getting a pooled connection it is now in our connection map"
+                  (let [stored-spec (sql-jdbc.conn/db->pooled-connection-spec database)
+                        birds       (jdbc/query stored-spec ["SELECT * FROM birds"])]
+                    (is (seq birds))
+                    (is (contains? @@#'sql-jdbc.conn/database-id->connection-pool
+                                   (u/id database)))))
+                (testing "and is no longer in our connection map after cleanup"
+                  (#'sql-jdbc.conn/set-pool! (u/id database) nil)
+                  (is (not (contains? @@#'sql-jdbc.conn/database-id->connection-pool
+                                      (u/id database)))))
+                (testing "the pool has been destroyed"
+                  (is @destroyed?))))))))))


### PR DESCRIPTION
The ssh tunneling information is included in the pooled connection information so we reuse that. While diagnosing this, it seems that ssh tunneled connections will die after a couple minutes so i'm not sure how useful this has been in the meantime. I looked around and I couldn't find when the tunnels might time out on their own. One of the [associated issues](https://github.com/metabase/metabase/issues/10081) raises the possibility of some kind of heartbeat. I'm using `"idleConnectionTestPeriod"` to achieve this at the moment but the ticketer's concerns remain: we don't reestablish connections.

Fixes #8396 