### PR TITLE
Yet another dashboard interactivity fixes PR

### DIFF
--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
@@ -635,12 +635,14 @@ function LinkOptions({ clickBehavior, updateSettings, dashcard, parameters }) {
                 />
                 {isTableDisplay(dashcard) && (
                   <CustomLinkText
-                    dashcard={dashcard}
-                    parameters={parameters}
                     updateSettings={updateSettings}
                     clickBehavior={clickBehavior}
                   />
                 )}
+                <ValuesYouCanReference
+                  dashcard={dashcard}
+                  parameters={parameters}
+                />
                 <div className="flex">
                   <Button
                     primary
@@ -664,12 +666,16 @@ function LinkOptions({ clickBehavior, updateSettings, dashcard, parameters }) {
               updateSettings={updateSettings}
             />
             {isTableDisplay(dashcard) && (
-              <CustomLinkText
-                dashcard={dashcard}
-                parameters={parameters}
-                updateSettings={updateSettings}
-                clickBehavior={clickBehavior}
-              />
+              <div>
+                <CustomLinkText
+                  updateSettings={updateSettings}
+                  clickBehavior={clickBehavior}
+                />
+                <ValuesYouCanReference
+                  dashcard={dashcard}
+                  parameters={parameters}
+                />
+              </div>
             )}
           </div>
         )}
@@ -794,15 +800,32 @@ function QuestionDashboardPicker({ dashcard, clickBehavior, updateSettings }) {
   );
 }
 
