### PR TITLE
Smarter state fields

### DIFF
--- a/src/metabase/sync/analyze/classifiers/name.clj
+++ b/src/metabase/sync/analyze/classifiers/name.clj
@@ -40,6 +40,8 @@
    [#"^.*_url$"                    text-type        :type/URL]
    [#"^_latitude$"                 float-type       :type/Latitude]
    [#"^active$"                    bool-or-int-type :type/Category]
+   ;; state is conspicuously absent here as we use fingerprints to infer this to prevent marking fields like
+   ;; "order_state" (think status) as US states (#2735)
    [#"^city$"                      text-type        :type/City]
    [#"^country"                    text-type        :type/Country]
    [#"_country$"                   text-type        :type/Country]
@@ -58,8 +60,6 @@
    [#"^postal(?:_?)code$"          int-or-text-type :type/ZipCode]
    [#"^role$"                      int-or-text-type :type/Category]
    [#"^sex$"                       int-or-text-type :type/Category]
-   [#"^state$"                     text-type        :type/State]
-   [#"_state$"                     text-type        :type/State]
    [#"^status$"                    int-or-text-type :type/Category]
    [#"^type$"                      int-or-text-type :type/Category]
    [#"^url$"                       text-type        :type/URL]

--- a/src/metabase/sync/analyze/classifiers/name.clj
+++ b/src/metabase/sync/analyze/classifiers/name.clj
@@ -40,8 +40,6 @@
    [#"^.*_url$"                    text-type        :type/URL]
    [#"^_latitude$"                 float-type       :type/Latitude]
    [#"^active$"                    bool-or-int-type :type/Category]
-   ;; state is conspicuously absent here as we use fingerprints to infer this to prevent marking fields like
-   ;; "order_state" (think status) as US states (#2735)
    [#"^city$"                      text-type        :type/City]
    [#"^country"                    text-type        :type/Country]
    [#"_country$"                   text-type        :type/Country]

--- a/src/metabase/sync/analyze/classifiers/text_fingerprint.clj
+++ b/src/metabase/sync/analyze/classifiers/text_fingerprint.clj
@@ -8,46 +8,58 @@
             [metabase.util.schema :as su]
             [schema.core :as s]))
 
-(def ^:private ^:const ^Float percent-valid-threshold
+(def ^:private ^:const ^Double percent-valid-threshold
   "Fields that have at least this percent of values that are satisfy some predicate (such as `u/email?`)
    should be given the corresponding special type (such as `:type/Email`)."
   0.95)
 
-(s/defn ^:private percent-key-below-threshold? :- s/Bool
+(def ^:private ^Double lower-percent-valid-threshold
+  "Fields that have at least this lower percent of values that satisfy some predicate (such as `u/state?`) should be
+  given the corresponding special type (such as `:type/State`)"
+  0.7)
+
+(s/defn ^:private percent-key-above-threshold? :- s/Bool
   "Is the value of PERCENT-KEY inside TEXT-FINGERPRINT above the `percent-valid-threshold`?"
-  [text-fingerprint :- i/TextFingerprint, percent-key :- s/Keyword]
+  [^Double threshold, text-fingerprint :- i/TextFingerprint, percent-key :- s/Keyword]
   (boolean
    (when-let [percent (get text-fingerprint percent-key)]
-     (>= percent percent-valid-threshold))))
-
+     (>= percent threshold))))
 
 (def ^:private percent-key->special-type
   "Map of keys inside the `TextFingerprint` to the corresponding special types we should mark a Field as if the value of
   the key is over `percent-valid-thresold`."
-  {:percent-json  :type/SerializedJSON
-   :percent-url   :type/URL
-   :percent-email :type/Email
-   :percent-state :type/State})
+  {:percent-json  [:type/SerializedJSON percent-valid-threshold]
+   :percent-url   [:type/URL            percent-valid-threshold]
+   :percent-email [:type/Email          percent-valid-threshold]
+   :percent-state [:type/State          lower-percent-valid-threshold]})
 
 (s/defn ^:private infer-special-type-for-text-fingerprint :- (s/maybe su/FieldType)
   "Check various percentages inside the TEXT-FINGERPRINT and return the corresponding special type to mark the Field
   as if the percent passes the threshold."
   [text-fingerprint :- i/TextFingerprint]
-  (some (fn [[percent-key special-type]]
-          (when (percent-key-below-threshold? text-fingerprint percent-key)
+  (some (fn [[percent-key [special-type threshold]]]
+          (when (percent-key-above-threshold? threshold text-fingerprint percent-key)
             special-type))
-        (seq percent-key->special-type)))
+        percent-key->special-type))
+
+(defn- can-edit-special-type?
+  "We can edit the special type if its currently unset or if it was set during the current analysis phase."
+  [field]
+  (or (nil? (:special_type field))
+      (let [original (get (meta field) :sync.classify/original)]
+        (and original
+             (nil? (:special_type original))))))
 
 
 (s/defn infer-special-type :- (s/maybe i/FieldInstance)
   "Do classification for `:type/Text` Fields with a valid `TextFingerprint`.
    Currently this only checks the various recorded percentages, but this is subject to change in the future."
   [field :- i/FieldInstance, fingerprint :- (s/maybe i/Fingerprint)]
-  (when (isa? (:base_type field) :type/Text)
-    (when-not (:special_type field)
-      (when-let [text-fingerprint (get-in fingerprint [:type :type/Text])]
-        (when-let [inferred-special-type (infer-special-type-for-text-fingerprint text-fingerprint)]
-          (log/debug (format "Based on the fingerprint of %s, we're marking it as %s."
-                             (sync-util/name-for-logging field) inferred-special-type))
-          (assoc field
-            :special_type inferred-special-type))))))
+  (when (and (isa? (:base_type field) :type/Text)
+             (can-edit-special-type? field))
+    (when-let [text-fingerprint (get-in fingerprint [:type :type/Text])]
+      (when-let [inferred-special-type (infer-special-type-for-text-fingerprint text-fingerprint)]
+        (log/debug (format "Based on the fingerprint of %s, we're marking it as %s."
+                           (sync-util/name-for-logging field) inferred-special-type))
+        (assoc field
+               :special_type inferred-special-type)))))

--- a/src/metabase/sync/analyze/classifiers/text_fingerprint.clj
+++ b/src/metabase/sync/analyze/classifiers/text_fingerprint.clj
@@ -3,8 +3,8 @@
    These tests only run against Fields that *don't* have existing special types."
   (:require [clojure.tools.logging :as log]
             [metabase.sync
-             [util :as sync-util]
-             [interface :as i]]
+             [interface :as i]
+             [util :as sync-util]]
             [metabase.util.schema :as su]
             [schema.core :as s]))
 

--- a/src/metabase/sync/analyze/classifiers/text_fingerprint.clj
+++ b/src/metabase/sync/analyze/classifiers/text_fingerprint.clj
@@ -43,7 +43,10 @@
         percent-key->special-type))
 
 (defn- can-edit-special-type?
-  "We can edit the special type if its currently unset or if it was set during the current analysis phase."
+  "We can edit the special type if its currently unset or if it was set during the current analysis phase. The original
+  field might exist in the metadata at `:sync.classify/original`. This is an attempt at classifier refinement: we
+  never want to overwrite a user selection of special type but we allow for fingerprint results to give a better
+  special type than previous classifiers."
   [field]
   (or (nil? (:special_type field))
       (let [original (get (meta field) :sync.classify/original)]

--- a/src/metabase/sync/analyze/classifiers/text_fingerprint.clj
+++ b/src/metabase/sync/analyze/classifiers/text_fingerprint.clj
@@ -3,8 +3,8 @@
    These tests only run against Fields that *don't* have existing special types."
   (:require [clojure.tools.logging :as log]
             [metabase.sync
-             [interface :as i]
-             [util :as sync-util]]
+             [util :as sync-util]
+             [interface :as i]]
             [metabase.util.schema :as su]
             [schema.core :as s]))
 
@@ -26,7 +26,8 @@
   the key is over `percent-valid-thresold`."
   {:percent-json  :type/SerializedJSON
    :percent-url   :type/URL
-   :percent-email :type/Email})
+   :percent-email :type/Email
+   :percent-state :type/State})
 
 (s/defn ^:private infer-special-type-for-text-fingerprint :- (s/maybe su/FieldType)
   "Check various percentages inside the TEXT-FINGERPRINT and return the corresponding special type to mark the Field

--- a/src/metabase/sync/analyze/classify.clj
+++ b/src/metabase/sync/analyze/classify.clj
@@ -68,15 +68,19 @@
 (def ^:private classifiers
   "Various classifier functions available. These should all take two args, a `FieldInstance` and a possibly `nil`
   `Fingerprint`, and return `FieldInstance` with any inferred property changes, or `nil` if none could be inferred.
-  Order is important!"
+  Order is important!
+
+  A classifier may see the original field (before any classifiers were run) in the metadata of the field at
+  `:sync.classify/original`."
   [name/infer-and-assoc-special-type
    category/infer-is-category-or-list
    no-preview-display/infer-no-preview-display
    text-fingerprint/infer-special-type])
 
 (s/defn run-classifiers :- i/FieldInstance
-  "Run all the available `classifiers` against `field` and `fingerprint`, and return the resulting `field` with changes
-  decided upon by the classifiers."
+  "Run all the available `classifiers` against `field` and `fingerprint`, and return the resulting `field` with
+  changes decided upon by the classifiers. The original field can be accessed in the metadata at
+  `:sync.classify/original`."
   [field :- i/FieldInstance, fingerprint :- (s/maybe i/Fingerprint)]
   (reduce (fn [field classifier]
             (or (sync-util/with-error-handling (format "Error running classifier on %s"

--- a/src/metabase/sync/analyze/classify.clj
+++ b/src/metabase/sync/analyze/classify.clj
@@ -78,14 +78,13 @@
   "Run all the available `classifiers` against `field` and `fingerprint`, and return the resulting `field` with changes
   decided upon by the classifiers."
   [field :- i/FieldInstance, fingerprint :- (s/maybe i/Fingerprint)]
-  (loop [field field, [classifier & more] classifiers]
-    (if-not classifier
-      field
-      (recur (or (sync-util/with-error-handling (format "Error running classifier on %s"
-                                                        (sync-util/name-for-logging field))
-                   (classifier field fingerprint))
-                 field)
-             more))))
+  (reduce (fn [field classifier]
+            (or (sync-util/with-error-handling (format "Error running classifier on %s"
+                                                       (sync-util/name-for-logging field))
+                  (classifier field fingerprint))
+                field))
+          (vary-meta field assoc :sync.classify/original field)
+          classifiers))
 
 
 (s/defn ^:private classify!

--- a/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
@@ -246,6 +246,7 @@
    (robust-fuse {:percent-json   (stats/share valid-serialized-json?)
                  :percent-url    (stats/share u/url?)
                  :percent-email  (stats/share u/email?)
+                 :percent-state  (stats/share u/state?)
                  :average-length ((map count) stats/mean)})))
 
 (defn fingerprint-fields

--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -114,6 +114,7 @@
   {(s/optional-key :percent-json)   (s/maybe Percent)
    (s/optional-key :percent-url)    (s/maybe Percent)
    (s/optional-key :percent-email)  (s/maybe Percent)
+   (s/optional-key :percent-state)  (s/maybe Percent)
    (s/optional-key :average-length) (s/maybe s/Num)})
 
 (def TemporalFingerprint
@@ -170,7 +171,8 @@
   {1 #{:type/*}
    2 #{:type/Number}
    3 #{:type/DateTime}
-   4 #{:type/*}})
+   4 #{:type/*}
+   5 #{:type/Text}})
 
 (def latest-fingerprint-version
   "The newest (highest-numbered) version of our Field fingerprints."

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -97,17 +97,19 @@
 (defn state?
   "Is `s` a state string?"
   ^Boolean [^String s]
-  (contains? #{"alabama" "alaska" "arizona" "arkansas" "california" "colorado" "connecticut" "delaware"
-               "florida" "georgia" "hawaii" "idaho" "illinois" "indiana" "iowa" "kansas" "kentucky" "louisiana"
-               "maine" "maryland" "massachusetts" "michigan" "minnesota" "mississippi" "missouri" "montana"
-               "nebraska" "nevada" "new hampshire" "new jersey" "new mexico" "new york" "north carolina"
-               "north dakota" "ohio" "oklahoma" "oregon" "pennsylvania" "rhode island" "south carolina"
-               "south dakota" "tennessee" "texas" "utah" "vermont" "virginia" "washington" "west virginia"
-               "wisconsin" "wyoming"
-               "al" "mt" "ak" "ne" "az" "nv" "ar" "nh" "ca" "nj" "co" "nm" "ct" "ny" "de" "nc" "fl" "nd"
-               "ga" "oh" "hi" "ok" "id" "or" "il" "pa" "in" "ri" "ia" "sc" "ks" "sd" "ky" "tn" "la" "tx"
-               "me" "ut" "md" "vt" "ma" "va" "mi" "wa" "mn" "wv" "ms" "wi" "mo" "wy"}
-             (when s (str/lower-case s))))
+  (boolean
+    (when (string? s)
+      (contains? #{"alabama" "alaska" "arizona" "arkansas" "california" "colorado" "connecticut" "delaware"
+                   "florida" "georgia" "hawaii" "idaho" "illinois" "indiana" "iowa" "kansas" "kentucky" "louisiana"
+                   "maine" "maryland" "massachusetts" "michigan" "minnesota" "mississippi" "missouri" "montana"
+                   "nebraska" "nevada" "new hampshire" "new jersey" "new mexico" "new york" "north carolina"
+                   "north dakota" "ohio" "oklahoma" "oregon" "pennsylvania" "rhode island" "south carolina"
+                   "south dakota" "tennessee" "texas" "utah" "vermont" "virginia" "washington" "west virginia"
+                   "wisconsin" "wyoming"
+                   "ak" "al" "ar" "az" "ca" "co" "ct" "de" "fl" "ga" "hi" "ia" "id" "il" "in" "ks" "ky" "la"
+                   "ma" "md" "me" "mi" "mn" "mo" "ms" "mt" "nc" "nd" "ne" "nh" "nj" "nm" "nv" "ny" "oh" "ok"
+                   "or" "pa" "ri" "sc" "sd" "tn" "tx" "ut" "va" "vt" "wa" "wi" "wv" "wy"}
+                 (str/lower-case s)))))
 
 (defn url?
   "Is `s` a valid HTTP/HTTPS URL string?"

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -95,6 +95,7 @@
                          (str/lower-case s)))))
 
 (defn state?
+  "Is `s` a state string?"
   ^Boolean [^String s]
   (contains? #{"alabama" "alaska" "arizona" "arkansas" "california" "colorado" "connecticut" "delaware"
                "florida" "georgia" "hawaii" "idaho" "illinois" "indiana" "iowa" "kansas" "kentucky" "louisiana"

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -94,6 +94,20 @@
              (re-matches #"[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
                          (str/lower-case s)))))
 
+(defn state?
+  ^Boolean [^String s]
+  (contains? #{"alabama" "alaska" "arizona" "arkansas" "california" "colorado" "connecticut" "delaware"
+               "florida" "georgia" "hawaii" "idaho" "illinois" "indiana" "iowa" "kansas" "kentucky" "louisiana"
+               "maine" "maryland" "massachusetts" "michigan" "minnesota" "mississippi" "missouri" "montana"
+               "nebraska" "nevada" "new hampshire" "new jersey" "new mexico" "new york" "north carolina"
+               "north dakota" "ohio" "oklahoma" "oregon" "pennsylvania" "rhode island" "south carolina"
+               "south dakota" "tennessee" "texas" "utah" "vermont" "virginia" "washington" "west virginia"
+               "wisconsin" "wyoming"
+               "al" "mt" "ak" "ne" "az" "nv" "ar" "nh" "ca" "nj" "co" "nm" "ct" "ny" "de" "nc" "fl" "nd"
+               "ga" "oh" "hi" "ok" "id" "or" "il" "pa" "in" "ri" "ia" "sc" "ks" "sd" "ky" "tn" "la" "tx"
+               "me" "ut" "md" "vt" "ma" "va" "mi" "wa" "mn" "wv" "ms" "wi" "mo" "wy"}
+             (when s (str/lower-case s))))
+
 (defn url?
   "Is `s` a valid HTTP/HTTPS URL string?"
   ^Boolean [s]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -482,6 +482,7 @@
                                 :type   {:type/Text {:percent-json   0.0
                                                      :percent-url    0.0
                                                      :percent-email  0.0
+                                                     :percent-state  0.0
                                                      :average-length 12.0}}}}
                  (db/select-field->field :name :fingerprint Field
                    :table_id (db/select-one-id Table :db_id (u/get-id database))))))))))

--- a/test/metabase/query_processor/async_test.clj
+++ b/test/metabase/query_processor/async_test.clj
@@ -21,5 +21,6 @@
                                               {:percent-json   0.0,
                                                :percent-url    0.0,
                                                :percent-email  0.0,
+                                               :percent-state  0.0,
                                                :average-length 15.63}}}}]
              (mt/wait-for-result result-chan 1000))))))

