### PR TITLE
Catch query description errors and improve client error message

### DIFF
--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -410,6 +410,9 @@ export function createEntity(def: EntityDefinition): Entity {
       // contains the actual entries, if that is on the response we should
       // use that as the 'results'
       const results = fetched.data ? fetched.data : fetched;
+      if (!Array.isArray(results)) {
+        throw `Invalid response listing ${entity.name}`;
+      }
       return {
         ...entity.normalizeList(results),
         entityQuery,

--- a/src/metabase/api/query_description.clj
+++ b/src/metabase/api/query_description.clj
@@ -1,6 +1,7 @@
 (ns metabase.api.query-description
   "Functions for generating human friendly query descriptions"
   (:require [clojure.string :as str]
+            [clojure.tools.logging :as log]
             [metabase.mbql
              [predicates :as mbql.preds]
              [util :as mbql.u]]
@@ -109,6 +110,10 @@
 
   This data structure allows the UI to format the strings appropriately (including JSX)"
   [metadata query]
-  (apply merge
-         (map (fn [f] (f metadata query))
-              query-descriptor-functions)))
+  (try
+    (apply merge
+           (map (fn [f] (f metadata query))
+                query-descriptor-functions))
+    (catch Exception e
+      (log/warn e "Error generating query description")
+      {})))

--- a/test/metabase/api/query_description_test.clj
+++ b/test/metabase/api/query_description_test.clj
@@ -64,7 +64,13 @@
                                :arg  (deferred-tru "[Unknown Metric]")}]}
                (sut/generate-query-description (Table (mt/id :venues))
                                                (:query (mt/mbql-query :venues
-                                                         {:aggregation [[:metric -1]]}))))))
+                                                         {:aggregation [[:metric -1]]})))))
+
+        ;; confirm that it doesn't crash for non-integer metrics
+        (is (= {}
+               (sut/generate-query-description (Table (mt/id :venues))
+                                               (:query (mt/mbql-query :venues
+                                                         {:aggregation [[:metric "not-a-integer"]]}))))))
 
       (testing "with segment filters"
         (tt/with-temp Segment [segment {:name "Test Segment 1"}]


### PR DESCRIPTION
Fixes #13362 

There have been other similar crashes to this on metrics/segments listing pages. The server silently fails and returns an empty response to a list endpoint. This PR adds two mitigations:
- I'm not sure why the error was being swallowed in the server. To address it here, I added a try/catch in `generate-query-description`. This will return metrics/segments without a query description rather than failing the whole request.
- I updated the entities API code to explicitly fail when it gets a weird response listing objects. Previously it was failing downstream of that when attempting to normalize. This is a better error message.

This PR doesn't fix the specific failure causing #13362. It's breaking because metrics in GA queries don't refer to rows in the db but are hardcoded strings referring to GA's own metrics (e.g. `ga:users`). I'll still have this resolve #13362, but I opened another issue (#13507) for the more mild issue still affecting GA segments/metrics.
