### PR TITLE
Comment out the RollingFile appender

### DIFF
--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -7,6 +7,8 @@
       </PatternLayout>
     </Console>
 
+    <!-- This file appender is provided as an example -->
+    <!--
     <RollingFile name="FILE" fileName="${logfile.path}/metabase.log" filePattern="${logfile.path}/metabase.log.%i">
       <Policies>
         <SizeBasedTriggeringPolicy size="500 MB"/>
@@ -16,6 +18,7 @@
         <replace regex=":basic-auth \\[.*\\]" replacement=":basic-auth [redacted]"/>
       </PatternLayout>
     </RollingFile>
+    -->
   </Appenders>
 
   <Loggers>


### PR DESCRIPTION
Even though this Appender wasn't referenced anywhere, it still
initialized. Commented out this appender so it can be used as an
example, but it won't create a folder called ${logfile.path} now

Resolves #13422
