### PR TITLE
Only get substrings in fingerprinting when supported [ci drivers] (#1…

### DIFF
--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -50,22 +50,22 @@
   [table :- i/TableInstance, fields :- [i/FieldInstance]]
   (transduce identity
              (redux/post-complete
-              (f/fingerprint-fields fields)
-              (fn [fingerprints]
-                (reduce (fn [count-info [field fingerprint]]
-                          (cond
-                            (instance? Throwable fingerprint)
-                            (update count-info :failed-fingerprints inc)
+               (f/fingerprint-fields fields)
+               (fn [fingerprints]
+                 (reduce (fn [count-info [field fingerprint]]
+                           (cond
+                             (instance? Throwable fingerprint)
+                             (update count-info :failed-fingerprints inc)
 
-                            (some-> fingerprint :global :distinct-count zero?)
-                            (update count-info :no-data-fingerprints inc)
+                             (some-> fingerprint :global :distinct-count zero?)
+                             (update count-info :no-data-fingerprints inc)
 
-                            :else
-                            (do
-                              (save-fingerprint! field fingerprint)
-                              (update count-info :updated-fingerprints inc))))
-                        (empty-stats-map (count fingerprints))
-                        (map vector fields fingerprints))))
+                             :else
+                             (do
+                               (save-fingerprint! field fingerprint)
+                               (update count-info :updated-fingerprints inc))))
+                         (empty-stats-map (count fingerprints))
+                         (map vector fields fingerprints))))
              (metadata-queries/table-rows-sample table fields {:truncation-size truncation-size})))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
…3432)

* Only get substrings in fingerprinting when supported [ci drivers]

failing tests in bigquery and mongo as they don't support
expressions.

* Corrects ns form and gets driver from table def [ci drivers]

getting driver from dynamic var was not reliable at this place

* Move expression check into `metadata-queries/table-row-sample`

debated whether caller should know that whether to pass in truncation
options or they might "silently" be ignored. Probably best this way
and added that information to docstring.