### PR TITLE
Obfuscate database details in the APIs

### DIFF
--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -152,6 +152,11 @@
   "The string to replace passwords with when serializing Databases."
   "**MetabasePass**")
 
+(def ^:const sensitive-fields
+  "List of fields that should be obfuscated in API responses, as they contain sensitive data."
+  [:password :pass :tunnel-pass :tunnel-private-key :tunnel-private-key-passphrase
+   :access-token :refresh-token :service-account-json])
+
 ;; when encoding a Database as JSON remove the `details` for any non-admin User. For admin users they can still see
 ;; the `details` but remove anything resembling a password. No one gets to see this in an API response!
 (add-encoder
@@ -164,6 +169,5 @@
                             (reduce
                              #(m/update-existing %1 %2 (constantly protected-password))
                              details
-                             [:password :pass :tunnel-pass :tunnel-private-key :tunnel-private-key-passphrase
-                              :access-token :refresh-token :service-account-json]))))
+                             sensitive-fields))))
     json-generator)))


### PR DESCRIPTION
This will stop us from sending sensitive info (passwords, keys) via the
API for authenticated administrators. Note that non-administrator users
were never privvy to these fields.