### PR TITLE
Tooltip constrained width

### DIFF
--- a/frontend/src/metabase/components/Popover.css
+++ b/frontend/src/metabase/components/Popover.css
@@ -37,6 +37,10 @@
   background-color: var(--color-bg-black);
   border: none;
   pointer-events: none;
+  max-width: 120px;
+  font-size: 12px;
+  line-height: 1.26;
+  padding: 10px 12px;
 }
 
 /* shared arrow styles */

--- a/frontend/src/metabase/components/Popover.css
+++ b/frontend/src/metabase/components/Popover.css
@@ -37,7 +37,6 @@
   background-color: var(--color-bg-black);
   border: none;
   pointer-events: none;
-  max-width: 120px;
   font-size: 12px;
   line-height: 1.26;
   padding: 10px 12px;

--- a/frontend/src/metabase/components/Popover.css
+++ b/frontend/src/metabase/components/Popover.css
@@ -37,12 +37,12 @@
   background-color: var(--color-bg-black);
   border: none;
   pointer-events: none;
-  font-size: 12px;
   line-height: 1.26;
   padding: 10px 12px;
 }
 
-.PopoverBody.PopoverBody--tooltip.PopoverBody--tooltipConstrained {
+.PopoverBody.PopoverBody--tooltip.PopoverBody--tooltipConstrainedWidth {
+  font-size: 12px;
   max-width: 200px;
 }
 

--- a/frontend/src/metabase/components/Popover.css
+++ b/frontend/src/metabase/components/Popover.css
@@ -42,6 +42,10 @@
   padding: 10px 12px;
 }
 