-function prefixIfNeeded(values, prefix, otherLists) {
-  const otherValues = otherLists.flat().map(s => s.toLowerCase());
-  return values.map(value =>
-    otherValues.includes(value.toLowerCase()) ? `${prefix}:${value}` : value,
+const CustomLinkText = ({
+  clickBehavior,
+  dashcard,
+  parameters,
+  updateSettings,
+}) => {
+  return (
+    <div className="mt2 mb1">
+      <Heading>{t`Customize link text (optional)`}</Heading>
+      <InputBlurChange
+        className="input block full"
+        placeholder={t`E.x. Details for {{Column Name}}`}
+        value={clickBehavior.linkTextTemplate}
+        onBlurChange={e =>
+          updateSettings({
+            ...clickBehavior,
+            linkTextTemplate: e.target.value,
+          })
+        }
+      />
+    </div>
   );
-}
+};
 
-const CustomLinkText = withUserAttributes(
-  ({ clickBehavior, dashcard, parameters, userAttributes, updateSettings }) => {
+const ValuesYouCanReference = withUserAttributes(
+  ({ dashcard, parameters, userAttributes }) => {
     const columns = dashcard.card.result_metadata.map(c => c.name);
     const parameterNames = parameters.map(p => p.name);
     const sections = [
@@ -829,37 +852,30 @@ const CustomLinkText = withUserAttributes(
       },
     ].filter(section => section.items.length > 0);
     return (
-      <div className="mt2 mb1">
-        <Heading>{t`Customize link text (optional)`}</Heading>
-        <InputBlurChange
-          className="input block full"
-          placeholder={t`E.x. Details for {{Column Name}}`}
-          value={clickBehavior.linkTextTemplate}
-          onBlurChange={e =>
-            updateSettings({
-              ...clickBehavior,
-              linkTextTemplate: e.target.value,
-            })
-          }
+      <PopoverWithTrigger
+        triggerElement={
+          <div className="flex align-center cursor-pointer my2 text-medium text-brand-hover">
+            <h4>{t`Values you can reference`}</h4>
+            <Icon name="chevrondown" className="ml1" size={12} />
+          </div>
+        }
+      >
+        <AccordionList
+          alwaysExpanded
+          sections={sections}
+          renderItemName={name => name}
+          itemIsClickable={() => false}
         />
-        <PopoverWithTrigger
-          triggerElement={
-            <div className="flex align-center cursor-pointer mt2 text-medium text-brand-hover">
-              <h4>{t`Values you can reference`}</h4>
-              <Icon name="chevrondown" className="ml1" size={12} />
-            </div>
-          }
-        >
-          <AccordionList
-            alwaysExpanded
-            sections={sections}
-            renderItemName={name => name}
-            itemIsClickable={() => false}
-          />
-        </PopoverWithTrigger>
-      </div>
+      </PopoverWithTrigger>
     );
   },
 );
+
+function prefixIfNeeded(values, prefix, otherLists) {
+  const otherValues = otherLists.flat().map(s => s.toLowerCase());
+  return values.map(value =>
+    otherValues.includes(value.toLowerCase()) ? `${prefix}:${value}` : value,
+  );
+}
 
 export default ClickBehaviorSidebar;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
@@ -336,6 +336,7 @@ class ClickBehaviorSidebar extends React.Component {
         <Sidebar
           onClose={hideClickBehaviorSidebar}
           onCancel={this.handleCancel}
+          closeIsDisabled={!clickBehaviorIsValid(clickBehavior)}
         >
           <SidebarHeader>
             <Heading className="text-paragraph">{t`On-click behavior for each column`}</Heading>
@@ -391,7 +392,11 @@ class ClickBehaviorSidebar extends React.Component {
       return null;
     }
     return (
-      <Sidebar onClose={hideClickBehaviorSidebar} onCancel={this.handleCancel}>
+      <Sidebar
+        onClose={hideClickBehaviorSidebar}
+        onCancel={this.handleCancel}
+        closeIsDisabled={!clickBehaviorIsValid(clickBehavior)}
+      >
         <SidebarHeader>
           {selectedColumn == null ? (
             <Heading>{jt`Click behavior for ${(

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
@@ -653,6 +653,7 @@ function LinkOptions({ clickBehavior, updateSettings, dashcard, parameters }) {
                     primary
                     onClick={() => onClose()}
                     className="ml-auto mt2"
+                    disabled={!clickBehaviorIsValid(clickBehavior)}
                   >{t`Done`}</Button>
                 </div>
               </ModalContent>

--- a/frontend/src/metabase/dashboard/components/Sidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.jsx
@@ -5,7 +5,7 @@ import Button from "metabase/components/Button";
 
 const WIDTH = 384;
 
-function Sidebar({ onClose, onCancel, children }) {
+function Sidebar({ onClose, onCancel, closeIsDisabled, children }) {
   return (
     <div
       style={{ width: WIDTH }}
@@ -33,6 +33,7 @@ function Sidebar({ onClose, onCancel, children }) {
               small
               className="ml-auto"
               onClick={onClose}
+              disabled={closeIsDisabled}
             >{t`Done`}</Button>
           )}
         </div>

--- a/frontend/src/metabase/lib/click-behavior.js
+++ b/frontend/src/metabase/lib/click-behavior.js
@@ -242,7 +242,12 @@ export function formatSourceForTarget(
   if (datum.column && isDate(datum.column)) {
     if (target.type === "parameter") {
       // we should serialize differently based on the target parameter type
-      const parameter = getParameter(target, { extraData, clickBehavior });
+      const parameterPath =
+        clickBehavior.type === "crossfilter"
+          ? ["dashboard", "parameters"]
+          : ["dashboards", clickBehavior.targetId, "parameters"];
+      const parameters = getIn(extraData, parameterPath) || [];
+      const parameter = parameters.find(p => p.id === target.id);
       if (parameter) {
         return formatDateForParameterType(datum.value, parameter.type);
       }

--- a/frontend/src/metabase/lib/click-behavior.js
+++ b/frontend/src/metabase/lib/click-behavior.js
@@ -242,12 +242,7 @@ export function formatSourceForTarget(
   if (datum.column && isDate(datum.column)) {
     if (target.type === "parameter") {
       // we should serialize differently based on the target parameter type
-      const parameterPath =
-        clickBehavior.type === "crossfilter"
-          ? ["dashboard", "parameters"]
-          : ["dashboards", clickBehavior.targetId, "parameters"];
-      const parameters = getIn(extraData, parameterPath) || [];
-      const parameter = parameters.find(p => p.id === target.id);
+      const parameter = getParameter(target, { extraData, clickBehavior });
       if (parameter) {
         return formatDateForParameterType(datum.value, parameter.type);
       }


### PR DESCRIPTION
* Fixes #13407 
  * We now show the "Values you can reference" popover in the URL modal for non-tables.
* Fixes #13413
  * Disable "done" buttons in the sidebar and url modal until the click behavior is valid.
* Fixes #13375
  * When a dashboard is saved, revert any invalid click behaviors.