### PR TITLE
[Fixes #12349] Respect disabling of PulseChannels

### DIFF
--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -287,6 +287,7 @@
   (let [channel (when new-channel (assoc new-channel
                                     :pulse_id       (u/get-id notification-or-id)
                                     :id             (:id existing-channel)
+                                    :enabled        (:enabled new-channel)
                                     :channel_type   (keyword (:channel_type new-channel))
                                     :schedule_type  (keyword (:schedule_type new-channel))
                                     :schedule_frame (keyword (:schedule_frame new-channel))))]

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -242,11 +242,12 @@
 (defn create-pulse-channel!
   "Create a new `PulseChannel` along with all related data associated with the channel such as
   `PulseChannelRecipients`."
-  [{:keys [channel_type details pulse_id recipients schedule_type schedule_day schedule_hour schedule_frame]
+  [{:keys [channel_type details enabled pulse_id recipients schedule_type schedule_day schedule_hour schedule_frame]
     :or   {details          {}
            recipients       []}}]
   {:pre [(channel-type? channel_type)
          (integer? pulse_id)
+         (boolean? enabled)
          (schedule-type? schedule_type)
          (valid-schedule? schedule_type schedule_hour schedule_day schedule_frame)
          (coll? recipients)
@@ -257,6 +258,7 @@
                        :channel_type   channel_type
                        :details        (cond-> details
                                          (supports-recipients? channel_type) (assoc :emails (get recipients-by-type false)))
+                       :enabled        enabled
                        :schedule_type  schedule_type
                        :schedule_hour  (when (not= schedule_type :hourly)
                                          schedule_hour)

--- a/test/metabase/models/pulse_channel_test.clj
+++ b/test/metabase/models/pulse_channel_test.clj
@@ -152,6 +152,25 @@
 (deftest create-pulse-channel!-test
   (mt/with-temp Pulse [{:keys [id]}]
     (mt/with-model-cleanup [Pulse]
+      (testing "disabled"
+        (is (= {:enabled        false
+                :channel_type   :email
+                :schedule_type  :daily
+                :schedule_hour  18
+                :schedule_day   nil
+                :schedule_frame nil
+                :recipients     [(user-details :crowberto)
+                                 {:email "foo@bar.com"}
+                                 (user-details :rasta)]}
+               (create-channel-then-select!
+                {:pulse_id      id
+                 :enabled       false
+                 :channel_type  :email
+                 :schedule_type :daily
+                 :schedule_hour 18
+                 :recipients    [{:email "foo@bar.com"}
+                                 {:id (mt/user->id :rasta)}
+                                 {:id (mt/user->id :crowberto)}]}))))
       (testing "email"
         (is (= {:enabled        true
                 :channel_type   :email


### PR DESCRIPTION
When alerts are initially set up for a question, we drop the `enabled` flag on the floor and default it to `true`, leading to spurious emails as in #12349.

Interestingly `update-pulse-channel!` was already correct, it's just `create-pulse-channel!` that had the issue. I'm interested in the code similarities between the two but don't pretend to understand Toucan well enough to make a suggestion yet.

I reproduced the bug with a failing test (see diff):

```
metabase.models.pulse-channel-test
1 non-passing tests:

(with-model-cleanup "Pulse")
 disabled

<snip>
    diff: - {:enabled false}	  
          + {:enabled true}	    
```
and it now passes. I also did manual testing locally.