--- a/test/metabase/sample_dataset_test.clj
+++ b/test/metabase/sample_dataset_test.clj
@@ -62,6 +62,7 @@
                       :type   {:type/Text {:percent-json   0.0
                                            :percent-url    0.0
                                            :percent-email  0.0
+                                           :percent-state  0.0
                                            :average-length 13.532}}}
    :base_type        :type/Text}
   (with-temp-sample-dataset-db [db]

--- a/test/metabase/sync/analyze/classifiers/name_test.clj
+++ b/test/metabase/sync/analyze/classifiers/name_test.clj
@@ -1,48 +1,51 @@
 (ns metabase.sync.analyze.classifiers.name-test
-  (:require [expectations :refer :all]
+  (:require [clojure.test :refer :all]
             [metabase.models
              [field :refer [Field]]
              [table :as table :refer [Table]]]
-            [metabase.sync.analyze.classifiers.name :refer :all]
+            [metabase.sync.analyze.classifiers.name :as classify.names]
             [toucan.util.test :as tt]))
 
-;; Postfix + pluralization
-(expect
-  :entity/TransactionTable
-  (-> {:name "MY_ORDERS"} table/map->TableInstance infer-entity-type :entity_type))
+(deftest infer-entity-type-test
+  (testing "name matches"
+    (let [classify (fn [table-name] (-> {:name table-name}
+                                        table/map->TableInstance
+                                        classify.names/infer-entity-type
+                                        :entity_type))]
+      (testing "matches simple"
+        (is (= :entity/TransactionTable (classify "MY_ORDERS"))))
+      (testing "matches prefix"
+        (is (= :entity/ProductTable (classify "productcatalogue"))))
+      (testing "doesn't match in the middle"
+        (is (= :entity/GenericTable (classify "myproductcatalogue"))))
+      (testing "defaults to generic table"
+        (is (= :entity/GenericTable (classify "foo"))))))
+  (testing "When using field info"
+    (testing "doesn't infer on PK/FK special_types"
+      (tt/with-temp* [Table [{table-id :id}]
+                      Field [{field-id :id} {:table_id     table-id
+                                             :special_type :type/FK
+                                             :name         "City"
+                                             :base_type    :type/Text}]]
+        (is (nil? (-> field-id Field (classify.names/infer-and-assoc-special-type nil) :special_type)))))
+    (testing "but does infer on non-PK/FK fields"
+      (tt/with-temp* [Table [{table-id :id}]
+                      Field [{field-id :id} {:table_id     table-id
+                                             :special_type :type/Category
+                                             :name         "City"
+                                             :base_type    :type/Text}]]
+        (-> field-id Field (classify.names/infer-and-assoc-special-type nil) :special_type)))))
 
-;; Prefix
-(expect
-  :entity/ProductTable
-  (-> {:name "productcatalogue"} table/map->TableInstance infer-entity-type :entity_type))
-
-;; Don't match in the middle of the name
-(expect
-  :entity/GenericTable
-  (-> {:name "myproductcatalogue"} table/map->TableInstance infer-entity-type :entity_type))
-
-;; Not-match/default
-(expect
-  :entity/GenericTable
-  (-> {:name "foo"} table/map->TableInstance infer-entity-type :entity_type))
-
-
-;; Don't overwrite PK/FK `special_type`s.
-(expect
-  nil
-  (tt/with-temp* [Table [{table-id :id}]
-                  Field [{field-id :id} {:table_id     table-id
-                                         :special_type :type/FK
-                                         :name         "City"
-                                         :base_type    :type/Text}]]
-    (-> field-id Field (infer-and-assoc-special-type nil) :special_type)))
-
-;; ... but overwrite other types to alow evolution of our type system
-(expect
-  :type/City
-  (tt/with-temp* [Table [{table-id :id}]
-                  Field [{field-id :id} {:table_id     table-id
-                                         :special_type :type/Category
-                                         :name         "City"
-                                         :base_type    :type/Text}]]
-    (-> field-id Field (infer-and-assoc-special-type nil) :special_type)))
+(deftest infer-special-type-test
+  (let [infer (fn infer [column-name & [base-type]]
+                (classify.names/infer-special-type
+                  {:name column-name, :base_type (or base-type :type/Text)}))]
+    (testing "standard checks"
+      ;; not exhausting but a place for edge cases in the future
+      (are [expected info] (= expected (apply infer info))
+        :type/Name     ["first_name"]
+        :type/Name     ["name"]
+        :type/Quantity ["quantity" :type/Integer]))
+    (testing "Doesn't mark state columns (#2735)"
+      (doseq [column-name ["state" "order_state" "state_of_order"]]
+        (is (not= :type/State (infer column-name)))))))

--- a/test/metabase/sync/analyze/classifiers/text_fingerprint_test.clj
+++ b/test/metabase/sync/analyze/classifiers/text_fingerprint_test.clj
@@ -1,0 +1,47 @@
+(ns metabase.sync.analyze.classifiers.text-fingerprint-test
+  (:require [clojure.test :refer :all]
+            [metabase.models.field :as field]
+            [metabase.sync.analyze.classifiers.text-fingerprint :as text-fingerprint]))
+
+(def can-edit? #'text-fingerprint/can-edit-special-type?)
+
+(deftest can-edit-special-type?
+  (testing "When special type is nil we can change it"
+    (is (can-edit? {:name "field" :base_type :type/Text})))
+  (testing "If we include metadata, can see if original was not set"
+    (let [field {:name "field" :special_type :type/Category}]
+      (is (not (can-edit? field)))
+      (is (can-edit? (with-meta field {:sync.classify/original {:name "field" :special_type nil}}))))))
+
+(def infer #'text-fingerprint/infer-special-type-for-text-fingerprint)
+(def threshold @#'text-fingerprint/percent-valid-threshold)
+(def lower-threshold @#'text-fingerprint/lower-percent-valid-threshold)
+
+(deftest infer-special-type-for-text-fingerprint-test
+  (let [expectations [[:percent-json  :type/SerializedJSON]
+                      [:percent-url   :type/URL]
+                      [:percent-email :type/Email]
+                      [:percent-state :type/State]]
+        empty-fingerprint (zipmap (map first expectations) (repeat 0.0))]
+    (doseq [[metric expected-special-type] expectations]
+      (is (= expected-special-type (infer (merge empty-fingerprint {metric threshold})))))
+    (doseq [[metric expected-special-type] expectations]
+      (is (not (= expected-special-type (infer (merge empty-fingerprint {metric (/ threshold 2)}))))))
+    (testing "state has a lower threshold"
+      (is (= :type/State (infer (zipmap (map first expectations) (repeat lower-threshold))))))))
+
+(deftest infer-special-type-test
+  (let [fingerprint       {:type {:type/Text {:percent-json threshold}}}
+        state-fingerprint {:type {:type/Text {:percent-state lower-threshold}}}
+        field             (field/map->FieldInstance {:name "field" :base_type :type/Text})]
+    (testing "can infer a special type from text fingerprints"
+      (is (= :type/SerializedJSON
+             (:special_type (text-fingerprint/infer-special-type field fingerprint))))
+      (is (= :type/State
+             (:special_type (text-fingerprint/infer-special-type field state-fingerprint)))))
+    (testing "can infer a special type from text fingerprints if another classifier has put one one"
+      (let [field-with-original (with-meta (assoc field :special_type :type/Category) {:sync.classify/original field})]
+        (is (= :type/SerializedJSON
+               (:special_type (text-fingerprint/infer-special-type field-with-original fingerprint))))
+        (is (= :type/State
+               (:special_type (text-fingerprint/infer-special-type field-with-original state-fingerprint))))))))

--- a/test/metabase/sync/analyze/classify_test.clj
+++ b/test/metabase/sync/analyze/classify_test.clj
@@ -35,7 +35,29 @@
                               :last_analyzed       #t "2017-08-09"}]]
       (is (= ["expected"]
              (for [field (#'classify/fields-to-classify table)]
-               (:name field)))))))
+               (:name field))))))
+  (testing "Finds previously marked :type/category fields for state"
+    (tt/with-temp* [Table [table]
+                    Field [_ {:table_id            (u/get-id table)
+                              :name                "expected"
+                              :description         "Current fingerprint, not analyzed"
+                              :fingerprint_version i/latest-fingerprint-version
+                              :last_analyzed       nil}]
+                    Field [_ {:table_id            (u/get-id table)
+                              :name                "not expected 1"
+                              :description         "Current fingerprint, already analzed"
+                              :fingerprint_version i/latest-fingerprint-version
+                              :last_analyzed       #t "2017-08-09"}]
+                    Field [_ {:table_id            (u/get-id table)
+                              :name                "not expected 2"
+                              :description         "Old fingerprint, not analyzed"
+                              :fingerprint_version (dec i/latest-fingerprint-version)
+                              :last_analyzed       nil}]
+                    Field [_ {:table_id            (u/get-id table)
+                              :name                "not expected 3"
+                              :description         "Old fingerprint, already analzed"
+                              :fingerprint_version (dec i/latest-fingerprint-version)
+                              :last_analyzed       #t "2017-08-09"}]])))
 
 (deftest classify-fields-for-db!-test
   (testing "We classify decimal fields that have specially handled NaN values"

--- a/test/metabase/sync/analyze/classify_test.clj
+++ b/test/metabase/sync/analyze/classify_test.clj
@@ -1,75 +1,98 @@
 (ns metabase.sync.analyze.classify-test
-  (:require [expectations :refer :all]
+  (:require [clojure.test :refer :all]
             [metabase.models
              [database :refer [Database]]
-             [field :refer [Field]]
+             [field :as field :refer [Field]]
+             [field-values :as field-values]
              [table :refer [Table]]]
             [metabase.sync.analyze.classify :as classify]
             [metabase.sync.interface :as i]
             [metabase.util :as u]
             [toucan.util.test :as tt]))
 
-;; Check that only the right Fields get classified
-(expect
-  ["Current fingerprint, not analyzed"]
-  ;; For max version pick something we'll hopefully never hit. Don't think we'll ever have 32k different versions :D
-  (with-redefs [i/latest-fingerprint-version Short/MAX_VALUE]
+(deftest fields-to-classify-test
+  (testing "Finds current fingerprinted versions that are not analyzed"
     (tt/with-temp* [Table [table]
                     Field [_ {:table_id            (u/get-id table)
-                              :name                "Current fingerprint, not analyzed"
-                              :fingerprint_version Short/MAX_VALUE
+                              :name                "expected"
+                              :description         "Current fingerprint, not analyzed"
+                              :fingerprint_version i/latest-fingerprint-version
                               :last_analyzed       nil}]
                     Field [_ {:table_id            (u/get-id table)
-                              :name                "Current fingerprint, already analzed"
-                              :fingerprint_version Short/MAX_VALUE
+                              :name                "not expected 1"
+                              :description         "Current fingerprint, already analzed"
+                              :fingerprint_version i/latest-fingerprint-version
                               :last_analyzed       #t "2017-08-09"}]
                     Field [_ {:table_id            (u/get-id table)
-                              :name                "Old fingerprint, not analyzed"
-                              :fingerprint_version (dec Short/MAX_VALUE)
+                              :name                "not expected 2"
+                              :description         "Old fingerprint, not analyzed"
+                              :fingerprint_version (dec i/latest-fingerprint-version)
                               :last_analyzed       nil}]
                     Field [_ {:table_id            (u/get-id table)
-                              :name                "Old fingerprint, already analzed"
-                              :fingerprint_version (dec Short/MAX_VALUE)
+                              :name                "not expected 3"
+                              :description         "Old fingerprint, already analzed"
+                              :fingerprint_version (dec i/latest-fingerprint-version)
                               :last_analyzed       #t "2017-08-09"}]]
-      (for [field (#'classify/fields-to-classify table)]
-        (:name field)))))
+      (is (= ["expected"]
+             (for [field (#'classify/fields-to-classify table)]
+               (:name field)))))))
 
-;; Check that we can classify decimal fields that have specially handled NaN values
-(expect
-  [nil :type/Income]
-  (tt/with-temp* [Database [db]
-                  Table    [table {:db_id (u/get-id db)}]
-                  Field    [field {:table_id            (u/get-id table)
-                                   :name                "Income"
-                                   :base_type           :type/Float
-                                   :special_type        nil
-                                   :fingerprint_version i/latest-fingerprint-version
-                                   :fingerprint         {:type   {:type/Number {:min "NaN"
-                                                                                :max "NaN"
-                                                                                :avg "NaN"}}
-                                                         :global {:distinct-count 3}}
-                                   :last_analyzed       nil}]]
-    [(:special_type (Field (u/get-id field)))
-     (do
-       (classify/classify-fields-for-db! db [table] (constantly nil))
-       (:special_type (Field (u/get-id field))))]))
+(deftest classify-fields-for-db!-test
+  (testing "We classify decimal fields that have specially handled NaN values"
+    (tt/with-temp* [Database [db]
+                    Table    [table {:db_id (u/get-id db)}]
+                    Field    [field {:table_id            (u/get-id table)
+                                     :name                "Income"
+                                     :base_type           :type/Float
+                                     :special_type        nil
+                                     :fingerprint_version i/latest-fingerprint-version
+                                     :fingerprint         {:type   {:type/Number {:min "NaN"
+                                                                                  :max "NaN"
+                                                                                  :avg "NaN"}}
+                                                           :global {:distinct-count 3}}
+                                     :last_analyzed       nil}]]
+      (is (nil? (:special_type (Field (u/get-id field)))))
+      (classify/classify-fields-for-db! db [table] (constantly nil))
+      (is (= :type/Income (:special_type (Field (u/get-id field)))))))
+  (testing "We can classify decimal fields that have specially handled infinity values"
+    (tt/with-temp* [Database [db]
+                    Table    [table {:db_id (u/get-id db)}]
+                    Field    [field {:table_id            (u/get-id table)
+                                     :name                "Income"
+                                     :base_type           :type/Float
+                                     :special_type        nil
+                                     :fingerprint_version i/latest-fingerprint-version
+                                     :fingerprint         {:type   {:type/Number {:min "-Infinity"
+                                                                                  :max "Infinity"
+                                                                                  :avg "Infinity"}}
+                                                           :global {:distinct-count 3}}
+                                     :last_analyzed       nil}]]
+      (is (nil? (:special_type (Field (u/get-id field)))))
+      (classify/classify-fields-for-db! db [table] (constantly nil))
+      (is (= :type/Income (:special_type (Field (u/get-id field))))))))
 
-;; Check that we can classify decimal fields that have specially handled infinity values
-(expect
-  [nil :type/Income]
-  (tt/with-temp* [Database [db]
-                  Table    [table {:db_id (u/get-id db)}]
-                  Field    [field {:table_id            (u/get-id table)
-                                   :name                "Income"
-                                   :base_type           :type/Float
-                                   :special_type        nil
-                                   :fingerprint_version i/latest-fingerprint-version
-                                   :fingerprint         {:type   {:type/Number {:min "-Infinity"
-                                                                                :max "Infinity"
-                                                                                :avg "Infinity"}}
-                                                         :global {:distinct-count 3}}
-                                   :last_analyzed       nil}]]
-    [(:special_type (Field (u/get-id field)))
-     (do
-       (classify/classify-fields-for-db! db [table] (constantly nil))
-       (:special_type (Field (u/get-id field))))]))
+(defn- ->field [field]
+  (field/map->FieldInstance
+    (merge {:fingerprint_version i/latest-fingerprint-version
+            :special_type        nil}
+           field)))
+
+(deftest run-classifiers-test
+  (testing "Fields marked state are not overridden"
+    (let [field (->field {:name "state", :base_type :type/Text, :special_type :type/State})]
+      (is (= :type/State (:special_type (classify/run-classifiers field nil))))))
+  (testing "Fields with few values are marked as category and list"
+    (let [field      (->field {:name "state", :base_type :type/Text})
+          classified (classify/run-classifiers field {:global
+                                                      {:distinct-count
+                                                       (dec field-values/category-cardinality-threshold)
+                                                       :nil% 0.3}})]
+      (is (= {:has_field_values :auto-list, :special_type :type/Category}
+             (select-keys classified [:has_field_values :special_type])))))
+  (testing "Earlier classifiers prevent later classifiers"
+    (let [field       (->field {:name "site_url" :base_type :type/Text})
+          fingerprint {:global {:distinct-count 4
+                                :nil%           0}}
+          classified  (classify/run-classifiers field fingerprint)]
+      (is (= {:has_field_values :auto-list, :special_type :type/URL}
+             (select-keys classified [:has_field_values :special_type]))))))

--- a/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
@@ -111,6 +111,7 @@
           :type   {:type/Text {:percent-json   0.2
                                :percent-url    0.0
                                :percent-email  0.0
+                               :percent-state  0.0
                                :average-length 6.4}}}
          (transduce identity
                     (f/fingerprinter (field/map->FieldInstance {:base_type :type/Text}))
@@ -121,6 +122,7 @@
             :type   {:type/Text {:percent-json   0.2
                                  :percent-url    0.0
                                  :percent-email  0.0
+                                 :percent-state  0.0
                                  :average-length 10.6}}}
            (transduce identity
                       (f/fingerprinter (field/map->FieldInstance {:base_type :type/Text}))
@@ -135,6 +137,7 @@
                       :type   {:type/Text {:percent-json   (s/eq 0.0)
                                            :percent-url    (s/eq 0.0)
                                            :percent-email  (s/eq 0.0)
+                                           :percent-state  (s/eq 0.0)
                                            :average-length (s/pred #(< 15 % 16) "between 15 and 16")}}}
                      (db/select-one-field :fingerprint Field :id (mt/id :venues :name)))))
       (testing "date fingerprints"

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.sync.analyze.fingerprint-test
   "Basic tests to make sure the fingerprint generatation code is doing something that makes sense."
   (:require [clojure.test :refer :all]
-            [expectations :refer :all]
             [metabase
              [db :as mdb]
              [test :as mt]
@@ -22,106 +21,98 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 ;; Check that our `base-types->descendants` function properly returns a set of descendants including parent type
-(expect
-  #{"type/URL" "type/ImageURL" "type/AvatarURL"}
-  (#'fingerprint/base-types->descendants #{:type/URL}))
-
-(expect
-  #{"type/ImageURL" "type/AvatarURL"}
-  (#'fingerprint/base-types->descendants #{:type/ImageURL :type/AvatarURL}))
+(deftest base-type->descendats-test
+  (is (= #{"type/URL" "type/ImageURL" "type/AvatarURL"}
+         (#'fingerprint/base-types->descendants #{:type/URL})))
+  (is (= #{"type/ImageURL" "type/AvatarURL"}
+         (#'fingerprint/base-types->descendants #{:type/ImageURL :type/AvatarURL}))))
 
 
 ;; Make sure we generate the correct HoneySQL WHERE clause based on whatever is in
 ;; `fingerprint-version->types-that-should-be-re-fingerprinted`
-(expect
-  {:where
-   [:and
-    [:= :active true]
-    [:or
-     [:not (mdb/isa :special_type :type/PK)]
-     [:= :special_type nil]]
-    [:not-in :visibility_type ["retired" "sensitive"]]
-    [:not= :base_type "type/Structured"]
-    [:or
-     [:and
-      [:< :fingerprint_version 1]
-      [:in :base_type #{"type/URL" "type/ImageURL" "type/AvatarURL"}]]]]}
-  (with-redefs [i/fingerprint-version->types-that-should-be-re-fingerprinted {1 #{:type/URL}}]
-    (#'fingerprint/honeysql-for-fields-that-need-fingerprint-updating)))
+(deftest honeysql-for-fields-that-need-fingerprint-updating-test
+  (is (= {:where
+          [:and
+           [:= :active true]
+           [:or
+            [:not (mdb/isa :special_type :type/PK)]
+            [:= :special_type nil]]
+           [:not-in :visibility_type ["retired" "sensitive"]]
+           [:not= :base_type "type/Structured"]
+           [:or
+            [:and
+             [:< :fingerprint_version 1]
+             [:in :base_type #{"type/URL" "type/ImageURL" "type/AvatarURL"}]]]]}
+         (with-redefs [i/fingerprint-version->types-that-should-be-re-fingerprinted {1 #{:type/URL}}]
+           (#'fingerprint/honeysql-for-fields-that-need-fingerprint-updating))))
 
-(expect
-  {:where
-   [:and
-    [:= :active true]
-    [:or
-     [:not (mdb/isa :special_type :type/PK)]
-     [:= :special_type nil]]
-    [:not-in :visibility_type ["retired" "sensitive"]]
-    [:not= :base_type "type/Structured"]
-    [:or
-     [:and
-      [:< :fingerprint_version 2]
-      [:in :base_type #{"type/Decimal" "type/Latitude" "type/Longitude" "type/Coordinate" "type/Currency" "type/Float"
-                        "type/Share" "type/Income" "type/Price" "type/Discount" "type/GrossMargin" "type/Cost"}]]
-     [:and
-      [:< :fingerprint_version 1]
-      [:in :base_type #{"type/ImageURL" "type/AvatarURL"}]]]]}
-  (with-redefs [i/fingerprint-version->types-that-should-be-re-fingerprinted {1 #{:type/ImageURL :type/AvatarURL}
-                                                                              2 #{:type/Float}}]
-    (#'fingerprint/honeysql-for-fields-that-need-fingerprint-updating)))
-
-;; Make sure that our SQL generation code is clever enough to remove version checks when a newer version completely
-;; eclipses them
-(expect
-  {:where
-   [:and
-    [:= :active true]
-    [:or
-     [:not (mdb/isa :special_type :type/PK)]
-     [:= :special_type nil]]
-    [:not-in :visibility_type ["retired" "sensitive"]]
-    [:not= :base_type "type/Structured"]
-    [:or
-     [:and
-      [:< :fingerprint_version 2]
-      [:in :base_type #{"type/Decimal" "type/Latitude" "type/Longitude" "type/Coordinate" "type/Currency" "type/Float"
-                        "type/Share" "type/Income" "type/Price" "type/Discount" "type/GrossMargin" "type/Cost"}]]
-     ;; no type/Float stuff should be included for 1
-     [:and
-      [:< :fingerprint_version 1]
-      [:in :base_type #{"type/URL" "type/ImageURL" "type/AvatarURL"}]]]]}
-  (with-redefs [i/fingerprint-version->types-that-should-be-re-fingerprinted {1 #{:type/Float :type/URL}
-                                                                              2 #{:type/Float}}]
-    (#'fingerprint/honeysql-for-fields-that-need-fingerprint-updating)))
-
-;; Make sure that our SQL generation code is also clever enough to completely skip completely eclipsed versions
-(expect
-  {:where
-   [:and
-    [:= :active true]
-    [:or
-     [:not (mdb/isa :special_type :type/PK)]
-     [:= :special_type nil]]
-    [:not-in :visibility_type ["retired" "sensitive"]]
-    [:not= :base_type "type/Structured"]
-    [:or
-     [:and
-      [:< :fingerprint_version 4]
-      [:in :base_type #{"type/Decimal" "type/Latitude" "type/Longitude" "type/Coordinate" "type/Currency" "type/Float"
-                        "type/Share" "type/Income" "type/Price" "type/Discount" "type/GrossMargin" "type/Cost"}]]
-     [:and
-      [:< :fingerprint_version 3]
-      [:in :base_type #{"type/URL" "type/ImageURL" "type/AvatarURL"}]]
-     ;; version 2 can be eliminated completely since everything relevant there is included in 4
-     ;; The only things that should go in 1 should be `:type/City` since `:type/Coordinate` is included in 4
-     [:and
-      [:< :fingerprint_version 1]
-      [:in :base_type #{"type/City"}]]]]}
-  (with-redefs [i/fingerprint-version->types-that-should-be-re-fingerprinted {1 #{:type/Coordinate :type/City}
-                                                                              2 #{:type/Coordinate}
-                                                                              3 #{:type/URL}
-                                                                              4 #{:type/Float}}]
-    (#'fingerprint/honeysql-for-fields-that-need-fingerprint-updating)))
+  (is (= {:where
+          [:and
+           [:= :active true]
+           [:or
+            [:not (mdb/isa :special_type :type/PK)]
+            [:= :special_type nil]]
+           [:not-in :visibility_type ["retired" "sensitive"]]
+           [:not= :base_type "type/Structured"]
+           [:or
+            [:and
+             [:< :fingerprint_version 2]
+             [:in :base_type #{"type/Decimal" "type/Latitude" "type/Longitude" "type/Coordinate" "type/Currency" "type/Float"
+                               "type/Share" "type/Income" "type/Price" "type/Discount" "type/GrossMargin" "type/Cost"}]]
+            [:and
+             [:< :fingerprint_version 1]
+             [:in :base_type #{"type/ImageURL" "type/AvatarURL"}]]]]}
+         (with-redefs [i/fingerprint-version->types-that-should-be-re-fingerprinted {1 #{:type/ImageURL :type/AvatarURL}
+                                                                                     2 #{:type/Float}}]
+           (#'fingerprint/honeysql-for-fields-that-need-fingerprint-updating))))
+  (testing "our SQL generation code is clever enough to remove version checks when a newer version completely eclipses them"
+    (is (= {:where
+            [:and
+             [:= :active true]
+             [:or
+              [:not (mdb/isa :special_type :type/PK)]
+              [:= :special_type nil]]
+             [:not-in :visibility_type ["retired" "sensitive"]]
+             [:not= :base_type "type/Structured"]
+             [:or
+              [:and
+               [:< :fingerprint_version 2]
+               [:in :base_type #{"type/Decimal" "type/Latitude" "type/Longitude" "type/Coordinate" "type/Currency" "type/Float"
+                                 "type/Share" "type/Income" "type/Price" "type/Discount" "type/GrossMargin" "type/Cost"}]]
+              ;; no type/Float stuff should be included for 1
+              [:and
+               [:< :fingerprint_version 1]
+               [:in :base_type #{"type/URL" "type/ImageURL" "type/AvatarURL"}]]]]}
+           (with-redefs [i/fingerprint-version->types-that-should-be-re-fingerprinted {1 #{:type/Float :type/URL}
+                                                                                       2 #{:type/Float}}]
+             (#'fingerprint/honeysql-for-fields-that-need-fingerprint-updating)))))
+  (testing "our SQL generation code is also clever enough to completely skip completely eclipsed versions"
+    (is (= {:where
+            [:and
+             [:= :active true]
+             [:or
+              [:not (mdb/isa :special_type :type/PK)]
+              [:= :special_type nil]]
+             [:not-in :visibility_type ["retired" "sensitive"]]
+             [:not= :base_type "type/Structured"]
+             [:or
+              [:and
+               [:< :fingerprint_version 4]
+               [:in :base_type #{"type/Decimal" "type/Latitude" "type/Longitude" "type/Coordinate" "type/Currency" "type/Float"
+                                 "type/Share" "type/Income" "type/Price" "type/Discount" "type/GrossMargin" "type/Cost"}]]
+              [:and
+               [:< :fingerprint_version 3]
+               [:in :base_type #{"type/URL" "type/ImageURL" "type/AvatarURL"}]]
+              ;; version 2 can be eliminated completely since everything relevant there is included in 4
+              ;; The only things that should go in 1 should be `:type/City` since `:type/Coordinate` is included in 4
+              [:and
+               [:< :fingerprint_version 1]
+               [:in :base_type #{"type/City"}]]]]}
+           (with-redefs [i/fingerprint-version->types-that-should-be-re-fingerprinted {1 #{:type/Coordinate :type/City}
+                                                                                       2 #{:type/Coordinate}
+                                                                                       3 #{:type/URL}
+                                                                                       4 #{:type/Float}}]
+             (#'fingerprint/honeysql-for-fields-that-need-fingerprint-updating))))))
 
 
 ;; Make sure that the above functions are used correctly to determine which Fields get (re-)fingerprinted
@@ -142,94 +133,86 @@
   (merge default-stat-map {:updated-fingerprints 1, :fingerprints-attempted 1}))
 
 ;; Field is a subtype of newer fingerprint version
-(expect
-  [one-updated-map true]
-  (field-was-fingerprinted?
-    {2 #{:type/Float}}
-    {:base_type :type/Decimal, :fingerprint_version 1}))
+(deftest fingerprint-fields!-test
+  (testing "field is a substype of newer fingerprint version"
+    (is (= [one-updated-map true]
+           (field-was-fingerprinted?
+             {2 #{:type/Float}}
+             {:base_type :type/Decimal, :fingerprint_version 1}))))
 
-;; field is *not* a subtype of newer fingerprint version
-(expect
-  [default-stat-map false]
-  (field-was-fingerprinted?
-    {2 #{:type/Text}}
-    {:base_type :type/Decimal, :fingerprint_version 1}))
+  (testing "field is *not* a subtype of newer fingerprint version"
+    (is (= [default-stat-map false]
+           (field-was-fingerprinted?
+             {2 #{:type/Text}}
+             {:base_type :type/Decimal, :fingerprint_version 1}))))
 
-;; Field is a subtype of one of several types for newer fingerprint version
-(expect
-  [one-updated-map true]
-  (field-was-fingerprinted?
-    {2 #{:type/Float :type/Text}}
-    {:base_type :type/Decimal, :fingerprint_version 1}))
+  (testing "Field is a subtype of one of several types for newer fingerprint version"
+    (is (= [one-updated-map true]
+           (field-was-fingerprinted?
+             {2 #{:type/Float :type/Text}}
+             {:base_type :type/Decimal, :fingerprint_version 1}))))
 
-;; Field has same version as latest fingerprint version
-(expect
-  [default-stat-map false]
-  (field-was-fingerprinted?
-    {1 #{:type/Float}}
-    {:base_type :type/Decimal, :fingerprint_version 1}))
+  (testing "Field has same version as latest fingerprint version"
+    (is (= [default-stat-map false]
+           (field-was-fingerprinted?
+             {1 #{:type/Float}}
+             {:base_type :type/Decimal, :fingerprint_version 1}))))
 
-;; field has newer version than latest fingerprint version (should never happen)
-(expect
-  [default-stat-map false]
-  (field-was-fingerprinted?
-    {1 #{:type/Float}}
-    {:base_type :type/Decimal, :fingerprint_version 2}))
+  (testing "field has newer version than latest fingerprint version (should never happen)"
+    (is (= [default-stat-map false]
+           (field-was-fingerprinted?
+             {1 #{:type/Float}}
+             {:base_type :type/Decimal, :fingerprint_version 2}))))
 
-;; field has same exact type as newer fingerprint version
-(expect
-  [one-updated-map true]
-  (field-was-fingerprinted?
-    {2 #{:type/Float}}
-    {:base_type :type/Float, :fingerprint_version 1}))
+  (testing "field has same exact type as newer fingerprint version"
+    (is (= [one-updated-map true]
+           (field-was-fingerprinted?
+             {2 #{:type/Float}}
+             {:base_type :type/Float, :fingerprint_version 1}))))
 
-;; field is parent type of newer fingerprint version type
-(expect
-  [default-stat-map false]
-  (field-was-fingerprinted?
-    {2 #{:type/Decimal}}
-    {:base_type :type/Float, :fingerprint_version 1}))
+  (testing "field is parent type of newer fingerprint version type"
+    (is (= [default-stat-map false]
+           (field-was-fingerprinted?
+             {2 #{:type/Decimal}}
+             {:base_type :type/Float, :fingerprint_version 1}))))
 
-;; several new fingerprint versions exist
-(expect
-  [one-updated-map true]
-  (field-was-fingerprinted?
-    {2 #{:type/Float}
-     3 #{:type/Text}}
-    {:base_type :type/Decimal, :fingerprint_version 1}))
+  (testing "several new fingerprint versions exist"
+    (is (= [one-updated-map true]
+           (field-was-fingerprinted?
+             {2 #{:type/Float}
+              3 #{:type/Text}}
+             {:base_type :type/Decimal, :fingerprint_version 1}))))
 
-(expect
-  [one-updated-map true]
-  (field-was-fingerprinted?
-    {2 #{:type/Text}
-     3 #{:type/Float}}
-    {:base_type :type/Decimal, :fingerprint_version 1}))
+  (is (= [one-updated-map true]
+         (field-was-fingerprinted?
+           {2 #{:type/Text}
+            3 #{:type/Float}}
+           {:base_type :type/Decimal, :fingerprint_version 1})))
 
-;; field is sensitive
-(expect
-  [default-stat-map false]
-  (field-was-fingerprinted?
-    {1 #{:type/Text}}
-    {:base_type :type/Text, :fingerprint_version 1, :visibility_type :sensitive}))
+  (testing "field is sensitive"
+    (is (= [default-stat-map false]
+           (field-was-fingerprinted?
+             {1 #{:type/Text}}
+             {:base_type :type/Text, :fingerprint_version 1, :visibility_type :sensitive})))))
 
 
-;; Make sure the `fingerprint!` function is correctly updating the correct columns of Field
-(expect
-  [{:no-data-fingerprints 0, :failed-fingerprints    0,
-    :updated-fingerprints 1, :fingerprints-attempted 1}
-   {:fingerprint         {:experimental {:fake-fingerprint? true}}
-    :fingerprint_version 3
-    :last_analyzed       nil}]
-  (tt/with-temp Field [field {:base_type           :type/Integer
-                              :table_id            (data/id :venues)
-                              :fingerprint         nil
-                              :fingerprint_version 1
-                              :last_analyzed       #t "2017-08-09T00:00:00"}]
-    (with-redefs [i/latest-fingerprint-version       3
-                  metadata-queries/table-rows-sample (constantly [[1] [2] [3] [4] [5]])
-                  fingerprinters/fingerprinter       (constantly (fingerprinters/constant-fingerprinter {:experimental {:fake-fingerprint? true}}))]
-      [(#'fingerprint/fingerprint-table! (Table (data/id :venues)) [field])
-       (into {} (db/select-one [Field :fingerprint :fingerprint_version :last_analyzed] :id (u/get-id field)))])))
+(deftest fingerprint-table!-test
+  (testing "the `fingerprint!` function is correctly updating the correct columns of Field"
+    (tt/with-temp Field [field {:base_type           :type/Integer
+                                :table_id            (data/id :venues)
+                                :fingerprint         nil
+                                :fingerprint_version 1
+                                :last_analyzed       #t "2017-08-09T00:00:00"}]
+      (with-redefs [i/latest-fingerprint-version       3
+                    metadata-queries/table-rows-sample (constantly [[1] [2] [3] [4] [5]])
+                    fingerprinters/fingerprinter       (constantly (fingerprinters/constant-fingerprinter {:experimental {:fake-fingerprint? true}}))]
+        (is (= {:no-data-fingerprints 0, :failed-fingerprints    0,
+                :updated-fingerprints 1, :fingerprints-attempted 1}
+               (#'fingerprint/fingerprint-table! (Table (data/id :venues)) [field])))
+        (is (= {:fingerprint         {:experimental {:fake-fingerprint? true}}
+                :fingerprint_version 3
+                :last_analyzed       nil}
+               (into {} (db/select-one [Field :fingerprint :fingerprint_version :last_analyzed] :id (u/get-id field)))))))))
 
 (deftest test-fingerprint-failure
   (testing "if fingerprinting fails, the exception should not propagate"

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -119,7 +119,7 @@
 (defn- field-was-fingerprinted? {:style/indent 0} [fingerprint-versions field-properties]
   (let [fingerprinted? (atom false)]
     (with-redefs [i/fingerprint-version->types-that-should-be-re-fingerprinted fingerprint-versions
-                  metadata-queries/table-rows-sample                                     (constantly [[1] [2] [3] [4] [5]])
+                  metadata-queries/table-rows-sample                           (constantly [[1] [2] [3] [4] [5]])
                   fingerprint/save-fingerprint!                                (fn [& _] (reset! fingerprinted? true))]
       (tt/with-temp* [Table [table]
                       Field [_ (assoc field-properties :table_id (u/get-id table))]]

--- a/test/metabase/test/mock/util.clj
+++ b/test/metabase/test/mock/util.clj
@@ -44,8 +44,9 @@
   "Fingerprints for the full venues table"
   {:name        {:global {:distinct-count 100
                           :nil%           0.0},
-                 :type   {:type/Text {:percent-json  0.0, :percent-url    0.0,
-                                      :percent-email 0.0, :average-length 15.63}}}
+                 :type   {:type/Text {:percent-json   0.0, :percent-url   0.0,
+                                      :percent-email  0.0, :percent-state 0.0,
+                                      :average-length 15.63}}}
    :id          nil
    :price       {:global {:distinct-count 4
                           :nil%           0.0},

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -69,6 +69,16 @@
     ;; nil .getAuthority needs to be handled or NullPointerException
     "http:/"                                                                                 false))
 
+(deftest state?-test
+  (are+ [s expected] (= expected
+                        (u/state? s))
+    "louisiana"      true
+    "north carolina" true
+    "WASHINGTON"     true
+    "CA"             true
+    "NY"             true
+    "random"         false))
+
 (deftest qualified-name-test
   (are+ [k expected] (= expected
                         (u/qualified-name k))

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -77,7 +77,10 @@
     "WASHINGTON"     true
     "CA"             true
     "NY"             true
-    "random"         false))
+    "random"         false
+    nil              false
+    3                false
+    (Object.)        false))
 
 (deftest qualified-name-test
   (are+ [k expected] (= expected


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/2735

Removes marking fields as `:type/State` based on their name and introduces a new fingerprinter to check text values for full state names or abbreviations. A fingerprinting classifier then uses this, and if a column is marked at over 70% state-like it will be marked as a state.

Some intricacy as there are four classifiers and they are very order dependent. I've added the ability for fingerprint classifiers to override previous classifiers if the original field value didn't have a value. In the future i think this should get even smarter and we can compute possible classifications and then resolve the best one, or perhaps let downstream classifiers subclassify (ie `:text/Category` move to something that derives from category).

Lots of expectations -> clojure.test. 

Points to consider
- is the `metabase.util/state?` too simple to be in util and perhaps should be in the fingerprinter namespace. Is it too simple? should it have canadian states? allow for locales to load an edn file from resources with state names, etc.
- i debated moving the fingerprinting classifiers earlier but this seems pretty fraught with unintended consequences
```clojure
(def ^:private classifiers
  "Various classifier functions available. These should all take two args, a `FieldInstance` and a possibly `nil`
  `Fingerprint`, and return `FieldInstance` with any inferred property changes, or `nil` if none could be inferred.
  Order is important!"
  [name/infer-and-assoc-special-type
   category/infer-is-category-or-list
   no-preview-display/infer-no-preview-display
   text-fingerprint/infer-special-type])
```
- debated adding metadata to these classifiers of what they change, what they are allowed to change and have the reduction use that information but it got a bit hairy. I think something like this should be done and more smarts can go into classification but was scared of too many surfaces for regressions at one time.
- i debated adding the original field into the signature of these but kinda backed and snuck it in through metadata. not sure if there are strong feelings about that one way or another
- considered adding a check that if the original field had no `:special_type` but a classifier had added one, then only add one in the fingerprinters if the new special type was a derivation of the one already selected. I abandoned this as `:type/State` does derive from category but json, url, and email do not for obvious reasons.
- one change from this is that if anything was previously marked as `:type/Category` (and this happens for almost every field with fewer than 100 distinct items) it would never be marked as url, json, or email even if 100% of the values matched these fingerprints. Now we take the word of the fingerprinters.
- introduced a new threshold for states. kept the 95% threshold for email, url, and json but figured with states this is a bit stringent. Had in mind US territories, washington DC, Canadian provinces, etc. so wanted a bit more wiggle room for matching a state. 