### PR TITLE
QP: don't cache empty results

### DIFF
--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -89,7 +89,8 @@
         (log/error (trs "Cannot cache results: expected byte array, got {0}" (class x)))))))
 
 (defn- save-results-xform [start-time metadata query-hash rf]
-  (let [{:keys [in-chan out-chan]} (impl/serialize-async)]
+  (let [{:keys [in-chan out-chan]} (impl/serialize-async)
+        has-rows?                  (volatile! false)]
     (a/put! in-chan (assoc metadata
                            :cache-version cache-version
                            :last-ran      (t/zoned-date-time)))
@@ -97,18 +98,22 @@
       ([] (rf))
 
       ([result]
-       (a/put! in-chan (if (map? result) (m/dissoc-in result [:data :rows]) {}))
+       (a/put! in-chan (if (map? result)
+                         (m/dissoc-in result [:data :rows])
+                         {}))
        (a/close! in-chan)
        (let [duration-ms (- (System/currentTimeMillis) start-time)]
          (log/info (trs "Query took {0} to run; miminum for cache eligibility is {1}"
                         (u/format-milliseconds duration-ms) (u/format-milliseconds (min-duration-ms))))
-         (when (> duration-ms (min-duration-ms))
+         (when (and @has-rows?
+                    (> duration-ms (min-duration-ms)))
            (cache-results-async! query-hash out-chan)))
        (rf result))
 
       ([acc row]
        ;; Blocking so we don't exceed async's MAX-QUEUE-SIZE when transducing a large result set
        (a/>!! in-chan row)
+       (vreset! has-rows? true)
        (rf acc row)))))
 
 ;;; ----------------------------------------------------- Fetch ------------------------------------------------------

--- a/src/metabase/query_processor/middleware/cache/impl.clj
+++ b/src/metabase/query_processor/middleware/cache/impl.clj
@@ -9,7 +9,8 @@
   (:import [java.io BufferedInputStream BufferedOutputStream ByteArrayOutputStream DataInputStream DataOutputStream EOFException FilterOutputStream InputStream OutputStream]
            [java.util.zip GZIPInputStream GZIPOutputStream]))
 
-(defn- max-bytes-output-stream ^OutputStream [max-bytes ^OutputStream os]
+(defn- max-bytes-output-stream ^OutputStream
+  [max-bytes ^OutputStream os]
   (let [byte-count  (atom 0)
         check-total (fn [current-total]
                       (when (> current-total max-bytes)
@@ -52,7 +53,8 @@
     (a/close! out-chan)
     (a/close! in-chan)))
 
-(defn- freeze! [^OutputStream os obj]
+(defn- freeze!
+  [^OutputStream os obj]
   (try
     (nippy/freeze-to-out! os obj)
     (.flush os)
@@ -119,12 +121,15 @@
      (start-input-loop! in-chan out-chan bos os)
      {:in-chan in-chan, :out-chan out-chan})))
 
-(defn- thaw! [^InputStream is]
-  (try (nippy/thaw-from-in! is)
-       (catch EOFException _
-         ::eof)))
+(defn- thaw!
+  [^InputStream is]
+  (try
+    (nippy/thaw-from-in! is)
+    (catch EOFException e
+      ::eof)))
 
-(defn- reducible-rows [^InputStream is]
+(defn- reducible-rows
+  [^InputStream is]
   (reify clojure.lang.IReduceInit
     (reduce [_ rf init]
       (loop [acc init]

--- a/src/metabase/query_processor/middleware/cache_backend/db.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/db.clj
@@ -47,8 +47,6 @@
         (.close stmt)
         (throw e)))))
 
-
-
 (defn- cached-results [query-hash max-age-seconds respond]
   (with-open [conn (.getConnection (datasource))
               stmt (prepare-statement conn query-hash max-age-seconds)


### PR DESCRIPTION
Fixes a bug where if we timed out before getting results (but got metadata) we considered that a valid result and saved it. This could be fixed in two ways: either find all spots where we can timeout/cancel and propagate abnormal termination; or check that we got at least one row of results back. I opted for the latter because it also improves the UX of cases where we legit don't get any results but the query is expensive to run. I think in those cases you don't want to cache the no-result as you want values as soon as they become populated. 

No idea how to sanely test this though. The steps outlined in #13164 work, but only for MySQL (which also makes me less inclined to try and propagate all the exceptions as it is somewhat DB/driver dependent). I'm guessing some clever use of `with-redefs` but I couldn't find a spot that fully replicates the behaviour. 

Fixes #13164