### PR TITLE
Use "table - field" style for join aliases

### DIFF
--- a/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
@@ -1,4 +1,4 @@
-import { ORDERS, PRODUCTS } from "__support__/sample_dataset_fixture";
+import { ORDERS, PRODUCTS, REVIEWS } from "__support__/sample_dataset_fixture";
 
 import Join from "metabase-lib/lib/queries/structured/Join";
 
@@ -37,7 +37,31 @@ describe("Join", () => {
     });
   });
   describe("setDefaultAlias", () => {
-    it("should set default alias to be fk field name and update join condition", () => {
+    it("should set default alias to be table + field name and update join condition", () => {
+      const q = ORDERS.query().join({
+        alias: "x",
+        condition: [
+          "=",
+          ["field-id", ORDERS.PRODUCT_ID.id],
+          ["joined-field", "x", ["field-id", REVIEWS.PRODUCT_ID.id]],
+        ],
+        "source-table": REVIEWS.id,
+      });
+      const j = q
+        .joins()[0]
+        .setDefaultCondition()
+        .setDefaultAlias();
+      expect(j).toEqual({
+        alias: "Reviews - Product",
+        condition: [
+          "=",
+          ["field-id", ORDERS.PRODUCT_ID.id],
+          ["joined-field", "Reviews - Product", ["field-id", REVIEWS.PRODUCT_ID.id]],
+        ],
+        "source-table": REVIEWS.id,
+      });
+    });
+    it("should set default alias to be table name only if it is similar to field name", () => {
       const q = ORDERS.query().join({
         alias: "x",
         "source-table": PRODUCTS.id,
@@ -47,13 +71,13 @@ describe("Join", () => {
         .setDefaultCondition()
         .setDefaultAlias();
       expect(j).toEqual({
-        alias: "Product",
+        alias: "Products",
         condition: [
           "=",
-          ["field-id", 3],
-          ["joined-field", "Product", ["field-id", 24]],
+          ["field-id", ORDERS.PRODUCT_ID.id],
+          ["joined-field", "Products", ["field-id", PRODUCTS.ID.id]],
         ],
-        "source-table": 3,
+        "source-table": PRODUCTS.id,
       });
     });
   });

--- a/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
@@ -56,7 +56,11 @@ describe("Join", () => {
         condition: [
           "=",
           ["field-id", ORDERS.PRODUCT_ID.id],
-          ["joined-field", "Reviews - Product", ["field-id", REVIEWS.PRODUCT_ID.id]],
+          [
+            "joined-field",
+            "Reviews - Product",
+            ["field-id", REVIEWS.PRODUCT_ID.id],
+          ],
         ],
         "source-table": REVIEWS.id,
       });

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -2,8 +2,11 @@ import {
   createNativeQuestion,
   restore,
   signInAsAdmin,
+  openOrdersTable,
+  openProductsTable,
   popover,
   modal,
+  typeAndBlurUsingLabel,
 } from "__support__/cypress";
 
 describe("scenarios > question > notebook", () => {
@@ -129,6 +132,143 @@ describe("scenarios > question > notebook", () => {
       cy.findByText("Question 5 → B Column");
       cy.findByText("Showing 1 row");
     });
+
+    it("should allow joins based on saved questions (metabase#13000)", () => {
+      cy.server();
+      cy.route("POST", "/api/card/*/query").as("card");
+
+      cy.log("**Prepare Question 1**");
+      openOrdersTable();
+
+      cy.findByText("Summarize").click();
+      cy.findByText("Count").click();
+      popover().within(() => {
+        cy.findByText("Sum of ...").click();
+        cy.findByText("Total").click();
+      });
+
+      cy.findByText("Group by")
+        .parent()
+        .contains("Product ID")
+        .click();
+
+      // Mid-point check - generated title should be:
+      cy.contains("Sum of Total by Product ID");
+
+      cy.findByText("Done").click();
+      cy.findByText("Save").click();
+      // Save as Q1
+      modal().within(() => {
+        typeAndBlurUsingLabel("Name", "Q1");
+        cy.findByText("Save").click();
+      });
+      cy.findByText("Not now").click();
+
+      cy.log("**Prepare Question 2**");
+      openProductsTable();
+
+      cy.findByText("Summarize").click();
+      cy.findByText("Count").click();
+
+      popover().within(() => {
+        cy.findByText("Sum of ...").click();
+        cy.findByText("Rating").click();
+      });
+
+      cy.findByText("Group by")
+        .parent()
+        .contains("ID")
+        .click();
+
+      // Mid-point check - generated title should be:
+      cy.contains("Sum of Rating by ID");
+
+      cy.findByText("Done").click();
+      cy.findByText("Save").click();
+      // Save as Q2
+      modal().within(() => {
+        typeAndBlurUsingLabel("Name", "Q2");
+        cy.findByText("Save").click();
+      });
+      cy.findByText("Not now").click();
+
+      cy.log("**Create Question 3 based on 2 previously saved questions**");
+
+      cy.findByText("Ask a question").click();
+      cy.findByText("Custom question").click();
+      // Choose Q1
+      popover().within(() => {
+        cy.findByText("Saved Questions").click();
+        cy.findByText("Q1").click();
+      });
+      // and join it
+      cy.get(".Icon-join_left_outer").click();
+      // with Q2
+      popover().within(() => {
+        cy.findByText("Sample Dataset").click();
+        cy.findByText("Saved Questions").click();
+        cy.findByText("Q2").click();
+      });
+      // on Product ID = ID
+      popover()
+        .contains("Product ID")
+        .click();
+      popover()
+        .contains("ID")
+        .click();
+      // Save as Q3
+      cy.findByText("Save").click();
+      cy.get(".Modal").within(() => {
+        typeAndBlurUsingLabel("Name", "Q3");
+        cy.findByText("Save").click();
+      });
+      cy.findByText("Not now").click();
+
+      cy.log("**Assert that the Q3 is in 'Our analytics'**");
+
+      cy.visit("/");
+      cy.findByText("Browse all items").click();
+
+      cy.contains("Q3").click({ force: true });
+      cy.wait("@card");
+
+      cy.log("**The point where bug originated in v0.36.0**");
+      cy.get(".Icon-notebook").click();
+      cy.url().should("contain", "/notebook");
+      cy.findByText("Visualize").should("exist");
+    });
+
+    it.skip("should show correct column title with foreign keys (metabase#11452)", () => {
+      // (Orders join Reviews on Product ID)
+      openOrdersTable();
+      cy.get(".Icon-notebook").click();
+      cy.findByText("Join data").click();
+      cy.findByText("Reviews").click();
+      cy.findByText("Product ID").click();
+      popover().within(() => {
+        cy.findByText("Product ID").click();
+      });
+
+      cy.log("**It shouldn't use FK for a column title**");
+      cy.findByText("Summarize").click();
+      cy.findByText("Pick a column to group by").click();
+
+      // NOTE: Since there is no better way to "get" the element we need, below is a representation of the current DOM structure.
+      //       This can also be useful because some future DOM changes could easily introduce a flake.
+      //  the common parent
+      //    wrapper for the icon
+      //      the actual svg icon with the class `.Icon-join_left_outer`
+      //    h3.List-section-title with the text content we're actually testing
+      popover().within(() => {
+        cy.get(".Icon-join_left_outer")
+          .parent()
+          .next()
+          // NOTE from Flamber's warning:
+          // this name COULD be "normalized" to "Review" instead of "Reviews" - that's why we use Regex match here
+          .invoke("text")
+          .should("match", /review/i);
+      });
+    });
   });
 
   describe("nested", () => {
@@ -164,9 +304,7 @@ describe("scenarios > question > notebook", () => {
         cy.findByText("Save").click();
       });
 
-      modal().within(() => {
-        cy.findByText("Not now").click();
-      });
+      cy.findByText("Not now").click();
 
       cy.get(".Icon-notebook").click();
 

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -238,7 +238,7 @@ describe("scenarios > question > notebook", () => {
       cy.findByText("Visualize").should("exist");
     });
 
-    it.skip("should show correct column title with foreign keys (metabase#11452)", () => {
+    it("should show correct column title with foreign keys (metabase#11452)", () => {
       // (Orders join Reviews on Product ID)
       openOrdersTable();
       cy.get(".Icon-notebook").click();
@@ -264,9 +264,9 @@ describe("scenarios > question > notebook", () => {
           .parent()
           .next()
           // NOTE from Flamber's warning:
-          // this name COULD be "normalized" to "Review" instead of "Reviews" - that's why we use Regex match here
+          // this name COULD be "normalized" to "Review - Product" instead of "Reviews - Products" - that's why we use Regex match here
           .invoke("text")
-          .should("match", /review/i);
+          .should("match", /reviews? - products?/i);
       });
     });
   });

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.query-processor-test.explicit-joins-test
   (:require [clojure.test :refer :all]
-            [expectations :refer [expect]]
             [metabase
              [driver :as driver]
              [query-processor :as qp]
@@ -17,26 +16,26 @@
 (defn- native-form [query]
   (:query (qp/query->native query)))
 
-;; Can we specify an *explicit* JOIN using the default options?
-(expect
-  (str "SELECT \"PUBLIC\".\"VENUES\".\"ID\" AS \"ID\","
-       " \"PUBLIC\".\"VENUES\".\"NAME\" AS \"NAME\","
-       " \"PUBLIC\".\"VENUES\".\"CATEGORY_ID\" AS \"CATEGORY_ID\","
-       " \"PUBLIC\".\"VENUES\".\"LATITUDE\" AS \"LATITUDE\","
-       " \"PUBLIC\".\"VENUES\".\"LONGITUDE\" AS \"LONGITUDE\","
-       " \"PUBLIC\".\"VENUES\".\"PRICE\" AS \"PRICE\" "
-       "FROM \"PUBLIC\".\"VENUES\" "
-       "LEFT JOIN \"PUBLIC\".\"CATEGORIES\" \"source\""
-       " ON \"PUBLIC\".\"VENUES\".\"CATEGORY_ID\" = 1 "
-       "LIMIT 1048576")
-  (native-form
-   (data/mbql-query venues
-     {:joins [{:source-table $$categories
-               :condition    [:= $category_id 1]}]})))
+(deftest explict-join-with-default-options-test
+  (testing "Can we specify an *explicit* JOIN using the default options?"
+    (is (= (str "SELECT \"PUBLIC\".\"VENUES\".\"ID\" AS \"ID\","
+                " \"PUBLIC\".\"VENUES\".\"NAME\" AS \"NAME\","
+                " \"PUBLIC\".\"VENUES\".\"CATEGORY_ID\" AS \"CATEGORY_ID\","
+                " \"PUBLIC\".\"VENUES\".\"LATITUDE\" AS \"LATITUDE\","
+                " \"PUBLIC\".\"VENUES\".\"LONGITUDE\" AS \"LONGITUDE\","
+                " \"PUBLIC\".\"VENUES\".\"PRICE\" AS \"PRICE\" "
+                "FROM \"PUBLIC\".\"VENUES\" "
+                "LEFT JOIN \"PUBLIC\".\"CATEGORIES\" \"source\""
+                " ON \"PUBLIC\".\"VENUES\".\"CATEGORY_ID\" = 1 "
+                "LIMIT 1048576")
+           (native-form
+            (mt/mbql-query venues
+              {:joins [{:source-table $$categories
+                        :condition    [:= $category_id 1]}]}))))))
 
 (defn- query-with-strategy [strategy]
   (data/dataset bird-flocks
-    (data/mbql-query bird
+    (mt/mbql-query bird
       {:fields   [$name &f.flock.name]
        :joins    [{:source-table $$flock
                    :condition    [:= $flock_id &f.flock.id]
@@ -44,74 +43,10 @@
                    :alias        "f"}]
        :order-by [[:asc $name]]})))
 
-;; Can we supply a custom alias? Can we do a left outer join ??
-(datasets/expect-with-drivers (mt/normal-drivers-with-feature :left-join)
-  [["Big Red"          "Bayview Brood"]
-   ["Callie Crow"      "Mission Street Murder"]
-   ["Camellia Crow"    nil]
-   ["Carson Crow"      "Mission Street Murder"]
-   ["Chicken Little"   "Bayview Brood"]
-   ["Geoff Goose"      nil]
-   ["Gerald Goose"     "Green Street Gaggle"]
-   ["Greg Goose"       "Green Street Gaggle"]
-   ["McNugget"         "Bayview Brood"]
-   ["Olita Owl"        nil]
-   ["Oliver Owl"       "Portrero Hill Parliament"]
-   ["Orville Owl"      "Portrero Hill Parliament"]
-   ["Oswald Owl"       nil]
-   ["Pamela Pelican"   nil]
-   ["Patricia Pelican" nil]
-   ["Paul Pelican"     "SoMa Squadron"]
-   ["Peter Pelican"    "SoMa Squadron"]
-   ["Russell Crow"     "Mission Street Murder"]]
-  (qp.test/rows
-    (qp/process-query
-      (query-with-strategy :left-join))))
-
-;; Can we do a right outer join?
-(datasets/expect-with-drivers (mt/normal-drivers-with-feature :right-join)
-  ;; the [nil "Fillmore Flock"] row will either come first or last depending on the driver; the rest of the rows will
-  ;; be the same
-  (let [rows [["Big Red"        "Bayview Brood"]
-              ["Callie Crow"    "Mission Street Murder"]
-              ["Carson Crow"    "Mission Street Murder"]
-              ["Chicken Little" "Bayview Brood"]
-              ["Gerald Goose"   "Green Street Gaggle"]
-              ["Greg Goose"     "Green Street Gaggle"]
-              ["McNugget"       "Bayview Brood"]
-              ["Oliver Owl"     "Portrero Hill Parliament"]
-              ["Orville Owl"    "Portrero Hill Parliament"]
-              ["Paul Pelican"   "SoMa Squadron"]
-              ["Peter Pelican"  "SoMa Squadron"]
-              ["Russell Crow"   "Mission Street Murder"]]]
-    (if (tx/sorts-nil-first? driver/*driver*)
-      (cons [nil "Fillmore Flock"] rows)
-      (conj rows [nil "Fillmore Flock"])))
-  (qp.test/rows
-    (qp/process-query
-      (query-with-strategy :right-join))))
-
-;; Can we do an inner join?
-(datasets/expect-with-drivers (mt/normal-drivers-with-feature :inner-join)
-  [["Big Red"        "Bayview Brood"]
-   ["Callie Crow"    "Mission Street Murder"]
-   ["Carson Crow"    "Mission Street Murder"]
-   ["Chicken Little" "Bayview Brood"]
-   ["Gerald Goose"   "Green Street Gaggle"]
-   ["Greg Goose"     "Green Street Gaggle"]
-   ["McNugget"       "Bayview Brood"]
-   ["Oliver Owl"     "Portrero Hill Parliament"]
-   ["Orville Owl"    "Portrero Hill Parliament"]
-   ["Paul Pelican"   "SoMa Squadron"]
-   ["Peter Pelican"  "SoMa Squadron"]
-   ["Russell Crow"   "Mission Street Murder"]]
-  (qp.test/rows
-    (qp/process-query
-      (query-with-strategy :inner-join))))
-
-;; Can we do a full join?
-(datasets/expect-with-drivers (mt/normal-drivers-with-feature :full-join)
-  (let [rows [["Big Red"          "Bayview Brood"]
+(deftest left-outer-join-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
+    (testing "Can we supply a custom alias? Can we do a left outer join ??"
+      (is (= [["Big Red"          "Bayview Brood"]
               ["Callie Crow"      "Mission Street Murder"]
               ["Camellia Crow"    nil]
               ["Carson Crow"      "Mission Street Murder"]
@@ -128,75 +63,147 @@
               ["Patricia Pelican" nil]
               ["Paul Pelican"     "SoMa Squadron"]
               ["Peter Pelican"    "SoMa Squadron"]
-              ["Russell Crow"     "Mission Street Murder"]]]
-    (if (tx/sorts-nil-first? driver/*driver*)
-      (cons [nil "Fillmore Flock"] rows)
-      (conj rows [nil "Fillmore Flock"])))
-  (qp.test/rows
-    (qp/process-query
-      (query-with-strategy :full-join))))
+              ["Russell Crow"     "Mission Street Murder"]]
+             (qp.test/rows
+               (qp/process-query
+                (query-with-strategy :left-join))))))))
 
-;; Can we automatically include `:all` Fields?
-(datasets/expect-with-drivers (mt/normal-drivers-with-feature :left-join)
-  {:columns (mapv data/format-name ["id" "name" "flock_id" "id_2" "name_2"])
-   :rows    [[2  "Big Red"          5   5   "Bayview Brood"]
-             [7  "Callie Crow"      4   4   "Mission Street Murder"]
-             [3  "Camellia Crow"    nil nil nil]
-             [16 "Carson Crow"      4   4   "Mission Street Murder"]
-             [12 "Chicken Little"   5   5   "Bayview Brood"]
-             [5  "Geoff Goose"      nil nil nil]
-             [9  "Gerald Goose"     1   1   "Green Street Gaggle"]
-             [6  "Greg Goose"       1   1   "Green Street Gaggle"]
-             [14 "McNugget"         5   5   "Bayview Brood"]
-             [17 "Olita Owl"        nil nil nil]
-             [18 "Oliver Owl"       3   3   "Portrero Hill Parliament"]
-             [15 "Orville Owl"      3   3   "Portrero Hill Parliament"]
-             [11 "Oswald Owl"       nil nil nil]
-             [10 "Pamela Pelican"   nil nil nil]
-             [8  "Patricia Pelican" nil nil nil]
-             [13 "Paul Pelican"     2   2   "SoMa Squadron"]
-             [4  "Peter Pelican"    2   2   "SoMa Squadron"]
-             [1  "Russell Crow"     4   4   "Mission Street Murder"]]}
-  (mt/format-rows-by [int str #(some-> % int) #(some-> % int) identity]
-    (qp.test/rows+column-names
-      (data/dataset bird-flocks
-        (mt/run-mbql-query bird
-          {:joins    [{:source-table $$flock
-                       :condition    [:= $flock_id &f.flock.id]
-                       :alias        "f"
-                       :fields       :all}]
-           :order-by [[:asc [:field-id $name]]]})))))
+(deftest right-outer-join-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :right-join)
+    (testing "Can we do a right outer join?"
+      ;; the [nil "Fillmore Flock"] row will either come first or last depending on the driver; the rest of the rows will
+      ;; be the same
+      (let [rows [["Big Red"        "Bayview Brood"]
+                  ["Callie Crow"    "Mission Street Murder"]
+                  ["Carson Crow"    "Mission Street Murder"]
+                  ["Chicken Little" "Bayview Brood"]
+                  ["Gerald Goose"   "Green Street Gaggle"]
+                  ["Greg Goose"     "Green Street Gaggle"]
+                  ["McNugget"       "Bayview Brood"]
+                  ["Oliver Owl"     "Portrero Hill Parliament"]
+                  ["Orville Owl"    "Portrero Hill Parliament"]
+                  ["Paul Pelican"   "SoMa Squadron"]
+                  ["Peter Pelican"  "SoMa Squadron"]
+                  ["Russell Crow"   "Mission Street Murder"]]
+            rows (if (tx/sorts-nil-first? driver/*driver*)
+                   (cons [nil "Fillmore Flock"] rows)
+                   (conj rows [nil "Fillmore Flock"]))]
+        (is (= rows
+               (qp.test/rows
+                 (qp/process-query
+                  (query-with-strategy :right-join)))))))))
 
-;; Can we include no Fields (with `:none`)
-(datasets/expect-with-drivers (mt/normal-drivers-with-feature :left-join)
-  {:columns (mapv data/format-name ["id" "name" "flock_id"])
-   :rows    [[2  "Big Red"          5  ]
-             [7  "Callie Crow"      4  ]
-             [3  "Camellia Crow"    nil]
-             [16 "Carson Crow"      4  ]
-             [12 "Chicken Little"   5  ]
-             [5  "Geoff Goose"      nil]
-             [9  "Gerald Goose"     1  ]
-             [6  "Greg Goose"       1  ]
-             [14 "McNugget"         5  ]
-             [17 "Olita Owl"        nil]
-             [18 "Oliver Owl"       3  ]
-             [15 "Orville Owl"      3  ]
-             [11 "Oswald Owl"       nil]
-             [10 "Pamela Pelican"   nil]
-             [8  "Patricia Pelican" nil]
-             [13 "Paul Pelican"     2  ]
-             [4  "Peter Pelican"    2  ]
-             [1  "Russell Crow"     4  ]]}
-  (mt/format-rows-by [#(some-> % int) str #(some-> % int)]
-    (qp.test/rows+column-names
-      (data/dataset bird-flocks
-        (mt/run-mbql-query bird
-          {:joins    [{:source-table $$flock
-                       :condition    [:= $flock_id &f.flock.id]
-                       :alias        "f"
-                       :fields       :none}]
-           :order-by [[:asc [:field-id $name]]]})))))
+(deftest inner-join-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :inner-join)
+    (testing "Can we do an inner join?"
+      (is (= [["Big Red"        "Bayview Brood"]
+              ["Callie Crow"    "Mission Street Murder"]
+              ["Carson Crow"    "Mission Street Murder"]
+              ["Chicken Little" "Bayview Brood"]
+              ["Gerald Goose"   "Green Street Gaggle"]
+              ["Greg Goose"     "Green Street Gaggle"]
+              ["McNugget"       "Bayview Brood"]
+              ["Oliver Owl"     "Portrero Hill Parliament"]
+              ["Orville Owl"    "Portrero Hill Parliament"]
+              ["Paul Pelican"   "SoMa Squadron"]
+              ["Peter Pelican"  "SoMa Squadron"]
+              ["Russell Crow"   "Mission Street Murder"]]
+             (qp.test/rows
+               (qp/process-query
+                (query-with-strategy :inner-join))))))))
+
+(deftest full-join-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :full-join)
+    (testing "Can we do a full join?"
+      (let [rows [["Big Red"          "Bayview Brood"]
+                  ["Callie Crow"      "Mission Street Murder"]
+                  ["Camellia Crow"    nil]
+                  ["Carson Crow"      "Mission Street Murder"]
+                  ["Chicken Little"   "Bayview Brood"]
+                  ["Geoff Goose"      nil]
+                  ["Gerald Goose"     "Green Street Gaggle"]
+                  ["Greg Goose"       "Green Street Gaggle"]
+                  ["McNugget"         "Bayview Brood"]
+                  ["Olita Owl"        nil]
+                  ["Oliver Owl"       "Portrero Hill Parliament"]
+                  ["Orville Owl"      "Portrero Hill Parliament"]
+                  ["Oswald Owl"       nil]
+                  ["Pamela Pelican"   nil]
+                  ["Patricia Pelican" nil]
+                  ["Paul Pelican"     "SoMa Squadron"]
+                  ["Peter Pelican"    "SoMa Squadron"]
+                  ["Russell Crow"     "Mission Street Murder"]]
+            rows (if (tx/sorts-nil-first? driver/*driver*)
+                   (cons [nil "Fillmore Flock"] rows)
+                   (conj rows [nil "Fillmore Flock"]))]
+        (is (= rows
+               (qp.test/rows
+                 (qp/process-query
+                  (query-with-strategy :full-join)))))))))
+
+(deftest automatically-include-all-fields-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
+    (testing "Can we automatically include `:all` Fields?"
+      (is (= {:columns (mapv data/format-name ["id" "name" "flock_id" "id_2" "name_2"])
+              :rows    [[2  "Big Red"          5   5   "Bayview Brood"]
+                        [7  "Callie Crow"      4   4   "Mission Street Murder"]
+                        [3  "Camellia Crow"    nil nil nil]
+                        [16 "Carson Crow"      4   4   "Mission Street Murder"]
+                        [12 "Chicken Little"   5   5   "Bayview Brood"]
+                        [5  "Geoff Goose"      nil nil nil]
+                        [9  "Gerald Goose"     1   1   "Green Street Gaggle"]
+                        [6  "Greg Goose"       1   1   "Green Street Gaggle"]
+                        [14 "McNugget"         5   5   "Bayview Brood"]
+                        [17 "Olita Owl"        nil nil nil]
+                        [18 "Oliver Owl"       3   3   "Portrero Hill Parliament"]
+                        [15 "Orville Owl"      3   3   "Portrero Hill Parliament"]
+                        [11 "Oswald Owl"       nil nil nil]
+                        [10 "Pamela Pelican"   nil nil nil]
+                        [8  "Patricia Pelican" nil nil nil]
+                        [13 "Paul Pelican"     2   2   "SoMa Squadron"]
+                        [4  "Peter Pelican"    2   2   "SoMa Squadron"]
+                        [1  "Russell Crow"     4   4   "Mission Street Murder"]]}
+             (mt/format-rows-by [int str #(some-> % int) #(some-> % int) identity]
+               (qp.test/rows+column-names
+                 (data/dataset bird-flocks
+                   (mt/run-mbql-query bird
+                     {:joins    [{:source-table $$flock
+                                  :condition    [:= $flock_id &f.flock.id]
+                                  :alias        "f"
+                                  :fields       :all}]
+                      :order-by [[:asc [:field-id $name]]]})))))))))
+
+(deftest include-no-fields-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
+    (testing "Can we include no Fields (with `:none`)"
+      (is (= {:columns (mapv data/format-name ["id" "name" "flock_id"])
+              :rows    [[2  "Big Red"          5  ]
+                        [7  "Callie Crow"      4  ]
+                        [3  "Camellia Crow"    nil]
+                        [16 "Carson Crow"      4  ]
+                        [12 "Chicken Little"   5  ]
+                        [5  "Geoff Goose"      nil]
+                        [9  "Gerald Goose"     1  ]
+                        [6  "Greg Goose"       1  ]
+                        [14 "McNugget"         5  ]
+                        [17 "Olita Owl"        nil]
+                        [18 "Oliver Owl"       3  ]
+                        [15 "Orville Owl"      3  ]
+                        [11 "Oswald Owl"       nil]
+                        [10 "Pamela Pelican"   nil]
+                        [8  "Patricia Pelican" nil]
+                        [13 "Paul Pelican"     2  ]
+                        [4  "Peter Pelican"    2  ]
+                        [1  "Russell Crow"     4  ]]}
+             (mt/format-rows-by [#(some-> % int) str #(some-> % int)]
+               (qp.test/rows+column-names
+                 (data/dataset bird-flocks
+                   (mt/run-mbql-query bird
+                     {:joins    [{:source-table $$flock
+                                  :condition    [:= $flock_id &f.flock.id]
+                                  :alias        "f"
+                                  :fields       :none}]
+                      :order-by [[:asc [:field-id $name]]]})))))))))
 
 (deftest specific-fields-test
   (datasets/test-drivers (mt/normal-drivers-with-feature :left-join)
@@ -274,139 +281,144 @@
         (is (= [[1 5] [2 1] [3 8]]
                rows))))))
 
-;; Can we join against a source nested MBQL query?
-(datasets/expect-with-drivers (mt/normal-drivers-with-feature :left-join)
-  [[29 "20th Century Cafe" 12  37.775 -122.423 2]
-   [ 8 "25°"               11 34.1015 -118.342 2]
-   [93 "33 Taps"            7 34.1018 -118.326 2]]
-  (mt/format-rows-by :venues
-    (qp.test/rows
-      (mt/run-mbql-query venues
-        {:source-table $$venues
-         :joins        [{:alias        "cat"
-                         :source-query {:source-table $$categories}
-                         :condition    [:= $category_id &cat.*categories.id]}]
-         :order-by     [[:asc $name]]
-         :limit        3}))))
+(deftest join-against-nested-mbql-query-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
+    (testing "Can we join against a source nested MBQL query?"
+      (is (= [[29 "20th Century Cafe" 12  37.775 -122.423 2]
+              [ 8 "25°"               11 34.1015 -118.342 2]
+              [93 "33 Taps"            7 34.1018 -118.326 2]]
+             (mt/format-rows-by :venues
+               (qp.test/rows
+                 (mt/run-mbql-query venues
+                   {:source-table $$venues
+                    :joins        [{:alias        "cat"
+                                    :source-query {:source-table $$categories}
+                                    :condition    [:= $category_id &cat.*categories.id]}]
+                    :order-by     [[:asc $name]]
+                    :limit        3}))))))))
 
-;; Can we join against a `card__id` source query and use `:fields` `:all`?
-(datasets/expect-with-drivers (mt/normal-drivers-with-feature :left-join)
-  {:rows
-   [[29 "20th Century Cafe" 12 37.775  -122.423 2 12 "Café"]
-    [8  "25°"               11 34.1015 -118.342 2 11 "Burger"]
-    [93 "33 Taps"           7  34.1018 -118.326 2  7 "Bar"]]
+(deftest join-against-card-source-query-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
+    (testing "Can we join against a `card__id` source query and use `:fields` `:all`?"
+      (is (= {:rows
+              [[29 "20th Century Cafe" 12 37.775  -122.423 2 12 "Café"]
+               [8  "25°"               11 34.1015 -118.342 2 11 "Burger"]
+               [93 "33 Taps"           7  34.1018 -118.326 2  7 "Bar"]]
 
-   :columns
-   (mapv data/format-name ["id" "name" "category_id" "latitude" "longitude" "price" "id_2" "name_2"])}
-  (tt/with-temp Card [{card-id :id} (qp.test-util/card-with-source-metadata-for-query (data/mbql-query categories))]
-    (mt/format-rows-by [int identity int 4.0 4.0 int int identity]
-      (qp.test/rows+column-names
-        (mt/run-mbql-query venues
-          {:joins    [{:alias        "cat"
-                       :source-table (str "card__" card-id)
-                       :fields       :all
-                       :condition    [:= $category_id &cat.*categories.id]}]
-           :order-by [[:asc $name]]
-           :limit    3})))))
+              :columns
+              (mapv data/format-name ["id" "name" "category_id" "latitude" "longitude" "price" "id_2" "name_2"])}
+             (tt/with-temp Card [{card-id :id} (qp.test-util/card-with-source-metadata-for-query (mt/mbql-query categories))]
+               (mt/format-rows-by [int identity int 4.0 4.0 int int identity]
+                 (qp.test/rows+column-names
+                   (mt/run-mbql-query venues
+                     {:joins    [{:alias        "cat"
+                                  :source-table (str "card__" card-id)
+                                  :fields       :all
+                                  :condition    [:= $category_id &cat.*categories.id]}]
+                      :order-by [[:asc $name]]
+                      :limit    3})))))))))
 
-;; Can we join on a Field literal for a source query?
-;;
-;; Also: if you join against an *explicit* source query, do all columns for both queries come back? (Only applies if
-;; you include `:source-metadata`)
-(datasets/expect-with-drivers (mt/normal-drivers-with-feature :left-join)
-  {:rows
-   [["2013-01-01T00:00:00Z"  8 "2013-01-01T00:00:00Z"  8]
-    ["2013-02-01T00:00:00Z" 11 "2013-02-01T00:00:00Z" 11]
-    ["2013-03-01T00:00:00Z" 21 "2013-03-01T00:00:00Z" 21]
-    ["2013-04-01T00:00:00Z" 26 "2013-04-01T00:00:00Z" 26]
-    ["2013-05-01T00:00:00Z" 23 "2013-05-01T00:00:00Z" 23]
-    ["2013-06-01T00:00:00Z" 26 "2013-06-01T00:00:00Z" 26]
-    ["2013-07-01T00:00:00Z" 20 "2013-07-01T00:00:00Z" 20]
-    ["2013-08-01T00:00:00Z" 22 "2013-08-01T00:00:00Z" 22]
-    ["2013-09-01T00:00:00Z" 13 "2013-09-01T00:00:00Z" 13]
-    ["2013-10-01T00:00:00Z" 26 "2013-10-01T00:00:00Z" 26]]
-   :columns [(data/format-name "date") "count" (data/format-name "date_2") "count_2"]}
-  (mt/format-rows-by [identity int identity int]
-    (qp.test/rows+column-names
-      (tt/with-temp Card [{card-id :id} (qp.test-util/card-with-source-metadata-for-query
-                                         (data/mbql-query checkins
-                                           {:aggregation [[:count]]
-                                            :breakout    [!month.date]}))]
-        (mt/run-mbql-query checkins
-          {:source-query {:source-table $$checkins
-                          :aggregation  [[:count]]
-                          :breakout     [!month.date]}
-           :joins
-           [{:fields       :all
-             :alias        "checkins_2"
-             :source-table (str "card__" card-id)
-             :condition    [:= !month.*date &checkins_2.*date]}]
-           :order-by     [[:asc !month.*date]]
-           :limit        10})))))
+(deftest join-on-field-literal-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
+    (testing "Can we join on a Field literal for a source query?"
+      ;; Also: if you join against an *explicit* source query, do all columns for both queries come back? (Only applies
+      ;; if you include `:source-metadata`)
+      (is (= {:rows
+              [["2013-01-01T00:00:00Z"  8 "2013-01-01T00:00:00Z"  8]
+               ["2013-02-01T00:00:00Z" 11 "2013-02-01T00:00:00Z" 11]
+               ["2013-03-01T00:00:00Z" 21 "2013-03-01T00:00:00Z" 21]
+               ["2013-04-01T00:00:00Z" 26 "2013-04-01T00:00:00Z" 26]
+               ["2013-05-01T00:00:00Z" 23 "2013-05-01T00:00:00Z" 23]
+               ["2013-06-01T00:00:00Z" 26 "2013-06-01T00:00:00Z" 26]
+               ["2013-07-01T00:00:00Z" 20 "2013-07-01T00:00:00Z" 20]
+               ["2013-08-01T00:00:00Z" 22 "2013-08-01T00:00:00Z" 22]
+               ["2013-09-01T00:00:00Z" 13 "2013-09-01T00:00:00Z" 13]
+               ["2013-10-01T00:00:00Z" 26 "2013-10-01T00:00:00Z" 26]]
+              :columns [(data/format-name "date") "count" (data/format-name "date_2") "count_2"]}
+             (mt/format-rows-by [identity int identity int]
+               (qp.test/rows+column-names
+                 (tt/with-temp Card [{card-id :id} (qp.test-util/card-with-source-metadata-for-query
+                                                    (mt/mbql-query checkins
+                                                      {:aggregation [[:count]]
+                                                       :breakout    [!month.date]}))]
+                   (mt/run-mbql-query checkins
+                     {:source-query {:source-table $$checkins
+                                     :aggregation  [[:count]]
+                                     :breakout     [!month.date]}
+                      :joins
+                      [{:fields       :all
+                        :alias        "checkins_2"
+                        :source-table (str "card__" card-id)
+                        :condition    [:= !month.*date &checkins_2.*date]}]
+                      :order-by     [[:asc !month.*date]]
+                      :limit        10})))))))))
 
-;; Can we aggregate on the results of a JOIN?
-(datasets/expect-with-drivers (mt/normal-drivers-with-feature :left-join)
-  ;; for whatever reason H2 gives slightly different answers :unamused:
-  {:rows    (let [driver-avg #(if (= metabase.driver/*driver* :h2) %1 %2)]
-              [["2014-01-01T00:00:00Z" 77]
-               ["2014-02-01T00:00:00Z" 81]
-               ["2014-04-01T00:00:00Z" (driver-avg 50 49)]
-               ["2014-07-01T00:00:00Z" (driver-avg 69 68)]
-               ["2014-08-01T00:00:00Z" 64]
-               ["2014-10-01T00:00:00Z" (driver-avg 66 65)]
-               ["2014-11-01T00:00:00Z" (driver-avg 75 74)]
-               ["2014-12-01T00:00:00Z" 70]])
-   :columns [(data/format-name "last_login") "avg"]}
-  (mt/format-rows-by [identity int]
-    (qp.test/rows+column-names
-      (tt/with-temp Card [{card-id :id} (qp.test-util/card-with-source-metadata-for-query
-                                         (data/mbql-query checkins
-                                           {:aggregation [[:count]]
-                                            :breakout    [$user_id]}))]
-        (mt/run-mbql-query users
-          {:joins       [{:fields       :all
-                          :alias        "checkins_by_user"
-                          :source-table (str "card__" card-id)
-                          :condition    [:= $id &checkins_by_user.*checkins.user_id]}]
-           :aggregation [[:avg &checkins_by_user.*count/Float]]
-           :breakout    [!month.last_login]})))))
+(deftest aggregate-join-results-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
+    (testing "Can we aggregate on the results of a JOIN?"
+      ;; for whatever reason H2 gives slightly different answers :unamused:
+      (is (= {:rows    (let [driver-avg #(if (= metabase.driver/*driver* :h2) %1 %2)]
+                         [["2014-01-01T00:00:00Z" 77]
+                          ["2014-02-01T00:00:00Z" 81]
+                          ["2014-04-01T00:00:00Z" (driver-avg 50 49)]
+                          ["2014-07-01T00:00:00Z" (driver-avg 69 68)]
+                          ["2014-08-01T00:00:00Z" 64]
+                          ["2014-10-01T00:00:00Z" (driver-avg 66 65)]
+                          ["2014-11-01T00:00:00Z" (driver-avg 75 74)]
+                          ["2014-12-01T00:00:00Z" 70]])
+              :columns [(data/format-name "last_login") "avg"]}
+             (mt/format-rows-by [identity int]
+               (qp.test/rows+column-names
+                 (tt/with-temp Card [{card-id :id} (qp.test-util/card-with-source-metadata-for-query
+                                                    (mt/mbql-query checkins
+                                                      {:aggregation [[:count]]
+                                                       :breakout    [$user_id]}))]
+                   (mt/run-mbql-query users
+                     {:joins       [{:fields       :all
+                                     :alias        "checkins_by_user"
+                                     :source-table (str "card__" card-id)
+                                     :condition    [:= $id &checkins_by_user.*checkins.user_id]}]
+                      :aggregation [[:avg &checkins_by_user.*count/Float]]
+                      :breakout    [!month.last_login]})))))))))
 
-;; NEW! Can we still get all of our columns, even if we *DON'T* specify the metadata?
-(datasets/expect-with-drivers (mt/normal-drivers-with-feature :left-join)
-  {:rows    [["2013-01-01T00:00:00Z"  8 "2013-01-01T00:00:00Z"  8]
-             ["2013-02-01T00:00:00Z" 11 "2013-02-01T00:00:00Z" 11]
-             ["2013-03-01T00:00:00Z" 21 "2013-03-01T00:00:00Z" 21]]
-   :columns [(data/format-name "date") "count" (data/format-name "date_2") "count_2"]}
-  (tt/with-temp Card [{card-id               :id
-                       {source-query :query} :dataset_query
-                       source-metadata       :result_metadata} (qp.test-util/card-with-source-metadata-for-query
-                       (data/mbql-query checkins
-                         {:aggregation [[:count]]
-                          :breakout    [!month.date]}))]
-    (qp.test/rows+column-names
-      (mt/format-rows-by [identity int identity int]
-        (mt/run-mbql-query checkins
-          {:source-query source-query
-           :joins        [{:source-table (str "card__" card-id)
-                           :alias        "checkins_by_month"
-                           :fields       :all
-                           :condition    [:= *checkins.date &checkins_by_month.*checkins.date]}]
-           :order-by     [[:asc *checkins.date]]
-           :limit        3})))))
+(deftest get-all-columns-without-metadata-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
+    (testing "NEW! Can we still get all of our columns, even if we *DON'T* specify the metadata?"
+      (tt/with-temp Card [{card-id               :id
+                           {source-query :query} :dataset_query
+                           source-metadata       :result_metadata} (qp.test-util/card-with-source-metadata-for-query
+                                                                    (mt/mbql-query checkins
+                                                                      {:aggregation [[:count]]
+                                                                       :breakout    [!month.date]}))]
+        (is (= {:rows    [["2013-01-01T00:00:00Z"  8 "2013-01-01T00:00:00Z"  8]
+                          ["2013-02-01T00:00:00Z" 11 "2013-02-01T00:00:00Z" 11]
+                          ["2013-03-01T00:00:00Z" 21 "2013-03-01T00:00:00Z" 21]]
+                :columns [(data/format-name "date") "count" (data/format-name "date_2") "count_2"]}
+               (qp.test/rows+column-names
+                 (mt/format-rows-by [identity int identity int]
+                   (mt/run-mbql-query checkins
+                     {:source-query source-query
+                      :joins        [{:source-table (str "card__" card-id)
+                                      :alias        "checkins_by_month"
+                                      :fields       :all
+                                      :condition    [:= *checkins.date &checkins_by_month.*checkins.date]}]
+                      :order-by     [[:asc *checkins.date]]
+                      :limit        3})))))))))
 
-;; Should be able to use a joined field in a `:time-interval` clause
-(datasets/expect-with-drivers (mt/normal-drivers-with-feature :left-join)
-  {:rows    []
-   :columns (mapv data/format-name ["id" "name" "category_id" "latitude" "longitude" "price"])}
-  (qp.test/rows+column-names
-    (mt/run-mbql-query venues
-      {:joins    [{:source-table $$checkins
-                   :alias        "c"
-                   :strategy     :right-join
-                   :condition    [:= $id &c.checkins.venue_id]}]
-       :filter   [:time-interval &c.checkins.date -30 :day]
-       :order-by [[:asc &c.checkins.id]]
-       :limit    10})))
+(deftest joined-field-in-time-interval-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
+    (testing "Should be able to use a joined field in a `:time-interval` clause"
+      (is (= {:rows    []
+              :columns (mapv data/format-name ["id" "name" "category_id" "latitude" "longitude" "price"])}
+             (qp.test/rows+column-names
+               (mt/run-mbql-query venues
+                 {:joins    [{:source-table $$checkins
+                              :alias        "c"
+                              :strategy     :right-join
+                              :condition    [:= $id &c.checkins.venue_id]}]
+                  :filter   [:time-interval &c.checkins.date -30 :day]
+                  :order-by [[:asc &c.checkins.id]]
+                  :limit    10})))))))
 
 (deftest deduplicate-column-names-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
@@ -453,17 +465,18 @@
                  1 "Red Medicine" 4 10.065 -165.374 3]]
                rows))))))
 
-;; we should be able to use a SQL question as a source query in a Join
-(datasets/expect-with-drivers (mt/normal-drivers-with-feature :nested-queries :left-join)
-  [[1 "2014-04-07T00:00:00Z" 5 12 12 "The Misfit Restaurant + Bar" 2 34.0154 -118.497 2]
-   [2 "2014-09-18T00:00:00Z" 1 31 31 "Bludso's BBQ"                5 33.8894 -118.207 2]]
-  (tt/with-temp Card [{card-id :id, :as card} (qp.test-util/card-with-source-metadata-for-query
-                                               (data/native-query (qp/query->native (data/mbql-query venues))))]
-    (qp.test/formatted-rows [int identity int int int identity int 4.0 4.0 int]
-      (mt/run-mbql-query checkins
-        {:joins    [{:fields       :all
-                     :source-table (str "card__" card-id)
-                     :alias        "card"
-                     :condition    [:= $venue_id &card.*venues.id]}]
-         :order-by [[:asc $id]]
-         :limit    2}))))
+(deftest sql-question-source-query-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join)
+    (testing "we should be able to use a SQL question as a source query in a Join"
+      (tt/with-temp Card [{card-id :id, :as card} (qp.test-util/card-with-source-metadata-for-query
+                                                   (data/native-query (qp/query->native (mt/mbql-query venues))))]
+        (is (= [[1 "2014-04-07T00:00:00Z" 5 12 12 "The Misfit Restaurant + Bar" 2 34.0154 -118.497 2]
+                [2 "2014-09-18T00:00:00Z" 1 31 31 "Bludso's BBQ"                5 33.8894 -118.207 2]]
+               (qp.test/formatted-rows [int identity int int int identity int 4.0 4.0 int]
+                 (mt/run-mbql-query checkins
+                   {:joins    [{:fields       :all
+                                :source-table (str "card__" card-id)
+                                :alias        "card"
+                                :condition    [:= $venue_id &card.*venues.id]}]
+                    :order-by [[:asc $id]]
+                    :limit    2}))))))))


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1455846/96200531-fa67d680-0f0e-11eb-926f-1d547fa22b94.png)

Fixes #11452.

IIRC we were originally using just the name of the Table we joined against when showing it in UI widgets. This caused problems for Tables that had more than one FK pointing to the same dest Table, e.g. both a `start_event_id` and an `end_event_id` -- see #8418. At some point I think @tlrobinson changed the code to use the name of the FK Field instead. This causes a different set of problems, if two different Tables in the query both had FKs to the Table being joined -- see #11452.

For those reasons we need to use both the Table and Field name when displaying the join. In cases where these are basically the same, e.g. `Products`/`product_id`, displayed as `Products - Product`, I've tweaked this so it only shows the Table name, so it doesn't look ridiculous)

The actual relevant part of this PR is in `Join.js`. The other stuff is the reproduction test from #13317 backported from `master` and me reworking some Clojure tests to the new style as I started tackling this issue.