### PR TITLE
Add Cypress metadata test for custom remapping

### DIFF
--- a/frontend/test/metabase/scenarios/admin/datamodel/field.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/field.cy.spec.js
@@ -144,24 +144,6 @@ describe("scenarios > admin > datamodel > field", () => {
       cy.contains("Title");
     });
 
-    it("lets you change to 'Custom mapping' and set custom values (metabase#12771)", () => {
-      visitAlias("@ORDERS_QUANTITY_URL");
-
-      cy.contains("Use original value").click();
-      cy.contains("Custom mapping").click();
-
-      cy.get('input[value="0"]')
-        .clear()
-        .type("foo")
-        .blur();
-      cy.contains("button", "Save").click({ force: true });
-      cy.wait("@fieldValuesUpdate");
-
-      cy.reload();
-      cy.contains("Custom mapping");
-      cy.get('input[value="foo"]');
-    });
-
     it("allows 'Custom mapping' null values", () => {
       restore("withSqlite");
       signInAsAdmin();

--- a/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
@@ -35,6 +35,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
   });
 
   it("should correctly apply and display custom remapping for numeric values", () => {
+    // this test also indirectly reproduces metabase#12771
     const customMap = {
       1: "Awful",
       2: "Unpleasant",
@@ -59,11 +60,11 @@ describe("scenarios > admin > datamodel > metadata", () => {
       "You might want to update the field name to make sure it still makes sense based on your remapping choices.",
     );
 
-    Object.keys(customMap).forEach(key => {
+    Object.entries(customMap).forEach(([key, value]) => {
       cy.findByDisplayValue(key)
         .click()
         .clear()
-        .type(customMap[key]);
+        .type(value);
     });
     cy.findByText("Save").click();
 

--- a/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
@@ -12,7 +12,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
   it("should correctly show remapped column value", () => {
     // go directly to Data Model page for Sample Dataset
     cy.visit("/admin/datamodel/database/1");
-    // edit "Product ID" columnn in "Orders" table
+    // edit "Product ID" column in "Orders" table
     cy.findByText("Orders").click();
     cy.findByDisplayValue("Product ID")
       .parent()
@@ -32,5 +32,45 @@ describe("scenarios > admin > datamodel > metadata", () => {
     cy.log("**Name of the product should be displayed instead of its ID**");
     openOrdersTable();
     cy.findAllByText("Awesome Concrete Shoes");
+  });
+
+  it("should correctly apply and display custom remapping for numeric values", () => {
+    const customMap = {
+      1: "Awful",
+      2: "Unpleasant",
+      3: "Meh",
+      4: "Enjoyable",
+      5: "Perfecto",
+    };
+
+    // go directly to Data Model page for Sample Dataset
+    cy.visit("/admin/datamodel/database/1");
+    // edit "Rating" values in "Reviews" table
+    cy.findByText("Reviews").click();
+    cy.findByDisplayValue("Rating")
+      .parent()
+      .find(".Icon-gear")
+      .click();
+
+    // apply custom remapping for "Rating" values 1-5
+    cy.findByText("Use original value").click();
+    cy.findByText("Custom mapping").click();
+    cy.findByText(
+      "You might want to update the field name to make sure it still makes sense based on your remapping choices.",
+    );
+
+    Object.keys(customMap).forEach(key => {
+      cy.findByDisplayValue(key)
+        .click()
+        .clear()
+        .type(customMap[key]);
+    });
+    cy.findByText("Save").click();
+
+    cy.log("**Numeric ratings should be remapped to custom strings**");
+    cy.visit("/question/new?database=1&table=4");
+    Object.values(customMap).forEach(rating => {
+      cy.findAllByText(rating);
+    });
   });
 });


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- adds a Cypress test that covers [custom remapping](https://www.metabase.com/docs/latest/administration-guide/03-metadata-editing.html#remapping-column-values) for numeric values
- fixes a small typo in other test title
- removes older, less complete test from `frontend/test/metabase/scenarios/admin/datamodel/field.cy.spec.js`
- indirectly reproduces #12771

### How should this be manually tested?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js`
- tests should pass
