### PR TITLE
Backport OSS namespaced collection code from EE

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -47,7 +47,7 @@
       ;; include Root Collection at beginning or results if archived isn't `true`
       (if archived?
         collections
-        (cons (root-collection) collections))
+        (cons (root-collection namespace) collections))
       (hydrate collections :can_write)
       ;; remove the :metabase.models.collection.root/is-root? tag since FE doesn't need it
       (for [collection collections]
@@ -73,7 +73,8 @@
 
   *  `collection` will be either a CollectionInstance, or the Root Collection special placeholder object, so do not use
      `u/get-id` on it! Use `:id`, which will return `nil` for the Root Collection, which is exactly what we want."
-  (fn [model collection options] model))
+  {:arglists '([model collection options])}
+  (fn [model _ _] (keyword model)))
 
 (defmethod fetch-collection-children :card
   [_ collection {:keys [archived?]}]
@@ -163,13 +164,14 @@
 
 ;;; -------------------------------------------- GET /api/collection/root --------------------------------------------
 
-(defn- root-collection []
-  (collection-detail (collection/root-collection-with-ui-details)))
+(defn- root-collection [collection-namespace]
+  (collection-detail (collection/root-collection-with-ui-details collection-namespace)))
 
 (api/defendpoint GET "/root"
   "Return the 'Root' Collection object with standard details added"
-  []
-  (dissoc (root-collection) ::collection.root/is-root?))
+  [namespace]
+  {namespace (s/maybe su/NonBlankString)}
+  (dissoc (root-collection namespace) ::collection.root/is-root?))
 
 (api/defendpoint GET "/root/items"
   "Fetch objects that the current user should see at their root level. As mentioned elsewhere, the 'Root' Collection
@@ -191,12 +193,13 @@
    namespace (s/maybe su/NonBlankString)}
   ;; Return collection contents, including Collections that have an effective location of being in the Root
   ;; Collection for the Current User.
-  (collection-children
-   (assoc collection/root-collection :namespace namespace)
-   {:model     (if (mi/can-read? collection/root-collection)
-                 (keyword model)
-                 :collection)
-    :archived? (Boolean/parseBoolean archived)}))
+  (let [root-collection (assoc collection/root-collection :namespace namespace)]
+    (collection-children
+     root-collection
+     {:model     (if (mi/can-read? root-collection)
+                   (keyword model)
+                   :collection)
+      :archived? (Boolean/parseBoolean archived)})))
 
 
 ;;; ----------------------------------------- Creating/Editing a Collection ------------------------------------------
@@ -276,7 +279,6 @@
                                                                     :collection_id (u/get-id collection-before-update))))]
         (card-api/delete-alert-and-notify-archived! alerts))))
 
-
 (api/defendpoint PUT "/:id"
   "Modify an existing Collection, including archiving or unarchiving it, or moving it."
   [id, :as {{:keys [name color description archived parent_id], :as collection-updates} :body}]
@@ -299,7 +301,8 @@
     ;; if we *did* end up archiving this Collection, we most post a few notifications
     (maybe-send-archived-notificaitons! collection-before-update collection-updates))
   ;; finally, return the updated object
-  (Collection id))
+  (-> (Collection id)
+      (hydrate :parent_id)))
 
 
 ;;; ------------------------------------------------ GRAPH ENDPOINTS -------------------------------------------------
@@ -332,12 +335,13 @@
 
 (api/defendpoint PUT "/graph"
   "Do a batch update of Collections Permissions by passing in a modified graph."
-  [namespace :as {body :body}]
+  [:as {{:keys [namespace], :as body} :body}]
   {body      su/Map
    namespace (s/maybe su/NonBlankString)}
   (api/check-superuser)
-  (collection.graph/update-graph! namespace (dejsonify-graph body))
+  (->> (dissoc body :namespace)
+       dejsonify-graph
+       (collection.graph/update-graph! namespace))
   (collection.graph/graph namespace))
-
 
 (api/define-routes)

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -352,8 +352,10 @@
    (check-404 obj)
    (check-403 (mi/can-read? obj))
    obj)
