### PR TITLE
Attempt to fix flake in public.cy.spec.js

### DIFF
--- a/frontend/test/metabase/scenarios/public/public.cy.spec.js
+++ b/frontend/test/metabase/scenarios/public/public.cy.spec.js
@@ -68,10 +68,7 @@ describe("scenarios > public", () => {
   let dashboardPublicLink;
   let dashboardEmbedUrl;
 
-  // [quarantined 2020-10-09]: - constantly breaking in CI,
-  //                           - React console errors,
-  //                           - needs fixing in isolation before being introduced to master again
-  describe.skip("questions", () => {
+  describe("questions", () => {
     // Note: Test suite is sequential, so individual test cases can't be run individually
     it("should allow users to create parameterized dashboards", () => {
       cy.visit(`/question/${questionId}`);
@@ -102,6 +99,7 @@ describe("scenarios > public", () => {
 
       cy.contains("Done").click();
       cy.contains("Save").click();
+      cy.findByText("You're editing this dashboard").should("not.exist");
 
       cy.contains(COUNT_ALL);
       cy.contains("Category")

--- a/frontend/test/metabase/scenarios/public/public.cy.spec.js
+++ b/frontend/test/metabase/scenarios/public/public.cy.spec.js
@@ -99,7 +99,7 @@ describe("scenarios > public", () => {
 
       cy.contains("Done").click();
       cy.contains("Save").click();
-      cy.findByText("You're editing this dashboard").should("not.exist");
+      cy.findByText("You're editing this dashboard.").should("not.exist");
 
       cy.contains(COUNT_ALL);
       cy.contains("Category")


### PR DESCRIPTION
Based on this screen from a previous CI test run, I though I'd try ensuring we wait to leave edit mode. I've seen that cause issues before, but I'm not sure why recent changes would have affect it here.

![image](https://user-images.githubusercontent.com/691495/95762076-397df980-0c7b-11eb-835d-a7ddbe88c1ba.png)

If that proves to be the issue, we should add a `saveDashboard()` helper that waits for the UI to update after clicking "Save".