### PR TITLE
Fix logic error that showed field values for filtered fields

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -408,7 +408,7 @@ export class FieldValuesWidget extends Component {
     }
 
     let options = [];
-    if (this.hasList()) {
+    if (this.hasList() && !this.useChainFilterEndpoints()) {
       options = dedupeValues(fields.map(field => field.values));
     } else if (
       loadingState === "LOADED" &&

--- a/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
@@ -1,83 +1,97 @@
-import { signIn, restore, popover } from "__support__/cypress";
+import {
+  signIn,
+  restore,
+  popover,
+  withSampleDataset,
+} from "__support__/cypress";
 
 describe("scenarios > dashboard > chained filter", () => {
-  before(restore);
-  beforeEach(signIn);
-
-  it("limit search options based on linked filter", () => {
-    cy.visit("/dashboard/1");
-    // start editing
-    cy.get(".Icon-pencil").click();
-
-    // add a state filter
-    cy.get(".Icon-filter").click();
-    popover().within(() => {
-      cy.findByText("Location").click();
-      cy.findByText("State").click();
-    });
-
-    // connect that to people.state
-    cy.findByText("Column to filter on")
-      .parent()
-      .within(() => {
-        cy.findByText("Select…").click();
-      });
-    popover().within(() => {
-      cy.findByText("State").click();
-    });
-
-    // open the linked filters tab, and click the click to add a City filter
-    cy.findByText("Linked filters").click();
-    cy.findByText("add another dashboard filter").click();
-    popover().within(() => {
-      cy.findByText("Location").click();
-      cy.findByText("City").click();
-    });
-
-    // connect that to person.city
-    cy.findByText("Column to filter on")
-      .parent()
-      .within(() => {
-        cy.findByText("Select…").click();
-      });
-    popover().within(() => {
-      cy.findByText("City").click();
-    });
-
-    // Link city to state
-    cy.findByText("Limit this filter's choices")
-      .parent()
-      .within(() => {
-        // turn on the toggle
-        cy.findByText("State")
-          .parent()
-          .within(() => {
-            cy.get("a").click();
-          });
-
-        // open up the list of linked columns
-        cy.findByText("State").click();
-        // It's hard to assert on the "table.column" pairs.
-        // We just assert that the headers are there to know that something appeared.
-        cy.findByText("Filtering column");
-        cy.findByText("Filtered column");
-      });
-
-    cy.findByText("Save").click();
-    cy.findByText("You're editing this dashboard.").should("not.exist");
-
-    // now test that it worked!
-    // Select Alaska as a state. We should see Anchorage as a option but not Anacoco
-    cy.findByText("State").click();
-    popover().within(() => {
-      cy.findByText("AK").click();
-      cy.findByText("Add filter").click();
-    });
-    cy.findByText("City").click();
-    popover().within(() => {
-      cy.findByPlaceholderText("Search by City").type("An");
-      cy.findByText("Anchorage");
-      cy.findByText("Anacoco").should("not.exist");
-    });
+  beforeEach(() => {
+    restore();
+    signIn();
   });
+
+  for (const has_field_values of ["search", "list"]) {
+    it(`limit ${has_field_values} options based on linked filter`, () => {
+      withSampleDataset(({ PEOPLE }) =>
+        cy.request("PUT", `/api/field/${PEOPLE.CITY}`, { has_field_values }),
+      );
+      cy.visit("/dashboard/1");
+      // start editing
+      cy.get(".Icon-pencil").click();
+
+      // add a state filter
+      cy.get(".Icon-filter").click();
+      popover().within(() => {
+        cy.findByText("Location").click();
+        cy.findByText("State").click();
+      });
+
+      // connect that to people.state
+      cy.findByText("Column to filter on")
+        .parent()
+        .within(() => {
+          cy.findByText("Select…").click();
+        });
+      popover().within(() => {
+        cy.findByText("State").click();
+      });
+
+      // open the linked filters tab, and click the click to add a City filter
+      cy.findByText("Linked filters").click();
+      cy.findByText("add another dashboard filter").click();
+      popover().within(() => {
+        cy.findByText("Location").click();
+        cy.findByText("City").click();
+      });
+
+      // connect that to person.city
+      cy.findByText("Column to filter on")
+        .parent()
+        .within(() => {
+          cy.findByText("Select…").click();
+        });
+      popover().within(() => {
+        cy.findByText("City").click();
+      });
+
+      // Link city to state
+      cy.findByText("Limit this filter's choices")
+        .parent()
+        .within(() => {
+          // turn on the toggle
+          cy.findByText("State")
+            .parent()
+            .within(() => {
+              cy.get("a").click();
+            });
+
+          // open up the list of linked columns
+          cy.findByText("State").click();
+          // It's hard to assert on the "table.column" pairs.
+          // We just assert that the headers are there to know that something appeared.
+          cy.findByText("Filtering column");
+          cy.findByText("Filtered column");
+        });
+
+      cy.findByText("Save").click();
+      cy.findByText("You're editing this dashboard.").should("not.exist");
+
+      // now test that it worked!
+      // Select Alaska as a state. We should see Anchorage as a option but not Anacoco
+      cy.findByText("State").click();
+      popover().within(() => {
+        cy.findByText("AK").click();
+        cy.findByText("Add filter").click();
+      });
+      cy.findByText("City").click();
+      popover().within(() => {
+        cy.findByPlaceholderText(
+          has_field_values === "search" ? "Search by City" : "Search the list",
+        ).type("An");
+        cy.findByText("Anchorage");
+        cy.findByText("Anacoco").should("not.exist");
+      });
+    });
+  }
 });


### PR DESCRIPTION
Fixes #13491

The structure of the if statement determining what to show for options was broken. This PR fixes it so we only show field values if we're not using the chained filter endpoints.