+
   ([entity id]
    (read-check (entity id)))
+
   ([entity id & other-conditions]
    (read-check (apply db/select-one entity :id id other-conditions))))
 
@@ -376,10 +378,20 @@
 
   This function was added *years* after `read-check` and `write-check`, and at the time of this writing most models do
   not implement this method. Most `POST` API endpoints instead have the `can-create?` logic for a given model
-  hardcoded into this -- this should be considered an antipattern and be refactored out going forward."
+  hardcoded into them -- this should be considered an antipattern and be refactored out going forward."
   {:added "0.32.0", :style/indent 2}
   [entity m]
   (check-403 (mi/can-create? entity m)))
+
+(defn update-check
+  "NEW! Check whether the current user has permissions to UPDATE an object by applying a map of `changes`.
+
+  This function was added *years* after `read-check` and `write-check`, and at the time of this writing most models do
+  not implement this method. Most `PUT` API endpoints instead have the `can-update?` logic for a given model hardcoded
+  into them -- this should be considered an antipattern and be refactored out going forward."
+  {:added "0.36.0", :style/indent 2}
+  [instance changes]
+  (check-403 (mi/can-update? instance changes)))
 
 ;;; ------------------------------------------------ OTHER HELPER FNS ------------------------------------------------
 
@@ -387,7 +399,7 @@
   "Check that the `public-sharing-enabled` Setting is `true`, or throw a `400`."
   []
   (check (public-settings/enable-public-sharing)
-         [400 (tru "Public sharing is not enabled.")]))
+    [400 (tru "Public sharing is not enabled.")]))
 
 (defn check-embedding-enabled
   "Is embedding of Cards or Objects (secured access via `/api/embed` endpoints with a signed JWT enabled?"

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -173,9 +173,11 @@
 
 (defn root-collection-with-ui-details
   "The special Root Collection placeholder object with some extra details to facilitate displaying it on the FE."
-  []
+  [collection-namespace]
   (assoc root-collection
-         :name (tru "Our analytics")
+         :name (case (keyword collection-namespace)
+                 :snippets (tru "Top folder")
+                 (tru "Our analytics"))
          :id   "root"))
 
 (def ^:private CollectionWithLocationOrRoot
@@ -336,7 +338,7 @@
   [collection :- CollectionWithLocationAndIDOrRoot]
   (if (collection.root/is-root-collection? collection)
     []
-    (filter i/can-read? (cons (root-collection-with-ui-details) (ancestors collection)))))
+    (filter i/can-read? (cons (root-collection-with-ui-details (:namespace collection)) (ancestors collection)))))
 
 (s/defn parent-id :- (s/maybe su/IntGreaterThanZero)
   "Get the immediate parent `collection` id, if set."
@@ -631,10 +633,11 @@
   application database.
 
   For newly created Collections at the root-level, copy the existing permissions for the Root Collection."
-  [{:keys [location id], :as collection}]
+  [{:keys [location id], collection-namespace :namespace, :as collection}]
   (when-not (is-personal-collection-or-descendant-of-one? collection)
     (let [parent-collection-id (location-path->parent-id location)]
-      (copy-collection-permissions! (or parent-collection-id root-collection) [id]))))
+      (copy-collection-permissions! (or parent-collection-id (assoc root-collection :namespace collection-namespace))
+                                    [id]))))
 
 (defn- post-insert [collection]
   (u/prog1 collection
@@ -809,12 +812,18 @@
 (defn perms-objects-set
   "Return the required set of permissions to `read-or-write` `collection-or-id`."
   [collection-or-id read-or-write]
-  ;; This is not entirely accurate as you need to be a superuser to modifiy a collection itself (e.g., changing its
-  ;; name) but if you have write perms you can add/remove cards
-  #{(case read-or-write
-      :read  (perms/collection-read-path collection-or-id)
-      :write (perms/collection-readwrite-path collection-or-id))})
-
+  (let [collection (if (integer? collection-or-id)
+                     (db/select-one [Collection :id :namespace] :id (collection-or-id))
+                     collection-or-id)]
+    ;; HACK Collections in the "snippets" namespace have no-op permissions unless EE enhancements are enabled
+    ;; This code differs slightly in EE. We need to reconcile this when we do repo unification.
+    (if (= (u/qualified-name (:namespace collection)) "snippets")
+      #{}
+      ;; This is not entirely accurate as you need to be a superuser to modifiy a collection itself (e.g., changing its
+      ;; name) but if you have write perms you can add/remove cards
+      #{(case read-or-write
+          :read  (perms/collection-read-path collection-or-id)
+          :write (perms/collection-readwrite-path collection-or-id))})))
 
 (u/strict-extend (class Collection)
   models/IModel
@@ -947,8 +956,8 @@
                                                 (user->personal-collection-id (u/get-id user))))))))
 
 (defmulti allowed-namespaces
-  "Set of Collection namespaces instances of this model are allowed to go in. By default, only the default
-  namespace (namespace = `nil`)."
+  "Set of Collection namespaces (as keywords) that instances of this model are allowed to go in. By default, only the
+  default namespace (namespace = `nil`)."
   {:arglists '([model])}
   class)
 

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -2,8 +2,11 @@
   (:require [cheshire.core :as json]
             [clojure.core.memoize :as memoize]
             [clojure.tools.logging :as log]
+            [honeysql.core :as hsql]
+            [metabase
+             [db :as mdb]
+             [util :as u]]
             [metabase.mbql.normalize :as normalize]
-            [metabase.util :as u]
             [metabase.util
              [cron :as cron-util]
              [encryption :as encryption]
@@ -154,11 +157,19 @@
 
 ;;; properties
 
+;; use now() for Postgres and H2. now() for MySQL/MariaDB only returns second resolution. So use now(6) which uses the
+;; max (nanosecond) resolution.
+(def ^:private now
+  (delay
+    (case (mdb/db-type)
+      :mysql (hsql/call :now 6)
+      :%now)))
+
 (defn- add-created-at-timestamp [obj & _]
-  (assoc obj :created_at :%now))
+  (assoc obj :created_at @now))
 
 (defn- add-updated-at-timestamp [obj & _]
-  (assoc obj :updated_at :%now))
+  (assoc obj :updated_at @now))
 
 (models/add-property! :timestamped?
   :insert (comp add-created-at-timestamp add-updated-at-timestamp)
@@ -177,37 +188,46 @@
 (p.types/defprotocol+ IObjectPermissions
   "Methods for determining whether the current user has read/write permissions for a given object."
 
-  (perms-objects-set [this, ^clojure.lang.Keyword read-or-write]
+  (perms-objects-set [this ^clojure.lang.Keyword read-or-write]
     "Return a set of permissions object paths that a user must have access to in order to access this object. This
     should be something like #{\"/db/1/schema/public/table/20/\"}. READ-OR-WRITE will be either `:read` or `:write`,
     depending on which permissions set we're fetching (these will be the same sets for most models; they can ignore
     this param).")
 
-  (can-read? ^Boolean [instance], ^Boolean [entity, ^Integer id]
+  (can-read? [instance] [entity ^Integer id]
     "Return whether `*current-user*` has *read* permissions for an object. You should use one of these implmentations:
 
-     *  `(constantly true)`
-     *  `superuser?`
-     *  `(partial current-user-has-full-permissions? :read)` (you must also implement `perms-objects-set` to use this)
-     *  `(partial current-user-has-partial-permissions? :read)` (you must also implement `perms-objects-set` to use
-        this)")
+  *  `(constantly true)`
+  *  `superuser?`
+  *  `(partial current-user-has-full-permissions? :read)` (you must also implement `perms-objects-set` to use this)
+  *  `(partial current-user-has-partial-permissions? :read)` (you must also implement `perms-objects-set` to use
+     this)")
 
-  (^{:hydrate :can_write} can-write? ^Boolean [instance], ^Boolean [entity, ^Integer id]
+  (^{:hydrate :can_write} can-write? [instance] [entity ^Integer id]
    "Return whether `*current-user*` has *write* permissions for an object. You should use one of these implmentations:
 
-     *  `(constantly true)`
-     *  `superuser?`
-     *  `(partial current-user-has-full-permissions? :write)` (you must also implement `perms-objects-set` to use this)
-     *  `(partial current-user-has-partial-permissions? :write)` (you must also implement `perms-objects-set` to use
-        this)")
+  *  `(constantly true)`
+  *  `superuser?`
+  *  `(partial current-user-has-full-permissions? :write)` (you must also implement `perms-objects-set` to use this)
+  *  `(partial current-user-has-partial-permissions? :write)` (you must also implement `perms-objects-set` to use
+      this)")
 
-  (^{:added "0.32.0"} can-create? ^Boolean [entity m]
+  (^{:added "0.32.0"} can-create? [entity m]
     "NEW! Check whether or not current user is allowed to CREATE a new instance of `entity` with properties in map
     `m`.
 
-    Because this method was added YEARS after `can-read?` and `can-write?`, most models do not have an implementation
-    for this method, and instead `POST` API endpoints themselves contain the appropriate permissions logic (ick).
-    Implement this method as you come across models that are missing it."))
+  Because this method was added YEARS after `can-read?` and `can-write?`, most models do not have an implementation
+  for this method, and instead `POST` API endpoints themselves contain the appropriate permissions logic (ick).
+  Implement this method as you come across models that are missing it.")
+
+  (^{:added "0.36.0"} can-update? [instance changes]
+   "NEW! Check whether or not the current user is allowed to update an object and by updating properties to values in
+   the `changes` map. This is equivalent to checking whether you're allowed to perform `(toucan.db/update! entity id
+   changes)`.
+
+  This method is appropriate for powering `PUT` API endpoints. Like `can-create?` this method was added YEARS after
+  most of the current API endpoints were written, so it is used in very few places, and this logic is determined
+  ad-hoc in the API endpoints themselves. Use this method going forward!"))
 
 (def IObjectPermissionsDefaults
   "Default implementations for `IObjectPermissions`."
@@ -218,42 +238,54 @@
    (fn [entity _]
      (throw
       (NoSuchMethodException.
-       (format "%s does not yet have an implementation for `can-create?`. Feel free to add one!" (name entity)))))})
+       (str (format "%s does not yet have an implementation for `can-create?`. " (name entity))
+            "Please consider adding one. See dox for `can-create?` for more details."))))
+
+   :can-update?
+   (fn
+     [instance _]
+     (throw
+      (NoSuchMethodException.
+       (str (format "%s does not yet have an implementation for `can-update?`. " (name instance))
+            "Please consider adding one. See dox for `can-update?` for more details."))))})
 
 (defn superuser?
   "Is `*current-user*` is a superuser? Ignores args.
    Intended for use as an implementation of `can-read?` and/or `can-write?`."
   [& _]
-  @(resolve 'metabase.api.common/*is-superuser?*))
-
+  @(requiring-resolve 'metabase.api.common/*is-superuser?*))
 
 (defn- current-user-permissions-set []
-  @@(resolve 'metabase.api.common/*current-user-permissions-set*))
+  @@(requiring-resolve 'metabase.api.common/*current-user-permissions-set*))
 
-(defn- current-user-has-root-permissions? ^Boolean []
+(defn- current-user-has-root-permissions? []
   (contains? (current-user-permissions-set) "/"))
 
-(defn- make-perms-check-fn [perms-check-fn-symb]
-  (fn -has-perms?
-    ([read-or-write entity object-id]
-     (or (current-user-has-root-permissions?)
-         (-has-perms? read-or-write (entity object-id))))
-    ([read-or-write object]
-     (and object
-          (-has-perms? (perms-objects-set object read-or-write))))
-    ([perms-set]
-     ((resolve perms-check-fn-symb) (current-user-permissions-set) perms-set))))
+(defn- check-perms-with-fn
+  ([fn-symb read-or-write entity object-id]
+   (or (current-user-has-root-permissions?)
+       (check-perms-with-fn fn-symb read-or-write (entity object-id))))
+
+  ([fn-symb read-or-write object]
+   (and object
+        (check-perms-with-fn fn-symb (perms-objects-set object read-or-write))))
+
+  ([fn-symb perms-set]
+   (let [f (requiring-resolve fn-symb)]
+     (assert f)
+     (u/prog1 (f (current-user-permissions-set) perms-set)
+       (log/tracef "Perms check: %s -> %s" (pr-str (list fn-symb (current-user-permissions-set) perms-set)) <>)))))
 
 (def ^{:arglists '([read-or-write entity object-id] [read-or-write object] [perms-set])}
-  ^Boolean current-user-has-full-permissions?
+  current-user-has-full-permissions?
   "Implementation of `can-read?`/`can-write?` for the old permissions system. `true` if the current user has *full*
-  permissions for the paths returned by its implementation of `perms-objects-set`. (READ-OR-WRITE is either `:read` or
+  permissions for the paths returned by its implementation of `perms-objects-set`. (`read-or-write` is either `:read` or
   `:write` and passed to `perms-objects-set`; you'll usually want to partially bind it in the implementation map)."
-  (make-perms-check-fn 'metabase.models.permissions/set-has-full-permissions-for-set?))
+  (partial check-perms-with-fn 'metabase.models.permissions/set-has-full-permissions-for-set?))
 
 (def ^{:arglists '([read-or-write entity object-id] [read-or-write object] [perms-set])}
-  ^Boolean current-user-has-partial-permissions?
+  current-user-has-partial-permissions?
   "Implementation of `can-read?`/`can-write?` for the old permissions system. `true` if the current user has *partial*
-  permissions for the paths returned by its implementation of `perms-objects-set`. (READ-OR-WRITE is either `:read` or
+  permissions for the paths returned by its implementation of `perms-objects-set`. (`read-or-write` is either `:read` or
   `:write` and passed to `perms-objects-set`; you'll usually want to partially bind it in the implementation map)."
-  (make-perms-check-fn 'metabase.models.permissions/set-has-partial-permissions-for-set?))
+  (partial check-perms-with-fn 'metabase.models.permissions/set-has-partial-permissions-for-set?))

--- a/src/metabase/models/native_query_snippet.clj
+++ b/src/metabase/models/native_query_snippet.clj
@@ -50,7 +50,8 @@
    i/IObjectPermissionsDefaults
    {:can-read?   snippet.perms/can-read?
     :can-write?  snippet.perms/can-write?
-    :can-create? snippet.perms/can-create?}))
+    :can-create? snippet.perms/can-create?
+    :can-update? snippet.perms/can-update?}))
 
 
 ;;; ---------------------------------------------------- Schemas -----------------------------------------------------

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -4,7 +4,8 @@
              [string :as str]
              [test :refer :all]]
             [metabase
-             [models :refer [Card Collection Dashboard NativeQuerySnippet PermissionsGroup PermissionsGroupMembership Pulse PulseCard PulseChannel PulseChannelRecipient]]
+             [models :refer [Card Collection Dashboard NativeQuerySnippet Permissions PermissionsGroup
+                             PermissionsGroupMembership Pulse PulseCard PulseChannel PulseChannelRecipient]]
              [test :as mt]
              [util :as u]]
             [metabase.models
@@ -67,6 +68,12 @@
                   "Rasta Toucan's Personal Collection"]
                  (map :name ((mt/user->client :rasta) :get 200 "collection")))))))
 
+    (testing "sanity check: All Users should have Root Collection readwrite perms"
+      (is (= true
+             (db/exists? Permissions
+               :group_id (u/get-id (group/all-users))
+               :object (perms/collection-readwrite-path collection/root-collection)))))
+
     (testing "check that we don't see collections if they're archived"
       (mt/with-temp* [Collection [collection-1 {:name "Archived Collection", :archived true}]
                       Collection [collection-2 {:name "Regular Collection"}]]
@@ -81,7 +88,7 @@
         (is (= ["Archived Collection"]
                (map :name ((mt/user->client :rasta) :get 200 "collection" :archived :true))))))
 
-    (testing "?namespace= parameter"
+    (testing "?namespace= parameter\n"
       (mt/with-temp* [Collection [{normal-id :id} {:name "Normal Collection"}]
                       Collection [{coins-id  :id} {:name "Coin Collection", :namespace "currency"}]]
         (letfn [(collection-names [collections]
@@ -89,17 +96,32 @@
                        (filter #(#{normal-id coins-id} (:id %)))
                        (map :name)))]
           (testing "shouldn't show Collections of a different `:namespace` by default"
-            (is (= ["Normal Collection"]
-                   (collection-names ((mt/user->client :rasta) :get 200 "collection")))))
+            (mt/with-discarded-collections-perms-changes coins-id
+              (perms/grant-collection-read-permissions! (group/all-users) coins-id)
+              (is (= ["Normal Collection"]
+                     (collection-names ((mt/user->client :rasta) :get 200 "collection"))))))
 
-          (testing "By passing `:namespace` we should be able to see Collections of that `:namespace`"
-            (testing "?namespace=currency"
-              (is (= ["Coin Collection"]
-                     (collection-names ((mt/user->client :rasta) :get 200 "collection?namespace=currency")))))
+          (testing "By passing `:namespace` we should be able to see Collections of that `:namespace`\n"
+            (testing "?namespace=currency\n"
+              (testing "w/o permissions"
+                (is (= []
+                       (collection-names ((mt/user->client :rasta) :get 200 "collection?namespace=currency")))))
+
+              (perms/grant-collection-read-permissions! (group/all-users) coins-id)
+              (testing "w/ permissions"
+                (is (= ["Coin Collection"]
+                       (collection-names ((mt/user->client :rasta) :get 200 "collection?namespace=currency"))))))
 
             (testing "?namespace=stamps"
               (is (= []
-                     (collection-names ((mt/user->client :rasta) :get 200 "collection?namespace=stamps")))))))))))
+                     (collection-names ((mt/user->client :rasta) :get 200 "collection?namespace=stamps")))))
+
+            (testing "Root Collection should have a different name for the 'snippets' Collection"
+              (is (= "Top folder"
+                     (some (fn [{collection-id :id, collection-name :name}]
+                             (when (= collection-id "root")
+                               collection-name))
+                           ((mt/user->client :crowberto) :get 200 "collection?namespace=snippets")))))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -412,15 +434,21 @@
 
 (deftest fetch-root-collection-test
   (testing "GET /api/collection/root"
-    (testing "Check that we can see stuff that isn't in any Collection -- meaning they're in the so-called \"Root\" Collection"
-      (is (= {:name                "Our analytics"
-              :id                  "root"
-              :can_write           true
-              :effective_location  nil
-              :effective_ancestors []
-              :parent_id           nil}
-             (with-some-children-of-collection nil
-               ((mt/user->client :crowberto) :get 200 "collection/root")))))
+    (testing "\nCheck that we can see stuff that isn't in any Collection -- meaning they're in the so-called \"Root\" Collection"
+      (doseq [collection-namespace [nil "snippets"]]
+        (testing (format "namespace = %s" (pr-str collection-namespace))
+          (is (= {:name                (case collection-namespace
+                                         ;; Snippets use a different name for the Root Collection
+                                         "snippets" "Top folder"
+                                         "Our analytics")
+                  :id                  "root"
+                  :can_write           true
+                  :effective_location  nil
+                  :effective_ancestors []
+                  :parent_id           nil}
+                 (with-some-children-of-collection nil
+                   ((mt/user->client :crowberto) :get 200
+                    (str "collection/root" (when collection-namespace (str "?namespace=" collection-namespace))))))))))
 
     (testing "Make sure you can see everything for Users that can see everything"
       (is (= [(default-item {:name "Birthday Card", :description nil, :favorite false, :model "card", :display "table"})
@@ -538,9 +566,10 @@
           (is (= [(collection-item "A")]
                  (api-get-root-collection-children :archived true))))))
 
-    (testing "\n?namespace= parameter"
+    (testing "\n?namespace= parameter\n"
       (mt/with-temp* [Collection [{normal-id :id} {:name "Normal Collection"}]
                       Collection [{coins-id :id}  {:name "Coin Collection", :namespace "currency"}]]
+        (perms/grant-collection-read-permissions! (group/all-users) coins-id)
         (letfn [(collection-names [items]
                   (->> items
                        (filter #(and (= (:model %) "collection")
@@ -681,11 +710,12 @@
       (mt/with-temp Collection [collection]
         (is (= (merge
                 (mt/object-defaults Collection)
-                {:id       (u/get-id collection)
-                 :name     "My Beautiful Collection"
-                 :slug     "my_beautiful_collection"
-                 :color    "#ABCDEF"
-                 :location "/"})
+                {:id        (u/get-id collection)
+                 :name      "My Beautiful Collection"
+                 :slug      "my_beautiful_collection"
+                 :color     "#ABCDEF"
+                 :location  "/"
+                 :parent_id nil})
                ((mt/user->client :crowberto) :put 200 (str "collection/" (u/get-id collection))
                 {:name "My Beautiful Collection", :color "#ABCDEF"})))))
 
@@ -752,11 +782,12 @@
       (with-collection-hierarchy [a b e]
         (is (= (merge
                 (mt/object-defaults Collection)
-                {:id       true
-                 :name     "E"
-                 :slug     "e"
-                 :color    "#ABCDEF"
-                 :location "/A/B/"})
+                {:id        true
+                 :name      "E"
+                 :slug      "e"
+                 :color     "#ABCDEF"
+                 :location  "/A/B/"
+                 :parent_id (u/get-id b)})
                (-> ((mt/user->client :crowberto) :put 200 (str "collection/" (u/get-id e))
                     {:parent_id (u/get-id b)})
                    (update :location collection-test/location-path-ids->names)
@@ -864,12 +895,16 @@
 
         (testing "Should be able to update the graph for a non-default namespace.\n"
           (testing "Should ignore updates to Collections outside of the namespace"
-            (let [response ((mt/user->client :crowberto) :put 200 "collection/graph?namespace=currency"
-                            (assoc (graph/graph) :groups {group-id {default-a :write, currency-a :write}}))]
+            (let [response ((mt/user->client :crowberto) :put 200 "collection/graph"
+                            (assoc (graph/graph)
+                                   :groups {group-id {default-a :write, currency-a :write}}
+                                   :namespace :currency))]
               (is (= {"Currency A" "write", "Currency A -> B" "read"}
                      (nice-graph response))))))
 
         (testing "have to be a superuser"
           (is (= "You don't have permissions to do that."
-                 ((mt/user->client :rasta) :put 403 "collection/graph?namespace=currency"
-                  (assoc (graph/graph) :groups {group-id {default-a :write, currency-a :write}})))))))))
+                 ((mt/user->client :rasta) :put 403 "collection/graph"
+                  (assoc (graph/graph)
+                         :groups {group-id {default-a :write, currency-a :write}}
+                         :namespace :currency)))))))))

--- a/test/metabase/models/table_test.clj
+++ b/test/metabase/models/table_test.clj
@@ -8,7 +8,7 @@
             [metabase.test.data.one-off-dbs :as one-off-dbs]
             [toucan.db :as db]))
 
-(deftest valud-field-order?-test
+(deftest valid-field-order?-test
   (testing "A valid field ordering is a set IDs  of all active fields in a given table"
     (is (#'table/valid-field-order? (mt/id :venues)
                                     [(mt/id :venues :name)

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -162,8 +162,13 @@
   round-all-decimals
   scheduler-current-tasks
   throw-if-called
+  with-discarded-collections-perms-changes
   with-locale
+  with-log-level
+  with-log-messages
+  with-log-messages-for-level
   with-model-cleanup
+  with-non-admin-groups-no-root-collection-for-namespace-perms
   with-non-admin-groups-no-root-collection-perms
   with-scheduler
   with-temp-scheduler


### PR DESCRIPTION
There's some OSS code in the EE repo related to handling "namespaced root collections" (i.e., the "Root Snippets Folder") and some new model permissions methods like `can-update?` and `can-insert?` that hasn't been backported yet.

This is mostly here to make the upcoming repo unification a little simpler

Wait until #13482 is merged to merge this