+.PopoverBody.PopoverBody--tooltip.PopoverBody--tooltipConstrained {
+  max-width: 200px;
+}
+
 /* shared arrow styles */
 .PopoverBody--withArrow:before,
 .PopoverBody--withArrow:after {

--- a/frontend/src/metabase/components/Tooltip.info.js
+++ b/frontend/src/metabase/components/Tooltip.info.js
@@ -1,0 +1,24 @@
+import React from "react";
+import Tooltip from "./Tooltip";
+
+export const component = Tooltip;
+
+export const description = `
+Add context to a target element.
+`;
+
+export const examples = {
+  default: (
+    <Tooltip tooltip="Action">
+      <a className="link">Hover on me</a>
+    </Tooltip>
+  ),
+  longerString: (
+    <Tooltip tooltip="This does an action that needs some explaining">
+      <a className="link">Hover on me</a>
+    </Tooltip>
+  ),
+};
+
+// disable snapshot testing due to issue with Popover
+export const noSnapshotTest = true;

--- a/frontend/src/metabase/components/TooltipPopover.jsx
+++ b/frontend/src/metabase/components/TooltipPopover.jsx
@@ -4,7 +4,7 @@ import cx from "classnames";
 
 import Popover from "./Popover";
 
-const TooltipPopover = ({ children, constrained, ...props }) => {
+const TooltipPopover = ({ children, constrainedWidth, ...props }) => {
   let popoverContent;
 
   if (typeof children === "string") {
@@ -16,7 +16,7 @@ const TooltipPopover = ({ children, constrained, ...props }) => {
   return (
     <Popover
       className={cx("PopoverBody--tooltip", {
-        "PopoverBody--tooltipConstrained": constrained,
+        "PopoverBody--tooltipConstrained": constrainedWidth,
       })}
       targetOffsetY={10}
       hasArrow
@@ -33,7 +33,7 @@ const TooltipPopover = ({ children, constrained, ...props }) => {
 
 TooltipPopover.defaultProps = {
   // default to having a constrained toolip, which limits the width so longer strings wrap.
-  constrained: true,
+  constrainedWidth: true,
 };
 
 export default pure(TooltipPopover);

--- a/frontend/src/metabase/components/TooltipPopover.jsx
+++ b/frontend/src/metabase/components/TooltipPopover.jsx
@@ -16,7 +16,7 @@ const TooltipPopover = ({ children, constrainedWidth, ...props }) => {
   return (
     <Popover
       className={cx("PopoverBody--tooltip", {
-        "PopoverBody--tooltipConstrained": constrainedWidth,
+        "PopoverBody--tooltipConstrainedWidth": constrainedWidth,
       })}
       targetOffsetY={10}
       hasArrow

--- a/frontend/src/metabase/components/TooltipPopover.jsx
+++ b/frontend/src/metabase/components/TooltipPopover.jsx
@@ -1,9 +1,10 @@
 import React from "react";
 import pure from "recompose/pure";
+import cx from "classnames";
 
 import Popover from "./Popover";
 
-const TooltipPopover = ({ children, maxWidth, ...props }) => {
+const TooltipPopover = ({ children, constrained, ...props }) => {
   let popoverContent;
 
   if (typeof children === "string") {
@@ -14,7 +15,9 @@ const TooltipPopover = ({ children, maxWidth, ...props }) => {
 
   return (
     <Popover
-      className="PopoverBody--tooltip"
+      className={cx("PopoverBody--tooltip", {
+        "PopoverBody--tooltipConstrained": constrained,
+      })}
       targetOffsetY={10}
       hasArrow
       horizontalAttachments={["center", "left", "right"]}
@@ -26,6 +29,11 @@ const TooltipPopover = ({ children, maxWidth, ...props }) => {
       {popoverContent}
     </Popover>
   );
+};
+
+TooltipPopover.defaultProps = {
+  // default to having a constrained toolip, which limits the width so longer strings wrap.
+  constrained: true,
 };
 
 export default pure(TooltipPopover);

--- a/frontend/src/metabase/components/TooltipPopover.jsx
+++ b/frontend/src/metabase/components/TooltipPopover.jsx
@@ -1,32 +1,13 @@
 import React from "react";
-import cx from "classnames";
 import pure from "recompose/pure";
 
 import Popover from "./Popover";
-
-// if the tooltip is passed a long description we'll want to conditionally
-// format it to make it easier to read.
-// we use the number of words as an approximation
-const CONDITIONAL_WORD_COUNT = 10;
-
-const wordCount = string => string.split(" ").length;
 
 const TooltipPopover = ({ children, maxWidth, ...props }) => {
   let popoverContent;
 
   if (typeof children === "string") {
-    const needsSpace = wordCount(children) > CONDITIONAL_WORD_COUNT;
-    popoverContent = (
-      <div
-        className={cx({ "py1 px2": !needsSpace }, { "py2 px3": needsSpace })}
-        style={{
-          maxWidth: maxWidth || "12em",
-          lineHeight: needsSpace ? 1.54 : 1,
-        }}
-      >
-        {children}
-      </div>
-    );
+    popoverContent = <span>{children}</span>;
   } else {
     popoverContent = children;
   }

--- a/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
@@ -53,7 +53,7 @@ export default class ChartTooltip extends Component {
         verticalAttachments={["bottom", "top"]}
         isOpen={isOpen}
         // Make sure that for chart tooltips we don't constrain the width so longer strings don't get cut off
-        constrained={false}
+        constrainedWidth={false}
       >
         <table className="py1 px2">
           <tbody>

--- a/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
@@ -52,6 +52,8 @@ export default class ChartTooltip extends Component {
         targetEvent={hovered && hovered.event}
         verticalAttachments={["bottom", "top"]}
         isOpen={isOpen}
+        // Make sure that for chart tooltips we don't constrain the width so longer strings don't get cut off
+        constrained={false}
       >
         <table className="py1 px2">
           <tbody>


### PR DESCRIPTION
Allows for more constrained width on UI tooltips for better legibility but removes the constraint when dealing with chart tooltips.

Closes https://github.com/metabase/metabase-enterprise/issues/592