### PR TITLE
[Fixes #8504] Remove default Slack channel

### DIFF
--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -94,7 +94,7 @@
            :fields            [{:name        "channel"
                                 :type        "select"
                                 :displayName "Post to"
-                                :options     ["#general"]
+                                :options     []
                                 :required    true}]}})
 
 (defn channel-type?

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -855,11 +855,13 @@
                  (-> ((mt/user->client :rasta) :get 200 "pulse/form_input")
                      (get-in [:channels :slack :fields])))))))
 
-    (testing "When slack is not configured, `form_input` returns just the #genreal slack channel"
+    (testing "When slack is not configured, `form_input` returns no channels"
       (mt/with-temporary-setting-values [slack-token nil]
-        (is (= [{:name "channel", :type "select", :displayName "Post to", :options ["#general"], :required true}]
+        (is (empty?
                (-> ((mt/user->client :rasta) :get 200 "pulse/form_input")
-                   (get-in [:channels :slack :fields]))))))))
+                   (get-in [:channels :slack :fields])
+                   (first)
+                   (:options))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
c.f. #8504

It wasn't used elsewhere in the codebase and was generating incorrect output in `/api/pulse/form_input` (spuriously adding #general as a channel when Slack wasn't configured)