### PR TITLE
Don't add duplicate joins when adding implicit joins

### DIFF
--- a/src/metabase/query_processor/middleware/resolve_joins.clj
+++ b/src/metabase/query_processor/middleware/resolve_joins.clj
@@ -126,7 +126,7 @@
   [{:keys [joins], :as inner-query} :- UnresolvedMBQLQuery]
   (let [join-fields (when (should-add-join-fields? inner-query)
                       (joins->fields joins))
-        inner-query(update inner-query :joins remove-joins-fields)]
+        inner-query (update inner-query :joins remove-joins-fields)]
     (cond-> inner-query
       (seq join-fields) (update :fields (comp vec distinct concat) join-fields))))
 


### PR DESCRIPTION
Fixes a bug where we'd needlessly generate additional joins in queries that used tables with fk remaps that were joined to the same tables as the remap.  