### PR TITLE
Fix Cypress CI Timeouts

### DIFF
--- a/frontend/test/cypress.json
+++ b/frontend/test/cypress.json
@@ -5,9 +5,5 @@
   "integrationFolder": "frontend/test/metabase",
   "supportFile": "frontend/test/__support__/cypress.js",
   "viewportHeight": 800,
-  "viewportWidth": 1280,
-  "retries": {
-    "runMode": 2,
-    "openMode": 0
-  }
+  "viewportWidth": 1280
 }


### PR DESCRIPTION
### Brief context:
We started seeing increased number of Cypress timeouts in CI today. Unfortunately, the whole day of research didn't bring me any closer to the solution. Timeouts coincide with the recent [Cypress Upgrade](https://github.com/metabase/metabase/pull/13343). Naturally, it was the first place to start looking for a cause.
It could be any number of reasons, really. We had too many moving pieces today, but let's start eliminating some of the suspects.

#### First step:
Before completely reverting Cypress upgrade, I thought we should first try disabling test retries from the global config, then check how that affects weird CI timeouts. After all, @dacort sent me the very first failed log exactly after a commit including test retries was introduced.

_Note_: individual test retries can always be set within a test group `describe(...)` or within an individual test `it(...)`.
