### PR TITLE
Fix #11974 -- Respond with 200 code on public csv export

### DIFF
--- a/src/metabase/async/streaming_response.clj
+++ b/src/metabase/async/streaming_response.clj
@@ -179,12 +179,12 @@
 
 (defn- respond
   [{:keys [^HttpServletResponse response ^AsyncContext async-context request-map response-map request]}
-   f {:keys [content-type], :as options} finished-chan]
+   f {:keys [content-type status headers], :as options} finished-chan]
   (let [canceled-chan (a/promise-chan)]
     (try
-      (.setStatus response 202)
+      (.setStatus response (or status 202))
       (let [gzip?   (should-gzip-response? request-map)
-            headers (cond-> (assoc (:headers response-map) "Content-Type" content-type)
+            headers (cond-> (assoc (merge headers (:headers response-map)) "Content-Type" content-type)
                       gzip? (assoc "Content-Encoding" "gzip"))]
         (#'ring.servlet/set-headers response headers)
         (let [output-stream-delay (output-stream-delay gzip? response)

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -11,6 +11,7 @@
 (defmethod i/stream-options :csv
   [_]
   {:content-type              "text/csv"
+   :status                    200
    :headers                   {"Content-Disposition" (format "attachment; filename=\"query_result_%s.csv\""
                                                              (u.date/format (t/zoned-date-time)))}
    :write-keepalive-newlines? false})

--- a/src/metabase/query_processor/streaming/json.clj
+++ b/src/metabase/query_processor/streaming/json.clj
@@ -13,6 +13,7 @@
 (defmethod i/stream-options :json
   [_]
   {:content-type "application/json; charset=utf-8"
+   :status       200
    :headers      {"Content-Disposition" (format "attachment; filename=\"query_result_%s.json\""
                                                 (u.date/format (t/zoned-date-time)))}})
 

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -14,6 +14,7 @@
   [_]
   {:content-type              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
    :write-keepalive-newlines? false
+   :status                    200
    :headers                   {"Content-Disposition" (format "attachment; filename=\"query_result_%s.xlsx\""
                                                              (u.date/format (t/zoned-date-time)))}})
 

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -1116,7 +1116,7 @@
         (is (= ["COUNT(*)"
                 "75"]
                (str/split-lines
-                ((mt/user->client :rasta) :post 202 (format "card/%d/query/csv"
+                ((mt/user->client :rasta) :post 200 (format "card/%d/query/csv"
                                                                     (u/get-id card)))))))))
   (testing "with-paramters"
     (with-temp-native-card-with-params [_ card]
@@ -1124,7 +1124,7 @@
         (is (= ["COUNT(*)"
                 "8"]
                (str/split-lines
-                ((mt/user->client :rasta) :post 202 (format "card/%d/query/csv?parameters=%s"
+                ((mt/user->client :rasta) :post 200 (format "card/%d/query/csv?parameters=%s"
                                                                     (u/get-id card) encoded-params)))))))))
 
 (deftest json-download-test
@@ -1132,12 +1132,12 @@
     (with-temp-native-card [_ card]
       (with-cards-in-readable-collection card
         (is (= [{(keyword "COUNT(*)") 75}]
-               ((mt/user->client :rasta) :post 202 (format "card/%d/query/json" (u/get-id card))))))))
+               ((mt/user->client :rasta) :post 200 (format "card/%d/query/json" (u/get-id card))))))))
   (testing "with parameters"
     (with-temp-native-card-with-params [_ card]
       (with-cards-in-readable-collection card
         (is (= [{(keyword "COUNT(*)") 8}]
-               ((mt/user->client :rasta) :post 202 (format "card/%d/query/json?parameters=%s"
+               ((mt/user->client :rasta) :post 200 (format "card/%d/query/json?parameters=%s"
                                                                    (u/get-id card) encoded-params))))))))
 
 (defn- parse-xlsx-results [results]
@@ -1153,14 +1153,14 @@
       (with-cards-in-readable-collection card
         (is (= [{:col "COUNT(*)"} {:col 75.0}]
                (parse-xlsx-results
-                ((mt/user->client :rasta) :post 202 (format "card/%d/query/xlsx" (u/get-id card))
+                ((mt/user->client :rasta) :post 200 (format "card/%d/query/xlsx" (u/get-id card))
                  {:request-options {:as :byte-array}})))))))
   (testing "with parameters"
     (with-temp-native-card-with-params [_ card]
       (with-cards-in-readable-collection card
         (is (= [{:col "COUNT(*)"} {:col 8.0}]
                (parse-xlsx-results
-                ((mt/user->client :rasta) :post 202 (format "card/%d/query/xlsx?parameters=%s"
+                ((mt/user->client :rasta) :post 200 (format "card/%d/query/xlsx?parameters=%s"
                                                                     (u/get-id card) encoded-params)
                  {:request-options {:as :byte-array}}))))))))
 

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -184,7 +184,7 @@
           ["3" "2014-09-15" "8" "56"]
           ["4" "2014-03-11" "5" "4"]
           ["5" "2013-05-05" "3" "49"]]
-         (let [result ((mt/user->client :rasta) :post 202 "dataset/csv" :query
+         (let [result ((mt/user->client :rasta) :post 200 "dataset/csv" :query
                        (json/generate-string (mt/mbql-query checkins)))]
            (take 5 (parse-and-sort-csv result))))))
 
@@ -196,7 +196,7 @@
             "Expires"             "Tue, 03 Jul 2001 06:00:00 GMT"
             "X-Accel-Buffering"   "no"}
            (-> (http-client/client-full-response (test-users/username->token :rasta)
-                                                 :post 202 "dataset/csv"
+                                                 :post 200 "dataset/csv"
                                                  :query (json/generate-string (mt/mbql-query checkins {:limit 1})))
                :headers
                (select-keys ["Cache-Control" "Content-Disposition" "Content-Type" "Expires" "X-Accel-Buffering"])
@@ -205,7 +205,7 @@
 
 (deftest check-an-empty-date-column
   (mt/dataset defs/test-data-with-null-date-checkins
-    (let [result ((mt/user->client :rasta) :post 202 "dataset/csv" :query
+    (let [result ((mt/user->client :rasta) :post 200 "dataset/csv" :query
                   (json/generate-string (mt/mbql-query checkins)))]
       (is (= [["1" "2014-04-07" "" "5" "12"]
               ["2" "2014-09-18" "" "1" "31"]
@@ -227,7 +227,7 @@
                (parse-and-sort-csv result)))))))
 
 (deftest datetime-fields-are-untouched-when-exported
-  (let [result ((mt/user->client :rasta) :post 202 "dataset/csv" :query
+  (let [result ((mt/user->client :rasta) :post 200 "dataset/csv" :query
                 (json/generate-string (mt/mbql-query users {:order-by [[:asc $id]], :limit 5})))]
     (is (= [["1" "Plato Yeshua"        "2014-04-01T08:30:00"]
             ["2" "Felipinho Asklepios" "2014-12-05T15:15:00"]
@@ -240,7 +240,7 @@
   (mt/with-temp Card [card {:dataset_query {:database (mt/id)
                                             :type     :native
                                             :native   {:query "SELECT * FROM USERS;"}}}]
-    (let [result ((mt/user->client :rasta) :post 202 "dataset/csv"
+    (let [result ((mt/user->client :rasta) :post 200 "dataset/csv"
                   :query (json/generate-string
                           {:database mbql.s/saved-questions-virtual-database-id
                            :type     :query
@@ -257,7 +257,7 @@
 ;; from one that had it -- see #9831)
 (deftest formatted-results-ignore-query-constraints
   (with-redefs [constraints/default-query-constraints {:max-results 10, :max-results-bare-rows 10}]
-    (let [result ((mt/user->client :rasta) :post 202 "dataset/csv"
+    (let [result ((mt/user->client :rasta) :post 200 "dataset/csv"
                   :query (json/generate-string
                           {:database   (mt/id)
                            :type       :query

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -150,16 +150,16 @@
 
         (testing ":json download response format"
           (is (= [{:Count 100}]
-                 (http/client :get 202 (str "public/card/" uuid "/query/json")))))
+                 (http/client :get 200 (str "public/card/" uuid "/query/json")))))
 
         (testing ":csv download response format"
           (is (= "Count\n100\n"
-                 (http/client :get 202 (str "public/card/" uuid "/query/csv"), :format :csv))))
+                 (http/client :get 200 (str "public/card/" uuid "/query/csv"), :format :csv))))
 
         (testing ":xlsx download response format"
           (is (= [{:col "Count"} {:col 100.0}]
                  (parse-xlsx-response
-                  (http/client :get 202 (str "public/card/" uuid "/query/xlsx") {:request-options {:as :byte-array}})))))))))
+                  (http/client :get 200 (str "public/card/" uuid "/query/xlsx") {:request-options {:as :byte-array}})))))))))
 
 (deftest execute-public-card-as-user-without-perms-test
   (testing "A user that doesn't have permissions to run the query normally should still be able to run a public Card as if they weren't logged in"
@@ -234,7 +234,7 @@
   (mt/with-temporary-setting-values [enable-public-sharing true]
     (mt/with-temp Card [{uuid :public_uuid} (card-with-date-field-filter)]
       (is (= "count\n107\n"
-             (http/client :get 202 (str "public/card/" uuid "/query/csv")
+             (http/client :get 200 (str "public/card/" uuid "/query/csv")
                           :parameters (json/encode [{:type   :date/quarter-year
                                                      :target [:dimension [:template-tag :date]]
                                                      :value  "Q1-2014"}])))))))
@@ -247,7 +247,7 @@
       (binding [http/*url-prefix* (str/replace http/*url-prefix* #"/api/$" "/")]
         (mt/with-temporary-setting-values [site-url http/*url-prefix*]
           (is (= "count\n107\n"
-                 (http/client :get 202 (str "public/question/" uuid ".csv")
+                 (http/client :get 200 (str "public/question/" uuid ".csv")
                               :parameters (json/encode [{:type   :date/quarter-year
                                                          :target [:dimension [:template-tag :date]]
                                                          :value  "Q1-2014"}])))))))))


### PR DESCRIPTION
This replaces #12577 with an updated rebase and a target of `release-0.36.x`

Thank you, @codingjoe!

Resolves #11974 