### PR TITLE
Add repro for #4506

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -9,6 +9,35 @@ describe("scenarios > admin > settings", () => {
   before(restore);
   beforeEach(signInAsAdmin);
 
+  it("should surface an error when validation for any field fails (metabase#4506)", () => {
+    const BASE_URL = Cypress.config().baseUrl;
+    const DOMAIN_AND_PORT = BASE_URL.replace("http://", "");
+    const ERR_MESSAGE = `Invalid site URL: "${BASE_URL}!"`;
+
+    cy.server();
+    cy.route("PUT", "/api/setting/site-url").as("url");
+
+    cy.visit("/admin/settings/general");
+
+    // Needed to strip down protocol from the url to accomodate our UI (<select> PORT | <input> DOMAIN_AND_PORT)
+    cy.findByDisplayValue(DOMAIN_AND_PORT) // findByDisplayValue comes from @testing-library/cypress
+      .click()
+      .type("!")
+      .blur();
+
+    cy.wait("@url")
+      .wait("@url") // cy.wait("@url.2") doesn't work for some reason
+      .should(xhr => {
+        expect(xhr.status).to.eq(500);
+        expect(xhr.response.body.cause).to.eq(ERR_MESSAGE);
+      });
+
+    // NOTE: This test is not concerned with HOW we style the error message - only that there is one.
+    //       If we update UI in the future (for example: we show an error within a popup/modal), the test in current form could fail.
+    cy.log("**Making sure we display an error message in UI**");
+    cy.get(".SaveStatus").contains(`Error: ${ERR_MESSAGE}`);
+  });
+
   it("should render the proper auth options", () => {
     // Ported from `SettingsAuthenticationOptions.e2e.spec.js`
     // Google sign in


### PR DESCRIPTION
### Status
PENDING CI

### What does this PR accomplish?
- reproduces #4506 (more specifically @robdaemon 's [example](https://github.com/metabase/metabase/issues/4506#issuecomment-681137803))
- tests that we display an error in UI (not concerned about the style)

### How should this be manually tested?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js`
- either isolate this test with `it.only()` or let all tests run
- in both cases, test(s) should pass

### Additional notes
- like I wrote in the code comment, should we update UI at some point in future, it could break the test
- when and if that happens, we will know to update the test to suit the new UI
- skipped CI until all reviews pass