### PR TITLE
Add QP middleware to auto-parse string values to correct type (backported from master)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,6 +175,11 @@ executors:
       - image: circleci/clojure:lein-2.8.1-node-browsers
       - image: circleci/mongo:4.0
 
+  fe-postgres-12:
+    working_directory: /home/circleci/metabase/metabase/
+    docker:
+      - image: circleci/clojure:lein-2.8.1-node-browsers
+      - image: metabase/qa-databases:postgres-sample-12
 
 ########################################################################################################################
 #                                                       COMMANDS                                                       #
@@ -984,6 +989,16 @@ workflows:
           driver: mongo
           only-single-database: true
           test-files-location: frontend/test/metabase-db/mongo
+
+      - fe-tests-cypress:
+          name: fe-tests-cypress-postgres-12
+          requires:
+            - build-uberjar
+            - fe-deps
+          e: fe-postgres-12
+          cypress-group: "postgres"
+          only-single-database: true
+          test-files-location: frontend/test/metabase-db/postgres
 
       - deploy-master:
           requires:

--- a/frontend/test/metabase-db/postgres/add.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/add.cy.spec.js
@@ -54,7 +54,7 @@ describe("postgres > admin > add", () => {
       .click();
   });
 
-  it.skip("should show row details when clicked on its entity key (metabase#13263)", () => {
+  it("should show row details when clicked on its entity key (metabase#13263)", () => {
     cy.route({
       method: "POST",
       url: "/api/database",

--- a/frontend/test/metabase-db/postgres/add.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/add.cy.spec.js
@@ -1,0 +1,96 @@
+import {
+  signInAsAdmin,
+  restore,
+  modal,
+  typeAndBlurUsingLabel,
+} from "__support__/cypress";
+
+function addPostgresDatabase() {
+  cy.visit("/admin/databases/create");
+  cy.contains("Database type")
+    .closest(".Form-field")
+    .find("a")
+    .click();
+  cy.contains("PostgreSQL").click({ force: true });
+  cy.contains("Additional JDBC connection string options");
+
+  typeAndBlurUsingLabel("Name", "QA Postgres12");
+  typeAndBlurUsingLabel("Host", "localhost");
+  // TODO: "Port" label and input field are misconfigured (input field is missing `aria-labeledby` attribute)
+  // typeAndBlurUsingLabel("Port", "5432") => this will not work (switching to placeholder temporarily)
+  cy.findByPlaceholderText("5432")
+    .click()
+    .type("5432");
+  typeAndBlurUsingLabel("Database name", "sample");
+  typeAndBlurUsingLabel("Username", "metabase");
+  typeAndBlurUsingLabel("Password", "metasample123");
+
+  cy.findByText("Save")
+    .should("not.be.disabled")
+    .click();
+}
+
+describe("postgres > admin > add", () => {
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+    cy.server();
+  });
+
+  it("should add a database and redirect to listing", () => {
+    cy.route({
+      method: "POST",
+      url: "/api/database",
+    }).as("createDatabase");
+
+    addPostgresDatabase();
+
+    cy.wait("@createDatabase");
+
+    cy.url().should("match", /\/admin\/databases\?created=\d+$/);
+    cy.contains("Your database has been added!");
+    modal()
+      .contains("I'm good thanks")
+      .click();
+  });
+
+  it.skip("should show row details when clicked on its entity key (metabase#13263)", () => {
+    cy.route({
+      method: "POST",
+      url: "/api/database",
+    }).as("createDatabase");
+
+    addPostgresDatabase();
+
+    cy.wait("@createDatabase");
+
+    cy.url().should("match", /\/admin\/databases\?created=\d+$/);
+    cy.contains("Your database has been added!");
+    modal()
+      .contains("I'm good thanks")
+      .click();
+
+    // Repro starts here
+    cy.visit("/");
+    cy.findByText("Ask a question").click();
+    cy.findByText("Simple question").click();
+    cy.findByText("QA Postgres12").click();
+    cy.findByText("Orders").click();
+
+    // We're clicking on ID: 1 (the first order) => do not change!
+    // It is tightly coupled to the assertion ("37.65"), which is "Subtotal" value for that order.
+    cy.get(".Table-ID")
+      .eq(0)
+      .click();
+
+    // Wait until "doing science" spinner disappears (DOM is ready for assertions)
+    // TODO: if this proves to be reliable, extract it as a helper function for waiting on DOM to render
+    cy.get(".LoadingSpinner").should("not.exist");
+
+    // Assertions
+    cy.log("**Fails in v0.36.6**");
+    // This could be omitted because real test is searching for "37.65" on the page
+    cy.findByText("There was a problem with your question").should("not.exist");
+    cy.contains("37.65");
+  });
+});

--- a/frontend/test/snapshot-creators/default.cy.snap.js
+++ b/frontend/test/snapshot-creators/default.cy.snap.js
@@ -194,6 +194,11 @@ describe("snapshots", () => {
       cy.request("POST", "/api/database/2/rescan_values");
       cy.wait(1000); // wait for sync
       snapshot("withSqlite");
+      // TODO: Temporary HACK that requires further investigation and a better solution.
+      // sqlite driver was messing with the sync of postres database in CY tests
+      // ("probably some weird race condition" @Damon)
+      // Deleting it here keeps snapshots intact, and enables for unobstructed postgres testing.
+      cy.request("DELETE", "/api/database/2");
       restore("blank");
     });
   });

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -19,6 +19,7 @@
              [add-timezone-info :as add-timezone-info]
              [annotate :as annotate]
              [auto-bucket-datetimes :as bucket-datetime]
+             [auto-parse-filter-values :as auto-parse-filter-values]
              [binning :as binning]
              [cache :as cache]
              [catch-exceptions :as catch-exceptions]
@@ -62,6 +63,7 @@
   [#'mbql-to-native/mbql->native
    #'check-features/check-features
    #'optimize-datetime-filters/optimize-datetime-filters
+   #'auto-parse-filter-values/auto-parse-filter-values
    #'wrap-value-literals/wrap-value-literals
    #'annotate/add-column-info
    #'perms/check-query-permissions

--- a/src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+++ b/src/metabase/query_processor/middleware/auto_parse_filter_values.clj
@@ -17,7 +17,7 @@
   (try
     (condp #(isa? %2 %1) base-type
       :type/BigInteger (bigint v)
-      :type/Integer    (Integer/parseInt v)
+      :type/Integer    (Long/parseLong v)
       :type/Decimal    (bigdec v)
       :type/Float      (Double/parseDouble v)
       :type/Boolean    (Boolean/parseBoolean v)

--- a/src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+++ b/src/metabase/query_processor/middleware/auto_parse_filter_values.clj
@@ -1,0 +1,44 @@
+(ns metabase.query-processor.middleware.auto-parse-filter-values
+  "Middleware that parses filter clause values that come in as strings (e.g. from the API) to the appropriate type. E.g.
+  a String value in a filter clause against a `:type/Integer` Field should get parsed into an integer.
+
+  Note that logic for automatically parsing temporal values lives in the `wrap-values-literals` middleware for
+  historic reasons. When time permits it should be moved into this middleware since it's really a separate
+  transformation from wrapping the value literals themselves."
+  (:require [metabase.mbql.util :as mbql.u]
+            [metabase.query-processor.error-type :as error-type]
+            [metabase.util
+             [i18n :refer [tru]]
+             [schema :as su]]
+            [schema.core :as s]))
+
+(s/defn ^:private parse-value-for-base-type [v :- s/Str, base-type :- su/FieldType]
+  {:pre [(string? v)]}
+  (try
+    (condp #(isa? %2 %1) base-type
+      :type/BigInteger (bigint v)
+      :type/Integer    (Integer/parseInt v)
+      :type/Decimal    (bigdec v)
+      :type/Float      (Double/parseDouble v)
+      :type/Boolean    (Boolean/parseBoolean v)
+      v)
+    (catch Throwable e
+      (throw (ex-info (tru "Error filtering against {0} Field: unable to parse String {1} to a {2}"
+                           base-type
+                           (pr-str v)
+                           base-type)
+                      {:type error-type/invalid-query}
+                      e)))))
+
+(defn- auto-parse-filter-values* [query]
+  (mbql.u/replace-in query [:query]
+    [:value (v :guard string?) (info :guard (fn [{base-type :base_type}]
+                                              (and base-type
+                                                   (not (isa? base-type :type/Text)))))]
+    [:value (parse-value-for-base-type v (:base_type info)) info]))
+
+(defn auto-parse-filter-values
+  "Automatically parse String filter clause values to the appropriate type."
+  [qp]
+  (fn [query rff context]
+    (qp (auto-parse-filter-values* query) rff context)))

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -515,3 +515,11 @@
                    :field_ref    [:field-literal "sleep" :type/Text]
                    :name         "sleep"}]
                  (mt/cols results))))))))
