### PR TITLE
Fix interval typo in description

### DIFF
--- a/frontend/src/metabase/lib/expressions/helper_text_strings.js
+++ b/frontend/src/metabase/lib/expressions/helper_text_strings.js
@@ -457,7 +457,7 @@ const helperTextStrings = [
       },
       {
         name: t`text`,
-        description: t`Type of internal like "day", "month", "year".`,
+        description: t`Type of interval like "day", "month", "year".`,
       },
     ],
   },


### PR DESCRIPTION
Per @mazameli 

>If we merge this, we can then fix these two strings manually/directly in POEditor to keep from having to push strings to POEditor again.
