### PR TITLE
MBQL: handle nils in SQL filters more intuitively

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -615,6 +615,6 @@
 
 (defmulti db-start-of-week
   "Return start of week for given database"
-  {:added "0.37.0" :arlists '([driver database])}
+  {:added "0.37.0" :arlists '([driver])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -615,6 +615,6 @@
 
 (defmulti db-start-of-week
   "Return start of week for given database"
-  {:added "0.37.0" :arlists '([driver])}
+  {:added "0.37.0" :arglists '([driver])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -19,7 +19,9 @@
             [metabase.query-processor
              [interface :as i]
              [store :as qp.store]]
-            [metabase.query-processor.middleware.annotate :as annotate]
+            [metabase.query-processor.middleware
+             [annotate :as annotate]
+             [wrap-value-literals :as value-literal]]
             [metabase.util
              [honeysql-extensions :as hx]
              [i18n :refer [deferred-tru]]
@@ -646,8 +648,8 @@
 
 (defmethod ->honeysql [:sql :!=]
   [driver [_ field value]]
-  (if (nil? value)
-    [:not= (->honeysql driver field) nil]
+  (if (nil? (value-literal/unwrap-value-literal value))
+    [:not= (->honeysql driver field) (->honeysql driver value)]
     (correct-null-behaviour driver [:not= field value])))
 
 (defmethod ->honeysql [:sql :and]

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -29,7 +29,8 @@
             [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]]
             [schema.core :as s])
-  (:import metabase.util.honeysql_extensions.Identifier))
+  (:import metabase.util.honeysql_extensions.Identifier
+           metabase.models.field.FieldInstance))
 
 ;; TODO - yet another `*query*` dynamic var. We should really consolidate them all so we only need a single one.
 (def ^:dynamic *query*
@@ -639,8 +640,8 @@
 (defn- correct-null-behaviour
   [driver [op & args]]
   (let [field-arg (mbql.u/match-one args
-                    :field-id      &match
-                    :field-literal &match)]
+                    FieldInstance               &match
+                    #{:field-id :field-literal} &match)]
     ;; We must not transform the head again else we'll have an infinite loop
     ;; (and we can't do it at the call-site as then it will be harder to fish out field references)
     [:or (into [op] (map (partial ->honeysql driver)) args)

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -29,8 +29,8 @@
             [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]]
             [schema.core :as s])
-  (:import metabase.util.honeysql_extensions.Identifier
-           metabase.models.field.FieldInstance))
+  (:import metabase.models.field.FieldInstance
+           metabase.util.honeysql_extensions.Identifier))
 
 ;; TODO - yet another `*query*` dynamic var. We should really consolidate them all so we only need a single one.
 (def ^:dynamic *query*

--- a/src/metabase/query_processor/middleware/wrap_value_literals.clj
+++ b/src/metabase/query_processor/middleware/wrap_value_literals.clj
@@ -119,6 +119,13 @@
     (let [s (add-type-info s (type-info field), :parse-datetime-strings? false)]
       (into [clause field s] more))))
 
+(defn unwrap-value-literal
+  "Extract value literal from `:value` form or returns form as is if not a `:value` form."
+  [maybe-value-form]
+  (mbql.u/match-one maybe-value-form
+    [:value x & _] x
+    _              &match))
+
 (defn ^:private wrap-value-literals-in-mbql-query
   [{:keys [source-query], :as inner-query} options]
   (let [inner-query (cond-> inner-query

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -160,7 +160,7 @@
   (testing "params from source queries should get passed in to the top-level. Semicolons should be removed"
     (mt/with-everything-store
       (driver/with-driver :h2
-        (is (= {:query  "SELECT \"source\".* FROM (SELECT * FROM some_table WHERE name = ?) \"source\" WHERE \"source\".\"name\" <> ?"
+        (is (= {:query  "SELECT \"source\".* FROM (SELECT * FROM some_table WHERE name = ?) \"source\" WHERE (\"source\".\"name\" <> ? OR \"source\".\"name\" IS NULL)"
                 :params ["Cam" "Lucky Pigeon"]}
                (sql.qp/mbql->native :h2
                  (mt/mbql-query venues

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -324,7 +324,8 @@
                       [:source.LONGITUDE :LONGITUDE]
                       [:source.PRICE :PRICE]]
              :from   [[venues-source-honeysql :source]]
-             :where  [:not= :source.text "Coo"]
+             :where  [:or [:not= :source.text "Coo"]
+                      [:= :source.text nil]]
              :limit  10})
            (qp/query->native
             (mt/mbql-query nil


### PR DESCRIPTION
SQL has somewhat unintuitive semantics where NULLs get propagated to the top filter expressions. For example
`my_field NOT LIKE '%ar'` will not return rows where `my_field` is null. This is not intuitive and as a user almost never what I want. This PR changes our MBQL compiler for SQL dialects to emit an additional `OR my_field IS NULL` in such cases.

Since this is SQL-only behaviour it's implemented in the query processor for SQL only. 

I opted for an end-to-end test as I think we should be testing the result, rather than the query generated which is just an implementation detail.

Fixes #13332

p.s. it would be nice to have a test dataset with nils in it.