### PR TITLE
[Fixes #7044] Don't render negative values for bar charts in pulses

### DIFF
--- a/src/metabase/pulse/render/table.clj
+++ b/src/metabase/pulse/render/table.clj
@@ -85,7 +85,7 @@
                                      :max-height       :10px
                                      :height           :10px
                                      :border-radius    :2px
-                                     :width            (str bar-width "%")})}
+                                     :width            (str (max bar-width 0) "%")})}
           "&#160;"]])])])
 
 (defn render-table


### PR DESCRIPTION
Fixes #7044 

Before:

![bar-chart-before](https://user-images.githubusercontent.com/784417/96516298-825e2100-122c-11eb-98c5-cab912fbebe6.png)

After:

![bar-chart-after](https://user-images.githubusercontent.com/784417/96516304-8722d500-122c-11eb-973f-76c975e7a09e.png)


I couldn't think of a non-contrived way of testing it.
