### PR TITLE
Remove any stray parameters from url when component unmounts

### DIFF
--- a/frontend/src/metabase/parameters/components/Parameters.jsx
+++ b/frontend/src/metabase/parameters/components/Parameters.jsx
@@ -97,6 +97,7 @@ export default class Parameters extends Component {
   }
 
   componentDidUpdate() {
+    // TODO move this to redux
     if (this.props.syncQueryString) {
       // sync parameters to URL query string
       const queryParams = {};
@@ -116,6 +117,17 @@ export default class Parameters extends Component {
           window.location.pathname + search + window.location.hash,
         );
       }
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.props.syncQueryString) {
+      // replaceState again to remove any params
+      history.replaceState(
+        null,
+        document.title,
+        window.location.pathname + window.location.hash,
+      );
     }
   }
 

--- a/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
@@ -65,7 +65,7 @@ describe("scenarios > dashboard > parameters", () => {
       .contains("4,939");
   });
 
-  it.skip("should remove previously deleted dashboard parameter from URL (metabase#10829)", () => {
+  it("should remove previously deleted dashboard parameter from URL (metabase#10829)", () => {
     // Mirrored issue in metabase-enterprise#275
 
     // Go directly to "Orders in a dashboard" dashboard


### PR DESCRIPTION
Fixes #10829 (kinda)

The main issue in #10829 was fixed in #10323. The repro test hit on a slightly different issue where the parameter was removed rather than its name. This PR fixes that issue.

The second suggestion in #10829 was to fix any parameters that may already be affected in addition to prevent new ghost parameters. Since it was fixed over a year ago, I didn't think it was worth doing this.

This PR is against master because that's where the repro is. It's not severe so I don't think we need to put it on 36 too. 