### PR TITLE
Show sync exception in troubleshooting log UI

### DIFF
--- a/frontend/src/metabase/admin/tasks/containers/Logs.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/Logs.jsx
@@ -110,12 +110,13 @@ export default class Logs extends Component {
     const processUUIDs = _.uniq(
       logs.map(ev => ev.process_uuid).filter(Boolean),
     ).sort();
-    const renderedLogs = filteredLogs.map(ev => {
+    const renderedLogs = filteredLogs.flatMap(ev => {
       const timestamp = moment(ev.timestamp).format();
       const uuid = ev.process_uuid || "---";
-      return `[${uuid}] ${timestamp} ${ev.level} ${ev.fqns} ${ev.msg}${
-        ev.exception ? "\n" + ev.exception : ""
-      }`;
+      return [
+        `[${uuid}] ${timestamp} ${ev.level} ${ev.fqns} ${ev.msg}`,
+        ...(ev.exception || []),
+      ];
     });
 
     let processUUIDSelect = null;
@@ -156,8 +157,9 @@ export default class Logs extends Component {
               style={{
                 fontFamily: '"Lucida Console", Monaco, monospace',
                 fontSize: "14px",
-                whiteSpace: "pre-line",
+                whiteSpace: "pre",
                 padding: "1em",
+                overflowX: "scroll",
               }}
             >
               {reactAnsiStyle(React, renderedLogs.join("\n"))}

--- a/frontend/src/metabase/admin/tasks/containers/Logs.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/Logs.jsx
@@ -113,7 +113,9 @@ export default class Logs extends Component {
     const renderedLogs = filteredLogs.map(ev => {
       const timestamp = moment(ev.timestamp).format();
       const uuid = ev.process_uuid || "---";
-      return `[${uuid}] ${timestamp} ${ev.level} ${ev.fqns} ${ev.msg}`;
+      return `[${uuid}] ${timestamp} ${ev.level} ${ev.fqns} ${ev.msg}${
+        ev.exception ? "\n" + ev.exception : ""
+      }`;
     });
 
     let processUUIDSelect = null;

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -3,7 +3,6 @@
             [clj-time
              [coerce :as coerce]
              [format :as time]]
-            [clojure.string :as str]
             [metabase.config :refer [local-process-uuid]])
   (:import [org.apache.log4j Appender AppenderSkeleton Logger]
            org.apache.log4j.spi.LoggingEvent))
@@ -23,7 +22,7 @@
    :level        (.getLevel event)
    :fqns         (.getLoggerName event)
    :msg          (.getMessage event)
-   :exception    (str/join "\n" (.getThrowableStrRep event))
+   :exception    (seq (.getThrowableStrRep event))
    :process_uuid local-process-uuid})
 
 (defn- metabase-appender ^Appender []

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -3,6 +3,7 @@
             [clj-time
              [coerce :as coerce]
              [format :as time]]
+            [clojure.string :as str]
             [metabase.config :refer [local-process-uuid]])
   (:import [org.apache.log4j Appender AppenderSkeleton Logger]
            org.apache.log4j.spi.LoggingEvent))
@@ -22,7 +23,7 @@
    :level        (.getLevel event)
    :fqns         (.getLoggerName event)
    :msg          (.getMessage event)
-   :exception    (.getThrowableStrRep event)
+   :exception    (str/join "\n" (.getThrowableStrRep event))
    :process_uuid local-process-uuid})
 
 (defn- metabase-appender ^Appender []


### PR DESCRIPTION
This PR fixes #12851 by doing ~two~ one thing:
1. Including the `exception` field in the UI when present
~2. Joining the stacktrace's lines into one newline-separated string~

~I'm not sure why 2. was necessary. Without that the object got serialized as `"[Ljava.lang.String;@3c78dc82"`. I'm guessing the java object returned by `getThrowableStrRep` doesn't play nicely with our Clojure-specific API serialization logic?~

I also tweaked the CSS so whitespace is preserved.