### PR TITLE
Disable file appender

### DIFF
--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -27,7 +27,6 @@
 
     <Root level="WARN">
       <AppenderRef ref="STDOUT"/>
-      <AppenderRef ref="FILE"/>
     </Root>
   </Loggers>
 </Configuration>


### PR DESCRIPTION
We should not be logging to a file by default, this was an oversight in
the migration to log4j2

Resolves #13422
