### PR TITLE
Fix crash using field filter without perms

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -151,17 +151,20 @@ export class FieldValuesWidget extends Component {
       options: [],
     });
 
-    const { dashboard, parameter, parameters } = this.props;
-    const options = await fetchParameterPossibleValues(
-      dashboard && dashboard.id,
-      parameter,
-      parameters,
-    );
-
-    this.setState({
-      loadingState: "LOADED",
-      options,
-    });
+    let options;
+    try {
+      const { dashboard, parameter, parameters } = this.props;
+      options = await fetchParameterPossibleValues(
+        dashboard && dashboard.id,
+        parameter,
+        parameters,
+      );
+    } finally {
+      this.setState({
+        loadingState: "LOADED",
+        options,
+      });
+    }
   };
 
   componentWillUnmount() {
@@ -303,7 +306,12 @@ export class FieldValuesWidget extends Component {
       cancelDeferred.resolve();
     };
 
-    const results = await this.search(value, cancelDeferred.promise);
+    let results;
+    try {
+      results = await this.search(value, cancelDeferred.promise);
+    } catch (e) {
+      console.warn(e);
+    }
 
     this._cancel = null;
 

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -90,7 +90,9 @@ export default class ParameterValueWidget extends Component {
     if (!metadata) {
       return [];
     }
-    return this.fieldIds(this.props).map(id => metadata.field(id));
+    return this.fieldIds(this.props)
+      .map(id => metadata.field(id))
+      .filter(f => f != null);
   }
 
   getWidget() {

--- a/frontend/test/metabase/scenarios/question/view.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/view.cy.spec.js
@@ -188,7 +188,7 @@ describe("scenarios > question > view", () => {
         .click();
 
       cy.findAllByText("Widget");
-      cy.findByText("Gizmo").should("not.exist");
+      cy.findAllByText("Gizmo").should("not.exist");
     });
 
     it("should be able to filter Q by Vendor as user (from Dashboard) (metabase#12654)", () => {

--- a/frontend/test/metabase/scenarios/question/view.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/view.cy.spec.js
@@ -106,7 +106,7 @@ describe("scenarios > question > view", () => {
       openOrdersTable();
       cy.contains("Filter").click();
       cy.contains("Vendor").click();
-      cy.get("input[placeholder='Search by Vendor']")
+      cy.findByPlaceholderText("Search by Vendor")
         .clear()
         .type("Alfreda Konopelski II Group")
         .blur();
@@ -115,7 +115,7 @@ describe("scenarios > question > view", () => {
     });
   });
 
-  describe("apply filters without data permissions", () => {
+  describe.only("apply filters without data permissions", () => {
     before(() => {
       // All users upgraded to collection view access
       signInAsAdmin();
@@ -195,27 +195,56 @@ describe("scenarios > question > view", () => {
       });
     });
 
-    it.skip("should be able to filter Q by Category as no data user (from Q link) (metabase#12654)", () => {
+    it("should be able to filter Q by Category as no data user (from Q link) (metabase#12654)", () => {
       signIn("nodata");
       cy.visit("/question/4");
 
       // Filter by category and vendor
-      filterByCategory();
-      filterByVendor();
+      // TODO: this should show values and allow searching
+      cy.findByPlaceholderText("VENDOR")
+        .click()
+        .clear()
+        .type("Balistreri-Muller");
+      cy.findByPlaceholderText("CATEGORY")
+        .click()
+        .clear()
+        .type("Widget");
+      cy.get(".RunButton")
+        .last()
+        .click();
 
       cy.findAllByText("Widget");
       cy.findByText("Gizmo").should("not.exist");
     });
 
-    it.skip("should be able to filter Q by Vendor as user (from Dashboard) (metabase#12654)", () => {
+    it("should be able to filter Q by Vendor as user (from Dashboard) (metabase#12654)", () => {
       // Navigate to Q from Dashboard
       signIn("nodata");
       cy.visit("/dashboard/2");
       cy.findByText("Question").click();
 
       // Filter by category and vendor
-      filterByCategory();
-      filterByVendor();
+      // TODO: this should show values and allow searching
+      cy.findAllByText("VENDOR")
+        .first()
+        .click();
+      popover().within(() => {
+        cy.findByPlaceholderText("Search by Vendor").type("Balistreri-Muller");
+        cy.findByText("Add filter").click();
+      });
+      cy.get(".RunButton")
+        .first()
+        .click();
+      cy.findAllByText("CATEGORY")
+        .first()
+        .click();
+      popover().within(() => {
+        cy.findByText("Widget").click();
+        cy.findByText("Add filter").click();
+      });
+      cy.get(".RunButton")
+        .last()
+        .click();
 
       cy.get(".TableInteractive-cellWrapper--firstColumn").should(
         "have.length",

--- a/frontend/test/metabase/scenarios/question/view.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/view.cy.spec.js
@@ -175,6 +175,7 @@ describe("scenarios > question > view", () => {
 
       // Filter by category and vendor
       // TODO: this should show values and allow searching
+      cy.findByText("This question is written in SQL.");
       cy.findByPlaceholderText("VENDOR")
         .click()
         .clear()
@@ -199,6 +200,7 @@ describe("scenarios > question > view", () => {
 
       // Filter by category and vendor
       // TODO: this should show values and allow searching
+      cy.findByText("This question is written in SQL.");
       cy.findAllByText("VENDOR")
         .first()
         .click();

--- a/frontend/test/metabase/scenarios/question/view.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/view.cy.spec.js
@@ -7,32 +7,6 @@ import {
   withSampleDataset,
 } from "__support__/cypress";
 
-function filterByVendor() {
-  cy.findAllByText("VENDOR")
-    .first()
-    .click();
-  popover().within(() => {
-    cy.findByPlaceholderText("Search by Vendor").type("b");
-    cy.findByText("Balistreri-Muller").click();
-    cy.findByText("Add filter").click();
-  });
-  cy.get(".RunButton")
-    .first()
-    .click();
-}
-function filterByCategory() {
-  cy.findAllByText("CATEGORY")
-    .first()
-    .click();
-  popover().within(() => {
-    cy.findByText("Widget").click();
-    cy.findByText("Add filter").click();
-  });
-  cy.get(".RunButton")
-    .last()
-    .click();
-}
-
 describe("scenarios > question > view", () => {
   before(restore);
   beforeEach(signInAsAdmin);


### PR DESCRIPTION
The core issue is that we don't have a way to list/search field values for questions without data perms. We could add field metadata endpoints like we have for public cards, but I didn't do that here. Instead, I think the right answer is to switch this over to chained filter endpoints. I created a new issue (#13480) to track that.

In this PR, I fixed the crash and forever spinner when using the dropdown/search. This doesn't totally fix the UI since you can't search or select a populated value, but it lets you manually type in values. I'll leave #12654 open but downgrade the priority since questions aren't totally broken. It should be fixed by #13480.

