### PR TITLE
Fix "typing" flake for `admin > settings.spec.cy`

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -50,6 +50,7 @@ describe("scenarios > admin > settings", () => {
         .find("input");
 
     emailInput()
+      .click()
       .clear()
       .type("other.email@metabase.com")
       .blur();
@@ -61,6 +62,7 @@ describe("scenarios > admin > settings", () => {
 
     // reset the email
     emailInput()
+      .click()
       .clear()
       .type("bob@metabase.com")
       .blur();


### PR DESCRIPTION
### Status
NEEDS REVIEW

### What does this PR accomplish?
- attempts a fix for the [recent flake](https://app.circleci.com/pipelines/github/metabase/metabase/9510/workflows/c03f78b4-390a-461f-a0aa-0b020bd9ff96/jobs/332959) that was caused by Cypress not being able to clear the input field before it started typing new value.

### Additional notes:
- it happened on the merge of https://github.com/metabase/metabase/commit/5d957a1a6971aba61468971a29e3d73ed1a98b73 into the master
- according to the Cypress dashboard, it happened last time 5 months before that