+
+(deftest id-field-parameter-test
+  (mt/test-driver :postgres
+    (testing "We should be able to filter a PK column with a String value -- should get parsed automatically (#13263)"
+      (is (= [[2 "Stout Burgers & Beers" 11 34.0996 -118.329 2]]
+             (mt/rows
+               (mt/run-mbql-query venues
+                 {:filter [:= $id "2"]})))))))

--- a/test/metabase/query_processor/middleware/auto_parse_filter_values_test.clj
+++ b/test/metabase/query_processor/middleware/auto_parse_filter_values_test.clj
@@ -1,0 +1,28 @@
+(ns metabase.query-processor.middleware.auto-parse-filter-values-test
+  (:require [clojure.test :refer :all]
+            [metabase.query-processor.middleware.auto-parse-filter-values :as auto-parse-filter-values]
+            [metabase.test :as mt]))
+
+(deftest parse-value-for-base-type-test
+  (testing "Should throw an Exception with a useful error message if parsing fails"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Error filtering against :type/Integer Field: unable to parse String \"s\" to a :type/Integer"
+         (#'auto-parse-filter-values/parse-value-for-base-type "s" :type/Integer)))))
+
+(defn- auto-parse-filter-values [query]
+  (mt/test-qp-middleware auto-parse-filter-values/auto-parse-filter-values query))
+
+(deftest auto-parse-filter-values-test
+  (doseq [[base-type expected] {:type/Integer    4
+                                :type/BigInteger 4N
+                                :type/Float      4.0
+                                :type/Decimal    4M
+                                :type/Boolean    true}]
+    (testing (format "A String parameter that has %s should get parsed to a %s"
+                     base-type (.getCanonicalName (class expected)))
+      (is (= (mt/$ids venues
+               [:= $price [:value expected {:base_type base-type}]])
+             (-> (mt/mbql-query venues {:filter [:= $price [:value (str expected) {:base_type base-type}]]})
+                 auto-parse-filter-values
+                 :pre :query :filter))))))

--- a/test/metabase/query_processor/middleware/auto_parse_filter_values_test.clj
+++ b/test/metabase/query_processor/middleware/auto_parse_filter_values_test.clj
@@ -26,3 +26,15 @@
              (-> (mt/mbql-query venues {:filter [:= $price [:value (str expected) {:base_type base-type}]]})
                  auto-parse-filter-values
                  :pre :query :filter))))))
+
+(deftest parse-large-integers-test
+  (testing "Should parse Integer strings to Longs in case they're extra-big"
+    (let [n     (inc (long Integer/MAX_VALUE))
+          query (mt/mbql-query venues {:filter [:= $price [:value (str n) {:base_type :type/Integer}]]})]
+      (testing (format "\nQuery = %s" (pr-str query))
+        (is (= (mt/$ids venues
+                 [:= $price [:value n {:base_type :type/Integer}]])
+               (-> (auto-parse-filter-values query)
+                   :pre
+                   :query
+                   :filter)))))))


### PR DESCRIPTION
Fixes #13263

I added this middleware as part of #13354 to get the new endpoints working. This PR backports that middleware from `master` as well as the Postgres Cypress tests from #13311