### PR TITLE
Handle infinity/-infinity (fixes #12761) [ci all]

### DIFF
--- a/src/metabase/query_processor/middleware/format_rows.clj
+++ b/src/metabase/query_processor/middleware/format_rows.clj
@@ -51,9 +51,12 @@
   OffsetDateTime
   (format-value [t, ^ZoneId timezone-id]
     (t/format :iso-offset-date-time
-              (let [rules  (.getRules timezone-id)
-                    offset (.getOffset rules (t/instant t))]
-                (t/with-offset-same-instant t offset))))
+              (if (or (= t OffsetDateTime/MAX)
+                      (= t OffsetDateTime/MIN))
+                t
+                (let [rules  (.getRules timezone-id)
+                      offset (.getOffset rules (t/instant t))]
+                  (t/with-offset-same-instant t offset)))))
 
   ZonedDateTime
   (format-value [t timezone-id]

--- a/test/metabase/query_processor/middleware/format_rows_test.clj
+++ b/test/metabase/query_processor/middleware/format_rows_test.clj
@@ -160,7 +160,10 @@
         (mt/with-clock (t/mock-clock (t/instant clock-instant) clock-zone)
           (is (= expected
                  (format-rows/format-value t (t/zone-id zone)))
-              (format "format %s '%s' with results timezone ID '%s'" (.getName (class t)) t zone)))))))
+              (format "format %s '%s' with results timezone ID '%s'" (.getName (class t)) t zone))))))
+  (testing "can handle infinity dates (#12761)"
+    (is (format-rows/format-value java.time.OffsetDateTime/MAX (t/zone-id "UTC")))
+    (is (format-rows/format-value java.time.OffsetDateTime/MIN (t/zone-id "UTC")))))
 
 (deftest results-timezone-test
   (testing "Make sure ISO-8601 timestamps are written correctly based on the report-timezone"


### PR DESCRIPTION
fixes https://github.com/metabase/metabase/issues/12761

we can't add time to infinity and its not important how it displays really.

<img width="552" alt="image" src="https://user-images.githubusercontent.com/6377293/96623809-87c17700-12d1-11eb-8808-dff83db35396.png">

It appears our UI date formatting doesn't handle it super well.