### PR TITLE
Fix tests for mariadb and mysqldb [ci drivers]

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -375,7 +375,7 @@
       (when-let [x (.getObject rs i)]
         (.toLocalDate ^java.sql.Date x)))
     (let [parent-thunk ((get-method sql-jdbc.execute/read-column-thunk [:sql-jdbc Types/DATE]) driver rs rsmeta i)]
-      (parent-thunk))))
+      parent-thunk)))
 
 (defn- format-offset [t]
   (let [offset (t/format "ZZZZZ" (t/zone-offset t))]

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -93,7 +93,7 @@
   (mt/test-driver :mysql
     (mt/dataset year-db
       (testing "By default YEAR"
-        (is (= #{{:name "year_column", :base_type :type/Date, :special_type :type/Category}
+        (is (= #{{:name "year_column", :base_type :type/Date, :special_type nil}
                  {:name "id", :base_type :type/Integer, :special_type :type/PK}}
                (db->fields (mt/db)))))
       (let [table  (db/select-one Table :db_id (u/id (mt/db)))


### PR DESCRIPTION
following template too closely with the `(parent-thunk)` call and
forgot it was wrapped in its own thunk so i was calling it before we
were using the result set.

lesson learned about `[ci drivers]` :)
