### PR TITLE
Update timeseries scale to align with the data's week boundaries

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -2,7 +2,7 @@
 
 import d3 from "d3";
 import inflection from "inflection";
-import moment from "moment";
+import moment from "moment-timezone";
 import Humanize from "humanize-plus";
 import React from "react";
 import { ngettext, msgid } from "ttag";
@@ -436,13 +436,12 @@ export function formatDateTimeRangeWithUnit(
       );
     }
   } else {
+    // TODO: when is this used?
     return formatWeek(m, options);
   }
 }
 
 function formatWeek(m: Moment, options: FormattingOptions = {}) {
-  // force 'en' locale for now since our weeks currently always start on Sundays
-  m = m.locale("en");
   return formatMajorMinor(m.format("wo"), m.format("gggg"), options);
 }
 

--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -1,5 +1,5 @@
 import { addLocale, useLocale } from "ttag";
-import moment from "moment";
+import moment from "moment-timezone";
 
 // note this won't refresh strings that are evaluated at load time
 export async function loadLocalization(locale) {

--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -1,4 +1,4 @@
-import moment from "moment";
+import moment from "moment-timezone";
 
 const NUMERIC_UNIT_FORMATS = {
   // workaround for https://github.com/metabase/metabase/issues/1992

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -3,7 +3,7 @@
 import _ from "underscore";
 import d3 from "d3";
 import dc from "dc";
-import moment from "moment";
+import moment from "moment-timezone";
 
 import { datasetContainsNoResults } from "metabase/lib/dataset";
 import { formatValue } from "metabase/lib/formatting";

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -148,12 +148,17 @@ export function applyChartTimeseriesXAxis(
         tickFormatUnit = "month";
         tickInterval = { interval: "month", count: 1, timezone };
       }
+      const domainStart = xDomain[0];
+      const startOfWeek = domainStart.clone().startOf("week");
+      const shiftDays = domainStart.diff(startOfWeek, "days");
+      tickInterval = { ...tickInterval, shiftDays };
     }
 
     chart.xAxis().tickFormat(tickFormat);
 
     // Compute a sane interval to display based on the data granularity, domain, and chart width
     tickInterval = {
+      ...tickInterval,
       ...computeTimeseriesTicksInterval(
         xDomain,
         tickInterval,

--- a/frontend/src/metabase/visualizations/lib/timeseriesScale.js
+++ b/frontend/src/metabase/visualizations/lib/timeseriesScale.js
@@ -3,7 +3,7 @@ import moment from "moment-timezone";
 
 // moment-timezone based d3 scale
 const timeseriesScale = (
-  { count, interval, timezone },
+  { count, interval, timezone, shiftDays },
   linear = d3.scale.linear(),
 ) => {
   const s = x => linear(toInt(x));
@@ -31,9 +31,11 @@ const timeseriesScale = (
     return s;
   };
 
-  s.ticks = () => ticksForRange(s.domain(), { count, timezone, interval });
+  s.ticks = () =>
+    ticksForRange(s.domain(), { count, timezone, interval, shiftDays });
 
-  s.copy = () => timeseriesScale({ count, interval, timezone }, linear);
+  s.copy = () =>
+    timeseriesScale({ count, interval, timezone, shiftDays }, linear);
 
   d3.rebind(s, linear, "rangeRound", "interpolate", "clamp", "invert");
 
@@ -81,12 +83,13 @@ function firstAndLast(a) {
   return [a[0], a[a.length - 1]];
 }
 
-function ticksForRange([start, end], { count, timezone, interval }) {
+function ticksForRange([start, end], { count, timezone, interval, shiftDays }) {
   const ticks = [];
   let tick = start
     .clone()
     .tz(timezone)
-    .startOf(interval);
+    .startOf(interval)
+    .add(shiftDays, "days");
 
   // We want to use "round" ticks for a given interval (unit). If we're
   // creating ticks every 50 years, but and the start of the domain is in 1981

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -1,5 +1,5 @@
 import { isElementOfType } from "react-dom/test-utils";
-import moment from "moment";
+import moment from "moment-timezone";
 
 import {
   formatNumber,

--- a/frontend/test/metabase/lib/i18n.unit.spec.js
+++ b/frontend/test/metabase/lib/i18n.unit.spec.js
@@ -1,4 +1,4 @@
-import moment from "moment";
+import moment from "moment-timezone";
 
 import { isLocale24Hour } from "metabase/lib/i18n";
 

--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -4,7 +4,7 @@ describe("scenarios > admin > permissions", () => {
   before(restore);
   beforeEach(signInAsAdmin);
 
-  it.skip("should correctly apply start of the week to a bar chart (metabase#13516)", () => {
+  it("should correctly apply start of the week to a bar chart (metabase#13516)", () => {
     // set the beginning of the week to "Monday"
     cy.visit("/admin/settings/localization");
     cy.findByText("Sunday").click();

--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -1,0 +1,50 @@
+import {
+  restore,
+  withSampleDataset,
+  openOrdersTable,
+  signInAsAdmin,
+} from "__support__/cypress";
+
+describe("scenarios > admin > permissions", () => {
+  before(restore);
+  beforeEach(signInAsAdmin);
+
+  it.skip("should correctly apply start of the week to a bar chart (metabase#13516)", () => {
+    // set the beginning of the week to "Monday"
+    cy.visit("/admin/settings/localization");
+    cy.findByText("Sunday").click();
+    cy.findByText("Monday").click({ force: true });
+    // make sure popover closed
+    cy.findByText("Thursday").should("not.be.visible");
+
+    // programatically create and save a question based on Orders table
+    // filter: created before June 1st, 2016
+    // summarize: Count by CreatedAt: Week
+    withSampleDataset(({ ORDERS }) => {
+      cy.request("POST", "/api/card", {
+        name: "Orders created before June 1st 2016",
+        dataset_query: {
+          database: 1,
+          query: {
+            "source-table": 2,
+            aggregation: [["count"]],
+            breakout: [["datetime-field", ORDERS.CREATED_AT, "week"]],
+            filter: ["<", ORDERS.CREATED_AT, "2016-06-01"],
+          },
+          type: "query",
+        },
+        display: "line",
+        visualization_settings: {},
+      });
+    });
+
+    // find and open that question
+    cy.visit("/collection/root");
+    cy.findByText("Orders created before June 1st 2016").click();
+
+    cy.log("**Assert the dates on the X axis**");
+    // it's hard and tricky to invoke hover in Cypress, especially in our graphs
+    // that's why we have to assert on the x-axis, instead of a popover that shows on a dot hover
+    cy.get(".axis.x").contains("April 25, 2016");
+  });
+});

--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -1,9 +1,4 @@
-import {
-  restore,
-  withSampleDataset,
-  openOrdersTable,
-  signInAsAdmin,
-} from "__support__/cypress";
+import { restore, withSampleDataset, signInAsAdmin } from "__support__/cypress";
 
 describe("scenarios > admin > permissions", () => {
   before(restore);

--- a/frontend/test/metabase/visualizations/lib/timeseriesScale.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/timeseriesScale.unit.spec.js
@@ -238,6 +238,22 @@ describe("timeseriesScale", () => {
     );
   });
 
+  it(`should shift week ticks by shiftDays`, () => {
+    const ticks = timeseriesScale({
+      interval: "week",
+      count: 1,
+      timezone: "Etc/UTC",
+      shiftDays: 1,
+    })
+      .domain([moment("2000-01-02T12:34:56Z"), moment("2000-02-02T12:34:56Z")])
+      .ticks();
+
+    expect(ticks[0].toISOString()).toEqual("2000-01-03T00:00:00.000Z");
+    expect(ticks[ticks.length - 1].toISOString()).toEqual(
+      "2000-01-31T00:00:00.000Z",
+    );
+  });
+
   it("should evenly space months", () => {
     const scale = timeseriesScale({
       interval: "month",


### PR DESCRIPTION
Fixes #13516

Like formatted ranges, ticks also rely on finding the boundary points between weeks. We had already updated the formatting code to check for an offset between the data's week boundary and the clients. I took the same approach here and made our timeseries scale aware of how many days to shift the ticks.