### PR TITLE
Pin some versions to prevent issues when yarn.lock merges are needed

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -13,7 +13,7 @@
 .*/node_modules/update-notifier/.*
 .*/node_modules/boxen/.*
 .*/node_modules/libnpx/.*
-.*/node_modules/@babel/standalone/.*
+.*/node_modules/@babel/.*
 .*/node_modules/@testing-library/jest-dom/.*
 .*/node_modules/.*/node_modules/chalk/.*
 .*/node_modules/react-draggable/lib/.*

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "crossfilter": "^1.3.12",
     "d3": "^3.5.17",
     "d3-scale": "^2.1.0",
-    "dc": "^2.0.0",
+    "dc": "2.1.9",
     "diff": "^3.2.0",
-    "grid-styled": "^4.1.0",
+    "grid-styled": "4.1.0",
     "history": "3",
     "humanize-plus": "^1.8.1",
     "icepick": "2.3.0",
@@ -83,7 +83,9 @@
     "screenfull": "^4.2.1",
     "simple-statistics": "^3.0.0",
     "stack-source-map": "^1.0.4",
-    "system-components": "^2.0.3",
+    "styled-components": "3.2.6",
+    "styled-system": "2.2.5",
+    "system-components": "2.0.3",
     "tether": "^1.2.0",
     "ttag": "^1.7.8",
     "underscore": "^1.8.3",
@@ -210,6 +212,8 @@
     ]
   },
   "resolutions": {
-    "cypress": "3.8.2"
+    "cypress": "3.8.2",
+    "styled-components": "3.2.6",
+    "styled-system": "2.2.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3100,9 +3100,9 @@ buffer@^4.3.0:
     isarray "^1.0.0"
 
 buffer@^5.0.3:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.1.0.tgz#c913e43678c7cb7c8bd16afbcddb6c5505e8f9fe"
-  integrity sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
+  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -3234,6 +3234,11 @@ camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
+
+camelize@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
+  integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-api@^1.5.2, caniuse-api@^1.5.3:
   version "1.6.1"
@@ -3505,13 +3510,13 @@ clean-css@4.1.x:
     source-map "0.5.x"
 
 clean-tag@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/clean-tag/-/clean-tag-1.0.4.tgz#9b407b306fadce114e6dffa774e7b61bdfc0c190"
-  integrity sha512-PlYwlA+mfgGLf7NLfNm2KxmjNSNo7gJqDVqf8o4tSphqKQ4ZRYlZeMzh9Op04bl+HRIvxe+lMQMKDHYlR7phpA==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/clean-tag/-/clean-tag-1.1.0.tgz#83d0d3650d84805f7edeeda15a23d773069bf242"
+  integrity sha512-ly8usTlnKRFrL+D3+vZrX7lsDV+T9prxdL+IxLzjhKRIUYJlMWC4R3mUABWjb8AW33Wijy6UT2UUD2vYjPRF7A==
   dependencies:
     html-tags "^2.0.0"
     react ">=16.0.0"
-    styled-system ">=1.1 || >=2.0"
+    styled-system ">=2.0.0 || >=3.0.0"
 
 cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
@@ -4209,12 +4214,12 @@ css-selector-tokenizer@^0.7.0:
     regexpu-core "^1.0.0"
 
 css-to-react-native@^2.0.3:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.1.2.tgz#c06d628467ef961c85ec358a90f3c87469fb0095"
-  integrity sha512-akxvxNPNm+Qb7kGswgWhD8rLENM8857NVIn1lX0Dr9BQuju8vx6ypet7KvwvqBC01FUEne5V/jvt7FJXWJPtgw==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.3.2.tgz#e75e2f8f7aa385b4c3611c52b074b70a002f2e7d"
+  integrity sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==
   dependencies:
+    camelize "^1.0.0"
     css-color-keywords "^1.0.0"
-    fbjs "^0.8.5"
     postcss-value-parser "^3.3.0"
 
 css-what@2.1:
@@ -4441,7 +4446,7 @@ date-now@^0.1.4:
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
   integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
 
-dc@^2.0.0:
+dc@2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/dc/-/dc-2.1.9.tgz#693621dbbded18c4dac5023d7bd6a0c1215cd99a"
   integrity sha512-nSkbdSiJrSqgp4thpA57i/JAEqFwYuJkncTjZRjA8NFlEdHTYCod8yh5NaImvw0VizrxPXVTUghqIqtYB12uKg==
@@ -5732,10 +5737,10 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.9:
-  version "0.8.16"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
-  integrity sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=
+fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -5743,7 +5748,7 @@ fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.9:
     object-assign "^4.1.0"
     promise "^7.1.1"
     setimmediate "^1.0.5"
-    ua-parser-js "^0.7.9"
+    ua-parser-js "^0.7.18"
 
 fd-slicer@~1.0.1:
   version "1.0.1"
@@ -6349,7 +6354,7 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4,
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
   integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
-grid-styled@^4.1.0:
+grid-styled@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/grid-styled/-/grid-styled-4.1.0.tgz#adb060021b9562e02750ce515dae47f03559b4b9"
   integrity sha512-WtDIJMCkS5UEUvnYVzCGuAKX/WuJbORKLOh4AWkQoDuzMXuGswIdU5e9eJFgSqllPkU9ZXHL+4y4WEWkbQ+ujg==
@@ -13052,7 +13057,7 @@ style-loader@^0.19.0:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
 
-styled-components@>=3.0.0:
+styled-components@3.2.6, styled-components@>=3.0.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.2.6.tgz#99e6e75a746bdedd295a17e03dd1493055a1cc3b"
   integrity sha1-mebnWnRr3t0pWhfgPdFJMFWhzDs=
@@ -13068,7 +13073,7 @@ styled-components@>=3.0.0:
     stylis-rule-sheet "^0.0.10"
     supports-color "^3.2.3"
 
-"styled-system@>=1.1 || >=2.0", styled-system@>=2.0.1, styled-system@>=2.0.2:
+styled-system@2.2.5, "styled-system@>=1.1 || >=2.0", styled-system@>=2.0.1, styled-system@>=2.0.2:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-2.2.5.tgz#95f1e2c2c9ddc5c462cc56237cf039aa9ecfd27d"
   integrity sha512-/KJxEzd+mPQxTdr85l7K3b6ac97R4G0M2SlTm9sM48dGkg1CjTIURIvvSV3Y92kE+9GUfrPsG2MpeV8QnmSIQg==
@@ -13081,9 +13086,9 @@ stylis-rule-sheet@^0.0.10:
   integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
 
 stylis@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.0.tgz#016fa239663d77f868fef5b67cf201c4b7c701e1"
-  integrity sha512-pP7yXN6dwMzAR29Q0mBrabPCe0/mNO1MSr93bhay+hcZondvMMTpeGyd8nbhYJdyperNT2DRxONQuUGcJr5iPw==
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
+  integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
 subarg@^1.0.0:
   version "1.0.0"
@@ -13158,7 +13163,7 @@ symbol-tree@^3.2.1:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
   integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
 
-system-components@^2.0.3:
+system-components@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/system-components/-/system-components-2.0.3.tgz#39fa5051c7f276f6b7b0ea990e5fdaef98949343"
   integrity sha512-6SSV146Tc9BIp7C8s1TAVjcTU2wUvXIfEniK4pAI5Vk1qVBMNXGYKIF9yG/Bhy9m+rlQKkYJMLynli2c+Us/KA==


### PR DESCRIPTION
We've hit issues here in some CE -> EE merges recently. This PR upstreams fixes to CE so we won't have problems on the next merge.