### PR TITLE
Handle mysql YEAR column types (Fixes #13203) [ci drivers]

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -372,9 +372,8 @@
   [driver ^ResultSet rs ^ResultSetMetaData rsmeta ^Integer i]
   (if (= "YEAR" (.getColumnTypeName rsmeta i))
     (fn read-time-thunk []
-      (let [x (.getObject rs i)]
-        (when x
-          (.toLocalDate ^java.sql.Date x))))
+      (when-let [x (.getObject rs i)]
+        (.toLocalDate ^java.sql.Date x)))
     (let [parent-thunk ((get-method sql-jdbc.execute/read-column-thunk [:sql-jdbc Types/DATE]) driver rs rsmeta i)]
       (parent-thunk))))
 

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -371,20 +371,20 @@
 (defmethod sql-jdbc.execute/read-column-thunk [:mysql Types/DATE]
   [driver ^ResultSet rs ^ResultSetMetaData rsmeta ^Integer i]
   (let [parent-thunk ((get-method sql-jdbc.execute/read-column-thunk [:sql-jdbc Types/DATE]) driver rs rsmeta i)]
-    (fn read-time-thunk []
-      ;; YEAR type is stored as smallint and exposed in the driver as either java.sql.Date or a short, depending on
-      ;; the mysql configuration option `yearIsDateType`. The parent thunk will try (.getObject rs i
-      ;; java.time.LocalDate) but this errors with "Cannot read LocalDate using a Types.SMALLINT
-      ;; field". https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-type-conversions.html. (NOTE: the
-      ;; documentation mentions the return type is java.sql.Short but I believe this is a typo for java.lang.Short:
-      ;; https://bugs.mysql.com/bug.php?id=35115)
-      (if (= "YEAR" (.getColumnTypeName rsmeta i))
+    (if (= "YEAR" (.getColumnTypeName rsmeta i))
+      (fn read-time-thunk []
+        ;; YEAR type is stored as smallint and exposed in the driver as either java.sql.Date or a short, depending on
+        ;; the mysql configuration option `yearIsDateType`. The parent thunk will try (.getObject rs i
+        ;; java.time.LocalDate) but this errors with "Cannot read LocalDate using a Types.SMALLINT
+        ;; field". https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-type-conversions.html. (NOTE: the
+        ;; documentation mentions the return type is java.sql.Short but I believe this is a typo for java.lang.Short:
+        ;; https://bugs.mysql.com/bug.php?id=35115)
         (let [x (.getObject rs i)]
           (condp instance? x
             java.sql.Date (.toLocalDate ^java.sql.Date x)
             java.lang.Short (long x)
-            :else x))
-        (parent-thunk)))))
+            :else x)))
+      (parent-thunk))))
 
 (defn- format-offset [t]
   (let [offset (t/format "ZZZZZ" (t/zone-offset t))]

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -369,7 +369,7 @@
           (.getString rs i))))))
 
 (defmethod sql-jdbc.execute/read-column-thunk [:mysql Types/DATE]
-  [driver ^ResultSet rs rsmeta ^Integer i]
+  [driver ^ResultSet rs ^ResultSetMetaData rsmeta ^Integer i]
   (let [parent-thunk ((get-method sql-jdbc.execute/read-column-thunk [:sql-jdbc Types/DATE]) driver rs rsmeta i)]
     (fn read-time-thunk []
       ;; YEAR type is stored as smallint and exposed in the driver as either java.sql.Date or a short, depending on
@@ -381,7 +381,7 @@
       (if (= "YEAR" (.getColumnTypeName rsmeta i))
         (let [x (.getObject rs i)]
           (condp instance? x
-            java.sql.Date (.toLocalDate x)
+            java.sql.Date (.toLocalDate ^java.sql.Date x)
             java.lang.Short (long x)
             :else x))
         (parent-thunk)))))

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -380,10 +380,10 @@
         ;; documentation mentions the return type is java.sql.Short but I believe this is a typo for java.lang.Short:
         ;; https://bugs.mysql.com/bug.php?id=35115)
         (let [x (.getObject rs i)]
-          (condp instance? x
-            java.sql.Date (.toLocalDate ^java.sql.Date x)
-            java.lang.Short (long x)
-            :else x)))
+          (when x
+            (condp instance? x
+              java.sql.Date (.toLocalDate ^java.sql.Date x)
+              java.lang.Short (long x)))))
       (parent-thunk))))
 
 (defn- format-offset [t]

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -93,16 +93,16 @@
   (mt/test-driver :mysql
     (mt/dataset year-db
       (testing "By default YEAR"
-        (is (= #{{:name "year_column", :base_type :type/Integer, :special_type :type/Category}
+        (is (= #{{:name "year_column", :base_type :type/Date, :special_type :type/Category}
                  {:name "id", :base_type :type/Integer, :special_type :type/PK}}
                (db->fields (mt/db)))))
       (let [table  (db/select-one Table :db_id (u/id (mt/db)))
-            fields (db/select Field :table_id (u/id table))]
+            fields (db/select Field :table_id (u/id table) :name "year_column")]
         (testing "Can select from this table"
-          (is (= [[#t "2001-01-01" 1] [#t "2002-01-01" 2] [#t "1999-01-01" 3]]
+          (is (= [[#t "2001-01-01"] [#t "2002-01-01"] [#t "1999-01-01"]]
                  (metadata-queries/table-rows-sample table fields))))
         (testing "We can fingerprint this table"
-          (is (= 2
+          (is (= 1
                  (:updated-fingerprints (#'fingerprint/fingerprint-table! table fields)))))))))
 
 (deftest db-timezone-id-test


### PR DESCRIPTION
- year columns are very small in the db. The tricky part is how the
driver hands them back: either as shorts or as java.sql.Dates. Our
standard trick of reading them right into the java.time.LocalDate
doesn't work and we instead get the java.sql.Date (which the driver
converts from the short internal representation) or the short if
`yearIsDateType` is configured to false.

It seems to be an open question if Metabase should always consume this
as a Date. That seems most likely but I have no idea how often this
comes up in practice.

Fixes https://github.com/metabase/metabase/issues/13203
