### PR TITLE
Amazing test improvements

### DIFF
--- a/src/metabase/api/alert.clj
+++ b/src/metabase/api/alert.clj
@@ -145,6 +145,8 @@
    archived            (s/maybe s/Bool)}
   ;; fethc the existing Alert in the DB
   (let [alert-before-update (api/check-404 (pulse/retrieve-alert id))]
+    (assert (:card alert-before-update)
+            (tru "Invalid Alert: Alert does not have a Card associated with it"))
     ;; check permissions as needed.
     ;; Check permissions to update existing Card
     (api/write-check Card (u/get-id (:card alert-before-update)))

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -59,7 +59,12 @@
    ;; can only have one Card
    (-> (hydrate alert :cards) :cards first)
    ;; if there's still not a Card, throw an Exception!
-   (throw (Exception. (tru "Invalid Alert: Alert does not have a Card assoicated with it")))))
+   (throw (Exception. (tru "Invalid Alert: Alert does not have a Card associated with it")))))
+
+(defn is-alert?
+  "Whether `notification` is an Alert (as opposed to a regular Pulse)."
+  [notification]
+  (boolean (:alert_condition notification)))
 
 (defn- perms-objects-set
   "Permissions to read or write a *Pulse* are the same as those of its parent Collection.
@@ -67,10 +72,9 @@
   Permissions to read or write an *Alert* are the same as those of its 'parent' *Card*. For all intents and purposes,
   an Alert cannot be put into a Collection."
   [notification read-or-write]
-  (let [is-alert? (boolean (:alert_condition notification))]
-    (if is-alert?
-      (i/perms-objects-set (alert->card notification) read-or-write)
-      (perms/perms-objects-set-for-parent-collection notification read-or-write))))
+  (if (is-alert? notification)
+    (i/perms-objects-set (alert->card notification) read-or-write)
+    (perms/perms-objects-set-for-parent-collection notification read-or-write)))
 
 (u/strict-extend (class Pulse)
   models/IModel
@@ -149,11 +153,18 @@
 ;;; ---------------------------------------- Notification Fetching Helper Fns ----------------------------------------
 
 (s/defn hydrate-notification :- PulseInstance
-  "Hydrate a Pulse or Alert with the Fields needed for sending it."
+  "Hydrate Pulse or Alert with the Fields needed for sending it."
   [notification :- PulseInstance]
   (-> notification
       (hydrate :creator :cards [:channels :recipients])
       (m/dissoc-in [:details :emails])))
+
+(s/defn ^:private hydrate-notifications :- [PulseInstance]
+  "Batched-hydrate multiple Pulses or Alerts."
+  [notifications :- [PulseInstance]]
+  (as-> notifications <>
+    (hydrate <> :creator :cards [:channels :recipients])
+    (map #(m/dissoc-in % [:details :emails]) <>)))
 
 (s/defn ^:private notification->pulse :- PulseInstance
   "Take a generic `Notification`, and put it in the standard Pulse format the frontend expects. This really just
@@ -197,12 +208,19 @@
   "Fetch all Alerts."
   ([]
    (retrieve-alerts nil))
+
   ([{:keys [archived?]
      :or   {archived? false}}]
-   (for [alert (db/select Pulse, :alert_condition [:not= nil], :archived archived?, {:order-by [[:%lower.name :asc]]})]
-     (-> alert
-         hydrate-notification
-         notification->alert))))
+   (for [alert (hydrate-notifications (db/select Pulse
+                                        :alert_condition [:not= nil]
+                                        :archived        archived?
+                                        {:order-by [[:%lower.name :asc]]}))
+         :let [alert (notification->alert alert)]
+         ;; if for whatever reason the Alert doesn't have a Card associated with it (e.g. the Card was deleted) don't
+         ;; return the Alert -- it's basically orphaned/invalid at this point. See #13575 -- we *should* be deleting
+         ;; Alerts if their associated PulseCard is deleted, but that's not currently the case.
+         :when (:card alert)]
+     alert)))
 
 (s/defn retrieve-pulses :- [PulseInstance]
   "Fetch all `Pulses`."
@@ -234,7 +252,7 @@
                            [:= :pcr.user_id user-id]]})))
 
 (defn retrieve-alerts-for-cards
-  "Find all alerts for `CARD-IDS`, used for admin users"
+  "Find all alerts for `card-ids`, used for admin users"
   [& card-ids]
   (when (seq card-ids)
     (map (comp notification->alert hydrate-notification)
@@ -413,10 +431,11 @@
 (defn- alert->notification
   "Convert an 'Alert` back into the generic 'Notification' format."
   [{:keys [card cards], :as alert}]
-  (let [card (or card (first cards))]
-    (-> alert
-        (assoc :skip_if_empty true, :cards (when card [(card->ref card)]))
-        (dissoc :card))))
+  (let [card  (or card (first cards))
+        cards (when card [(card->ref card)])]
+    (cond-> (-> (assoc alert :skip_if_empty true)
+                (dissoc :card))
+      (seq cards) (assoc :cards cards))))
 
 ;; TODO - why do we make sure to strictly validate everything when we create a PULSE but not when we create an ALERT?
 (defn update-alert!

--- a/src/metabase/related.clj
+++ b/src/metabase/related.clj
@@ -94,7 +94,8 @@
 
 (def ^:private ^{:arglists '([entities])} filter-visible
   (partial filter (fn [{:keys [archived visibility_type active] :as entity}]
-                    (and (or (nil? visibility_type)
+                    (and (some? entity)
+                         (or (nil? visibility_type)
                              (= (qp.util/normalize-token visibility_type) :normal))
                          (not archived)
                          (not= active false)

--- a/test/expectations.clj
+++ b/test/expectations.clj
@@ -137,8 +137,8 @@
     ;; expecting it.
     (when-not (env/env :drivers)
       (t/testing "Don't write any new tests using expect!"
-        (t/is (<= total-expect-forms 1084))
-        (t/is (<= total-namespaces-using-expect 97))))))
+        (t/is (<= total-expect-forms 882))
+        (t/is (<= total-namespaces-using-expect 85))))))
 
 (defmacro ^:deprecated expect
   "Simple macro that simulates converts an Expectations-style `expect` form into a `clojure.test` `deftest` form."

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -1,30 +1,18 @@
 (ns metabase.api.alert-test
   "Tests for `/api/alert` endpoints."
   (:require [clojure.test :refer :all]
-            [expectations :refer :all]
             [metabase
-             [email-test :as et]
              [http-client :as http]
+             [models :refer [Card Collection Pulse PulseCard PulseChannel PulseChannelRecipient]]
              [test :as mt]
              [util :as u]]
             [metabase.middleware.util :as middleware.u]
             [metabase.models
-             [card :refer [Card]]
-             [collection :refer [Collection]]
              [permissions :as perms]
              [permissions-group :as group]
-             [pulse :as pulse :refer [Pulse]]
-             [pulse-card :refer [PulseCard]]
-             [pulse-channel :refer [PulseChannel]]
-             [pulse-channel-recipient :refer [PulseChannelRecipient]]
              [pulse-test :as pulse-test]]
-            [metabase.test
-             [data :as data]
-             [util :as tu]]
-            [metabase.test.data.users :as users :refer :all]
             [metabase.test.mock.util :refer [pulse-channel-defaults]]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]))
+            [toucan.db :as db]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                              Helper Fns & Macros                                               |
@@ -32,7 +20,7 @@
 
 (defn- user-details [user-kwd]
   (-> user-kwd
-      fetch-user
+      mt/fetch-user
       (select-keys [:email :first_name :last_login :is_qbnewb :is_superuser :last_name :common_name :locale])
       (assoc :id true, :date_joined true, :last_login false)))
 
@@ -50,11 +38,11 @@
 
 (defn- alert-client
   [username]
-  (comp tu/boolean-ids-and-timestamps (user->client username)))
+  (comp mt/boolean-ids-and-timestamps mt/user-http-request username))
 
 (defn- default-email-channel
   ([pulse-card]
-   (default-email-channel pulse-card [(fetch-user :rasta)]))
+   (default-email-channel pulse-card [(mt/fetch-user :rasta)]))
 
   ([pulse-card recipients]
    {:id            pulse-card
@@ -67,14 +55,14 @@
     :details       {}}))
 
 (defmacro ^:private with-test-email [& body]
-  `(tu/with-temporary-setting-values [~'site-url "https://metabase.com/testmb"]
-     (et/with-fake-inbox
+  `(mt/with-temporary-setting-values [~'site-url "https://metabase.com/testmb"]
+     (mt/with-fake-inbox
        ~@body)))
 
 (defmacro ^:private with-alert-setup
   "Macro that will cleanup any created pulses and setups a fake-inbox to validate emails are sent for new alerts"
   [& body]
-  `(tu/with-model-cleanup [Pulse]
+  `(mt/with-model-cleanup [Pulse]
      (with-test-email
        ~@body)))
 
@@ -101,8 +89,8 @@
   (The name of this function is somewhat of a misnomer since the Alerts themselves aren't in Collections; it is their
   Cards that are. Alerts do not go in Collections; their perms are derived from their Cards.)"
   [grant-collection-perms-fn! alerts-or-ids f]
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp Collection [collection]
+  (mt/with-non-admin-groups-no-root-collection-perms
+    (mt/with-temp Collection [collection]
       (grant-collection-perms-fn! (group/all-users) collection)
       ;; Go ahead and put all the Cards for all of the Alerts in the temp Collection
       (when (seq alerts-or-ids)
@@ -125,93 +113,91 @@
 ;; We assume that all endpoints for a given context are enforced by the same middleware, so we don't run the same
 ;; authentication test on every single individual endpoint
 
-(expect (get middleware.u/response-unauthentic :body) (http/client :get 401 "alert"))
-(expect (get middleware.u/response-unauthentic :body) (http/client :put 401 "alert/13"))
+(deftest api-alert-auth-tests
+  (is (= (get middleware.u/response-unauthentic :body)
+         (http/client :get 401 "alert")
+         (http/client :put 401 "alert/13"))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                 GET /api/alert                                                 |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-;; by default, archived Alerts should be excluded
-(expect
-  #{"Not Archived"}
-  (with-alert-in-collection [_ _ not-archived-alert]
-    (with-alert-in-collection [_ _ archived-alert]
-      (db/update! Pulse (u/get-id not-archived-alert) :name "Not Archived")
-      (db/update! Pulse (u/get-id archived-alert)     :name "Archived", :archived true)
-      (with-alerts-in-readable-collection [not-archived-alert archived-alert]
-        (set (map :name ((user->client :rasta) :get 200 "alert")))))))
+(deftest fetch-alerts-test
+  (testing "GET /api/alert"
+    (with-alert-in-collection [_ _ not-archived-alert]
+      (with-alert-in-collection [_ _ archived-alert]
+        (db/update! Pulse (u/get-id not-archived-alert) :name "Not Archived")
+        (db/update! Pulse (u/get-id archived-alert)     :name "Archived", :archived true)
+        (with-alerts-in-readable-collection [not-archived-alert archived-alert]
+          (testing "by default, archived Alerts should be excluded"
+            (is (= #{"Not Archived"}
+                   (set (map :name (mt/user-http-request :rasta :get 200 "alert"))))))
 
-;; can we fetch archived Alerts?
-(expect
-  #{"Archived"}
-  (with-alert-in-collection [_ _ not-archived-alert]
-    (with-alert-in-collection [_ _ archived-alert]
-      (db/update! Pulse (u/get-id not-archived-alert) :name "Not Archived")
-      (db/update! Pulse (u/get-id archived-alert)     :name "Archived", :archived true)
-      (with-alerts-in-readable-collection [not-archived-alert archived-alert]
-        (set (map :name ((user->client :rasta) :get 200 "alert?archived=true")))))))
+          (testing "can we fetch archived Alerts?"
+            (is (= #{"Archived"}
+                   (set (map :name (mt/user-http-request :rasta :get 200 "alert?archived=true")))))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                POST /api/alert                                                 |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(expect
-  {:errors {:alert_condition "value must be one of: `goal`, `rows`."}}
-  ((user->client :rasta) :post 400 "alert" {:alert_condition "not rows"
-                                            :card            "foobar"}))
+(deftest create-alert-parameter-validation-test
+  (testing "POST /api/alert"
+    (is (= {:errors {:alert_condition "value must be one of: `goal`, `rows`."}}
+           (mt/user-http-request :rasta :post 400 "alert" {:alert_condition "not rows"
+                                                           :card            "foobar"})))
 
-(expect
-  {:errors {:alert_first_only "value must be a boolean."}}
-  ((user->client :rasta) :post 400 "alert" {:alert_condition "rows"}))
+    (is (= {:errors {:alert_first_only "value must be a boolean."}}
+           (mt/user-http-request :rasta :post 400 "alert" {:alert_condition "rows"})))
 
-(expect
-  {:errors {:card "value must be a map with the keys `id`, `include_csv`, and `include_xls`."}}
-  ((user->client :rasta) :post 400 "alert" {:alert_condition  "rows"
-                                            :alert_first_only false}))
+    (is (= {:errors {:card "value must be a map with the keys `id`, `include_csv`, and `include_xls`."}}
+           (mt/user-http-request :rasta :post 400 "alert" {:alert_condition  "rows"
+                                                           :alert_first_only false})))
 
-(expect
-  {:errors {:channels "value must be an array. Each value must be a map. The array cannot be empty."}}
-  ((user->client :rasta) :post 400 "alert" {:alert_condition  "rows"
-                                            :alert_first_only false
-                                            :card             {:id 100, :include_csv false, :include_xls false}}))
+    (is (= {:errors {:channels "value must be an array. Each value must be a map. The array cannot be empty."}}
+           (mt/user-http-request :rasta :post 400 "alert" {:alert_condition  "rows"
+                                                           :alert_first_only false
+                                                           :card             {:id          100
+                                                                              :include_csv false
+                                                                              :include_xls false}})))
 
-(expect
-  {:errors {:channels "value must be an array. Each value must be a map. The array cannot be empty."}}
-  ((user->client :rasta) :post 400 "alert" {:alert_condition  "rows"
-                                            :alert_first_only false
-                                            :card             {:id 100, :include_csv false, :include_xls false}
-                                            :channels         "foobar"}))
+    (is (= {:errors {:channels "value must be an array. Each value must be a map. The array cannot be empty."}}
+           (mt/user-http-request :rasta :post 400 "alert" {:alert_condition  "rows"
+                                                           :alert_first_only false
+                                                           :card             {:id          100
+                                                                              :include_csv false
+                                                                              :include_xls false}
+                                                           :channels         "foobar"})))
 
-(expect
-  {:errors {:channels "value must be an array. Each value must be a map. The array cannot be empty."}}
-  ((user->client :rasta) :post 400 "alert" {:alert_condition  "rows"
-                                            :alert_first_only false
-                                            :card             {:id 100, :include_csv false, :include_xls false}
-                                            :channels         ["abc"]}))
-
+    (is (= {:errors {:channels "value must be an array. Each value must be a map. The array cannot be empty."}}
+           (mt/user-http-request :rasta :post 400 "alert" {:alert_condition  "rows"
+                                                           :alert_first_only false
+                                                           :card             {:id          100
+                                                                              :include_csv false
+                                                                              :include_xls false}
+                                                           :channels         ["abc"]})))))
 
 (defn- rasta-new-alert-email [body-map]
-  (et/email-to :rasta {:subject "You set up an alert",
+  (mt/email-to :rasta {:subject "You set up an alert",
                        :body (merge {"https://metabase.com/testmb" true,
                                      "My question" true}
                                     body-map)}))
 
 (defn- rasta-added-to-alert-email [body-map]
-  (et/email-to :rasta {:subject "Crowberto Corv added you to an alert",
+  (mt/email-to :rasta {:subject "Crowberto Corv added you to an alert",
                        :body (merge {"https://metabase.com/testmb" true,
                                      "now getting alerts" true}
                                     body-map)}))
 
 (defn- rasta-unsubscribe-email [body-map]
-  (et/email-to :rasta {:subject "You unsubscribed from an alert",
+  (mt/email-to :rasta {:subject "You unsubscribed from an alert",
                        :body (merge {"https://metabase.com/testmb" true}
                                     body-map)}))
 
 (defn- rasta-deleted-email [body-map]
-  (et/email-to :rasta {:subject "Crowberto Corv deleted an alert you created",
+  (mt/email-to :rasta {:subject "Crowberto Corv deleted an alert you created",
                        :body (merge {"Crowberto Corv deleted an alert" true}
                                     body-map)}))
 
@@ -248,145 +234,150 @@
    :schedule_day  nil
    :recipients    []})
 
-;; Check creation of a new rows alert with email notification
-(tt/expect-with-temp [Card [card {:name "My question"}]]
-  [(-> (default-alert card)
-       (assoc-in [:card :include_csv] true)
-       (assoc-in [:card :collection_id] true)
-       (update-in [:channels 0] merge {:schedule_hour 12, :schedule_type "daily", :recipients []}))
-   (rasta-new-alert-email {"has any results" true})]
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp Collection [collection]
-      (db/update! Card (u/get-id card) :collection_id (u/get-id collection))
-      (with-alert-setup
-        (perms/grant-collection-readwrite-permissions! (group/all-users) collection)
-        [(et/with-expected-messages 1
-           ((alert-client :rasta) :post 200 "alert"
-            {:card             {:id (u/get-id card), :include_csv false, :include_xls false}
-             :collection_id    (u/get-id collection)
-             :alert_condition  "rows"
-             :alert_first_only false
-             :channels         [daily-email-channel]}))
-         (et/regex-email-bodies #"https://metabase.com/testmb"
-                                #"has any results"
-                                #"My question")]))))
+(deftest new-rows-alert-email-notification-test
+  (testing "Check creation of a new rows alert with email notification"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp* [Collection [collection]
+                      Card       [card {:name "My question", :collection_id (:id collection)}]]
+        (with-alert-setup
+          (perms/grant-collection-readwrite-permissions! (group/all-users) collection)
+          (is (= (-> (default-alert card)
+                     (assoc-in [:card :include_csv] true)
+                     (assoc-in [:card :collection_id] true)
+                     (update-in [:channels 0] merge {:schedule_hour 12, :schedule_type "daily", :recipients []}))
+                 (mt/with-expected-messages 1
+                   ((alert-client :rasta) :post 200 "alert"
+                    {:card             {:id (u/get-id card), :include_csv false, :include_xls false}
+                     :collection_id    (u/get-id collection)
+                     :alert_condition  "rows"
+                     :alert_first_only false
+                     :channels         [daily-email-channel]}))))
+          (is (= (rasta-new-alert-email {"has any results" true})
+                 (mt/regex-email-bodies #"https://metabase.com/testmb"
+                                        #"has any results"
+                                        #"My question"))))))))
 
 (defn- setify-recipient-emails [results]
   (update results :channels (fn [channels]
                               (map #(update % :recipients set) channels))))
 
-;; An admin created alert should notify others they've been subscribed
-(tt/expect-with-temp [Card [card {:name "My question"}]]
-  {:response (-> (default-alert card)
-                 (assoc :creator (user-details :crowberto))
-                 (assoc-in [:card :include_csv] true)
-                 (update-in [:channels 0] merge {:schedule_hour 12
-                                                 :schedule_type "daily"
-                                                 :recipients    (set (map recipient-details [:rasta :crowberto]))}))
-   :emails (merge (et/email-to :crowberto {:subject "You set up an alert"
-                                           :body    {"https://metabase.com/testmb"  true
-                                                     "My question"                  true
-                                                     "now getting alerts"           false
-                                                     "confirmation that your alert" true}})
-                  (rasta-added-to-alert-email {"My question"                  true
-                                               "now getting alerts"           true
-                                               "confirmation that your alert" false}))}
+(deftest subscription-notification-test
+  (testing "An admin created alert should notify others they've been subscribed"
+    (mt/with-temp Card [card {:name "My question"}]
 
-  (with-alert-setup
-    (array-map
-     :response (et/with-expected-messages 2
-                 (-> ((alert-client :crowberto) :post 200 "alert"
-                      {:card             {:id (u/get-id card), :include_csv false, :include_xls false}
-                       :alert_condition  "rows"
-                       :alert_first_only false
-                       :channels         [(assoc daily-email-channel
-                                            :details       {:emails nil}
-                                            :recipients    (mapv fetch-user [:crowberto :rasta]))]})
-                     setify-recipient-emails))
-     :emails (et/regex-email-bodies #"https://metabase.com/testmb"
-                                    #"now getting alerts"
-                                    #"confirmation that your alert"
-                                    #"My question"))))
 
-;; Check creation of a below goal alert
-(expect
-  (rasta-new-alert-email {"goes below its goal" true})
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp* [Collection [collection]
-                    Card       [card {:name          "My question"
-                                      :display       "line"
-                                      :collection_id (u/get-id collection)}]]
-      (perms/grant-collection-readwrite-permissions! (group/all-users) collection)
       (with-alert-setup
-        (et/with-expected-messages 1
-          ((user->client :rasta) :post 200 "alert"
-           {:card             {:id (u/get-id card), :include_csv false, :include_xls false}
-            :alert_condition  "goal"
-            :alert_above_goal false
-            :alert_first_only false
-            :channels         [daily-email-channel]}))
-        (et/regex-email-bodies #"https://metabase.com/testmb"
-                               #"goes below its goal"
-                               #"My question")))))
+        (is (= (-> (default-alert card)
+                   (assoc :creator (user-details :crowberto))
+                   (assoc-in [:card :include_csv] true)
+                   (update-in [:channels 0] merge {:schedule_hour 12
+                                                   :schedule_type "daily"
+                                                   :recipients    (set (map recipient-details [:rasta :crowberto]))}))
+               (mt/with-expected-messages 2 (-> ((alert-client :crowberto) :post 200 "alert"
+                                                 {:card             {:id          (u/get-id card)
+                                                                     :include_csv false
+                                                                     :include_xls false}
+                                                  :alert_condition  "rows"
+                                                  :alert_first_only false
+                                                  :channels         [(assoc daily-email-channel
+                                                                            :details {:emails nil}
+                                                                            :recipients (mapv mt/fetch-user [:crowberto :rasta]))]})
+                                                setify-recipient-emails))))
+        (is (= (merge (mt/email-to :crowberto
+                                   {:subject "You set up an alert"
+                                    :body    {"https://metabase.com/testmb"  true
+                                              "My question"                  true
+                                              "now getting alerts"           false
+                                              "confirmation that your alert" true}})
+                      (rasta-added-to-alert-email
+                       {"My question" true, "now getting alerts" true, "confirmation that your alert" false}))
+               (mt/regex-email-bodies
+                #"https://metabase.com/testmb"
+                #"now getting alerts"
+                #"confirmation that your alert"
+                #"My question")))))))
 
-;; Check creation of a above goal alert
-(expect
-  (rasta-new-alert-email {"meets its goal" true})
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp* [Collection [collection]
-                    Card       [card {:name          "My question"
-                                      :display       "bar"
-                                      :collection_id (u/get-id collection)}]]
-      (perms/grant-collection-readwrite-permissions! (group/all-users) collection)
-      (with-alert-setup
-        (et/with-expected-messages 1
-          ((user->client :rasta) :post 200 "alert"
-           {:card             {:id (u/get-id card), :include_csv false, :include_xls false}
-            :collection_id    (u/get-id collection)
-            :alert_condition  "goal"
-            :alert_above_goal true
-            :alert_first_only false
-            :channels         [daily-email-channel]}))
-        (et/regex-email-bodies #"https://metabase.com/testmb"
-                               #"meets its goal"
-                               #"My question")))))
+
+(deftest below-goal-alert-test
+  (testing "Check creation of a below goal alert"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp* [Collection [collection]
+                      Card       [card {:name          "My question"
+                                        :display       "line"
+                                        :collection_id (u/get-id collection)}]]
+        (perms/grant-collection-readwrite-permissions! (group/all-users) collection)
+        (with-alert-setup
+          (mt/with-expected-messages 1
+            (mt/user-http-request :rasta :post 200 "alert"
+                                  {:card             {:id (u/get-id card), :include_csv false, :include_xls false}
+                                   :alert_condition  "goal"
+                                   :alert_above_goal false
+                                   :alert_first_only false
+                                   :channels         [daily-email-channel]}))
+          (is (= (rasta-new-alert-email {"goes below its goal" true})
+                 (mt/regex-email-bodies #"https://metabase.com/testmb"
+                                        #"goes below its goal"
+                                        #"My question"))))))))
+
+(deftest above-goal-alert-test
+  (testing "Check creation of a above goal alert"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp* [Collection [collection]
+                      Card       [card {:name          "My question"
+                                        :display       "bar"
+                                        :collection_id (u/get-id collection)}]]
+        (perms/grant-collection-readwrite-permissions! (group/all-users) collection)
+        (with-alert-setup
+          (mt/with-expected-messages 1
+            (mt/user-http-request :rasta :post 200 "alert"
+                                  {:card             {:id (u/get-id card), :include_csv false, :include_xls false}
+                                   :collection_id    (u/get-id collection)
+                                   :alert_condition  "goal"
+                                   :alert_above_goal true
+                                   :alert_first_only false
+                                   :channels         [daily-email-channel]}))
+          (is (= (rasta-new-alert-email {"meets its goal" true})
+                 (mt/regex-email-bodies #"https://metabase.com/testmb"
+                                        #"meets its goal"
+                                        #"My question"))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               PUT /api/alert/:id                                               |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(expect
-  {:errors {:alert_condition "value may be nil, or if non-nil, value must be one of: `goal`, `rows`."}}
-  ((user->client :rasta) :put 400 "alert/1" {:alert_condition "not rows"}))
+(deftest update-alert-parameter-validation-test
+  (testing "PUT /api/alert/:id"
+    (is (= {:errors {:alert_condition "value may be nil, or if non-nil, value must be one of: `goal`, `rows`."}}
+           (mt/user-http-request :rasta :put 400 "alert/1" {:alert_condition "not rows"})))
 
-(expect
-  {:errors {:alert_first_only "value may be nil, or if non-nil, value must be a boolean."}}
-  ((user->client :rasta) :put 400 "alert/1" {:alert_first_only 1000}))
+    (is (= {:errors {:alert_first_only "value may be nil, or if non-nil, value must be a boolean."}}
+           (mt/user-http-request :rasta :put 400 "alert/1" {:alert_first_only 1000})))
 
-(expect
-  {:errors {:card (str "value may be nil, or if non-nil, value must be a map with the keys `id`, `include_csv`, "
-                       "and `include_xls`.")}}
-  ((user->client :rasta) :put 400 "alert/1" {:alert_condition  "rows"
-                                             :alert_first_only false
-                                             :card             "foobar"}))
+    (is (= {:errors {:card (str "value may be nil, or if non-nil, value must be a map with the keys `id`, "
+                                "`include_csv`, and `include_xls`.")}}
+           (mt/user-http-request :rasta :put 400 "alert/1" {:alert_condition  "rows"
+                                                            :alert_first_only false
+                                                            :card             "foobar"})))
 
-(expect
-  {:errors {:channels (str "value may be nil, or if non-nil, value must be an array. Each value must be a map. The "
-                           "array cannot be empty.")}}
-  ((user->client :rasta) :put 400 "alert/1" {:alert_condition  "rows"
-                                             :alert_first_only false
-                                             :card             {:id 100, :include_csv false, :include_xls false}
-                                             :channels         "foobar"}))
+    (is (= {:errors {:channels (str "value may be nil, or if non-nil, value must be an array. Each value must be a "
+                                    "map. The array cannot be empty.")}}
+           (mt/user-http-request :rasta :put 400 "alert/1" {:alert_condition  "rows"
+                                                            :alert_first_only false
+                                                            :card             {:id          100
+                                                                               :include_csv false
+                                                                               :include_xls false}
+                                                            :channels         "foobar"})))
 
-(expect
-  {:errors {:channels (str "value may be nil, or if non-nil, value must be an array. Each value must be a map. The "
-                           "array cannot be empty.")}}
-  ((user->client :rasta) :put 400 "alert/1" {:name             "abc"
-                                             :alert_condition  "rows"
-                                             :alert_first_only false
-                                             :card             {:id 100, :include_csv false, :include_xls false}
-                                             :channels         ["abc"]}))
+    (is (= {:errors {:channels (str "value may be nil, or if non-nil, value must be an array. Each value must be a "
+                                    "map. The array cannot be empty.")}}
+           (mt/user-http-request :rasta :put 400 "alert/1" {:name             "abc"
+                                                            :alert_condition  "rows"
+                                                            :alert_first_only false
+                                                            :card             {:id 100
+                                                                               :include_csv false
+                                                                               :include_xls false}
+                                                            :channels         ["abc"]})))))
 
 (defn- default-alert-req
   ([card pulse-card-or-id]
@@ -404,11 +395,11 @@
 (defn- basic-alert []
   {:alert_condition  "rows"
    :alert_first_only false
-   :creator_id       (user->id :rasta)
+   :creator_id       (mt/user->id :rasta)
    :name             nil})
 
 (defn- recipient [pulse-channel-or-id username-keyword]
-  (let [user (users/fetch-user username-keyword)]
+  (let [user (mt/fetch-user username-keyword)]
     {:user_id          (u/get-id user)
      :pulse_channel_id (u/get-id pulse-channel-or-id)}))
 
@@ -423,66 +414,62 @@
 (defn- alert-url [alert-or-id]
   (format "alert/%d" (u/get-id alert-or-id)))
 
-;; Non-admin users can update alerts they created *if* they are in the recipient list
-(tt/expect-with-temp [Pulse                 [alert (basic-alert)]
-                      Card                  [card]
-                      PulseCard             [_     (pulse-card alert card)]
-                      PulseChannel          [pc    (pulse-channel alert)]
-                      PulseChannelRecipient [_     (recipient pc :rasta)]]
-  (-> (default-alert card)
-      (assoc-in [:card :collection_id] true))
-  (with-alerts-in-writeable-collection [alert]
-    (tu/with-model-cleanup [Pulse]
-      ((alert-client :rasta) :put 200 (alert-url alert)
-       (default-alert-req card pc)))))
+(deftest non-admin-update-alert-test
+  (testing "Non-admin users can update alerts they created *if* they are in the recipient list"
+    (mt/with-temp* [Pulse                 [alert (basic-alert)]
+                    Card                  [card]
+                    PulseCard             [_     (pulse-card alert card)]
+                    PulseChannel          [pc    (pulse-channel alert)]
+                    PulseChannelRecipient [_     (recipient pc :rasta)]]
 
-;; Admin users can update any alert
-(tt/expect-with-temp [Pulse                 [alert (basic-alert)]
-                      Card                  [card]
-                      PulseCard             [_     (pulse-card alert card)]
-                      PulseChannel          [pc    (pulse-channel alert)]
-                      PulseChannelRecipient [_     (recipient pc :rasta)]]
-  (default-alert card)
+      (with-alerts-in-writeable-collection [alert]
+        (mt/with-model-cleanup [Pulse]
+          (is (= (-> (default-alert card)
+                     (assoc-in [:card :collection_id] true))
+                 ((alert-client :rasta) :put 200 (alert-url alert)
+                  (default-alert-req card pc)))))))))
 
-  (tu/with-model-cleanup [Pulse]
-    ((alert-client :crowberto) :put 200 (alert-url alert)
-     (default-alert-req card pc))))
+(deftest admin-update-alert-test
+  (mt/with-temp* [Pulse                 [alert (basic-alert)]
+                  Card                  [card]
+                  PulseCard             [_     (pulse-card alert card)]
+                  PulseChannel          [pc    (pulse-channel alert)]
+                  PulseChannelRecipient [_     (recipient pc :rasta)]]
+    (testing "Admin users can update any alert"
+      (is (= (default-alert card)
+             ((alert-client :crowberto) :put 200 (alert-url alert)
+              (default-alert-req card pc)))))
 
-;; Admin users can update any alert, changing the related alert attributes
-(tt/expect-with-temp [Pulse                 [alert (basic-alert)]
-                      Card                  [card]
-                      PulseCard             [_     (pulse-card alert card)]
-                      PulseChannel          [pc    (pulse-channel alert)]
-                      PulseChannelRecipient [_     (recipient pc :rasta)]]
-  (assoc (default-alert card)
-    :alert_first_only true
-    :alert_above_goal true
-    :alert_condition  "goal")
+    (testing "Admin users can update any alert, changing the related alert attributes"
+      (is (= (assoc (default-alert card)
+                    :alert_first_only true
+                    :alert_above_goal true
+                    :alert_condition  "goal")
+             ((alert-client :crowberto) :put 200 (alert-url alert)
+              (default-alert-req card (u/get-id pc) {:alert_first_only true
+                                                     :alert_above_goal true
+                                                     :alert_condition  "goal"}
+                                 [(mt/fetch-user :rasta)])))))))
 
-  (tu/with-model-cleanup [Pulse]
-    ((alert-client :crowberto) :put 200 (alert-url alert)
-     (default-alert-req card (u/get-id pc) {:alert_first_only true, :alert_above_goal true, :alert_condition "goal"}
-                        [(fetch-user :rasta)]))))
-
-;; Admin users can add a recipieint, that recipient should be notified
-(tt/expect-with-temp [Pulse                 [alert (basic-alert)]
-                      Card                  [card]
-                      PulseCard             [_     (pulse-card alert card)]
-                      PulseChannel          [pc    (pulse-channel alert)]
-                      PulseChannelRecipient [_     (recipient pc :crowberto)]]
-  [(-> (default-alert card)
-       (assoc-in [:channels 0 :recipients] (set (map recipient-details [:crowberto :rasta]))))
-   (et/email-to :rasta {:subject "Crowberto Corv added you to an alert"
-                        :body    {"https://metabase.com/testmb" true, "now getting alerts" true}})]
-
-  (with-alert-setup
-    [(et/with-expected-messages 1
-       (setify-recipient-emails
-        ((alert-client :crowberto) :put 200 (alert-url alert)
-         (default-alert-req card pc {} [(fetch-user :crowberto)
-                                        (fetch-user :rasta)]))))
-     (et/regex-email-bodies #"https://metabase.com/testmb"
-                            #"now getting alerts")]))
+(deftest admin-add-recipient-test
+  (testing "Admin users can add a recipieint, that recipient should be notified"
+    (mt/with-temp* [Pulse                 [alert (basic-alert)]
+                    Card                  [card]
+                    PulseCard             [_     (pulse-card alert card)]
+                    PulseChannel          [pc    (pulse-channel alert)]
+                    PulseChannelRecipient [_     (recipient pc :crowberto)]]
+      (with-alert-setup
+        (is (= (-> (default-alert card)
+                   (assoc-in [:channels 0 :recipients] (set (map recipient-details [:crowberto :rasta]))))
+               (mt/with-expected-messages 1
+                 (setify-recipient-emails
+                  ((alert-client :crowberto) :put 200 (alert-url alert)
+                   (default-alert-req card pc {} [(mt/fetch-user :crowberto)
+                                                  (mt/fetch-user :rasta)]))))))
+        (is (= (mt/email-to :rasta {:subject "Crowberto Corv added you to an alert"
+                                    :body    {"https://metabase.com/testmb" true, "now getting alerts" true}})
+               (mt/regex-email-bodies #"https://metabase.com/testmb"
+                                      #"now getting alerts")))))))
 
 (deftest admin-users-remove-recipient-test
   (testing "PUT /api/alert/:id"
@@ -497,59 +484,54 @@
           (testing "API response"
             (is (= (-> (default-alert card)
                        (assoc-in [:channels 0 :recipients] [(recipient-details :crowberto)]))
-                   (et/with-expected-messages 1
+                   (mt/with-expected-messages 1
                      ((alert-client :crowberto) :put 200 (alert-url alert)
-                      (default-alert-req card (u/get-id pc) {} [(fetch-user :crowberto)]))))))
+                      (default-alert-req card (u/get-id pc) {} [(mt/fetch-user :crowberto)]))))))
           (testing "emails"
-            (is (= (et/email-to :rasta {:subject "You’ve been unsubscribed from an alert"
+            (is (= (mt/email-to :rasta {:subject "You’ve been unsubscribed from an alert"
                                         :body    {"https://metabase.com/testmb"          true
                                                   "letting you know that Crowberto Corv" true}})
-                   (et/regex-email-bodies #"https://metabase.com/testmb"
+                   (mt/regex-email-bodies #"https://metabase.com/testmb"
                                           #"letting you know that Crowberto Corv")))))))))
 
-;; Non-admin users can't edit alerts they didn't create
-(expect
-  "You don't have permissions to do that."
-  (tt/with-temp* [Pulse                 [alert (assoc (basic-alert) :creator_id (user->id :crowberto))]
-                  Card                  [card]
-                  PulseCard             [_     (pulse-card alert card)]
-                  PulseChannel          [pc    (pulse-channel alert)]
-                  PulseChannelRecipient [_     (recipient pc :rasta)]]
-    (tu/with-non-admin-groups-no-root-collection-perms
-      (with-alert-setup
-        ((alert-client :rasta) :put 403 (alert-url alert)
-         (default-alert-req card pc))))))
-
-;; Non-admin users can't edit alerts if they're not in the recipient list
-(expect
-  "You don't have permissions to do that."
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp* [Pulse                 [alert (basic-alert)]
+(deftest non-admin-edit-perms-test
+  (testing "Non-admin users can't edit alerts they didn't create"
+    (mt/with-temp* [Pulse                 [alert (assoc (basic-alert) :creator_id (mt/user->id :crowberto))]
                     Card                  [card]
                     PulseCard             [_     (pulse-card alert card)]
                     PulseChannel          [pc    (pulse-channel alert)]
-                    PulseChannelRecipient [_     (recipient pc :crowberto)]]
-      (with-alert-setup
-        ((alert-client :rasta) :put 403 (alert-url alert)
-         (default-alert-req card pc))))))
+                    PulseChannelRecipient [_     (recipient pc :rasta)]]
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (with-alert-setup
+          (is (= "You don't have permissions to do that."
+                 ((alert-client :rasta) :put 403 (alert-url alert)
+                  (default-alert-req card pc))))))))
 
-;; Can we archive an Alert?
-(expect
+  (testing "Non-admin users can't edit alerts if they're not in the recipient list"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp* [Pulse                 [alert (basic-alert)]
+                      Card                  [card]
+                      PulseCard             [_     (pulse-card alert card)]
+                      PulseChannel          [pc    (pulse-channel alert)]
+                      PulseChannelRecipient [_     (recipient pc :crowberto)]]
+        (with-alert-setup
+          (is (= "You don't have permissions to do that."
+                 ((alert-client :rasta) :put 403 (alert-url alert)
+                  (default-alert-req card pc)))))))))
+
+(deftest archive-alert-test
   (with-alert-in-collection [_ collection alert]
     (perms/grant-collection-readwrite-permissions! (group/all-users) collection)
-    ((user->client :rasta) :put 200 (str "alert/" (u/get-id alert))
-     {:archived true})
-    (db/select-one-field :archived Pulse :id (u/get-id alert))))
-
-;; Can we unarchive an Alert?
-(expect
-  false
-  (with-alert-in-collection [_ collection alert]
-    (perms/grant-collection-readwrite-permissions! (group/all-users) collection)
-    (db/update! Pulse (u/get-id alert) :archived true)
-    ((user->client :rasta) :put 200 (str "alert/" (u/get-id alert))
-     {:archived false})
-    (db/select-one-field :archived Pulse :id (u/get-id alert))))
+    (testing "Can we archive an Alert?"
+      (mt/user-http-request :rasta :put 200 (str "alert/" (u/get-id alert))
+                            {:archived true})
+      (is (= true
+             (db/select-one-field :archived Pulse :id (u/get-id alert)))))
+    (testing "Can we unarchive an Alert?"
+      (mt/user-http-request :rasta :put 200 (str "alert/" (u/get-id alert))
+                            {:archived false})
+      (is (= false
+             (db/select-one-field :archived Pulse :id (u/get-id alert)))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -558,11 +540,11 @@
 
 (defn- basic-alert-query []
   {:name          "Foo"
-   :dataset_query {:database (data/id)
+   :dataset_query {:database (mt/id)
                    :type     :query
-                   :query    {:source-table (data/id :checkins)
+                   :query    {:source-table (mt/id :checkins)
                               :aggregation  [["count"]]
-                              :breakout     [["datetime-field" (data/id :checkins :date) "hour"]]}}})
+                              :breakout     [["datetime-field" (mt/id :checkins :date) "hour"]]}}})
 
 (defn- alert-question-url [card-or-id]
   (format "alert/question/%d" (u/get-id card-or-id)))
@@ -570,65 +552,63 @@
 (defn- api:alert-question-count [user-kw card-or-id]
   (count ((alert-client user-kw) :get 200 (alert-question-url card-or-id))))
 
-(tt/expect-with-temp [Card                 [card  (basic-alert-query)]
-                      Pulse                [alert {:alert_condition  "rows"
-                                                   :alert_first_only false
-                                                   :alert_above_goal nil
-                                                   :skip_if_empty    true
-                                                   :name             nil}]
-                      PulseCard             [_    (pulse-card alert card)]
-                      PulseChannel          [pc   (pulse-channel alert)]
-                      PulseChannelRecipient [_    (recipient pc :rasta)]]
-  [(-> (default-alert card)
-       (assoc :can_write false)
-       (update-in [:channels 0] merge {:schedule_hour 15, :schedule_type "daily"})
-       (assoc-in [:card :collection_id] true))]
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (with-alert-setup
+(deftest fetch-alert-test
+  (mt/with-temp* [Card                 [card  (basic-alert-query)]
+                  Pulse                [alert {:alert_condition  "rows"
+                                               :alert_first_only false
+                                               :alert_above_goal nil
+                                               :skip_if_empty    true
+                                               :name             nil}]
+                  PulseCard             [_    (pulse-card alert card)]
+                  PulseChannel          [pc   (pulse-channel alert)]
+                  PulseChannelRecipient [_    (recipient pc :rasta)]]
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (with-alert-setup
+        (with-alerts-in-readable-collection [alert]
+          (is (= (-> (default-alert card)
+                     (assoc :can_write false)
+                     (update-in [:channels 0] merge {:schedule_hour 15, :schedule_type "daily"})
+                     (assoc-in [:card :collection_id] true))
+                 ((alert-client :rasta) :get 200 (alert-question-url card)))))))))
+
+(deftest non-admin-users-shouldnt-see-alerts-they-dont-recieve-test
+  (testing "Non-admin users shouldn't see alerts they created if they're no longer recipients"
+    (mt/with-temp* [Card                  [card  (basic-alert-query)]
+                    Pulse                 [alert (assoc (basic-alert) :alert_above_goal true)]
+                    PulseCard             [_     (pulse-card alert card)]
+                    PulseChannel          [pc    (pulse-channel alert)]
+                    PulseChannelRecipient [pcr   (recipient pc :rasta)]
+                    PulseChannelRecipient [_     (recipient pc :crowberto)]]
       (with-alerts-in-readable-collection [alert]
-        ((alert-client :rasta) :get 200 (alert-question-url card))))))
+        (with-alert-setup
+          (is (= 1
+                 (count ((alert-client :rasta) :get 200 (alert-question-url card)))))
+          (db/delete! PulseChannelRecipient :id (u/get-id pcr))
+          (is (= 0
+                 (api:alert-question-count :rasta card))))))))
 
-;; Non-admin users shouldn't see alerts they created if they're no longer recipients
-(expect
-  {:count-1 1
-   :count-2 0}
-  (tt/with-temp* [Card                  [card  (basic-alert-query)]
-                  Pulse                 [alert (assoc (basic-alert) :alert_above_goal true)]
-                  PulseCard             [_     (pulse-card alert card)]
-                  PulseChannel          [pc    (pulse-channel alert)]
-                  PulseChannelRecipient [pcr   (recipient pc :rasta)]
-                  PulseChannelRecipient [_     (recipient pc :crowberto)]]
-    (with-alerts-in-readable-collection [alert]
-      (with-alert-setup
-        (array-map
-         :count-1 (count ((alert-client :rasta) :get 200 (alert-question-url card)))
-         :count-2 (do
-                    (db/delete! PulseChannelRecipient :id (u/get-id pcr))
-                    (api:alert-question-count :rasta card)))))))
-
-;; Non-admin users should not see others alerts, admins see all alerts
-(expect
-  {:rasta     1
-   :crowberto 2}
-  (tt/with-temp* [Card                  [card    (basic-alert-query)]
-                  Pulse                 [alert-1 (assoc (basic-alert)
-                                                   :alert_above_goal false)]
-                  PulseCard             [_       (pulse-card alert-1 card)]
-                  PulseChannel          [pc-1    (pulse-channel alert-1)]
-                  PulseChannelRecipient [_       (recipient pc-1 :rasta)]
-                  ;; A separate admin created alert
-                  Pulse                 [alert-2 (assoc (basic-alert)
-                                                   :alert_above_goal false
-                                                   :creator_id       (user->id :crowberto))]
-                  PulseCard             [_       (pulse-card alert-2 card)]
-                  PulseChannel          [pc-2    (pulse-channel alert-2)]
-                  PulseChannelRecipient [_       (recipient pc-2 :crowberto)]
-                  PulseChannel          [_       (assoc (pulse-channel alert-2) :channel_type "slack")]]
-    (with-alerts-in-readable-collection [alert-1 alert-2]
-      (with-alert-setup
-        (array-map
-         :rasta     (api:alert-question-count :rasta     card)
-         :crowberto (api:alert-question-count :crowberto card))))))
+(deftest admins-see-all-alerts-test
+  (testing "Non-admin users should not see others alerts, admins see all alerts"
+    (mt/with-temp* [Card                  [card    (basic-alert-query)]
+                    Pulse                 [alert-1 (assoc (basic-alert)
+                                                          :alert_above_goal false)]
+                    PulseCard             [_       (pulse-card alert-1 card)]
+                    PulseChannel          [pc-1    (pulse-channel alert-1)]
+                    PulseChannelRecipient [_       (recipient pc-1 :rasta)]
+                    ;; A separate admin created alert
+                    Pulse                 [alert-2 (assoc (basic-alert)
+                                                          :alert_above_goal false
+                                                          :creator_id       (mt/user->id :crowberto))]
+                    PulseCard             [_       (pulse-card alert-2 card)]
+                    PulseChannel          [pc-2    (pulse-channel alert-2)]
+                    PulseChannelRecipient [_       (recipient pc-2 :crowberto)]
+                    PulseChannel          [_       (assoc (pulse-channel alert-2) :channel_type "slack")]]
+      (with-alerts-in-readable-collection [alert-1 alert-2]
+        (with-alert-setup
+          (is (= 1
+                 (api:alert-question-count :rasta     card)))
+          (is (= 2
+                 (api:alert-question-count :crowberto card))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -639,11 +619,11 @@
   (format "alert/%d/unsubscribe" (u/get-id alert-or-id)))
 
 (defn- api:unsubscribe! [user-kw expected-status-code alert-or-id]
-  ((user->client user-kw) :put expected-status-code (alert-unsubscribe-url alert-or-id)))
+  (mt/user-http-request user-kw :put expected-status-code (alert-unsubscribe-url alert-or-id)))
 
-(expect
-  "Admin users are not allowed to unsubscribe from alerts"
-  (api:unsubscribe! :crowberto 400 1))
+(deftest admin-user-cannot-unsubscribe-test
+  (is (= "Admin users are not allowed to unsubscribe from alerts"
+         (api:unsubscribe! :crowberto 400 1))))
 
 (defn- recipient-emails [results]
   (->> results
@@ -654,142 +634,118 @@
        (map :email)
        set))
 
-;; Alert has two recipients, remove one
-(expect
-  {:recipients-1 #{"crowberto@metabase.com" "rasta@metabase.com"}
-   :recipients-2 #{"crowberto@metabase.com"}
-   :emails       (rasta-unsubscribe-email {"Foo" true})}
-  (tt/with-temp* [Card                  [card  (basic-alert-query)]
-                  Pulse                 [alert (basic-alert)]
-                  PulseCard             [_     (pulse-card alert card)]
-                  PulseChannel          [pc    (pulse-channel alert)]
-                  PulseChannelRecipient [_     (recipient pc :rasta)]
-                  PulseChannelRecipient [_     (recipient pc :crowberto)]]
-    (with-alerts-in-readable-collection [alert]
-      (with-alert-setup
-        (array-map
-         :recipients-1 (recipient-emails ((user->client :rasta) :get 200 (alert-question-url card)))
-         :recipients-2 (do
-                         (et/with-expected-messages 1
-                           (api:unsubscribe! :rasta 204 alert))
-                         (recipient-emails ((user->client :crowberto) :get 200 (alert-question-url card))))
-         :emails       (et/regex-email-bodies #"https://metabase.com/testmb"
-                                              #"Foo"))))))
+(deftest unsubscribe-test
+  (testing "Alert has two recipients, remove one"
+    (mt/with-temp* [Card                  [card  (basic-alert-query)]
+                    Pulse                 [alert (basic-alert)]
+                    PulseCard             [_     (pulse-card alert card)]
+                    PulseChannel          [pc    (pulse-channel alert)]
+                    PulseChannelRecipient [_     (recipient pc :rasta)]
+                    PulseChannelRecipient [_     (recipient pc :crowberto)]]
+      (with-alerts-in-readable-collection [alert]
+        (with-alert-setup
+          (is (= #{"crowberto@metabase.com" "rasta@metabase.com"}
+                 (recipient-emails (mt/user-http-request :rasta :get 200 (alert-question-url card)))))
+          (mt/with-expected-messages 1 (api:unsubscribe! :rasta 204 alert))
+          (is (= #{"crowberto@metabase.com"}
+                 (recipient-emails (mt/user-http-request :crowberto :get 200 (alert-question-url card)))))
+          (is (= (rasta-unsubscribe-email {"Foo" true})
+                 (mt/regex-email-bodies #"https://metabase.com/testmb" #"Foo"))))))))
 
-;; Alert should be deleted if the creator unsubscribes and there's no one left
-(expect
-  {:count-1 1
-   :count-2 0
-   :emails  (rasta-unsubscribe-email {"Foo" true})}
-  (tt/with-temp* [Card                  [card  (basic-alert-query)]
-                  Pulse                 [alert (basic-alert)]
-                  PulseCard             [_     (pulse-card alert card)]
-                  PulseChannel          [pc    (pulse-channel alert)]
-                  PulseChannelRecipient [_     (recipient pc :rasta)]]
-    (with-alerts-in-readable-collection [alert]
-      (with-alert-setup
-        (array-map
-         :count-1 (api:alert-question-count :rasta card)
-         :count-2 (do
-                    (et/with-expected-messages 1
-                      (api:unsubscribe! :rasta 204 alert))
-                    (api:alert-question-count :crowberto card))
-         :emails  (et/regex-email-bodies #"https://metabase.com/testmb"
-                                         #"Foo"))))))
+(deftest delete-alert-when-creator-unsubscribes-test
+  (testing "Alert should be deleted if the creator unsubscribes and there's no one left"
+    (mt/with-temp* [Card                  [card  (basic-alert-query)]
+                    Pulse                 [alert (basic-alert)]
+                    PulseCard             [_     (pulse-card alert card)]
+                    PulseChannel          [pc    (pulse-channel alert)]
+                    PulseChannelRecipient [_     (recipient pc :rasta)]]
+      (with-alerts-in-readable-collection [alert]
+        (with-alert-setup
+          (is (= 1
+                 (api:alert-question-count :rasta card)))
+          (mt/with-expected-messages 1 (api:unsubscribe! :rasta 204 alert))
+          (is (= 0
+                 (api:alert-question-count :crowberto card)))
+          (is (= (rasta-unsubscribe-email {"Foo" true})
+                 (mt/regex-email-bodies #"https://metabase.com/testmb" #"Foo"))))))))
 
-;; Alert should not be deleted if there is a slack channel
-(expect
-  {:count-1 1
-   :count-2 1 ; <-- Alert should not be deleted
-   :emails  (rasta-unsubscribe-email {"Foo" true})}
-  (tt/with-temp* [Card                  [card  (basic-alert-query)]
-                  Pulse                 [alert (basic-alert)]
-                  PulseCard             [_     (pulse-card alert card)]
-                  PulseChannel          [pc-1  (assoc (pulse-channel alert) :channel_type :email)]
-                  PulseChannel          [_     (assoc (pulse-channel alert) :channel_type :slack)]
-                  PulseChannelRecipient [_     (recipient pc-1 :rasta)]]
-    (with-alerts-in-readable-collection [alert]
-      (with-alert-setup
-        (array-map
-         :count-1 (api:alert-question-count :rasta card)
-         :count-2 (do
-                    (et/with-expected-messages 1
-                      (api:unsubscribe! :rasta 204 alert))
-                    (api:alert-question-count :crowberto card))
-         :emails  (et/regex-email-bodies #"https://metabase.com/testmb"
-                                         #"Foo"))))))
+(deftest do-not-delete-alert-with-slack-channel-test
+  (testing "Alert should not be deleted if there is a slack channel"
+    (mt/with-temp* [Card                  [card  (basic-alert-query)]
+                    Pulse                 [alert (basic-alert)]
+                    PulseCard             [_     (pulse-card alert card)]
+                    PulseChannel          [pc-1  (assoc (pulse-channel alert) :channel_type :email)]
+                    PulseChannel          [_     (assoc (pulse-channel alert) :channel_type :slack)]
+                    PulseChannelRecipient [_     (recipient pc-1 :rasta)]]
+      (with-alerts-in-readable-collection [alert]
+        (with-alert-setup
+          (is (= 1
+                 (api:alert-question-count :rasta card)))
+          (mt/with-expected-messages 1 (api:unsubscribe! :rasta 204 alert))
+          (is (= 1
+                 (api:alert-question-count :crowberto card)))
+          (is (= (rasta-unsubscribe-email {"Foo" true})
+                 (mt/regex-email-bodies #"https://metabase.com/testmb" #"Foo"))))))))
 
-;; If email is disabled, users should be unsubscribed
-(expect
-  {:count-1 1
-   :count-2 1 ; <-- Alert should not be deleted
-   :emails  (et/email-to :rasta {:subject "You’ve been unsubscribed from an alert",
-                                 :body    {"https://metabase.com/testmb"          true,
-                                           "letting you know that Crowberto Corv" true}})}
-  (tt/with-temp* [Card                  [card  (basic-alert-query)]
-                  Pulse                 [alert (basic-alert)]
-                  PulseCard             [_     (pulse-card alert card)]
-                  PulseChannel          [pc-1  (assoc (pulse-channel alert) :channel_type :email)]
-                  PulseChannel          [pc-2  (assoc (pulse-channel alert) :channel_type :slack)]
-                  PulseChannelRecipient [_     (recipient pc-1 :rasta)]]
-    (with-alerts-in-readable-collection [alert]
-      (with-alert-setup
-        (array-map
-         :count-1 (api:alert-question-count :rasta card)
-         :count-2 (do
-                    (et/with-expected-messages 1
-                      ((alert-client :crowberto) :put 200 (alert-url alert)
-                       (assoc-in (default-alert-req card pc-1) [:channels 0 :enabled] false)))
-                    (api:alert-question-count :crowberto card))
-         :emails  (et/regex-email-bodies #"https://metabase.com/testmb"
-                                         #"letting you know that Crowberto Corv" ))))))
+(deftest disable-email-unsubscribe-test
+  (testing "If email is disabled, users should be unsubscribed"
+    (mt/with-temp* [Card                  [card  (basic-alert-query)]
+                    Pulse                 [alert (basic-alert)]
+                    PulseCard             [_     (pulse-card alert card)]
+                    PulseChannel          [pc-1  (assoc (pulse-channel alert) :channel_type :email)]
+                    PulseChannel          [pc-2  (assoc (pulse-channel alert) :channel_type :slack)]
+                    PulseChannelRecipient [_     (recipient pc-1 :rasta)]]
+      (with-alerts-in-readable-collection [alert]
+        (with-alert-setup
+          (is (= 1
+                 (api:alert-question-count :rasta card)))
+          (mt/with-expected-messages 1 ((alert-client :crowberto) :put 200
+                                        (alert-url alert)
+                                        (assoc-in (default-alert-req card pc-1) [:channels 0 :enabled] false)))
+          (is (= 1
+                 (api:alert-question-count :crowberto card)))
+          (is (= (mt/email-to :rasta {:subject "You’ve been unsubscribed from an alert",
+                                      :body    {"https://metabase.com/testmb"          true
+                                                "letting you know that Crowberto Corv" true}})
+                 (mt/regex-email-bodies #"https://metabase.com/testmb" #"letting you know that Crowberto Corv"))))))))
 
-;; Re-enabling email should send users a subscribe notification
-(expect
-  {:count-1 1
-   :count-2 1 ; <-- Alert should not be deleted
-   :emails  (et/email-to :rasta {:subject "Crowberto Corv added you to an alert",
-                                 :body    {"https://metabase.com/testmb"    true,
-                                           "now getting alerts about .*Foo" true}})}
-  (tt/with-temp* [Card                  [card  (basic-alert-query)]
-                  Pulse                 [alert (basic-alert)]
-                  PulseCard             [_     (pulse-card alert card)]
-                  PulseChannel          [pc-1  (assoc (pulse-channel alert) :channel_type :email, :enabled false)]
-                  PulseChannel          [pc-2  (assoc (pulse-channel alert) :channel_type :slack)]
-                  PulseChannelRecipient [_     (recipient pc-1 :rasta)]]
-    (with-alerts-in-readable-collection [alert]
-      (with-alert-setup
-        (array-map
-         :count-1 (api:alert-question-count :rasta card)
-         :count-2 (do
-                    (et/with-expected-messages 1
-                      ((alert-client :crowberto) :put 200 (alert-url alert)
-                       (assoc-in (default-alert-req card pc-1) [:channels 0 :enabled] true)))
-                    (api:alert-question-count :crowberto card))
-         :emails  (et/regex-email-bodies #"https://metabase.com/testmb"
-                                         #"now getting alerts about .*Foo" ))))))
+(deftest reenable-subscribe-notification-test
+  (testing "Re-enabling email should send users a subscribe notification"
+    (mt/with-temp* [Card                  [card  (basic-alert-query)]
+                    Pulse                 [alert (basic-alert)]
+                    PulseCard             [_     (pulse-card alert card)]
+                    PulseChannel          [pc-1  (assoc (pulse-channel alert) :channel_type :email, :enabled false)]
+                    PulseChannel          [pc-2  (assoc (pulse-channel alert) :channel_type :slack)]
+                    PulseChannelRecipient [_     (recipient pc-1 :rasta)]]
+      (with-alerts-in-readable-collection [alert]
+        (with-alert-setup
+          (is (= 1
+                 (api:alert-question-count :rasta card)))
+          (mt/with-expected-messages 1 ((alert-client :crowberto) :put 200 (alert-url alert)
+                                        (assoc-in (default-alert-req card pc-1) [:channels 0 :enabled] true)))
+          (is (= 1
+                 (api:alert-question-count :crowberto card)))
+          (is (= (mt/email-to :rasta {:subject "Crowberto Corv added you to an alert",
+                                      :body {"https://metabase.com/testmb" true, "now getting alerts about .*Foo" true}})
+                 (mt/regex-email-bodies #"https://metabase.com/testmb" #"now getting alerts about .*Foo"))))))))
 
-;; Alert should not be deleted if the unsubscriber isn't the creator
-(expect
-  {:count-1 1
-   :count-2 1 ; <-- Alert should not be deleted
-   :emails  (rasta-unsubscribe-email {"Foo" true})}
-  (tt/with-temp* [Card                  [card  (basic-alert-query)]
-                  Pulse                 [alert (assoc (basic-alert) :creator_id (user->id :crowberto))]
-                  PulseCard             [_     (pulse-card alert card)]
-                  PulseChannel          [pc-1  (assoc (pulse-channel alert) :channel_type :email)]
-                  PulseChannel          [pc-2  (assoc (pulse-channel alert) :channel_type :slack)]
-                  PulseChannelRecipient [_     (recipient pc-1 :rasta)]]
-    (with-alerts-in-readable-collection [alert]
-      (with-alert-setup
-        (array-map
-         :count-1 (api:alert-question-count :rasta card)
-         :count-2 (do
-                    (et/with-expected-messages 1
-                      (api:unsubscribe! :rasta 204 alert))
-                    (api:alert-question-count :crowberto card))
-         :emails  (et/regex-email-bodies #"https://metabase.com/testmb"
-                                         #"Foo"))))))
+(deftest do-not-delete-alert-if-unsubscriber-is-not-creator-test
+  (testing "Alert should not be deleted if the unsubscriber isn't the creator"
+    (mt/with-temp* [Card                  [card  (basic-alert-query)]
+                    Pulse                 [alert (assoc (basic-alert) :creator_id (mt/user->id :crowberto))]
+                    PulseCard             [_     (pulse-card alert card)]
+                    PulseChannel          [pc-1  (assoc (pulse-channel alert) :channel_type :email)]
+                    PulseChannel          [pc-2  (assoc (pulse-channel alert) :channel_type :slack)]
+                    PulseChannelRecipient [_     (recipient pc-1 :rasta)]]
+      (with-alerts-in-readable-collection [alert]
+        (with-alert-setup
+          (is (= 1
+                 (api:alert-question-count :rasta card)))
+          (mt/with-expected-messages 1 (api:unsubscribe! :rasta 204 alert))
+          (is (= 1
+                 (api:alert-question-count :crowberto card)))
+          (is (= (rasta-unsubscribe-email {"Foo" true})
+                 (mt/regex-email-bodies #"https://metabase.com/testmb" #"Foo"))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -797,106 +753,91 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn- api:delete! [user-kw expected-status-code alert-or-id]
-  ((user->client user-kw) :delete expected-status-code (alert-url alert-or-id)))
+  (mt/user-http-request user-kw :delete expected-status-code (alert-url alert-or-id)))
 
-;; Only admins can delete an alert
-(expect
-  {:count    1
-   :response "You don't have permissions to do that."}
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp* [Card                  [card  (basic-alert-query)]
-                    Pulse                 [alert (basic-alert)]
-                    PulseCard             [_     (pulse-card alert card)]
-                    PulseChannel          [pc    (pulse-channel alert)]
-                    PulseChannelRecipient [_     (recipient pc :rasta)]]
+(deftest only-admins-can-delete-alert-test
+  (testing "Only admins can delete an alert"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp* [Card                  [card  (basic-alert-query)]
+                      Pulse                 [alert (basic-alert)]
+                      PulseCard             [_     (pulse-card alert card)]
+                      PulseChannel          [pc    (pulse-channel alert)]
+                      PulseChannelRecipient [_     (recipient pc :rasta)]]
+        (with-alerts-in-readable-collection [alert]
+          (with-alert-setup
+            (is (= 1
+                   (api:alert-question-count :rasta card)))
+            (is (= "You don't have permissions to do that."
+                   (api:delete! :rasta 403 alert)))
+            (is (= 1
+                   (count (mt/user-http-request :crowberto :get 200 (alert-question-url card)))))
+            (is (= nil
+                   (api:delete! :crowberto 204 alert)))
+            (is (= 0
+                   (api:alert-question-count :rasta card)))))))))
+
+(deftest admin-delete-other-users-alert-test
+  (testing "An admin can delete a different user's alert"
+    (mt/with-temp*  [Card                  [card  (basic-alert-query)]
+                     Pulse                 [alert (basic-alert)]
+                     PulseCard             [_     (pulse-card alert card)]
+                     PulseChannel          [pc    (pulse-channel alert)]
+                     PulseChannelRecipient [_     (recipient pc :rasta)]]
       (with-alerts-in-readable-collection [alert]
         (with-alert-setup
-          (array-map
-           :count    (api:alert-question-count :rasta card)
-           :response (api:delete! :rasta 403 alert)))))))
+          (is (= 1
+                 (api:alert-question-count :rasta card)))
+          (is (= nil
+                 (mt/with-expected-messages 1 (api:delete! :crowberto 204 alert))))
+          (is (= 0
+                 (api:alert-question-count :rasta card)))
+          (is (= (rasta-deleted-email {})
+                 (mt/regex-email-bodies #"Crowberto Corv deleted an alert"))))))))
 
-;; Testing a user can't delete an admin's alert
-(expect
-  {:count-1  1
-   :response nil
-   :count-2  0}
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp* [Card                  [card  (basic-alert-query)]
-                    Pulse                 [alert (basic-alert)]
+(deftest notify-when-alert-is-deleted-test
+  (testing "A deleted alert should notify the creator and any recipients"
+    (mt/with-temp*  [Card                  [card  (basic-alert-query)]
+                     Pulse                 [alert (basic-alert)]
+                     PulseCard             [_     (pulse-card alert card)]
+                     PulseChannel          [pc    (pulse-channel alert)]
+                     PulseChannelRecipient [_     (recipient pc :rasta)]
+                     PulseChannelRecipient [_     (recipient pc :lucky)]]
+      (with-alerts-in-readable-collection [alert]
+        (with-alert-setup
+          (is (= 1
+                 (api:alert-question-count :rasta card)))
+          (is (= nil
+                 (mt/with-expected-messages 2 (api:delete! :crowberto 204 alert))))
+          (is (= 0
+                 (api:alert-question-count :rasta card)))
+          (is (= (merge
+                  (rasta-deleted-email {"Crowberto Corv unsubscribed you from alerts" false})
+                  (mt/email-to
+                   :lucky
+                   {:subject "You’ve been unsubscribed from an alert"
+                    :body    {"Crowberto Corv deleted an alert"             false
+                              "Crowberto Corv unsubscribed you from alerts" true}}))
+                 (mt/regex-email-bodies #"Crowberto Corv deleted an alert" #"Crowberto Corv unsubscribed you from alerts")))))))
+
+  (testing "When an admin deletes their own alert, it should not notify them"
+    (mt/with-temp* [Card                  [card  (basic-alert-query)]
+                    Pulse                 [alert (assoc (basic-alert) :creator_id (mt/user->id :crowberto))]
                     PulseCard             [_     (pulse-card alert card)]
                     PulseChannel          [pc    (pulse-channel alert)]
-                    PulseChannelRecipient [_     (recipient pc :rasta)]]
+                    PulseChannelRecipient [_     (recipient pc :crowberto)]]
       (with-alert-setup
-        (let [original-alert-response ((user->client :crowberto) :get 200 (alert-question-url card))]
+        (is (= 1
+               (api:alert-question-count :crowberto card)))
+        (is (= nil
+               (api:delete! :crowberto 204 alert)))
+        (is (= 0
+               (api:alert-question-count :crowberto card)))
+        (is (= {}
+               (mt/regex-email-bodies #".*")))))))
 
-          ;; A user can't delete an admin's alert
-          (api:delete! :rasta 403 alert)
+;; NOCOMMIT
+(defn generate-beautiful-tests [x y]
+  (for [[expected actual] (partition 2 (interleave (map second (partition 2 x))
+                                                   (map second (partition 2 y))))]
 
-          (array-map
-           :count-1  (count original-alert-response)
-           :response (api:delete! :crowberto 204 alert)
-           :count-2  (api:alert-question-count :rasta card)))))))
-
-;; An admin can delete a user's alert
-(expect
-  {:count-1  1
-   :response nil
-   :count-2  0
-   :emails   (rasta-deleted-email {})}
-  (tt/with-temp*  [Card                  [card  (basic-alert-query)]
-                   Pulse                 [alert (basic-alert)]
-                   PulseCard             [_     (pulse-card alert card)]
-                   PulseChannel          [pc    (pulse-channel alert)]
-                   PulseChannelRecipient [_     (recipient pc :rasta)]]
-    (with-alerts-in-readable-collection [alert]
-      (with-alert-setup
-        (array-map
-         :count-1  (api:alert-question-count :rasta card)
-         :response (et/with-expected-messages 1
-                     (api:delete! :crowberto 204 alert))
-         :count-2  (api:alert-question-count :rasta card)
-         :emails   (et/regex-email-bodies #"Crowberto Corv deleted an alert"))))))
-
-;; A deleted alert should notify the creator and any recipients
-(expect
-  {:count-1  1
-   :response nil
-   :count-2  0
-   :emails   (merge
-              (rasta-deleted-email {"Crowberto Corv unsubscribed you from alerts" false})
-              (et/email-to :lucky {:subject "You’ve been unsubscribed from an alert",
-                                   :body    {"Crowberto Corv deleted an alert"             false
-                                             "Crowberto Corv unsubscribed you from alerts" true}}))}
-  (tt/with-temp*  [Card                  [card  (basic-alert-query)]
-                   Pulse                 [alert (basic-alert)]
-                   PulseCard             [_     (pulse-card alert card)]
-                   PulseChannel          [pc    (pulse-channel alert)]
-                   PulseChannelRecipient [_     (recipient pc :rasta)]
-                   PulseChannelRecipient [_     (recipient pc :lucky)]]
-    (with-alerts-in-readable-collection [alert]
-      (with-alert-setup
-        (array-map
-         :count-1  (api:alert-question-count :rasta card)
-         :response (et/with-expected-messages 2
-                     (api:delete! :crowberto 204 alert))
-         :count-2  (api:alert-question-count :rasta card)
-         :emails   (et/regex-email-bodies #"Crowberto Corv deleted an alert"
-                                          #"Crowberto Corv unsubscribed you from alerts"))))))
-
-;; When an admin deletes their own alert, it should not notify them
-(expect
-  {:count-1  1
-   :response nil
-   :count-2  0
-   :emails   {}}
-  (tt/with-temp* [Card                  [card  (basic-alert-query)]
-                  Pulse                 [alert (assoc (basic-alert) :creator_id (user->id :crowberto))]
-                  PulseCard             [_     (pulse-card alert card)]
-                  PulseChannel          [pc    (pulse-channel alert)]
-                  PulseChannelRecipient [_     (recipient pc :crowberto)]]
-    (with-alert-setup
-      (array-map
-       :count-1  (api:alert-question-count :crowberto card)
-       :response (api:delete! :crowberto 204 alert)
-       :count-2  (api:alert-question-count :crowberto card)
-       :emails   (et/regex-email-bodies #".*")))))
+    (list 'is (list '= expected actual))))

--- a/test/metabase/api/automagic_dashboards_test.clj
+++ b/test/metabase/api/automagic_dashboards_test.clj
@@ -160,7 +160,7 @@
     (mt/with-test-user :rasta
       (transforms.test/with-test-transform-specs
         (de.test/with-test-domain-entity-specs
-          (mt/with-model-cleanup ['Card 'Collection]
+          (mt/with-model-cleanup [Card Collection]
             (transforms/apply-transform! (mt/id) "PUBLIC" (first @transforms.specs/transform-specs))
             (is (= [[1 "Red Medicine" 4 10.0646 -165.374 3 1.5 4 3 2 1]
                     [2 "Stout Burgers & Beers" 11 34.0996 -118.329 2 2.0 11 2 1 1]

--- a/test/metabase/api/automagic_dashboards_test.clj
+++ b/test/metabase/api/automagic_dashboards_test.clj
@@ -32,13 +32,13 @@
    (mt/with-test-user :rasta
      (with-dashboard-cleanup
        (let [api-endpoint (apply format (str "automagic-dashboards/" template) args)
-             result       (validation-fn ((mt/user->client :rasta) :get 200 api-endpoint))]
+             result       (validation-fn (mt/user-http-request :rasta :get 200 api-endpoint))]
          (when (and result
                     (try
                       (testing "Endpoint should return 403 if user does not have permissions"
                         (perms/revoke-permissions! (perms-group/all-users) (mt/id))
                         (revoke-fn)
-                        (let [result ((mt/user->client :rasta) :get 403 api-endpoint)]
+                        (let [result (mt/user-http-request :rasta :get 403 api-endpoint)]
                           (is (= "You don't have permissions to do that."
                                  result))
                           (= "You don't have permissions to do that." result)))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -5,9 +5,9 @@
              [string :as str]
              [test :refer :all]]
             [dk.ative.docjure.spreadsheet :as spreadsheet]
+            [java-time :as t]
             [medley.core :as m]
             [metabase
-             [email-test :as et]
              [http-client :as http :refer :all]
              [models :refer [Card CardFavorite Collection Dashboard Database Pulse PulseCard PulseChannel PulseChannelRecipient Table ViewLog]]
              [test :as mt]
@@ -22,11 +22,8 @@
             [metabase.query-processor.middleware
              [constraints :as constraints]
              [results-metadata :as results-metadata]]
-            [metabase.test
-             [data :as data]
-             [util :as tu]]
-            [toucan.db :as db]
-            [toucan.util.test :as tt])
+            [schema.core :as s]
+            [toucan.db :as db])
   (:import java.io.ByteArrayInputStream
            java.util.UUID))
 
@@ -56,7 +53,7 @@
 
 (defn- mbql-count-query
   ([]
-   (mbql-count-query (data/id) (data/id :venues)))
+   (mbql-count-query (mt/id) (mt/id :venues)))
 
   ([db-or-id table-or-id]
    {:database (u/get-id db-or-id)
@@ -65,7 +62,8 @@
 
 (defn- card-with-name-and-query
   ([]
-   (card-with-name-and-query (tu/random-name)))
+   (card-with-name-and-query (mt/random-name)))
+
   ([card-name]
    (card-with-name-and-query card-name (mbql-count-query)))
   ([card-name query]
@@ -77,7 +75,7 @@
 (defn- do-with-temp-native-card
   {:style/indent 0}
   [f]
-  (tt/with-temp* [Database   [db    {:details (:details (data/db)), :engine :h2}]
+  (mt/with-temp* [Database   [db    {:details (:details (mt/db)), :engine :h2}]
                   Table      [table {:db_id (u/get-id db), :name "CATEGORIES"}]
                   Card       [card  {:dataset_query {:database (u/get-id db)
                                                      :type     :native
@@ -90,10 +88,9 @@
   `(do-with-temp-native-card (fn [~(or db-binding '_) ~(or card-binding '_)]
                                ~@body)))
 
-
 (defn do-with-cards-in-a-collection [card-or-cards-or-ids grant-perms-fn! f]
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp Collection [collection]
+  (mt/with-non-admin-groups-no-root-collection-perms
+    (mt/with-temp Collection [collection]
       ;; put all the Card(s) in our temp `collection`
       (doseq [card-or-id (if (sequential? card-or-cards-or-ids)
                            card-or-cards-or-ids
@@ -117,10 +114,9 @@
   [card-or-cards-or-ids & body]
   `(do-with-cards-in-a-collection ~card-or-cards-or-ids perms/grant-collection-readwrite-permissions! (fn [] ~@body)))
 
-
 (defn- do-with-temp-native-card-with-params {:style/indent 0} [f]
-  (tt/with-temp*
-    [Database   [db    {:details (:details (data/db)), :engine :h2}]
+  (mt/with-temp*
+    [Database   [db    {:details (:details (mt/db)), :engine :h2}]
      Table      [table {:db_id (u/get-id db), :name "VENUES"}]
      Card       [card  {:dataset_query
                         {:database (u/get-id db)
@@ -142,17 +138,17 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn- card-returned? [model object-or-id card-or-id]
-  (contains? (set (for [card ((mt/user->client :rasta) :get 200 "card", :f model, :model_id (u/get-id object-or-id))]
+  (contains? (set (for [card (mt/user-http-request :rasta :get 200 "card", :f model, :model_id (u/get-id object-or-id))]
                     (u/get-id card)))
              (u/get-id card-or-id)))
 
 (deftest filter-cards-by-db-test
-  (tt/with-temp* [Database [db]
-                  Card     [card-1 {:database_id (data/id)}]
+  (mt/with-temp* [Database [db]
+                  Card     [card-1 {:database_id (mt/id)}]
                   Card     [card-2 {:database_id (u/get-id db)}]]
     (with-cards-in-readable-collection [card-1 card-2]
       (is (= true
-             (card-returned? :database (data/id) card-1)))
+             (card-returned? :database (mt/id) card-1)))
       (is (= false
              (card-returned? :database db        card-1)))
       (is (= true
@@ -165,11 +161,11 @@
 
 (deftest model-id-requied-when-f-is-database-test
   (is (= {:errors {:model_id "model_id is a required parameter when filter mode is 'database'"}}
-         ((mt/user->client :crowberto) :get 400 "card" :f :database))))
+         (mt/user-http-request :crowberto :get 400 "card" :f :database))))
 
 (deftest filter-cards-by-table-test
   (testing "Filter cards by table"
-    (tt/with-temp* [Database [db]
+    (mt/with-temp* [Database [db]
                     Table    [table-1  {:db_id (u/get-id db)}]
                     Table    [table-2  {:db_id (u/get-id db)}]
                     Card     [card-1   {:table_id (u/get-id table-1)}]
@@ -185,71 +181,86 @@
 ;; Make sure `model_id` is required when `f` is :table
 (deftest model_id-requied-when-f-is-table
   (is (= {:errors {:model_id "model_id is a required parameter when filter mode is 'table'"}}
-         ((mt/user->client :crowberto) :get 400 "card", :f :table))))
+         (mt/user-http-request :crowberto :get 400 "card", :f :table))))
+
+(defn- do-with-card-views [card-or-id+username f]
+  (let [[f] (reduce
+             (fn [[f timestamp] [card-or-id username]]
+               [(fn []
+                  (let [card-id   (u/get-id card-or-id)
+                        card-name (db/select-one-field :name Card :id card-id)]
+                    (testing (format "\nCard %d %s viewed by %s on %s" card-id (pr-str card-name) username timestamp)
+                      (mt/with-temp ViewLog [_ {:model     "card"
+                                                :model_id  card-id
+                                                :user_id   (mt/user->id username)
+                                                :timestamp timestamp}]
+                        (f)))))
+                (t/plus timestamp (t/days 1))])
+             [f (t/zoned-date-time)]
+             card-or-id+username)]
+    (f)))
+
+(defmacro ^:private with-card-views [card-or-id+username & body]
+  `(do-with-card-views ~(mapv vec (partition 2 card-or-id+username)) (fn [] ~@body)))
 
 (deftest filter-by-recent-test
-  (testing "Filter by `recent`"
-    (tt/with-temp* [Card    [card-1 {:name "Card 1"}]
-                    Card    [card-2 {:name "Card 2"}]
-                    Card    [card-3 {:name "Card 3"}]
-                    Card    [card-4 {:name "Card 4"}]
-                    ;; 3 was viewed most recently, followed by 4, then 1. Card 2 was viewed by a different user so
-                    ;; shouldn't be returned
-                    ViewLog [_ {:model     "card", :model_id (u/get-id card-1), :user_id (mt/user->id :rasta)
-                                :timestamp #t "2015-12-01"}]
-                    ViewLog [_ {:model     "card", :model_id (u/get-id card-2), :user_id (mt/user->id :trashbird)
-                                :timestamp #t "2016-01-01"}]
-                    ViewLog [_ {:model     "card", :model_id (u/get-id card-3), :user_id (mt/user->id :rasta)
-                                :timestamp #t "2016-02-01"}]
-                    ViewLog [_ {:model     "card", :model_id (u/get-id card-4), :user_id (mt/user->id :rasta)
-                                :timestamp #t "2016-03-01"}]
-                    ViewLog [_ {:model     "card", :model_id (u/get-id card-3), :user_id (mt/user->id :rasta)
-                                :timestamp #t "2016-04-01"}]]
-      (with-cards-in-readable-collection [card-1 card-2 card-3 card-4]
-        (is (= ["Card 3"
-                "Card 4"
-                "Card 1"]
-               (map :name ((mt/user->client :rasta) :get 200 "card", :f :recent)))
-            "Should return cards that were recently viewed by current user only")))))
+  (testing "GET /api/card?f=recent"
+    (mt/with-temp* [Card [card-1 {:name "Card 1"}]
+                    Card [card-2 {:name "Card 2"}]
+                    Card [card-3 {:name "Card 3"}]
+                    Card [card-4 {:name "Card 4"}]]
+      ;; 3 was viewed most recently, followed by 4, then 1. Card 2 was viewed by a different user so shouldn't be
+      ;; returned
+      (with-card-views [card-1 :rasta
+                        card-2 :trashbird
+                        card-3 :rasta
+                        card-4 :rasta
+                        card-3 :rasta]
+        (with-cards-in-readable-collection [card-1 card-2 card-3 card-4]
+          (testing "\nShould return cards that were recently viewed by current user only"
+            (is (= ["Card 3"
+                    "Card 4"
+                    "Card 1"]
+                   (map :name (mt/user-http-request :rasta :get 200 "card", :f :recent))))))))))
 
 (deftest filter-by-popular-test
-  (testing "Filter by `popular`"
-    (tt/with-temp* [Card     [card-1 {:name "Card 1"}]
-                    Card     [card-2 {:name "Card 2"}]
-                    Card     [card-3 {:name "Card 3"}]
-                    ;; 3 entries for card 3, 2 for card 2, none for card 1,
-                    ViewLog  [_ {:model "card", :model_id (u/get-id card-3), :user_id (mt/user->id :rasta)}]
-                    ViewLog  [_ {:model "card", :model_id (u/get-id card-2), :user_id (mt/user->id :trashbird)}]
-                    ViewLog  [_ {:model "card", :model_id (u/get-id card-2), :user_id (mt/user->id :rasta)}]
-                    ViewLog  [_ {:model "card", :model_id (u/get-id card-3), :user_id (mt/user->id :crowberto)}]
-                    ViewLog  [_ {:model "card", :model_id (u/get-id card-3), :user_id (mt/user->id :rasta)}]]
-      (with-cards-in-readable-collection [card-1 card-2 card-3]
-        (is (= ["Card 3"
-                "Card 2"]
-               (map :name ((mt/user->client :rasta) :get 200 "card", :f :popular)))
-            (str "`f=popular` should return cards sorted by number of ViewLog entries for all users; cards with no "
-                 "entries should be excluded"))))))
+  (testing "GET /api/card?f=popular"
+    (mt/with-temp* [Card [card-1 {:name "Card 1"}]
+                    Card [card-2 {:name "Card 2"}]
+                    Card [card-3 {:name "Card 3"}]]
+      ;; 3 entries for card 3, 2 for card 2, none for card 1,
+      (with-card-views [card-3 :rasta
+                        card-2 :trashbird
+                        card-2 :rasta
+                        card-3 :crowberto
+                        card-3 :rasta]
+        (with-cards-in-readable-collection [card-1 card-2 card-3]
+          (testing (str "`f=popular` should return cards sorted by number of ViewLog entries for all users; cards with "
+                        "no entries should be excluded")
+            (is (= ["Card 3"
+                    "Card 2"]
+                   (map :name (mt/user-http-request :rasta :get 200 "card", :f :popular))))))))))
 
 (deftest filter-by-archived-test
-  (testing "Filter by `archived`"
-    (tt/with-temp* [Card [card-1 {:name "Card 1"}]
+  (testing "GET /api/card?f=archived"
+    (mt/with-temp* [Card [card-1 {:name "Card 1"}]
                     Card [card-2 {:name "Card 2", :archived true}]
                     Card [card-3 {:name "Card 3", :archived true}]]
       (with-cards-in-readable-collection [card-1 card-2 card-3]
         (is (= #{"Card 2" "Card 3"}
-               (set (map :name ((mt/user->client :rasta) :get 200 "card", :f :archived))))
+               (set (map :name (mt/user-http-request :rasta :get 200 "card", :f :archived))))
             "The set of Card returned with f=archived should be equal to the set of archived cards")))))
 
 (deftest filter-by-fav-test
   (testing "Filter by `fav`"
-    (tt/with-temp* [Card         [card-1 {:name "Card 1"}]
+    (mt/with-temp* [Card         [card-1 {:name "Card 1"}]
                     Card         [card-2 {:name "Card 2"}]
                     Card         [card-3 {:name "Card 3"}]
                     CardFavorite [_ {:card_id (u/get-id card-1), :owner_id (mt/user->id :rasta)}]
                     CardFavorite [_ {:card_id (u/get-id card-2), :owner_id (mt/user->id :crowberto)}]]
       (with-cards-in-readable-collection [card-1 card-2 card-3]
         (is (= [{:name "Card 1", :favorite true}]
-               (for [card ((mt/user->client :rasta) :get 200 "card", :f :fav)]
+               (for [card (mt/user-http-request :rasta :get 200 "card", :f :fav)]
                  (select-keys card [:name :favorite]))))))))
 
 
@@ -257,79 +268,78 @@
 ;;; |                                        CREATING A CARD (POST /api/card)                                        |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-;; Test that we can make a card
+;;
 (deftest create-a-card
-  (let [card-name (tu/random-name)]
-    (tu/with-non-admin-groups-no-root-collection-perms
-      (tt/with-temp* [Collection [collection]]
-        (tu/with-model-cleanup [Card]
+  (testing "POST /api/card"
+    (testing "Test that we can create a new Card"
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp Collection [collection]
           (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-          (is (= (merge
-                  card-defaults
-                  {:name                   card-name
-                   :collection_id          true
-                   :collection             true
-                   :creator_id             (mt/user->id :rasta)
-                   :dataset_query          true
-                   :query_type             "query"
-                   :visualization_settings {:global {:title nil}}
-                   :database_id            true
-                   :table_id               true
-                   :can_write              true
-                   :dashboard_count        0
-                   :result_metadata        true
-                   :creator                (merge
-                                            (select-keys (mt/fetch-user :rasta) [:id :date_joined :last_login :locale])
-                                            {:common_name  "Rasta Toucan"
-                                             :is_superuser false
-                                             :last_name    "Toucan"
-                                             :first_name   "Rasta"
-                                             :email        "rasta@metabase.com"})})
-                 (-> ((mt/user->client :rasta) :post 202 "card"
-                      (assoc (card-with-name-and-query card-name (mbql-count-query (data/id) (data/id :venues)))
-                             :collection_id (u/get-id collection)))
-                     (dissoc :created_at :updated_at :id)
-                     (update :table_id integer?)
-                     (update :database_id integer?)
-                     (update :collection_id integer?)
-                     (update :dataset_query map?)
-                     (update :collection map?)
-                     (update :result_metadata (partial every? map?))
-                     (update :creator dissoc :is_qbnewb)))))))))
+          (mt/with-model-cleanup [Card]
+            (let [card (assoc (card-with-name-and-query (mt/random-name)
+                                                        (mbql-count-query (mt/id) (mt/id :venues)))
+                              :collection_id (u/get-id collection))]
+              (is (= (merge
+                      card-defaults
+                      {:name                   (:name card)
+                       :collection_id          true
+                       :collection             true
+                       :creator_id             (mt/user->id :rasta)
+                       :dataset_query          true
+                       :query_type             "query"
+                       :visualization_settings {:global {:title nil}}
+                       :database_id            true
+                       :table_id               true
+                       :can_write              true
+                       :dashboard_count        0
+                       :result_metadata        true
+                       :creator                (merge
+                                                (select-keys (mt/fetch-user :rasta) [:id :date_joined :last_login :locale])
+                                                {:common_name  "Rasta Toucan"
+                                                 :is_superuser false
+                                                 :last_name    "Toucan"
+                                                 :first_name   "Rasta"
+                                                 :email        "rasta@metabase.com"})})
+                     (-> (mt/user-http-request :rasta :post 202 "card" card)
+                         (dissoc :created_at :updated_at :id)
+                         (update :table_id integer?)
+                         (update :database_id integer?)
+                         (update :collection_id integer?)
+                         (update :dataset_query map?)
+                         (update :collection map?)
+                         (update :result_metadata (partial every? map?))
+                         (update :creator dissoc :is_qbnewb)))))))))))
 
-;; Make sure when saving a Card the query metadata is saved (if correct)
 (deftest saving-card-saves-query-metadata
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (let [metadata  [{:base_type    :type/Integer
-                      :display_name "Count Chocula"
-                      :name         "count_chocula"
-                      :special_type :type/Number}]
-          card-name (tu/random-name)]
-      (tt/with-temp Collection [collection]
-        (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-        (tu/with-model-cleanup [Card]
-          ;; create a card with the metadata
-          ((mt/user->client :rasta) :post 202 "card"
-           (assoc (card-with-name-and-query card-name)
-                  :collection_id      (u/get-id collection)
-                  :result_metadata    metadata
-                  :metadata_checksum  (#'results-metadata/metadata-checksum metadata)))
-          ;; now check the metadata that was saved in the DB
-          (is (= [{:base_type    "type/Integer"
-                   :display_name "Count Chocula"
-                   :name         "count_chocula"
-                   :special_type "type/Number"}]
-                 (db/select-one-field :result_metadata Card :name card-name))))))))
+  (testing "Make sure when saving a Card the query metadata is saved (if correct)"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (let [metadata  [{:base_type    :type/Integer
+                        :display_name "Count Chocula"
+                        :name         "count_chocula"
+                        :special_type :type/Number}]
+            card-name (mt/random-name)]
+        (mt/with-temp Collection [collection]
+          (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
+          (mt/with-model-cleanup [Card]
+            ;; create a card with the metadata
+            (mt/user-http-request :rasta :post 202 "card" (assoc (card-with-name-and-query card-name)
+                                                                 :collection_id      (u/get-id collection)
+                                                                 :result_metadata    metadata
+                                                                 :metadata_checksum  (#'results-metadata/metadata-checksum metadata)))
+            ;; now check the metadata that was saved in the DB
+            (is (= [{:base_type    "type/Integer"
+                     :display_name "Count Chocula"
+                     :name         "count_chocula"
+                     :special_type "type/Number"}]
+                   (db/select-one-field :result_metadata Card :name card-name)))))))))
 
-;; we should be able to save a Card if the `result_metadata` is *empty* (but not nil) (#9286)
-(deftest save-card-with-empty-result-metadata
-  (is (tu/with-model-cleanup [Card]
-        ;; create a card with the metadata
-        ((mt/user->client :rasta) :post 202 "card"
-         (assoc (card-with-name-and-query)
-                :result_metadata    []
-                :metadata_checksum  (#'results-metadata/metadata-checksum []))))))
-
+(deftest save-card-with-empty-result-metadata-test
+  (testing "we should be able to save a Card if the `result_metadata` is *empty* (but not nil) (#9286)"
+    (mt/with-model-cleanup [Card]
+      (= :wow
+         (mt/user-http-request :rasta :post 202 "card" (assoc (card-with-name-and-query)
+                                                              :result_metadata    []
+                                                              :metadata_checksum  (#'results-metadata/metadata-checksum [])))))))
 
 (defn- fingerprint-integers->doubles
   "Converts the min/max fingerprint values to doubles so simulate how the FE will change the metadata when POSTing a
@@ -339,75 +349,80 @@
                                                       (update-in [:type :type/Number :min] double)
                                                       (update-in [:type :type/Number :max] double)))))
 
-;; When integer values are passed to the FE, they will be returned as floating point values. Our hashing should ensure
-;; that integer and floating point values hash the same so we don't needlessly rerun the query
 (deftest ints-returned-as-floating-point
-  (is (= [{:base_type    "type/Integer"
-           :display_name "Count Chocula"
-           :name         "count_chocula"
-           :special_type "type/Number"
-           :fingerprint  {:global {:distinct-count 285},
-                          :type {:type/Number {:min 5.0, :max 2384.0, :avg 1000.2}}}}]
-         (tu/with-non-admin-groups-no-root-collection-perms
-           (let [metadata  [{:base_type    :type/Integer
-                             :display_name "Count Chocula"
-                             :name         "count_chocula"
-                             :special_type :type/Number
-                             :fingerprint  {:global {:distinct-count 285},
-                                            :type {:type/Number {:min 5, :max 2384, :avg 1000.2}}}}]
-                 card-name (tu/random-name)]
-             (tt/with-temp Collection [collection]
-               (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-               (tu/throw-if-called qp.async/result-metadata-for-query-async
-                                   (tu/with-model-cleanup [Card]
-                                     ;; create a card with the metadata
-                                     ((mt/user->client :rasta) :post 202 "card"
-                                      (assoc (card-with-name-and-query card-name)
-                                             :collection_id      (u/get-id collection)
-                                             :result_metadata    (map fingerprint-integers->doubles metadata)
-                                             :metadata_checksum  (#'results-metadata/metadata-checksum metadata)))
-                                     ;; now check the metadata that was saved in the DB
-                                     (db/select-one-field :result_metadata Card :name card-name)))))))))
+  (testing (str "When integer values are passed to the FE, they will be returned as floating point values. Our hashing "
+                "should ensure that integer and floating point values hash the same so we don't needlessly rerun the "
+                "query"))
+  (mt/with-non-admin-groups-no-root-collection-perms
+    (let [metadata  [{:base_type    :type/Integer
+                      :display_name "Count Chocula"
+                      :name         "count_chocula"
+                      :special_type :type/Number
+                      :fingerprint  {:global {:distinct-count 285},
+                                     :type {:type/Number {:min 5, :max 2384, :avg 1000.2}}}}]
+          card-name (mt/random-name)]
+      (mt/with-temp Collection [collection]
+        (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
+        (mt/throw-if-called qp.async/result-metadata-for-query-async
+          (mt/with-model-cleanup [Card]
+            ;; create a card with the metadata
+            (mt/user-http-request :rasta :post 202 "card"
+                                  (assoc (card-with-name-and-query card-name)
+                                         :collection_id      (u/get-id collection)
+                                         :result_metadata    (map fingerprint-integers->doubles metadata)
+                                         :metadata_checksum  (#'results-metadata/metadata-checksum metadata)))
+            (testing "check the metadata that was saved in the DB"
+              (is (= [{:base_type    "type/Integer"
+                       :display_name "Count Chocula"
+                       :name         "count_chocula"
+                       :special_type "type/Number"
+                       :fingerprint  {:global {:distinct-count 285},
+                                      :type   {:type/Number {:min 5.0, :max 2384.0, :avg 1000.2}}}}]
+                     (db/select-one-field :result_metadata Card :name card-name))))))))))
 
-;; make sure when saving a Card the correct query metadata is fetched (if incorrect)
 (deftest saving-card-fetches-correct-metadata
-  (is (= [{:base_type    "type/BigInteger"
-           :display_name "Count"
-           :name         "count"
-           :special_type "type/Quantity"
-           :fingerprint  {:global {:distinct-count 1
-                                   :nil%           0.0},
-                          :type   {:type/Number {:min 100.0, :max 100.0, :avg 100.0, :q1 100.0, :q3 100.0 :sd nil}}}}]
-         (tu/with-non-admin-groups-no-root-collection-perms
-           (let [metadata  [{:base_type    :type/BigInteger
-                             :display_name "Count Chocula"
-                             :name         "count_chocula"
-                             :special_type :type/Quantity}]
-                 card-name (tu/random-name)]
-             (tt/with-temp Collection [collection]
-               (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-               (tu/with-model-cleanup [Card]
-                 ;; create a card with the metadata
-                 ((mt/user->client :rasta) :post 202 "card"
-                  (assoc (card-with-name-and-query card-name)
-                         :collection_id      (u/get-id collection)
-                         :result_metadata    metadata
-                         :metadata_checksum  "ABCDEF")) ; bad checksum
-                 ;; now check the correct metadata was fetched and was saved in the DB
-                 (db/select-one-field :result_metadata Card :name card-name))))))))
+  (testing "make sure when saving a Card the correct query metadata is fetched (if incorrect)"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (let [metadata  [{:base_type    :type/BigInteger
+                        :display_name "Count Chocula"
+                        :name         "count_chocula"
+                        :special_type :type/Quantity}]
+            card-name (mt/random-name)]
+        (mt/with-temp Collection [collection]
+          (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
+          (mt/with-model-cleanup [Card]
+            (mt/user-http-request :rasta :post 202 "card"
+                                  (assoc (card-with-name-and-query card-name)
+                                         :collection_id      (u/get-id collection)
+                                         :result_metadata    metadata
+                                         ;; bad checksum
+                                         :metadata_checksum  "ABCDEF"))
+            (testing "check the correct metadata was fetched and was saved in the DB"
+              (is (= [{:base_type    "type/BigInteger"
+                       :display_name "Count"
+                       :name         "count"
+                       :special_type "type/Quantity"
+                       :fingerprint  {:global {:distinct-count 1
+                                               :nil%           0.0},
+                                      :type   {:type/Number {:min 100.0
+                                                             :max 100.0
+                                                             :avg 100.0
+                                                             :q1  100.0
+                                                             :q3  100.0
+                                                             :sd  nil}}}}]
+                     (db/select-one-field :result_metadata Card :name card-name))))))))))
 
 (deftest fetch-results-metadata-test
   (testing "Check that the generated query to fetch the query result metadata includes user information in the generated query"
-    (tu/with-non-admin-groups-no-root-collection-perms
+    (mt/with-non-admin-groups-no-root-collection-perms
       (let [metadata  [{:base_type    :type/Integer
                         :display_name "Count Chocula"
                         :name         "count_chocula"
                         :special_type :type/Quantity}]
-            card-name (tu/random-name)]
-        (tt/with-temp Collection [collection]
+            card-name (mt/random-name)]
+        (mt/with-temp Collection [collection]
           (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-          (tu/with-model-cleanup [Card]
-            ;; TODO - FIXME - wrong impl
+          (mt/with-model-cleanup [Card]
             ;; Rebind the `prepared-statement` function so that we can capture the generated SQL and inspect it
             (let [orig       (var-get #'sql-jdbc.execute/prepared-statement)
                   sql-result (atom nil)]
@@ -416,11 +431,11 @@
                               (reset! sql-result sql)
                               (orig driver conn sql params))]
                 ;; create a card with the metadata
-                ((mt/user->client :rasta) :post 202 "card"
-                 (assoc (card-with-name-and-query card-name)
-                        :collection_id      (u/get-id collection)
-                        :result_metadata    metadata
-                        :metadata_checksum  "ABCDEF"))) ; bad checksum
+                (mt/user-http-request :rasta :post 202 "card"
+                                      (assoc (card-with-name-and-query card-name)
+                                             :collection_id      (u/get-id collection)
+                                             :result_metadata    metadata
+                                             :metadata_checksum  "ABCDEF"))) ; bad checksum
               (testing "check the correct metadata was fetched and was saved in the DB"
                 (is (= [{:base_type    (count-base-type)
                          :display_name "Count"
@@ -437,80 +452,73 @@
                           (re-find (re-pattern (str "userID: " (mt/user->id :rasta)))
                                    s)))))))))))))
 
-;; Make sure we can create a Card with a Collection position
 (deftest create-card-with-collection-position
-  (is (= #metabase.models.card.CardInstance{:collection_id true, :collection_position 1}
-         (tu/with-non-admin-groups-no-root-collection-perms
-           (tu/with-model-cleanup [Card]
-             (let [card-name (tu/random-name)]
-               (tt/with-temp Collection [collection]
-                 (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-                 ((mt/user->client :rasta) :post 202 "card" (assoc (card-with-name-and-query card-name)
-                                                                           :collection_id (u/get-id collection), :collection_position 1))
-                 (some-> (db/select-one [Card :collection_id :collection_position] :name card-name)
-                         (update :collection_id (partial = (u/get-id collection)))))))))))
+  (testing "Make sure we can create a Card with a Collection position"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (let [card-name (mt/random-name)]
+        (mt/with-temp Collection [collection]
+          (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
+          (mt/with-model-cleanup [Card]
+            (mt/user-http-request :rasta :post 202 "card"
+                                  (assoc (card-with-name-and-query card-name)
+                                         :collection_id (u/get-id collection), :collection_position 1))
+            (is (= #metabase.models.card.CardInstance{:collection_id true, :collection_position 1}
+                   (some-> (db/select-one [Card :collection_id :collection_position] :name card-name)
+                           (update :collection_id (partial = (u/get-id collection))))))))))))
 
-;; ...but not if we don't have permissions for the Collection
 (deftest need-permission-for-collection
-  (is (nil? (tu/with-non-admin-groups-no-root-collection-perms
-              (tu/with-model-cleanup [Card]
-                (let [card-name (tu/random-name)]
-                  (tt/with-temp Collection [collection]
-                    ((mt/user->client :rasta) :post 403 "card" (assoc (card-with-name-and-query card-name)
-                                                                              :collection_id (u/get-id collection)
-                                                                              :collection_position 1))
-                    (some-> (db/select-one [Card :collection_id :collection_position] :name card-name)
-                            (update :collection_id (partial = (u/get-id collection)))))))))))
+  (testing "You need to have Collection permissions to create a Card in a Collection"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (let [card-name (mt/random-name)]
+        (mt/with-temp Collection [collection]
+          (mt/with-model-cleanup [Card]
+            (mt/user-http-request :rasta :post 403 "card"
+                                  (assoc (card-with-name-and-query card-name)
+                                         :collection_id (u/get-id collection)
+                                         :collection_position 1))
+            (is (nil? (some-> (db/select-one [Card :collection_id :collection_position] :name card-name)
+                              (update :collection_id (partial = (u/get-id collection))))))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                            FETCHING A SPECIFIC CARD                                            |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(deftest basic-fetch-test
-  (testing "Test that we can fetch a card"
-    (mt/with-temp* [Database   [db          (select-keys (data/db) [:engine :details])]
-                    Table      [table       (-> (Table (data/id :venues))
-                                                (dissoc :id)
-                                                (assoc :db_id (u/get-id db)))]
-                    Collection [collection]
-                    Card       [card        {:collection_id (u/get-id collection)
-                                             :dataset_query (mbql-count-query (u/get-id db) (u/get-id table))}]]
-      (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
-      (is (= (merge
-              card-defaults
-              (select-keys card [:id :name :created_at :updated_at])
-              {:dashboard_count        0
-               :creator_id             (mt/user->id :rasta)
-               :creator                (merge
-                                        (select-keys (mt/fetch-user :rasta) [:id :date_joined :last_login])
-                                        {:common_name  "Rasta Toucan"
-                                         :is_superuser false
-                                         :is_qbnewb    true
-                                         :last_name    "Toucan"
-                                         :first_name   "Rasta"
-                                         :email        "rasta@metabase.com"})
-               :dataset_query          (tu/obj->json->obj (:dataset_query card))
-               :display                "table"
-               :query_type             "query"
-               :visualization_settings {}
-               :can_write              true
-               :database_id            (u/get-id db) ; these should be inferred from the dataset_query
-               :table_id               (u/get-id table)
-               :collection_id          (u/get-id collection)
-               :collection             (into {} collection)})
-             ((mt/user->client :rasta) :get 200 (str "card/" (u/get-id card))))))))
+(deftest fetch-card-test
+  (testing "GET /api/card/:id"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp* [Collection [collection]
+                      Card       [card {:collection_id (u/get-id collection)
+                                        :dataset_query (mt/mbql-query venues)}]]
+        (testing "You have to have Collection perms to fetch a Card"
+          (is (= "You don't have permissions to do that."
+                 (mt/user-http-request :rasta :get 403 (str "card/" (u/get-id card))))))
 
-(deftest check-that-a-user-without-permissions-isn-t-allowed-to-fetch-the-card
-  (is (= "You don't have permissions to do that."
-         (tu/with-non-admin-groups-no-root-collection-perms
-           (tt/with-temp* [Database [db]
-                           Table    [table {:db_id (u/get-id db)}]
-                           Card     [card  {:dataset_query (mbql-count-query (u/get-id db) (u/get-id table))}]]
-             ;; revoke permissions for default group to this database
-             (perms/revoke-permissions! (perms-group/all-users) (u/get-id db))
-             ;; now a non-admin user shouldn't be able to fetch this card
-             ((mt/user->client :rasta) :get 403 (str "card/" (u/get-id card))))))))
+        (testing "Should be able to fetch the Card if you have Collection read perms"
+          (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
+          (is (= (merge
+                  card-defaults
+                  (select-keys card [:id :name :created_at :updated_at])
+                  {:dashboard_count        0
+                   :creator_id             (mt/user->id :rasta)
+                   :creator                (merge
+                                            (select-keys (mt/fetch-user :rasta) [:id :date_joined :last_login])
+                                            {:common_name  "Rasta Toucan"
+                                             :is_superuser false
+                                             :is_qbnewb    true
+                                             :last_name    "Toucan"
+                                             :first_name   "Rasta"
+                                             :email        "rasta@metabase.com"})
+                   :dataset_query          (mt/obj->json->obj (:dataset_query card))
+                   :display                "table"
+                   :query_type             "query"
+                   :visualization_settings {}
+                   :can_write              false
+                   :database_id            (mt/id) ; these should be inferred from the dataset_query
+                   :table_id               (mt/id :venues)
+                   :collection_id          (u/get-id collection)
+                   :collection             (into {} collection)})
+                 (mt/user-http-request :rasta :get 200 (str "card/" (u/get-id card))))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                UPDATING A CARD                                                 |
@@ -519,24 +527,23 @@
 
 (deftest updating-a-card-that-doesnt-exist-should-give-a-404
   (is (= "Not found."
-         ((mt/user->client :crowberto) :put 404 "card/12345"))))
-
+         (mt/user-http-request :crowberto :put 404 "card/12345"))))
 
 (deftest test-that-we-can-edit-a-card
-  (tt/with-temp Card [card {:name "Original Name"}]
+  (mt/with-temp Card [card {:name "Original Name"}]
     (with-cards-in-writeable-collection card
       (is (= "Original Name"
              (db/select-one-field :name Card, :id (u/get-id card))))
-      ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:name "Updated Name"})
+      (mt/user-http-request :rasta :put 202 (str "card/" (u/get-id card)) {:name "Updated Name"})
       (is (= "Updated Name"
              (db/select-one-field :name Card, :id (u/get-id card)))))))
 
 (deftest can-we-update-a-card-s-archived-status-
-  (tt/with-temp Card [card]
+  (mt/with-temp Card [card]
     (with-cards-in-writeable-collection card
       (let [archived?     (fn [] (:archived (Card (u/get-id card))))
             set-archived! (fn [archived]
-                            ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:archived archived})
+                            (mt/user-http-request :rasta :put 202 (str "card/" (u/get-id card)) {:archived archived})
                             (archived?))]
         (is (= false
                (archived?)))
@@ -547,57 +554,59 @@
 
 (deftest we-shouldn-t-be-able-to-update-archived-status-if-we-don-t-have-collection--write--perms
   (is (= "You don't have permissions to do that."
-         (tu/with-non-admin-groups-no-root-collection-perms
-           (tt/with-temp* [Collection [collection]
+         (mt/with-non-admin-groups-no-root-collection-perms
+           (mt/with-temp* [Collection [collection]
                            Card       [card {:collection_id (u/get-id collection)}]]
              (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
-             ((mt/user->client :rasta) :put 403 (str "card/" (u/get-id card)) {:archived true}))))))
+             (mt/user-http-request :rasta :put 403 (str "card/" (u/get-id card)) {:archived true}))))))
 
 ;; Can we clear the description of a Card? (#4738)
 (deftest can-we-clear-the-description-of-a-card----4738-
-  (is (nil? (tt/with-temp Card [card {:description "What a nice Card"}]
+  (is (nil? (mt/with-temp Card [card {:description "What a nice Card"}]
               (with-cards-in-writeable-collection card
-                ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:description nil})
+                (mt/user-http-request :rasta :put 202 (str "card/" (u/get-id card)) {:description nil})
                 (db/select-one-field :description Card :id (u/get-id card)))))))
 
 (deftest description-should-be-blankable-as-well
-  (is (= ""
-         (tt/with-temp Card [card {:description "What a nice Card"}]
-           (with-cards-in-writeable-collection card
-             ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:description ""})
+  (mt/with-temp Card [card {:description "What a nice Card"}]
+    (with-cards-in-writeable-collection card
+      (mt/user-http-request :rasta :put 202 (str "card/" (u/get-id card)) {:description ""})
+      (is (= ""
              (db/select-one-field :description Card :id (u/get-id card)))))))
 
-(deftest can-we-update-a-card-s-embedding-params-
-  (is (= {:abc "enabled"}
-         (tt/with-temp Card [card]
-           (tu/with-temporary-setting-values [enable-embedding true]
-             ((mt/user->client :crowberto) :put 202 (str "card/" (u/get-id card)) {:embedding_params {:abc "enabled"}}))
-           (db/select-one-field :embedding_params Card :id (u/get-id card))))))
+(deftest update-embedding-params-test
+  (testing "PUT /api/card/:id"
+    (mt/with-temp Card [card]
+      (testing "If embedding is disabled, even an admin should not be allowed to update embedding params"
+        (mt/with-temporary-setting-values [enable-embedding false]
+          (is (= "Embedding is not enabled."
+                 (mt/user-http-request :crowberto :put 400 (str "card/" (u/get-id card))
+                                       {:embedding_params {:abc "enabled"}})))))
 
-(deftest we-shouldn-t-be-able-to-update-them-if-we-re-not-an-admin---
-  (is (= "You don't have permissions to do that."
-         (tt/with-temp Card [card]
-           (tu/with-temporary-setting-values [enable-embedding true]
-             ((mt/user->client :rasta) :put 403 (str "card/" (u/get-id card)) {:embedding_params {:abc "enabled"}}))))))
+      (mt/with-temporary-setting-values [enable-embedding true]
+        (testing "Non-admin should not be allowed to update Card's embedding parms"
+          (is (= "You don't have permissions to do that."
+                 (mt/user-http-request :rasta :put 403 (str "card/" (u/get-id card))
+                                       {:embedding_params {:abc "enabled"}}))))
 
-(deftest ---or-if-embedding-isn-t-enabled
-  (is (= "Embedding is not enabled."
-         (tt/with-temp Card [card]
-           (tu/with-temporary-setting-values [enable-embedding false]
-             ((mt/user->client :crowberto) :put 400 (str "card/" (u/get-id card)) {:embedding_params {:abc "enabled"}}))))))
+        (testing "Admin should be able to update Card's embedding params"
+          (mt/user-http-request :crowberto :put 202 (str "card/" (u/get-id card))
+                                {:embedding_params {:abc "enabled"}})
+          (is (= {:abc "enabled"}
+                 (db/select-one-field :embedding_params Card :id (u/get-id card)))))))))
 
 (deftest make-sure-when-updating-a-card-the-query-metadata-is-saved--if-correct-
   (let [metadata [{:base_type    :type/Integer
                    :display_name "Count Chocula"
                    :name         "count_chocula"
                    :special_type :type/Number}]]
-    (tt/with-temp Card [card]
+    (mt/with-temp Card [card]
       (with-cards-in-writeable-collection card
         ;; update the Card's query
-        ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id card))
-         {:dataset_query     (mbql-count-query)
-          :result_metadata   metadata
-          :metadata_checksum (#'results-metadata/metadata-checksum metadata)})
+        (mt/user-http-request :rasta :put 202 (str "card/" (u/get-id card))
+                              {:dataset_query     (mbql-count-query)
+                               :result_metadata   metadata
+                               :metadata_checksum (#'results-metadata/metadata-checksum metadata)})
         ;; now check the metadata that was saved in the DB
         (is (= [{:base_type    "type/Integer"
                  :display_name "Count Chocula"
@@ -610,13 +619,13 @@
                    :display_name "Count Chocula"
                    :name         "count_chocula"
                    :special_type :type/Quantity}]]
-    (tt/with-temp Card [card]
+    (mt/with-temp Card [card]
       (with-cards-in-writeable-collection card
         ;; update the Card's query
-        ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id card))
-         {:dataset_query     (mbql-count-query)
-          :result_metadata   metadata
-          :metadata_checksum "ABC123"}) ; invalid checksum
+        (mt/user-http-request :rasta :put 202 (str "card/" (u/get-id card))
+                              {:dataset_query     (mbql-count-query)
+                               :result_metadata   metadata
+                               :metadata_checksum "ABC123"}) ; invalid checksum
         ;; now check the metadata that was saved in the DB
         (is (= [{:base_type    "type/BigInteger"
                  :display_name "Count"
@@ -628,36 +637,36 @@
                (db/select-one-field :result_metadata Card :id (u/get-id card))))))))
 
 (deftest can-we-change-the-collection-position-of-a-card-
-  (tt/with-temp Card [card]
+  (mt/with-temp Card [card]
     (with-cards-in-writeable-collection card
-      ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id card))
-       {:collection_position 1})
+      (mt/user-http-request :rasta :put 202 (str "card/" (u/get-id card))
+                            {:collection_position 1})
       (is (= 1
              (db/select-one-field :collection_position Card :id (u/get-id card)))))))
 
 (deftest ---and-unset--unpin--it-as-well-
-  (tt/with-temp Card [card {:collection_position 1}]
+  (mt/with-temp Card [card {:collection_position 1}]
     (with-cards-in-writeable-collection card
-      ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id card))
-       {:collection_position nil})
+      (mt/user-http-request :rasta :put 202 (str "card/" (u/get-id card))
+                            {:collection_position nil})
       (is (= nil
              (db/select-one-field :collection_position Card :id (u/get-id card)))))))
 
 (deftest ---we-shouldn-t-be-able-to-if-we-don-t-have-permissions-for-the-collection
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp* [Collection [collection]
+  (mt/with-non-admin-groups-no-root-collection-perms
+    (mt/with-temp* [Collection [collection]
                     Card       [card {:collection_id (u/get-id collection)}]]
-      ((mt/user->client :rasta) :put 403 (str "card/" (u/get-id card))
-       {:collection_position 1})
+      (mt/user-http-request :rasta :put 403 (str "card/" (u/get-id card))
+                            {:collection_position 1})
       (is (= nil
              (db/select-one-field :collection_position Card :id (u/get-id card)))))))
 
 (deftest gets-a-card
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp* [Collection [collection]
+  (mt/with-non-admin-groups-no-root-collection-perms
+    (mt/with-temp* [Collection [collection]
                     Card       [card {:collection_id (u/get-id collection), :collection_position 1}]]
-      ((mt/user->client :rasta) :put 403 (str "card/" (u/get-id card))
-       {:collection_position nil})
+      (mt/user-http-request :rasta :put 403 (str "card/" (u/get-id card))
+                            {:collection_position nil})
       (is (= 1
              (db/select-one-field :collection_position Card :id (u/get-id card)))))))
 
@@ -674,12 +683,13 @@
   "Call the collection endpoint for `collection-id` as `user-kwd`. Will return a map with the names of the items as
   keys and their position as the value"
   [user-kwd collection-or-collection-id]
-  (name->position ((mt/user->client user-kwd) :get 200 (format "collection/%s/items" (u/get-id collection-or-collection-id)))))
+  (name->position (mt/user-http-request user-kwd :get 200
+                                        (format "collection/%s/items" (u/get-id collection-or-collection-id)))))
 
 (defmacro with-ordered-items
   "Macro for creating many sequetial collection_position model instances, putting each in `collection`"
   [collection model-and-name-syms & body]
-  `(tt/with-temp* ~(vec (mapcat (fn [idx [model-instance name-sym]]
+  `(mt/with-temp* ~(vec (mapcat (fn [idx [model-instance name-sym]]
                                   [model-instance [name-sym {:name                (name name-sym)
                                                              :collection_id       `(u/get-id ~collection)
                                                              :collection_position idx}]])
@@ -692,242 +702,197 @@
        ~@body)))
 
 (deftest check-to-make-sure-we-can-move-a-card-in-a-collection-of-just-cards
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp Collection [collection]
+  (mt/with-non-admin-groups-no-root-collection-perms
+    (mt/with-temp Collection [collection]
       (with-ordered-items collection [Card a
                                       Card b
                                       Card c
                                       Card d]
         (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-        ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id c))
-         {:collection_position 1})
+        (mt/user-http-request :rasta :put 202 (str "card/" (u/get-id c))
+                              {:collection_position 1})
         (is (= {"c" 1
                 "a" 2
                 "b" 3
                 "d" 4}
                (get-name->collection-position :rasta collection)))))))
 
-(deftest change-the-position-of-the-4th-card-to-1st--all-other-cards-should-inc-their-position
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp Collection [collection]
-      (with-ordered-items collection [Dashboard a
-                                      Dashboard b
-                                      Pulse     c
-                                      Card      d]
+(deftest add-new-card-update-positions-test
+  (testing "POST /api/card"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp Collection [collection]
+        (doseq [{:keys [message position expected]}
+                [{:message  (str "Add a new card to an existing collection at position 1, will cause all existing "
+                                 "positions to increment by 1")
+                  :position 1
+                  :expected {"d" 1
+                             "a" 2
+                             "b" 3
+                             "c" 4}}
+                 {:message  "Add new card in the middle, should only increment positions of objects that come after"
+                  :position 2
+                  :expected {"a" 1
+                             "d" 2
+                             "b" 3
+                             "c" 4}}
+                 {:message  "Add new card to end, shouldn't affect positions of other objects"
+                  :position 4
+                  :expected {"a" 1
+                             "b" 2
+                             "c" 3
+                             "d" 4}}
+                 {:message  (str "When adding a new Card to a Collection that does not have a position, it should not "
+                                 "change positions of other objects")
+                  :position nil
+                  :expected {"a" 1
+                             "b" 2
+                             "c" 3
+                             "d" nil}}]]
+          (testing (str "\n" message)
+            (with-ordered-items collection [Dashboard a
+                                            Pulse     b
+                                            Card      c]
+              (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
+              (testing "Original collection, before adding the new card"
+                (is (= {"a" 1
+                        "b" 2
+                        "c" 3}
+                       (get-name->collection-position :rasta collection))))
+              (mt/with-model-cleanup [Card]
+                (mt/user-http-request :rasta :post 202 "card"
+                                      (merge (card-with-name-and-query "d")
+                                             {:collection_id       (u/get-id collection)
+                                              :collection_position position}))
+                (is (= expected
+                       (get-name->collection-position :rasta collection)))))))))))
+
+(deftest move-existing-card-update-positions-test
+  (testing "PUT /api/card/:id"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp Collection [collection]
+        (doseq [{:keys [message position expected]}
+                [{:message  "Move existing Card to front"
+                  :position 1
+                  :expected {"d" 1
+                             "a" 2
+                             "b" 3
+                             "c" 4
+                             "e" 5
+                             "f" 6}}
+                 {:message  "Move existing Card to end"
+                  :position 6
+                  :expected {"a" 1
+                             "b" 2
+                             "c" 3
+                             "e" 4
+                             "f" 5
+                             "d" 6}}
+                 {:message  (str "When setting Collection position to nil, positions of other things should be adjusted "
+                                 "accordingly")
+                  :position nil
+                  :expected {"a" 1
+                             "b" 2
+                             "c" 3
+                             "e" 4
+                             "f" 5
+                             "d" nil}}]]
+          (testing (str "\n" message)
+            (with-ordered-items collection [Dashboard a
+                                            Dashboard b
+                                            Card      c
+                                            Card      d
+                                            Pulse     e
+                                            Pulse     f]
+              (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
+              (testing "Original collection, before moving the Card"
+                (is (= {"a" 1
+                        "b" 2
+                        "c" 3
+                        "d" 4
+                        "e" 5
+                        "f" 6}
+                       (get-name->collection-position :rasta collection))))
+              (mt/user-http-request :rasta :put 202 (str "card/" (u/get-id d))
+                                    {:collection_position position, :collection_id (u/get-id collection)})
+              (is (= expected
+                     (get-name->collection-position :rasta collection))))))))))
+
+(deftest give-existing-card-a-position-test
+  (testing "Give an existing Card without a `:collection_position` a position, and things should be adjusted accordingly"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp* [Collection [{coll-id :id :as collection}]
+                      Card       [_ {:name "a", :collection_id coll-id, :collection_position 1}]
+                      ;; Card b does not start with a collection_position
+                      Card       [b {:name "b", :collection_id coll-id}]
+                      Dashboard  [_ {:name "c", :collection_id coll-id, :collection_position 2}]
+                      Card       [_ {:name "d", :collection_id coll-id, :collection_position 3}]]
         (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-        ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id d))
-         {:collection_position 1})
-        (is (= {"d" 1
-                "a" 2
-                "b" 3
-                "c" 4}
-               (get-name->collection-position :rasta collection)))))))
+        (mt/user-http-request :rasta :put 202 (str "card/" (u/get-id b))
+                              {:collection_position 2})
+        (is (= {"a" 1
+                "b" 2
+                "c" 3
+                "d" 4}
+               (get-name->collection-position :rasta coll-id)))))))
 
-(deftest change-the-position-of-the-1st-card-to-the-4th--all-of-the-other-items-dec
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp Collection [collection]
-      (with-ordered-items collection [Card      a
-                                      Dashboard b
-                                      Pulse     c
-                                      Dashboard d]
-        (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-        ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id a))
-         {:collection_position 4})
-        (is (= {"b" 1
-                "c" 2
-                "d" 3
-                "a" 4}
-               (get-name->collection-position :rasta collection)))))))
+(deftest change-collections-update-positions-test
+  (testing (str "Change the Collection the Card is in, leave the position, should cause old and new collection to have "
+                "their positions updated")
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp* [Collection [collection-1]
+                      Collection [collection-2]]
+        (with-ordered-items collection-1 [Dashboard a
+                                          Card      b
+                                          Pulse     c
+                                          Dashboard d]
+          (with-ordered-items collection-2 [Pulse     e
+                                            Card      f
+                                            Card      g
+                                            Dashboard h]
+            (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-1)
+            (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-2)
+            (mt/user-http-request :rasta :put 202 (str "card/" (u/get-id f))
+                                  {:collection_id (u/get-id collection-1)})
+            (testing "Dest collection should get updated positions"
+              (is (= {"a" 1
+                      "f" 2
+                      "b" 3
+                      "c" 4
+                      "d" 5}
+                     (get-name->collection-position :rasta collection-1))))
+            (testing "Original collection should get updated positions"
+              (is (= {"e" 1
+                      "g" 2
+                      "h" 3}
+                     (get-name->collection-position :rasta collection-2))))))))))
 
-(deftest change-the-position-of-a-card-from-nil-to-2nd--should-adjust-the-existing-items
-  (is (= {"a" 1
-          "b" 2
-          "c" 3
-          "d" 4}
-         (tu/with-non-admin-groups-no-root-collection-perms
-           (tt/with-temp* [Collection [{coll-id :id :as collection}]
-                           Card       [_ {:name "a", :collection_id coll-id, :collection_position 1}]
-                           ;; Card b does not start with a collection_position
-                           Card       [b {:name "b", :collection_id coll-id}]
-                           Dashboard  [_ {:name "c", :collection_id coll-id, :collection_position 2}]
-                           Card       [_ {:name "d", :collection_id coll-id, :collection_position 3}]]
-             (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-             ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id b))
-              {:collection_position 2})
-             (get-name->collection-position :rasta coll-id))))))
-
-(deftest update-an-existing-card-to-no-longer-have-a-position--should-dec-items-after-it-s-position
-  (is (= {"a" 1
-          "b" nil
-          "c" 2
-          "d" 3}
-         (tu/with-non-admin-groups-no-root-collection-perms
-           (tt/with-temp Collection [collection]
-             (with-ordered-items collection [Card      a
-                                             Card      b
-                                             Dashboard c
-                                             Pulse     d]
-               (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-               ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id b))
-                {:collection_position nil})
-               (get-name->collection-position :rasta collection)))))))
-
-;; Change the collection the card is in, leave the position, should cause old and new collection to have their
-;; positions updated
-(deftest update-collection-positions
-  (is (= [{"a" 1
-           "f" 2
-           "b" 3
-           "c" 4
-           "d" 5}
-          {"e" 1
-           "g" 2
-           "h" 3}]
-         (tu/with-non-admin-groups-no-root-collection-perms
-           (tt/with-temp* [Collection [collection-1]
-                           Collection [collection-2]]
-             (with-ordered-items collection-1 [Dashboard a
-                                               Card      b
-                                               Pulse     c
-                                               Dashboard d]
-               (with-ordered-items collection-2 [Pulse     e
-                                                 Card      f
-                                                 Card      g
-                                                 Dashboard h]
-                 (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-1)
-                 (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-2)
-                 ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id f))
-                  {:collection_id (u/get-id collection-1)})
-                 [(get-name->collection-position :rasta collection-1)
-                  (get-name->collection-position :rasta collection-2)])))))))
-
-(deftest change-the-collection-and-the-position--causing-both-collections-and-the-updated-card-to-have-their-order-changed
-  (is (= [{"h" 1
-           "a" 2
-           "b" 3
-           "c" 4
-           "d" 5}
-          {"e" 1
-           "f" 2
-           "g" 3}]
-         (tu/with-non-admin-groups-no-root-collection-perms
-           (tt/with-temp* [Collection [collection-1]
-                           Collection [collection-2]]
-             (with-ordered-items collection-1 [Pulse     a
-                                               Pulse     b
-                                               Dashboard c
-                                               Dashboard d]
-               (with-ordered-items collection-2 [Dashboard e
-                                                 Dashboard f
-                                                 Pulse     g
-                                                 Card      h]
-                 (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-1)
-                 (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-2)
-                 ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id h))
-                  {:collection_position 1, :collection_id (u/get-id collection-1)})
-                 [(get-name->collection-position :rasta collection-1)
-                  (get-name->collection-position :rasta collection-2)])))))))
-
-
-;; Add a new card to an existing collection at position 1, will cause all existing positions to increment by 1
-(deftest add-new-card-to-existing-collection-at-position-1
-  (is (=
-       ;; Original collection, before adding the new card
-       [{"b" 1
-         "c" 2
-         "d" 3}
-        ;; Add new card at index 1
-        {"a" 1
-         "b" 2
-         "c" 3
-         "d" 4}]
-       (tu/with-non-admin-groups-no-root-collection-perms
-         (tt/with-temp Collection [collection]
-           (tu/with-model-cleanup [Card]
-             (with-ordered-items collection [Dashboard b
-                                             Pulse     c
-                                             Card      d]
-               (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-               [(get-name->collection-position :rasta collection)
-                (do
-                  ((mt/user->client :rasta) :post 202 "card"
-                   (merge (card-with-name-and-query "a")
-                          {:collection_id       (u/get-id collection)
-                           :collection_position 1}))
-                  (get-name->collection-position :rasta collection))])))))))
-
-(deftest add-new-card-to-end-of-existing-collection
-  ;; Add a new card to the end of an existing collection
-  (is (=
-       ;; Original collection, before adding the new card
-       [{"a" 1
-         "b" 2
-         "c" 3}
-        ;; Add new card at index 4
-        {"a" 1
-         "b" 2
-         "c" 3
-         "d" 4}]
-       (tu/with-non-admin-groups-no-root-collection-perms
-         (tt/with-temp Collection [collection]
-           (tu/with-model-cleanup [Card]
-             (with-ordered-items collection [Card      a
-                                             Dashboard b
-                                             Pulse     c]
-               (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-               [(get-name->collection-position :rasta collection)
-                (do
-                  ((mt/user->client :rasta) :post 202 "card"
-                   (merge (card-with-name-and-query "d")
-                          {:collection_id       (u/get-id collection)
-                           :collection_position 4}))
-                  (get-name->collection-position :rasta collection))])))))))
-
-;; When adding a new card to a collection that does not have a position, it should not change existing positions
-(deftest adding-card-doesn-not-change-existing-positions
-  (is (=
-       ;; Original collection, before adding the new card
-       [{"a" 1
-         "b" 2
-         "c" 3}
-        ;; Add new card without a position
-        {"a" 1
-         "b" 2
-         "c" 3
-         "d" nil}]
-       (tu/with-non-admin-groups-no-root-collection-perms
-         (tt/with-temp Collection [collection]
-           (tu/with-model-cleanup [Card]
-             (with-ordered-items collection [Pulse     a
-                                             Card      b
-                                             Dashboard c]
-               (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-               [(get-name->collection-position :rasta collection)
-                (do
-                  ((mt/user->client :rasta) :post 202 "card"
-                   (merge (card-with-name-and-query "d")
-                          {:collection_id       (u/get-id collection)
-                           :collection_position nil}))
-                  (get-name->collection-position :rasta collection))]))))))
-
-  (is (= {"d" 1
-          "a" 2
-          "b" 3
-          "c" 4
-          "e" 5
-          "f" 6}
-         (tu/with-non-admin-groups-no-root-collection-perms
-           (tt/with-temp Collection [collection]
-             (with-ordered-items collection [Dashboard a
-                                             Dashboard b
-                                             Card      c
-                                             Card      d
-                                             Pulse     e
-                                             Pulse     f]
-               (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-               ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id d))
-                {:collection_position 1, :collection_id (u/get-id collection)})
-               (name->position ((mt/user->client :rasta) :get 200 (format "collection/%s/items" (u/get-id collection))))))))))
+(deftest change-both-collection-and-position-test
+  (testing "Change the collection and the position, causing both collections and the updated card to have their order changed"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp* [Collection [collection-1]
+                      Collection [collection-2]]
+        (with-ordered-items collection-1 [Pulse     a
+                                          Pulse     b
+                                          Dashboard c
+                                          Dashboard d]
+          (with-ordered-items collection-2 [Dashboard e
+                                            Dashboard f
+                                            Pulse     g
+                                            Card      h]
+            (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-1)
+            (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-2)
+            (mt/user-http-request :rasta :put 202 (str "card/" (u/get-id h))
+                                  {:collection_position 1, :collection_id (u/get-id collection-1)})
+            (is (= {"h" 1
+                    "a" 2
+                    "b" 3
+                    "c" 4
+                    "d" 5}
+                   (get-name->collection-position :rasta collection-1)))
+            (is (= {"e" 1
+                    "f" 2
+                    "g" 3}
+                   (get-name->collection-position :rasta collection-2)))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -935,11 +900,11 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn- rasta-alert-not-working [body-map]
-  (et/email-to :rasta {:subject "One of your alerts has stopped working"
+  (mt/email-to :rasta {:subject "One of your alerts has stopped working"
                        :body    body-map}))
 
 (defn- crowberto-alert-not-working [body-map]
-  (et/email-to :crowberto {:subject "One of your alerts has stopped working"
+  (mt/email-to :crowberto {:subject "One of your alerts has stopped working"
                            :body    body-map}))
 
 (deftest alert-deletion-test
@@ -947,40 +912,40 @@
           [{:message        "Archiving a Card should trigger Alert deletion"
             :expected-email "the question was archived by Rasta Toucan"
             :f              (fn [{:keys [card]}]
-                              ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:archived true}))}
+                              (mt/user-http-request :rasta :put 202 (str "card/" (u/get-id card)) {:archived true}))}
            {:message        "Validate changing a display type triggers alert deletion"
             :card           {:display :table}
             :expected-email "the question was edited by Rasta Toucan"
             :f              (fn [{:keys [card]}]
-                              ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:display :line}))}
+                              (mt/user-http-request :rasta :put 202 (str "card/" (u/get-id card)) {:display :line}))}
            {:message        "Changing the display type from line to table should force a delete"
             :card           {:display :line}
             :expected-email "the question was edited by Rasta Toucan"
             :f              (fn [{:keys [card]}]
-                              ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:display :table}))}
+                              (mt/user-http-request :rasta :put 202 (str "card/" (u/get-id card)) {:display :table}))}
            {:message        "Removing the goal value will trigger the alert to be deleted"
             :card           {:display                :line
                              :visualization_settings {:graph.goal_value 10}}
             :expected-email "the question was edited by Rasta Toucan"
             :f              (fn [{:keys [card]}]
-                              ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:visualization_settings {:something "else"}}))}
+                              (mt/user-http-request :rasta :put 202 (str "card/" (u/get-id card)) {:visualization_settings {:something "else"}}))}
            {:message        "Adding an additional breakout will cause the alert to be removed"
             :card           {:display                :line
                              :visualization_settings {:graph.goal_value 10}
                              :dataset_query          (assoc-in
-                                                      (mbql-count-query (data/id) (data/id :checkins))
+                                                      (mbql-count-query (mt/id) (mt/id :checkins))
                                                       [:query :breakout]
                                                       [["datetime-field"
-                                                        (data/id :checkins :date)
+                                                        (mt/id :checkins :date)
                                                         "hour"]])}
             :expected-email "the question was edited by Crowberto Corv"
             :f              (fn [{:keys [card]}]
-                              ((mt/user->client :crowberto) :put 202 (str "card/" (u/get-id card))
-                               {:dataset_query (assoc-in (mbql-count-query (data/id) (data/id :checkins))
-                                                         [:query :breakout] [[:datetime-field (data/id :checkins :date) "hour"]
-                                                                             [:datetime-field (data/id :checkins :date) "minute"]])}))}]]
+                              (mt/user-http-request :crowberto :put 202 (str "card/" (u/get-id card))
+                                                    {:dataset_query (assoc-in (mbql-count-query (mt/id) (mt/id :checkins))
+                                                                              [:query :breakout] [[:datetime-field (mt/id :checkins :date) "hour"]
+                                                                                                  [:datetime-field (mt/id :checkins :date) "minute"]])}))}]]
     (testing message
-      (tt/with-temp* [Card                  [card  card]
+      (mt/with-temp* [Card                  [card  card]
                       Pulse                 [pulse {:alert_condition  "rows"
                                                     :alert_first_only false
                                                     :creator_id       (mt/user->id :rasta)
@@ -995,13 +960,13 @@
                       PulseChannelRecipient [_     {:user_id          (mt/user->id :rasta)
                                                     :pulse_channel_id (u/get-id pc)}]]
         (with-cards-in-writeable-collection card
-          (et/with-fake-inbox
-            (metabase.util/with-timeout 5000
-              (et/with-expected-messages 2
+          (mt/with-fake-inbox
+            (u/with-timeout 5000
+              (mt/with-expected-messages 2
                 (f {:card card})))
             (is (= (merge (crowberto-alert-not-working {expected-email true})
                           (rasta-alert-not-working     {expected-email true}))
-                   (et/regex-email-bodies (re-pattern expected-email)))
+                   (mt/regex-email-bodies (re-pattern expected-email)))
                 (format "Email containing %s should have been sent to Crowberto and Rasta" (pr-str expected-email)))
             (is (= nil
                    (Pulse (u/get-id pulse)))
@@ -1012,7 +977,7 @@
           :pulse-1  true
           :emails-2 {}
           :pulse-2  true}
-         (tt/with-temp* [Card                  [card  {:display                :line
+         (mt/with-temp* [Card                  [card  {:display                :line
                                                        :visualization_settings {:graph.goal_value 10}}]
                          Pulse                 [pulse {:alert_condition  "goal"
                                                        :alert_first_only false
@@ -1025,15 +990,15 @@
                          PulseChannelRecipient [_     {:user_id          (mt/user->id :rasta)
                                                        :pulse_channel_id (u/get-id pc)}]]
            (with-cards-in-writeable-collection card
-             (et/with-fake-inbox
+             (mt/with-fake-inbox
                (array-map
                 :emails-1 (do
-                            ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:display :area})
-                            (et/regex-email-bodies #"the question was edited by Rasta Toucan"))
+                            (mt/user-http-request :rasta :put 202 (str "card/" (u/get-id card)) {:display :area})
+                            (mt/regex-email-bodies #"the question was edited by Rasta Toucan"))
                 :pulse-1  (boolean (Pulse (u/get-id pulse)))
                 :emails-2 (do
-                            ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:display :bar})
-                            (et/regex-email-bodies #"the question was edited by Rasta Toucan"))
+                            (mt/user-http-request :rasta :put 202 (str "card/" (u/get-id card)) {:display :bar})
+                            (mt/regex-email-bodies #"the question was edited by Rasta Toucan"))
                 :pulse-2  (boolean (Pulse (u/get-id pulse))))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -1042,15 +1007,15 @@
 ;; Deprecated because you're not supposed to delete cards anymore. Archive them instead
 
 (deftest check-that-we-can-delete-a-card
-  (is (nil? (tt/with-temp Card [card]
+  (is (nil? (mt/with-temp Card [card]
               (with-cards-in-writeable-collection card
-                ((mt/user->client :rasta) :delete 204 (str "card/" (u/get-id card)))
+                (mt/user-http-request :rasta :delete 204 (str "card/" (u/get-id card)))
                 (Card (u/get-id card)))))))
 
 ;; deleting a card that doesn't exist should return a 404 (#1957)
 (deftest deleting-a-card-that-doesnt-exist-should-return-a-404---1957-
   (is (= "Not found."
-         ((mt/user->client :crowberto) :delete 404 "card/12345"))))
+         (mt/user-http-request :crowberto :delete 404 "card/12345"))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -1062,22 +1027,22 @@
   (db/exists? CardFavorite, :card_id (u/get-id card), :owner_id (mt/user->id :rasta)))
 
 (defn- fave! [card]
-  ((mt/user->client :rasta) :post 200 (format "card/%d/favorite" (u/get-id card))))
+  (mt/user-http-request :rasta :post 200 (format "card/%d/favorite" (u/get-id card))))
 
 (defn- unfave! [card]
-  ((mt/user->client :rasta) :delete 204 (format "card/%d/favorite" (u/get-id card))))
+  (mt/user-http-request :rasta :delete 204 (format "card/%d/favorite" (u/get-id card))))
 
 ;; ## GET /api/card/:id/favorite
 (deftest can-we-see-if-a-card-is-a-favorite--
   (is (= false
-         (tt/with-temp Card [card]
+         (mt/with-temp Card [card]
            (with-cards-in-readable-collection card
              (fave? card))))))
 
 (deftest favorite-test
   (testing "Can we favorite a Card?"
     (testing "POST /api/card/:id/favorite"
-      (tt/with-temp Card [card]
+      (mt/with-temp Card [card]
         (with-cards-in-readable-collection card
           (is (= false
                  (fave? card)))
@@ -1088,7 +1053,7 @@
 (deftest unfavorite-test
   (testing "Can we unfavorite a Card?"
     (testing "DELETE /api/card/:id/favorite"
-      (tt/with-temp Card [card]
+      (mt/with-temp Card [card]
         (with-cards-in-readable-collection card
           (is (= false
                  (fave? card)))
@@ -1116,29 +1081,29 @@
         (is (= ["COUNT(*)"
                 "75"]
                (str/split-lines
-                ((mt/user->client :rasta) :post 202 (format "card/%d/query/csv"
-                                                                    (u/get-id card)))))))))
+                (mt/user-http-request :rasta :post 202 (format "card/%d/query/csv"
+                                                               (u/get-id card)))))))))
   (testing "with-paramters"
     (with-temp-native-card-with-params [_ card]
       (with-cards-in-readable-collection card
         (is (= ["COUNT(*)"
                 "8"]
                (str/split-lines
-                ((mt/user->client :rasta) :post 202 (format "card/%d/query/csv?parameters=%s"
-                                                                    (u/get-id card) encoded-params)))))))))
+                (mt/user-http-request :rasta :post 202 (format "card/%d/query/csv?parameters=%s"
+                                                               (u/get-id card) encoded-params)))))))))
 
 (deftest json-download-test
   (testing "no parameters"
     (with-temp-native-card [_ card]
       (with-cards-in-readable-collection card
         (is (= [{(keyword "COUNT(*)") 75}]
-               ((mt/user->client :rasta) :post 202 (format "card/%d/query/json" (u/get-id card))))))))
+               (mt/user-http-request :rasta :post 202 (format "card/%d/query/json" (u/get-id card))))))))
   (testing "with parameters"
     (with-temp-native-card-with-params [_ card]
       (with-cards-in-readable-collection card
         (is (= [{(keyword "COUNT(*)") 8}]
-               ((mt/user->client :rasta) :post 202 (format "card/%d/query/json?parameters=%s"
-                                                                   (u/get-id card) encoded-params))))))))
+               (mt/user-http-request :rasta :post 202 (format "card/%d/query/json?parameters=%s"
+                                                              (u/get-id card) encoded-params))))))))
 
 (defn- parse-xlsx-results [results]
   (->> results
@@ -1153,21 +1118,21 @@
       (with-cards-in-readable-collection card
         (is (= [{:col "COUNT(*)"} {:col 75.0}]
                (parse-xlsx-results
-                ((mt/user->client :rasta) :post 202 (format "card/%d/query/xlsx" (u/get-id card))
-                 {:request-options {:as :byte-array}})))))))
+                (mt/user-http-request :rasta :post 202 (format "card/%d/query/xlsx" (u/get-id card))
+                                      {:request-options {:as :byte-array}})))))))
   (testing "with parameters"
     (with-temp-native-card-with-params [_ card]
       (with-cards-in-readable-collection card
         (is (= [{:col "COUNT(*)"} {:col 8.0}]
                (parse-xlsx-results
-                ((mt/user->client :rasta) :post 202 (format "card/%d/query/xlsx?parameters=%s"
-                                                                    (u/get-id card) encoded-params)
-                 {:request-options {:as :byte-array}}))))))))
+                (mt/user-http-request :rasta :post 202 (format "card/%d/query/xlsx?parameters=%s"
+                                                               (u/get-id card) encoded-params)
+                                      {:request-options {:as :byte-array}}))))))))
 
 (deftest download-default-constraints-test
-  (tt/with-temp Card [card {:dataset_query {:database   (data/id)
+  (mt/with-temp Card [card {:dataset_query {:database   (mt/id)
                                             :type       :query
-                                            :query      {:source-table (data/id :venues)}
+                                            :query      {:source-table (mt/id :venues)}
                                             :middleware {:add-default-userland-constraints? true
                                                          :userland-query?                   true}}}]
     (with-cards-in-readable-collection card
@@ -1179,18 +1144,18 @@
                                                                  options))]
           (testing "Sanity check: this CSV download should not be subject to C O N S T R A I N T S"
             (is (= {:constraints nil}
-                   ((mt/user->client :rasta) :post 200 (format "card/%d/query/csv" (u/get-id card))))))
+                   (mt/user-http-request :rasta :post 200 (format "card/%d/query/csv" (u/get-id card))))))
           (with-redefs [constraints/default-query-constraints {:max-results 10, :max-results-bare-rows 10}]
             (testing (str "Downloading CSV/JSON/XLSX results shouldn't be subject to the default query constraints -- even "
                           "if the query comes in with `add-default-userland-constraints` (as will be the case if the query "
                           "gets saved from one that had it -- see #9831)")
               (is (= {:constraints nil}
-                     ((mt/user->client :rasta) :post 200 (format "card/%d/query/csv" (u/get-id card))))))
+                     (mt/user-http-request :rasta :post 200 (format "card/%d/query/csv" (u/get-id card))))))
 
             (testing (str "non-\"download\" queries should still get the default constraints (this also is a sanitiy "
                           "check to make sure the `with-redefs` in the test above actually works)")
               (is (= {:constraints {:max-results 10, :max-results-bare-rows 10}}
-                     ((mt/user->client :rasta) :post 200 (format "card/%d/query" (u/get-id card))))))))))))
+                     (mt/user-http-request :rasta :post 200 (format "card/%d/query" (u/get-id card))))))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -1198,78 +1163,68 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (deftest make-sure-we-can-create-a-card-and-specify-its--collection-id--at-the-same-time
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp Collection [collection]
-      (tu/with-model-cleanup [Card]
-        (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-        (let [card ((mt/user->client :rasta) :post 202 "card"
-                    (assoc (card-with-name-and-query)
-                           :collection_id (u/get-id collection)))]
+  (mt/with-non-admin-groups-no-root-collection-perms
+    (mt/with-temp Collection [collection]
+      (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
+      (mt/with-model-cleanup [Card]
+        (let [card (mt/user-http-request :rasta :post 202 "card"
+                                         (assoc (card-with-name-and-query)
+                                                :collection_id (u/get-id collection)))]
           (= (db/select-one-field :collection_id Card :id (u/get-id card))
              (u/get-id collection)))))))
 
 (deftest make-sure-we-card-creation-fails-if-we-try-to-set-a--collection-id--we-don-t-have-permissions-for
-  (is (= "You don't have permissions to do that."
-         (tu/with-non-admin-groups-no-root-collection-perms
-           (tu/with-model-cleanup [Card]
-             (tt/with-temp Collection [collection]
-               ((mt/user->client :rasta) :post 403 "card"
-                (assoc (card-with-name-and-query)
-                       :collection_id (u/get-id collection)))))))))
+  (testing "POST /api/card"
+    (testing "You must have permissions for the parent Collection to create a new Card in it"
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp Collection [collection]
+          (mt/with-model-cleanup [Card]
+            (is (= "You don't have permissions to do that."
+                   (mt/user-http-request :rasta :post 403 "card"
+                                         (assoc (card-with-name-and-query) :collection_id (u/get-id collection)))))))))))
 
-(deftest make-sure-we-can-change-the--collection-id--of-a-card-if-it-s-not-in-any-collection
-  (tt/with-temp* [Card       [card]
-                  Collection [collection]]
-    ((mt/user->client :crowberto) :put 202 (str "card/" (u/get-id card)) {:collection_id (u/get-id collection)})
-    (= (db/select-one-field :collection_id Card :id (u/get-id card))
-       (u/get-id collection))))
-
-(deftest make-sure-we-can-still-change--anything--for-a-card-if-we-don-t-have-permissions-for-the-collection-it-belongs-to
-  (is (= "You don't have permissions to do that."
-         (tu/with-non-admin-groups-no-root-collection-perms
-           (tt/with-temp* [Collection [collection]
-                           Card       [card       {:collection_id (u/get-id collection)}]]
-             ((mt/user->client :rasta) :put 403 (str "card/" (u/get-id card))
-              {:name "Number of Blueberries Consumed Per Month"}))))))
-
-
-;; Make sure that we can't change the `collection_id` of a Card if we don't have write permissions for the new
-;; collection
-(deftest cant-change-collection-id-of-card-without-write-permission-in-new-collection
-  (is (= "You don't have permissions to do that."
-         (tu/with-non-admin-groups-no-root-collection-perms
-           (tt/with-temp* [Collection [original-collection]
-                           Collection [new-collection]
-                           Card       [card                {:collection_id (u/get-id original-collection)}]]
-             (perms/grant-collection-readwrite-permissions! (perms-group/all-users) original-collection)
-             ((mt/user->client :rasta) :put 403 (str "card/" (u/get-id card))
-              {:collection_id (u/get-id new-collection)}))))))
-
-
-;; Make sure that we can't change the `collection_id` of a Card if we don't have write permissions for the current
-;; collection
-(deftest cant-change-collection-id-of-card-without-write-permission-in-current-collection
-  (is (= "You don't have permissions to do that."
-         (tu/with-non-admin-groups-no-root-collection-perms
-           (tt/with-temp* [Collection [original-collection]
-                           Collection [new-collection]
-                           Card       [card                {:collection_id (u/get-id original-collection)}]]
-             (perms/grant-collection-readwrite-permissions! (perms-group/all-users) new-collection)
-             ((mt/user->client :rasta) :put 403 (str "card/" (u/get-id card))
-              {:collection_id (u/get-id new-collection)}))))))
-
-
-
-(deftest but-if-we-do-have-permissions-for-both--we-should-be-able-to-change-it-
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp* [Collection [original-collection]
-                    Collection [new-collection]
-                    Card       [card                {:collection_id (u/get-id original-collection)}]]
-      (perms/grant-collection-readwrite-permissions! (perms-group/all-users) original-collection)
-      (perms/grant-collection-readwrite-permissions! (perms-group/all-users) new-collection)
-      ((mt/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:collection_id (u/get-id new-collection)})
+(deftest set-card-collection-id-test
+  (testing "Should be able to set the Collection ID of a Card in the Root Collection (i.e., `collection_id` is nil)"
+    (mt/with-temp* [Card       [card]
+                    Collection [collection]]
+      (mt/user-http-request :crowberto :put 202 (str "card/" (u/get-id card)) {:collection_id (u/get-id collection)})
       (= (db/select-one-field :collection_id Card :id (u/get-id card))
-         (u/get-id new-collection)))))
+         (u/get-id collection)))))
+
+(deftest update-card-require-parent-perms-test
+  (testing "Should require perms for the parent collection to change a Card's properties"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp* [Collection [collection]
+                      Card       [card       {:collection_id (u/get-id collection)}]]
+        (is (= "You don't have permissions to do that."
+               (mt/user-http-request :rasta :put 403 (str "card/" (u/get-id card))
+                                     {:name "Number of Blueberries Consumed Per Month"})))))))
+
+(deftest change-collection-permissions-test
+  (testing "PUT /api/card/:id"
+    (testing "\nChange the `collection_id` of a Card"
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp* [Collection [original-collection]
+                        Collection [new-collection]
+                        Card       [card                {:collection_id (u/get-id original-collection)}]]
+          (letfn [(change-collection! [expected-status-code]
+                    (mt/user-http-request :rasta :put expected-status-code (str "card/" (u/get-id card))
+                                          {:collection_id (u/get-id new-collection)}))]
+            (testing "requires write permissions for the new Collection"
+              (is (= "You don't have permissions to do that."
+                     (change-collection! 403))))
+
+            (testing "requires write permissions for the current Collection"
+              (perms/grant-collection-readwrite-permissions! (perms-group/all-users) new-collection)
+              (is (= "You don't have permissions to do that."
+                     (change-collection! 403))))
+
+            (testing "Should be able to change it once you have perms for both collections"
+              (perms/grant-collection-readwrite-permissions! (perms-group/all-users) original-collection)
+              (change-collection! 202)
+              (is (= (db/select-one-field :collection_id Card :id (u/get-id card))
+                     (u/get-id new-collection))))))))))
+
 
 ;;; ------------------------------ Bulk Collections Update (POST /api/card/collections) ------------------------------
 
@@ -1291,110 +1246,114 @@
   [username expected-status-code collection-or-collection-id-or-nil cards-or-card-ids]
   (array-map
    :response
-   ((mt/user->client username) :post expected-status-code "card/collections"
-    {:collection_id (when collection-or-collection-id-or-nil
-                      (u/get-id collection-or-collection-id-or-nil))
-     :card_ids      (map u/get-id cards-or-card-ids)})
+   (mt/user-http-request username :post expected-status-code "card/collections"
+                         {:collection_id (when collection-or-collection-id-or-nil
+                                           (u/get-id collection-or-collection-id-or-nil))
+                          :card_ids      (map u/get-id cards-or-card-ids)})
 
    :collections
    (collection-names cards-or-card-ids)))
 
 (deftest test-that-we-can-bulk-move-some-cards-with-no-collection-into-a-collection
-  (is (= {:response    {:status "ok"}
-          :collections ["Pog Collection"
-                        "Pog Collection"]}
-         (tt/with-temp* [Collection [collection {:name "Pog Collection"}]
-                         Card       [card-1]
-                         Card       [card-2]]
+  (mt/with-temp* [Collection [collection {:name "Pog Collection"}]
+                  Card       [card-1]
+                  Card       [card-2]]
+    (is (= {:response    {:status "ok"}
+            :collections ["Pog Collection"
+                          "Pog Collection"]}
            (POST-card-collections! :crowberto 200 collection [card-1 card-2])))))
 
 (deftest test-that-we-can-bulk-move-some-cards-from-one-collection-to-another
-  (is (= {:response    {:status "ok"}
-          :collections ["New Collection" "New Collection"]}
-         (tt/with-temp* [Collection [old-collection {:name "Old Collection"}]
-                         Collection [new-collection {:name "New Collection"}]
-                         Card       [card-1         {:collection_id (u/get-id old-collection)}]
-                         Card       [card-2         {:collection_id (u/get-id old-collection)}]]
+  (mt/with-temp* [Collection [old-collection {:name "Old Collection"}]
+                  Collection [new-collection {:name "New Collection"}]
+                  Card       [card-1         {:collection_id (u/get-id old-collection)}]
+                  Card       [card-2         {:collection_id (u/get-id old-collection)}]]
+    (is (= {:response    {:status "ok"}
+            :collections ["New Collection" "New Collection"]}
            (POST-card-collections! :crowberto 200 new-collection [card-1 card-2])))))
 
 (deftest test-that-we-can-bulk-remove-some-cards-from-a-collection
-  (is (= {:response    {:status "ok"}
-          :collections [nil nil]}
-         (tt/with-temp* [Collection [collection]
-                         Card       [card-1     {:collection_id (u/get-id collection)}]
-                         Card       [card-2     {:collection_id (u/get-id collection)}]]
+  (mt/with-temp* [Collection [collection]
+                  Card       [card-1     {:collection_id (u/get-id collection)}]
+                  Card       [card-2     {:collection_id (u/get-id collection)}]]
+    (is (= {:response    {:status "ok"}
+            :collections [nil nil]}
            (POST-card-collections! :crowberto 200 nil [card-1 card-2])))))
 
 (deftest check-that-we-aren-t-allowed-to-move-cards-if-we-don-t-have-permissions-for-destination-collection
-  (is (= {:response    "You don't have permissions to do that."
-          :collections [nil nil]}
-         (tu/with-non-admin-groups-no-root-collection-perms
-           (tt/with-temp* [Collection [collection]
-                           Card       [card-1]
-                           Card       [card-2]]
+  (mt/with-non-admin-groups-no-root-collection-perms
+    (mt/with-temp* [Collection [collection]
+                    Card       [card-1]
+                    Card       [card-2]]
+      (is (= {:response    "You don't have permissions to do that."
+              :collections [nil nil]}
              (POST-card-collections! :rasta 403 collection [card-1 card-2]))))))
 
 (deftest check-that-we-aren-t-allowed-to-move-cards-if-we-don-t-have-permissions-for-source-collection
-  (is (= {:response    "You don't have permissions to do that."
-          :collections ["Horseshoe Collection" "Horseshoe Collection"]}
-         (tu/with-non-admin-groups-no-root-collection-perms
-           (tt/with-temp* [Collection [collection {:name "Horseshoe Collection"}]
-                           Card       [card-1     {:collection_id (u/get-id collection)}]
-                           Card       [card-2     {:collection_id (u/get-id collection)}]]
+  (mt/with-non-admin-groups-no-root-collection-perms
+    (mt/with-temp* [Collection [collection {:name "Horseshoe Collection"}]
+                    Card       [card-1     {:collection_id (u/get-id collection)}]
+                    Card       [card-2     {:collection_id (u/get-id collection)}]]
+      (is (= {:response    "You don't have permissions to do that."
+              :collections ["Horseshoe Collection" "Horseshoe Collection"]}
              (POST-card-collections! :rasta 403 nil [card-1 card-2]))))))
 
 (deftest check-that-we-aren-t-allowed-to-move-cards-if-we-don-t-have-permissions-for-the-card
-  (is (= {:response    "You don't have permissions to do that."
-          :collections [nil nil]}
-         (tu/with-non-admin-groups-no-root-collection-perms
-           (tt/with-temp* [Collection [collection]
-                           Database   [database]
-                           Table      [table      {:db_id (u/get-id database)}]
-                           Card       [card-1     {:dataset_query (mbql-count-query (u/get-id database) (u/get-id table))}]
-                           Card       [card-2     {:dataset_query (mbql-count-query (u/get-id database) (u/get-id table))}]]
-             (perms/revoke-permissions! (perms-group/all-users) (u/get-id database))
-             (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
+  (mt/with-non-admin-groups-no-root-collection-perms
+    (mt/with-temp* [Collection [collection]
+                    Database   [database]
+                    Table      [table      {:db_id (u/get-id database)}]
+                    Card       [card-1     {:dataset_query (mbql-count-query (u/get-id database) (u/get-id table))}]
+                    Card       [card-2     {:dataset_query (mbql-count-query (u/get-id database) (u/get-id table))}]]
+      (perms/revoke-permissions! (perms-group/all-users) (u/get-id database))
+      (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
+      (is (= {:response    "You don't have permissions to do that."
+              :collections [nil nil]}
              (POST-card-collections! :rasta 403 collection [card-1 card-2]))))))
 
 ;; Test that we can bulk move some Cards from one collection to another, while updating the collection position of the
 ;; old collection and the new collection
 (deftest bulk-move-cards
-  (is (= [{:response    {:status "ok"}
-           :collections ["New Collection" "New Collection"]}
-          {"a" 4                               ;-> Moved to the new collection, gets the first slot available
-           "b" 5
-           "c" 1                               ;-> With a and b no longer in the collection, c is first
-           "d" 1                               ;-> Existing cards in new collection are untouched and position unchanged
-           "e" 2
-           "f" 3}]
-         (tt/with-temp* [Collection [{coll-id-1 :id}      {:name "Old Collection"}]
-                         Collection [{coll-id-2 :id
-                                      :as new-collection} {:name "New Collection"}]
-                         Card       [card-a               {:name "a", :collection_id coll-id-1, :collection_position 1}]
-                         Card       [card-b               {:name "b", :collection_id coll-id-1, :collection_position 2}]
-                         Card       [card-c               {:name "c", :collection_id coll-id-1, :collection_position 3}]
-                         Card       [card-d               {:name "d", :collection_id coll-id-2, :collection_position 1}]
-                         Card       [card-e               {:name "e", :collection_id coll-id-2, :collection_position 2}]
-                         Card       [card-f               {:name "f", :collection_id coll-id-2, :collection_position 3}]]
-           [(POST-card-collections! :crowberto 200 new-collection [card-a card-b])
-            (merge (name->position ((mt/user->client :crowberto) :get 200 (format "collection/%s/items" coll-id-1)  :model "card" :archived "false"))
-                   (name->position ((mt/user->client :crowberto) :get 200 (format "collection/%s/items" coll-id-2)  :model "card" :archived "false")))]))))
+  (mt/with-temp* [Collection [{coll-id-1 :id}      {:name "Old Collection"}]
+                  Collection [{coll-id-2 :id
+                               :as new-collection} {:name "New Collection"}]
+                  Card       [card-a               {:name "a", :collection_id coll-id-1, :collection_position 1}]
+                  Card       [card-b               {:name "b", :collection_id coll-id-1, :collection_position 2}]
+                  Card       [card-c               {:name "c", :collection_id coll-id-1, :collection_position 3}]
+                  Card       [card-d               {:name "d", :collection_id coll-id-2, :collection_position 1}]
+                  Card       [card-e               {:name "e", :collection_id coll-id-2, :collection_position 2}]
+                  Card       [card-f               {:name "f", :collection_id coll-id-2, :collection_position 3}]]
+    (is (= {:response    {:status "ok"}
+            :collections ["New Collection" "New Collection"]}
+           (POST-card-collections! :crowberto 200 new-collection [card-a card-b])))
+    (is (= {"a" 4                       ;-> Moved to the new collection, gets the first slot available
+            "b" 5
+            "c" 1                       ;-> With a and b no longer in the collection, c is first
+            "d" 1                       ;-> Existing cards in new collection are untouched and position unchanged
+            "e" 2
+            "f" 3}
+           (merge (name->position (mt/user-http-request :crowberto :get 200 (format "collection/%s/items" coll-id-1)
+                                                        :model "card" :archived "false"))
+                  (name->position (mt/user-http-request :crowberto :get 200 (format "collection/%s/items" coll-id-2)
+                                                        :model "card" :archived "false")))))))
 
 (deftest moving-a-card-without-a-collection-position-keeps-the-collection-position-nil
-  (is (= [{:response    {:status "ok"}
-           :collections ["New Collection" "New Collection"]}
-          {"a" nil
-           "b" 1
-           "c" 2}]
-         (tt/with-temp* [Collection [{coll-id-1 :id}      {:name "Old Collection"}]
-                         Collection [{coll-id-2 :id
-                                      :as new-collection} {:name "New Collection"}]
-                         Card       [card-a               {:name "a", :collection_id coll-id-1}]
-                         Card       [card-b               {:name "b", :collection_id coll-id-2, :collection_position 1}]
-                         Card       [card-c               {:name "c", :collection_id coll-id-2, :collection_position 2}]]
-           [(POST-card-collections! :crowberto 200 new-collection [card-a card-b])
-            (merge (name->position ((mt/user->client :crowberto) :get 200 (format "collection/%s/items" coll-id-1)  :model "card" :archived "false"))
-                   (name->position ((mt/user->client :crowberto) :get 200 (format "collection/%s/items" coll-id-2)  :model "card" :archived "false")))]))))
+  (mt/with-temp* [Collection [{coll-id-1 :id}      {:name "Old Collection"}]
+                  Collection [{coll-id-2 :id
+                               :as new-collection} {:name "New Collection"}]
+                  Card       [card-a               {:name "a", :collection_id coll-id-1}]
+                  Card       [card-b               {:name "b", :collection_id coll-id-2, :collection_position 1}]
+                  Card       [card-c               {:name "c", :collection_id coll-id-2, :collection_position 2}]]
+    (is (= {:response    {:status "ok"}
+            :collections ["New Collection" "New Collection"]}
+           (POST-card-collections! :crowberto 200 new-collection [card-a card-b])))
+    (is (= {"a" nil
+            "b" 1
+            "c" 2}
+           (merge (name->position (mt/user-http-request :crowberto :get 200 (format "collection/%s/items" coll-id-1)
+                                                        :model "card" :archived "false"))
+                  (name->position (mt/user-http-request :crowberto :get 200 (format "collection/%s/items" coll-id-2)
+                                                        :model "card" :archived "false")))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                            PUBLIC SHARING ENDPOINTS                                            |
@@ -1404,86 +1363,94 @@
   {:public_uuid       (str (UUID/randomUUID))
    :made_public_by_id (mt/user->id :crowberto)})
 
-;;; ----------------------------------------- POST /api/card/:id/public_link -----------------------------------------
+(deftest share-card-test
+  (testing "POST /api/card/:id/public_link"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (mt/with-temp Card [card]
+        (let [{uuid :uuid} (mt/user-http-request :crowberto :post 200 (format "card/%d/public_link" (u/get-id card)))]
+          (is (= true
+                 (boolean (db/exists? Card :id (u/get-id card), :public_uuid uuid)))))))))
 
+(deftest share-card-preconditions-test
+  (testing "POST /api/card/:id/public_link"
+    (testing "Public sharing has to be enabled to share a Card"
+      (mt/with-temporary-setting-values [enable-public-sharing false]
+        (mt/with-temp Card [card]
+          (is (= "Public sharing is not enabled."
+                 (mt/user-http-request :crowberto :post 400 (format "card/%d/public_link" (u/get-id card))))))))
 
-(deftest test-that-we-can-share-a-card
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (tt/with-temp Card [card]
-      (let [{uuid :uuid} ((mt/user->client :crowberto) :post 200 (format "card/%d/public_link" (u/get-id card)))]
-        (is (= true
-               (boolean (db/exists? Card :id (u/get-id card), :public_uuid uuid))))))))
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (testing "Have to be an admin to share a Card"
+        (mt/with-temp Card [card]
+          (is (= "You don't have permissions to do that."
+                 (mt/user-http-request :rasta :post 403 (format "card/%d/public_link" (u/get-id card)))))))
 
-(deftest test-that-we--cannot--share-a-card-if-we-aren-t-admins
-  (is (= "You don't have permissions to do that."
-         (tu/with-temporary-setting-values [enable-public-sharing true]
-           (tt/with-temp Card [card]
-             ((mt/user->client :rasta) :post 403 (format "card/%d/public_link" (u/get-id card))))))))
+      (testing "Cannot share an archived Card"
+        (mt/with-temp Card [card {:archived true}]
+          (is (= {:message "The object has been archived.", :error_code "archived"}
+                 (mt/user-http-request :crowberto :post 404 (format "card/%d/public_link" (u/get-id card)))))))
 
-(deftest test-that-we--cannot--share-a-card-if-the-setting-is-disabled
-  (is (= "Public sharing is not enabled."
-         (tu/with-temporary-setting-values [enable-public-sharing false]
-           (tt/with-temp Card [card]
-             ((mt/user->client :crowberto) :post 400 (format "card/%d/public_link" (u/get-id card))))))))
+      (testing "Cannot share a Card that doesn't exist"
+        (is (= "Not found."
+               (mt/user-http-request :crowberto :post 404 (format "card/%d/public_link" Integer/MAX_VALUE))))))))
 
-(deftest test-that-we--cannot--share-a-card-if-the-card-has-been-archived
-  (is (= {:message "The object has been archived.", :error_code "archived"}
-         (tu/with-temporary-setting-values [enable-public-sharing true]
-           (tt/with-temp Card [card {:archived true}]
-             ((mt/user->client :crowberto) :post 404 (format "card/%d/public_link" (u/get-id card))))))))
+(deftest share-already-shared-card-test
+  (testing "POST /api/card/:id/public_link"
+    (testing "Attempting to share a Card that's already shared should return the existing public UUID"
+      (mt/with-temporary-setting-values [enable-public-sharing true]
+        (mt/with-temp Card [card (shared-card)]
+          (= (:public_uuid card)
+             (:uuid (mt/user-http-request :crowberto :post 200 (format "card/%d/public_link" (u/get-id card))))))))))
 
-(deftest test-that-we-get-a-404-if-the-card-doesnt-exist
-  (is (= "Not found."
-         (tu/with-temporary-setting-values [enable-public-sharing true]
-           ((mt/user->client :crowberto) :post 404 (format "card/%d/public_link" Integer/MAX_VALUE))))))
+(deftest unshare-card-test
+  (testing "DELETE /api/card/:id/public_link"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (mt/with-temp Card [card (shared-card)]
+        (mt/user-http-request :crowberto :delete 204 (format "card/%d/public_link" (u/get-id card)))
+        (is (= false
+               (db/exists? Card :id (u/get-id card), :public_uuid (:public_uuid card))))))))
 
-(deftest test-that-if-a-card-has-already-been-shared-we-re-se-the-existing-uuid
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (tt/with-temp Card [card (shared-card)]
-      (= (:public_uuid card)
-         (:uuid ((mt/user->client :crowberto) :post 200 (format "card/%d/public_link" (u/get-id card))))))))
+(deftest unshare-card-preconditions-test
+  (testing "DELETE /api/card/:id/public_link\n"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (testing "Endpoint should return 404 if Card isn't shared"
+        (mt/with-temp Card [card]
+          (is (= "Not found."
+                 (mt/user-http-request :crowberto :delete 404 (format "card/%d/public_link" (u/get-id card)))))))
 
-;;; ---------------------------------------- DELETE /api/card/:id/public_link ----------------------------------------
+      (testing "You have to be an admin to unshare a Card"
+        (mt/with-temp Card [card (shared-card)]
+          (is (= "You don't have permissions to do that."
+                 (mt/user-http-request :rasta :delete 403 (format "card/%d/public_link" (u/get-id card)))))))
 
-(deftest test-that-we-can-unshare-a-card
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (tt/with-temp Card [card (shared-card)]
-      ((mt/user->client :crowberto) :delete 204 (format "card/%d/public_link" (u/get-id card)))
-      (is (= false
-             (db/exists? Card :id (u/get-id card), :public_uuid (:public_uuid card)))))))
-
-(deftest test-that-we--cannot--unshare-a-card-if-we-are-not-admins
-  (is (= "You don't have permissions to do that."
-         (tu/with-temporary-setting-values [enable-public-sharing true]
-           (tt/with-temp Card [card (shared-card)]
-             ((mt/user->client :rasta) :delete 403 (format "card/%d/public_link" (u/get-id card))))))))
-
-(deftest test-that-we-get-a-404-if-card-isn-t-shared
-  (is (= "Not found."
-         (tu/with-temporary-setting-values [enable-public-sharing true]
-           (tt/with-temp Card [card]
-             ((mt/user->client :crowberto) :delete 404 (format "card/%d/public_link" (u/get-id card))))))))
-
-(deftest test-that-we-get-a-404-if-card-doesnt-exist
-  (is (= "Not found."
-         (tu/with-temporary-setting-values [enable-public-sharing true]
-           ((mt/user->client :crowberto) :delete 404 (format "card/%d/public_link" Integer/MAX_VALUE))))))
+      (testing "Endpoint should 404 if Card doesn't exist"
+        (is (= "Not found."
+               (mt/user-http-request :crowberto :delete 404 (format "card/%d/public_link" Integer/MAX_VALUE))))))))
 
 (deftest test-that-we-can-fetch-a-list-of-publicly-accessible-cards
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (tt/with-temp Card [card (shared-card)]
-      (is (= [{:name true, :id true, :public_uuid true}]
-             (for [card ((mt/user->client :crowberto) :get 200 "card/public")]
-               (m/map-vals boolean (select-keys card [:name :id :public_uuid]))))))))
+  (testing "GET /api/card/public"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (mt/with-temp Card [card (shared-card)]
+        (is (= [{:name true, :id true, :public_uuid true}]
+               (for [card (mt/user-http-request :crowberto :get 200 "card/public")]
+                 (m/map-vals boolean (select-keys card [:name :id :public_uuid])))))))))
 
 (deftest test-that-we-can-fetch-a-list-of-embeddable-cards
-  (tu/with-temporary-setting-values [enable-embedding true]
-    (tt/with-temp Card [card {:enable_embedding true}]
-      (is (= [{:name true, :id true}]
-             (for [card ((mt/user->client :crowberto) :get 200 "card/embeddable")]
-               (m/map-vals boolean (select-keys card [:name :id]))))))))
+  (testing "GET /api/card/embeddable"
+    (mt/with-temporary-setting-values [enable-embedding true]
+      (mt/with-temp Card [card {:enable_embedding true}]
+        (is (= [{:name true, :id true}]
+               (for [card (mt/user-http-request :crowberto :get 200 "card/embeddable")]
+                 (m/map-vals boolean (select-keys card [:name :id])))))))))
 
 (deftest test-related-recommended-entities
-  (tt/with-temp Card [card]
-    (is (= #{:table :metrics :segments :dashboard-mates :similar-questions :canonical-metric :dashboards :collections}
-           (-> ((mt/user->client :crowberto) :get 200 (format "card/%s/related" (u/get-id card))) keys set)))))
+  (mt/with-temp Card [card]
+    (is (schema= {:table             s/Any
+                  :metrics           s/Any
+                  :segments          s/Any
+                  :dashboard-mates   s/Any
+                  :similar-questions s/Any
+                  :canonical-metric  s/Any
+                  :dashboards        s/Any
+                  :collections       s/Any}
+                 (mt/user-http-request :crowberto :get 200 (format "card/%s/related" (u/get-id card)))))))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -721,6 +721,7 @@
   (testing "POST /api/card"
     (mt/with-non-admin-groups-no-root-collection-perms
       (mt/with-temp Collection [collection]
+        (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
         (doseq [{:keys [message position expected]}
                 [{:message  (str "Add a new card to an existing collection at position 1, will cause all existing "
                                  "positions to increment by 1")
@@ -752,7 +753,6 @@
             (with-ordered-items collection [Dashboard a
                                             Pulse     b
                                             Card      c]
-              (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
               (testing "Original collection, before adding the new card"
                 (is (= {"a" 1
                         "b" 2
@@ -770,6 +770,7 @@
   (testing "PUT /api/card/:id"
     (mt/with-non-admin-groups-no-root-collection-perms
       (mt/with-temp Collection [collection]
+        (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
         (doseq [{:keys [message position expected]}
                 [{:message  "Move existing Card to front"
                   :position 1
@@ -803,7 +804,6 @@
                                             Card      d
                                             Pulse     e
                                             Pulse     f]
-              (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
               (testing "Original collection, before moving the Card"
                 (is (= {"a" 1
                         "b" 2

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.models.dashboard-test
   (:require [clojure.test :refer :all]
-            [expectations :refer [expect]]
             [metabase
              [test :as mt]
              [util :as u]]
@@ -26,122 +25,94 @@
 
 ;; ## Dashboard Revisions
 
-;; serialize-dashboard
-(expect
-  {:name         "Test Dashboard"
-   :description  nil
-   :cards        [{:sizeX   2
-                   :sizeY   2
-                   :row     0
-                   :col     0
-                   :id      true
-                   :card_id true
-                   :series  true}]}
+(deftest serialize-dashboard-test
   (tt/with-temp* [Dashboard           [{dashboard-id :id :as dashboard} {:name "Test Dashboard"}]
                   Card                [{card-id :id}]
                   Card                [{series-id-1 :id}]
                   Card                [{series-id-2 :id}]
-                  DashboardCard       [{dashcard-id :id}                {:dashboard_id dashboard-id, :card_id card-id}]
-                  DashboardCardSeries [_                                {:dashboardcard_id dashcard-id, :card_id series-id-1, :position 0}]
-                  DashboardCardSeries [_                                {:dashboardcard_id dashcard-id, :card_id series-id-2, :position 1}]]
-    (update (serialize-dashboard dashboard) :cards (fn [[{:keys [id card_id series], :as card}]]
-                                                     [(assoc card
-                                                             :id      (= dashcard-id id)
-                                                             :card_id (= card-id card_id)
-                                                             :series  (= [series-id-1 series-id-2] series))]))))
+                  DashboardCard       [{dashcard-id :id} {:dashboard_id dashboard-id, :card_id card-id}]
+                  DashboardCardSeries [_                 {:dashboardcard_id dashcard-id, :card_id series-id-1, :position 0}]
+                  DashboardCardSeries [_                 {:dashboardcard_id dashcard-id, :card_id series-id-2, :position 1}]]
+    (is (= {:name         "Test Dashboard"
+            :description  nil
+            :cards        [{:sizeX   2
+                            :sizeY   2
+                            :row     0
+                            :col     0
+                            :id      true
+                            :card_id true
+                            :series  true}]}
+           (update (serialize-dashboard dashboard) :cards (fn [[{:keys [id card_id series], :as card}]]
+                                                            [(assoc card
+                                                                    :id      (= dashcard-id id)
+                                                                    :card_id (= card-id card_id)
+                                                                    :series  (= [series-id-1 series-id-2] series))]))))))
 
 
-;; diff-dashboards-str
-(expect
-  "renamed it from \"Diff Test\" to \"Diff Test Changed\" and added a description."
-  (#'dashboard/diff-dashboards-str
-   nil
-   {:name         "Diff Test"
-    :description  nil
-    :cards        []}
-    {:name         "Diff Test Changed"
-     :description  "foobar"
-     :cards        []}))
+(deftest diff-dashboards-str-test
+  (is (= "renamed it from \"Diff Test\" to \"Diff Test Changed\" and added a description."
+         (#'dashboard/diff-dashboards-str
+          nil
+          {:name        "Diff Test"
+           :description nil
+           :cards       []}
+          {:name        "Diff Test Changed"
+           :description "foobar"
+           :cards       []})))
 
-(expect
-  "added a card."
-  (#'dashboard/diff-dashboards-str
-   nil
-   {:name         "Diff Test"
-    :description  nil
-    :cards        []}
-    {:name         "Diff Test"
-     :description  nil
-     :cards        [{:sizeX   2
-                     :sizeY   2
-                     :row     0
-                     :col     0
-                     :id      1
-                     :card_id 1
-                     :series  []}]}))
+  (is (= "added a card."
+         (#'dashboard/diff-dashboards-str
+          nil
+          {:name        "Diff Test"
+           :description nil
+           :cards       []}
+          {:name        "Diff Test"
+           :description nil
+           :cards       [{:sizeX   2
+                          :sizeY   2
+                          :row     0
+                          :col     0
+                          :id      1
+                          :card_id 1
+                          :series  []}]})))
 
-(expect
-  "rearranged the cards, modified the series on card 1 and added some series to card 2."
-  (#'dashboard/diff-dashboards-str
-   nil
-   {:name         "Diff Test"
-    :description  nil
-    :cards        [{:sizeX   2
-                    :sizeY   2
-                    :row     0
-                    :col     0
-                    :id      1
-                    :card_id 1
-                    :series  [5 6]}
-                   {:sizeX   2
-                    :sizeY   2
-                    :row     0
-                    :col     0
-                    :id      2
-                    :card_id 2
-                    :series  []}]}
-    {:name         "Diff Test"
-     :description  nil
-     :cards        [{:sizeX   2
-                     :sizeY   2
-                     :row     0
-                     :col     0
-                     :id      1
-                     :card_id 1
-                     :series  [4 5]}
-                    {:sizeX   2
-                     :sizeY   2
-                     :row     2
-                     :col     0
-                     :id      2
-                     :card_id 2
-                     :series  [3 4 5]}]}))
+  (is (= "rearranged the cards, modified the series on card 1 and added some series to card 2."
+         (#'dashboard/diff-dashboards-str
+          nil
+          {:name        "Diff Test"
+           :description nil
+           :cards       [{:sizeX   2
+                          :sizeY   2
+                          :row     0
+                          :col     0
+                          :id      1
+                          :card_id 1
+                          :series  [5 6]}
+                         {:sizeX   2
+                          :sizeY   2
+                          :row     0
+                          :col     0
+                          :id      2
+                          :card_id 2
+                          :series  []}]}
+          {:name        "Diff Test"
+           :description nil
+           :cards       [{:sizeX   2
+                          :sizeY   2
+                          :row     0
+                          :col     0
+                          :id      1
+                          :card_id 1
+                          :series  [4 5]}
+                         {:sizeX   2
+                          :sizeY   2
+                          :row     2
+                          :col     0
+                          :id      2
+                          :card_id 2
+                          :series  [3 4 5]}]}))))
 
-
-;;; #'dashboard/revert-dashboard!
-
-(expect
-  [{:name         "Test Dashboard"
-    :description  nil
-    :cards        [{:sizeX   2
-                    :sizeY   2
-                    :row     0
-                    :col     0
-                    :id      true
-                    :card_id true
-                    :series  true}]}
-   {:name         "Revert Test"
-    :description  "something"
-    :cards        []}
-   {:name         "Test Dashboard"
-    :description  nil
-    :cards        [{:sizeX   2
-                    :sizeY   2
-                    :row     0
-                    :col     0
-                    :id      false
-                    :card_id true
-                    :series  true}]}]
+(deftest revert-dashboard!-test
   (tt/with-temp* [Dashboard           [{dashboard-id :id, :as dashboard}    {:name "Test Dashboard"}]
                   Card                [{card-id :id}]
                   Card                [{series-id-1 :id}]
@@ -151,24 +122,43 @@
                   DashboardCardSeries [_                                    {:dashboardcard_id dashcard-id, :card_id series-id-2, :position 1}]]
     (let [check-ids            (fn [[{:keys [id card_id series] :as card}]]
                                  [(assoc card
-                                    :id      (= dashcard-id id)
-                                    :card_id (= card-id card_id)
-                                    :series  (= [series-id-1 series-id-2] series))])
+                                         :id      (= dashcard-id id)
+                                         :card_id (= card-id card_id)
+                                         :series  (= [series-id-1 series-id-2] series))])
           serialized-dashboard (serialize-dashboard dashboard)]
-      ;; delete the dashcard and modify the dash attributes
-      (dashboard-card/delete-dashboard-card! dashboard-card (users/user->id :rasta))
-      (db/update! Dashboard dashboard-id
-        :name        "Revert Test"
-        :description "something")
-      ;; capture our updated dashboard state
-      (let [serialized-dashboard2 (serialize-dashboard (Dashboard dashboard-id))]
-        ;; now do the reversion
+      (testing "original state"
+        (is (= {:name         "Test Dashboard"
+                :description  nil
+                :cards        [{:sizeX   2
+                                :sizeY   2
+                                :row     0
+                                :col     0
+                                :id      true
+                                :card_id true
+                                :series  true}]}
+               (update serialized-dashboard :cards check-ids))))
+      (testing "delete the dashcard and modify the dash attributes"
+        (dashboard-card/delete-dashboard-card! dashboard-card (users/user->id :rasta))
+        (db/update! Dashboard dashboard-id
+          :name        "Revert Test"
+          :description "something")
+        (testing "capture updated Dashboard state"
+          (is (= {:name        "Revert Test"
+                  :description "something"
+                  :cards       []}
+                 (serialize-dashboard (Dashboard dashboard-id))))))
+      (testing "now do the reversion; state should return to original"
         (#'dashboard/revert-dashboard! nil dashboard-id (users/user->id :crowberto) serialized-dashboard)
-        ;; final output is original-state, updated-state, reverted-state
-        [(update serialized-dashboard :cards check-ids)
-         serialized-dashboard2
-         (update (serialize-dashboard (Dashboard dashboard-id)) :cards check-ids)]))))
-
+        (is (= {:name         "Test Dashboard"
+                :description  nil
+                :cards        [{:sizeX   2
+                                :sizeY   2
+                                :row     0
+                                :col     0
+                                :id      false
+                                :card_id true
+                                :series  true}]}
+               (update (serialize-dashboard (Dashboard dashboard-id)) :cards check-ids)))))))
 
 (deftest public-sharing-test
   (testing "test that a Dashboard's :public_uuid comes back if public sharing is enabled..."
@@ -208,30 +198,28 @@
     (fn [~db-binding ~collection-binding ~dash-binding]
       ~@body)))
 
-;; Check that if a Dashboard is in a Collection, someone who would not be able to see it under the old
-;; artifact-permissions regime will be able to see it if they have permissions for that Collection
-(expect
-  (with-dash-in-collection [_ collection dash]
-    (binding [api/*current-user-permissions-set* (atom #{(perms/collection-read-path collection)})]
-      (mi/can-read? dash))))
+(deftest perms-test
+  (with-dash-in-collection [db collection dash]
+    (testing (str "Check that if a Dashboard is in a Collection, someone who would not be able to see it under the old "
+                  "artifact-permissions regime will be able to see it if they have permissions for that Collection")
+      (binding [api/*current-user-permissions-set* (atom #{(perms/collection-read-path collection)})]
+        (is (= true
+               (mi/can-read? dash)))))
 
-;; Check that if a Dashboard is in a Collection, someone who would otherwise be able to see it under the old
-;; artifact-permissions regime will *NOT* be able to see it if they don't have permissions for that Collection
-(expect
-  false
-  (with-dash-in-collection [db _ dash]
+    (testing (str "Check that if a Dashboard is in a Collection, someone who would otherwise be able to see it under "
+                  "the old artifact-permissions regime will *NOT* be able to see it if they don't have permissions for "
+                  "that Collection"))
     (binding [api/*current-user-permissions-set* (atom #{(perms/object-path (u/get-id db))})]
-      (mi/can-read? dash))))
+      (is (= false
+             (mi/can-read? dash))))
 
-;; Do we have *write* Permissions for a Dashboard if we have *write* Permissions for the Collection its in?
-(expect
-  (with-dash-in-collection [_ collection dash]
-    (binding [api/*current-user-permissions-set* (atom #{(perms/collection-readwrite-path collection)})]
-      (mi/can-write? dash))))
+    (testing "Do we have *write* Permissions for a Dashboard if we have *write* Permissions for the Collection its in?"
+      (binding [api/*current-user-permissions-set* (atom #{(perms/collection-readwrite-path collection)})]
+        (mi/can-write? dash)))))
 
 (deftest transient-dashboards-test
   (testing "test that we save a transient dashboard"
-    (tu/with-model-cleanup ['Card 'Dashboard 'DashboardCard 'Collection]
+    (tu/with-model-cleanup [Card Dashboard DashboardCard Collection]
       (binding [api/*current-user-id*              (users/user->id :rasta)
                 api/*current-user-permissions-set* (-> :rasta
                                                        users/user->id

--- a/test/metabase/models/pulse_test.clj
+++ b/test/metabase/models/pulse_test.clj
@@ -236,7 +236,7 @@
 (defn do-with-pulse-in-collection [f]
   (mt/with-non-admin-groups-no-root-collection-perms
     (mt/with-temp* [Collection [collection]
-                    Pulse      [pulse  {:collection_id (u/get-id collection)}]
+                    Pulse      [pulse {:collection_id (u/get-id collection)}]
                     Database   [db    {:engine :h2}]
                     Table      [table {:db_id (u/get-id db)}]
                     Card       [card  {:dataset_query {:database (u/get-id db)

--- a/test/metabase/related_test.clj
+++ b/test/metabase/related_test.clj
@@ -1,94 +1,95 @@
 (ns metabase.related-test
   (:require [clojure.java.jdbc :as jdbc]
-            [expectations :refer :all]
+            [clojure.test :refer :all]
             [metabase
+             [models :refer [Card Collection Metric Segment]]
              [related :as r :refer :all]
-             [sync :as sync]]
-            [metabase.models
-             [card :refer [Card]]
-             [collection :refer [Collection]]
-             [metric :refer [Metric]]
-             [segment :refer [Segment]]]
-            [metabase.test.data :as data]
-            [metabase.test.data
-             [one-off-dbs :as one-off-dbs]
-             [users :as users]]
-            [toucan.util.test :as tt]))
+             [sync :as sync]
+             [test :as mt]]
+            [metabase.test.data.one-off-dbs :as one-off-dbs]))
 
-(expect
-  #{[:field-id 1] [:metric 1] [:field-id 2] [:segment 1]}
-  (#'r/collect-context-bearing-forms [[:> [:field-id 1] 3]
-                                      ["and" [:= ["FIELD-ID" 2] 2]
-                                       ["segment" 1]]
-                                      [:metric 1]]))
+(deftest collect-context-bearing-forms-test
+  (is (= #{[:field-id 1] [:metric 1] [:field-id 2] [:segment 1]}
+         (#'r/collect-context-bearing-forms [[:> [:field-id 1] 3]
+                                             ["and" [:= ["FIELD-ID" 2] 2]
+                                              ["segment" 1]]
+                                             [:metric 1]]))))
 
 
-(expect
-  [0.5
-   0.0
-   1.0]
-  (tt/with-temp* [Card [{card-id-1 :id}
-                        {:dataset_query {:query {:source-table (data/id :venues)
-                                                 :aggregation [:sum [:field-id (data/id :venues :price)]]
-                                                 :breakout [[:field-id (data/id :venues :category_id)]]}
-                                         :type  :query
-                                         :database (data/id)}}]
+(deftest similiarity-test
+  (mt/with-temp* [Card [{card-id-1 :id}
+                        {:dataset_query (mt/mbql-query venues
+                                          {:aggregation  [:sum $price]
+                                           :breakout     [$category_id]})}]
                   Card [{card-id-2 :id}
-                        {:dataset_query {:query {:source-table (data/id :venues)
-                                                 :aggregation [:sum [:field-id (data/id :venues :longitude)]]
-                                                 :breakout [[:field-id (data/id :venues :category_id)]]}
-                                         :type  :query
-                                         :database (data/id)}}]
+                        {:dataset_query (mt/mbql-query venues
+                                          {:aggregation [:sum $longitude]
+                                           :breakout    [$category_id]})}]
                   Card [{card-id-3 :id}
-                        {:dataset_query {:query {:source-table (data/id :venues)
-                                                 :aggregation [:sum [:field-id (data/id :venues :longitude)]]
-                                                 :breakout [[:field-id (data/id :venues :latitude)]]}
-                                         :type  :query
-                                         :database (data/id)}}]]
-    (map double [(#'r/similarity (Card card-id-1) (Card card-id-2))
-                 (#'r/similarity (Card card-id-1) (Card card-id-3))
-                 (#'r/similarity (Card card-id-1) (Card card-id-1))])))
+                        {:dataset_query (mt/mbql-query venues
+                                          {:aggregation  [:sum $longitude]
+                                           :breakout     [$latitude]})}]]
+    (let [cards {1 card-id-1
+                 2 card-id-2
+                 3 card-id-3}]
+      (doseq [[[card-x card-y] expected-similarity] {[1 2] 0.5
+                                                     [1 3] 0.0
+                                                     [1 1] 1.0}]
+        (testing (format "Similarity between Card #%d and Card #%d" card-x card-y)
+          (is (= expected-similarity
+                 (double (#'r/similarity (Card (get cards card-x)) (Card (get cards card-y)))))))))))
 
+(defn- do-with-world [f]
+  (mt/with-temp* [Collection [{collection-id :id}]
+                  Metric     [{metric-id-a :id} (mt/$ids venues
+                                                  {:table_id   $$venues
+                                                   :definition {:source-table $$venues
+                                                                :aggregation  [:sum $price]}})]
+                  Metric     [{metric-id-b :id} (mt/$ids venues
+                                                  {:table_id   $$venues
+                                                   :definition {:source-table $$venues
+                                                                :aggregation  [:count]}})]
+                  Segment    [{segment-id-a :id} (mt/$ids venues
+                                                   {:table_id   $$venues
+                                                    :definition {:source-table $$venues
+                                                                 :filter       [:!= $category_id nil]}})]
+                  Segment    [{segment-id-b :id} (mt/$ids venues
+                                                   {:table_id   $$venues
+                                                    :definition {:source-table $$venues
+                                                                 :filter       [:!= [:field-id (mt/id :venues :name)] nil]}})]
+                  Card       [{card-id-a :id :as card-a}
+                              {:table_id      (mt/id :venues)
+                               :dataset_query (mt/mbql-query venues
+                                                {:aggregation [:sum $price]
+                                                 :breakout    [$category_id]})}]
+                  Card       [{card-id-b :id :as card-b}
+                              {:table_id      (mt/id :venues)
+                               :collection_id collection-id
+                               :dataset_query (mt/mbql-query venues
+                                                {:aggregation [:sum $longitude]
+                                                 :breakout    [$category_id]})}]
+                  Card       [{card-id-c :id :as card-c}
+                              {:table_id      (mt/id :venues)
+                               :dataset_query (mt/mbql-query venues
+                                                {:aggregation [:sum $longitude]
+                                                 :breakout    [[:field-id (mt/id :venues :name)]
+                                                               $latitude]})}]]
+    (f {:collection-id collection-id
+        :metric-id-a   metric-id-a
+        :metric-id-b   metric-id-b
+        :segment-id-a  segment-id-a
+        :segment-id-b  segment-id-b
+        :card-id-a     card-id-a
+        :card-id-b     card-id-b
+        :card-id-c     card-id-c})))
 
-(defmacro ^:private expect-with-world
-  [& body]
-  `(tt/expect-with-temp [Collection [{~'collection-id :id}]
-                         Metric     [{~'metric-id-a :id} {:table_id (data/id :venues)
-                                                          :definition {:source-table (data/id :venues)
-                                                                       :aggregation [:sum [:field-id (data/id :venues :price)]]}}]
-                         Metric     [{~'metric-id-b :id} {:table_id (data/id :venues)
-                                                          :definition {:source-table (data/id :venues)
-                                                                       :aggregation [:count]}}]
-                         Segment    [{~'segment-id-a :id} {:table_id (data/id :venues)
-                                                           :definition {:source-table (data/id :venues)
-                                                                        :filter [:!= [:field-id (data/id :venues :category_id)] nil]}}]
-                         Segment    [{~'segment-id-b :id} {:table_id (data/id :venues)
-                                                           :definition {:source-table (data/id :venues)
-                                                                        :filter [:!= [:field-id (data/id :venues :name)] nil]}}]
-                         Card       [{~'card-id-a :id :as ~'card-a}
-                                     {:table_id (data/id :venues)
-                                      :dataset_query {:type :query
-                                                      :database (data/id)
-                                                      :query {:source-table (data/id :venues)
-                                                              :aggregation [:sum [:field-id (data/id :venues :price)]]
-                                                              :breakout [[:field-id (data/id :venues :category_id)]]}}}]
-                         Card       [{~'card-id-b :id :as ~'card-b}
-                                     {:table_id (data/id :venues)
-                                      :collection_id ~'collection-id
-                                      :dataset_query {:type :query
-                                                      :database (data/id)
-                                                      :query {:source-table (data/id :venues)
-                                                              :aggregation [:sum [:field-id (data/id :venues :longitude)]]
-                                                              :breakout [[:field-id (data/id :venues :category_id)]]}}}]
-                         Card       [{~'card-id-c :id :as ~'card-c}
-                                     {:table_id (data/id :venues)
-                                      :dataset_query {:type :query
-                                                      :database (data/id)
-                                                      :query {:source-table (data/id :venues)
-                                                              :aggregation [:sum [:field-id (data/id :venues :longitude)]]
-                                                              :breakout [[:field-id (data/id :venues :name)]
-                                                                         [:field-id (data/id :venues :latitude)]]}}}]]
-     ~@body))
+(defmacro ^:private with-world [& body]
+  `(do-with-world
+    (fn [{:keys [~'collection-id
+                 ~'metric-id-a ~'metric-id-b
+                 ~'segment-id-a ~'segment-id-b
+                 ~'card-id-a ~'card-id-b ~'card-id-c]}]
+      ~@body)))
 
 (defn- result-mask
   [x]
@@ -98,41 +99,45 @@
                (sort (map :id v))
                (:id v))])))
 
-(expect-with-world
-  {:table             (data/id :venues)
-   :metrics           (sort [metric-id-a metric-id-b])
-   :segments          (sort [segment-id-a segment-id-b])
-   :dashboard-mates   []
-   :similar-questions [card-id-b]
-   :canonical-metric  metric-id-a
-   :collections       [collection-id]
-   :dashboards        []}
-  (->> ((users/user->client :crowberto) :get 200 (format "card/%s/related" card-id-a))
-       result-mask))
+(deftest related-cards-test
+  (with-world
+    (is (= {:table             (mt/id :venues)
+            :metrics           (sort [metric-id-a metric-id-b])
+            :segments          (sort [segment-id-a segment-id-b])
+            :dashboard-mates   []
+            :similar-questions [card-id-b]
+            :canonical-metric  metric-id-a
+            :collections       [collection-id]
+            :dashboards        []}
+           (->> (mt/user-http-request :crowberto :get 200 (format "card/%s/related" card-id-a))
+                result-mask)))))
 
-(expect-with-world
-  {:table    (data/id :venues)
-   :metrics  [metric-id-b]
-   :segments (sort [segment-id-a segment-id-b])}
-  (->> ((users/user->client :crowberto) :get 200 (format "metric/%s/related" metric-id-a))
-       result-mask))
+(deftest related-metrics-test
+  (with-world
+    (is (= {:table    (mt/id :venues)
+            :metrics  [metric-id-b]
+            :segments (sort [segment-id-a segment-id-b])}
+           (->> (mt/user-http-request :crowberto :get 200 (format "metric/%s/related" metric-id-a))
+                result-mask)))))
 
-(expect-with-world
-  {:table       (data/id :venues)
-   :metrics     (sort [metric-id-a metric-id-b])
-   :segments    [segment-id-b]
-   :linked-from [(data/id :checkins)]}
-  (->> ((users/user->client :crowberto) :get 200 (format "segment/%s/related" segment-id-a))
-       result-mask))
+(deftest related-segments-test
+  (with-world
+    (is (= {:table       (mt/id :venues)
+            :metrics     (sort [metric-id-a metric-id-b])
+            :segments    [segment-id-b]
+            :linked-from [(mt/id :checkins)]}
+           (->> (mt/user-http-request :crowberto :get 200 (format "segment/%s/related" segment-id-a))
+                result-mask)))))
 
-(expect-with-world
-  {:metrics     (sort [metric-id-a metric-id-b])
-   :segments    (sort [segment-id-a segment-id-b])
-   :linking-to  [(data/id :categories)]
-   :linked-from [(data/id :checkins)]
-   :tables      [(data/id :users)]}
-  (->> ((users/user->client :crowberto) :get 200 (format "table/%s/related" (data/id :venues)))
-       result-mask))
+(deftest related-tables-test
+  (with-world
+    (is (= {:metrics     (sort [metric-id-a metric-id-b])
+            :segments    (sort [segment-id-a segment-id-b])
+            :linking-to  [(mt/id :categories)]
+            :linked-from [(mt/id :checkins)]
+            :tables      [(mt/id :users)]}
+           (->> (mt/user-http-request :crowberto :get 200 (format "table/%s/related" (mt/id :venues)))
+                result-mask)))))
 
 
 ;; We should ignore non-active entities
@@ -141,42 +146,43 @@
   (doseq [statement statements]
     (jdbc/execute! one-off-dbs/*conn* [statement])))
 
-(expect
-  [1 0]
+(deftest sync-related-fields-test
   (one-off-dbs/with-blank-db
     (exec! "CREATE TABLE blueberries_consumed (num SMALLINT NOT NULL, weight FLOAT)")
     (one-off-dbs/insert-rows-and-sync! (range 50))
     (let [count-related-fields (fn []
-                                 (->> ((users/user->client :crowberto) :get 200
-                                       (format "field/%s/related" (data/id :blueberries_consumed :num)))
+                                 (->> (mt/user-http-request :crowberto :get 200
+                                                            (format "field/%s/related" (mt/id :blueberries_consumed :num)))
                                       :fields
-                                      count))
-          before               (count-related-fields)]
+                                      count))]
+      (testing "before"
+        (is (= 1
+               (count-related-fields))))
       (exec! "ALTER TABLE blueberries_consumed DROP COLUMN weight")
-      (sync/sync-database! (data/db))
-      [before (count-related-fields)])))
+      (sync/sync-database! (mt/db))
+      (testing "after"
+        (is (= 0
+               (count-related-fields)))))))
 
+(deftest transitive-similarity-test
+  (testing "Test transitive similarity"
+    ;; (A is similar to B and B is similar to C, but A is not similar to C). Test if
+    ;; this property holds and `:similar-questions` for A returns B, for B A and C,
+    ;; and for C B. Note that C is less similar to B than A is, as C has an additional
+    ;; breakout dimension.
+    (with-world
+      (is (= [card-id-b]
+             (->> (mt/user-http-request :crowberto :get 200 (format "card/%s/related" card-id-a))
+                  result-mask
+                  :similar-questions)))
 
-;; Test transitive similarity:
-;; (A is similar to B and B is similar to C, but A is not similar to C). Test if
-;; this property holds and `:similar-questions` for A returns B, for B A and C,
-;; and for C B. Note that C is less similar to B than A is, as C has an additional
-;; breakout dimension.
+      (testing "Ordering matters as C is less similar to B than A."
+        (is (= [card-id-a card-id-c]
+               (->> (mt/user-http-request :crowberto :get 200 (format "card/%s/related" card-id-b))
+                    result-mask
+                    :similar-questions)))
 
-(expect-with-world
-  [card-id-b]
-  (->> ((users/user->client :crowberto) :get 200 (format "card/%s/related" card-id-a))
-       result-mask
-       :similar-questions))
-
-(expect-with-world
-  [card-id-a card-id-c] ; Ordering matters as C is less similar to B than A.
-  (->> ((users/user->client :crowberto) :get 200 (format "card/%s/related" card-id-b))
-       result-mask
-       :similar-questions))
-
-(expect-with-world
-  [card-id-b]
-  (->> ((users/user->client :crowberto) :get 200 (format "card/%s/related" card-id-c))
-       result-mask
-       :similar-questions))
+        (is (= [card-id-b]
+               (->> (mt/user-http-request :crowberto :get 200 (format "card/%s/related" card-id-c))
+                    result-mask
+                    :similar-questions)))))))

--- a/test/metabase/test/automagic_dashboards.clj
+++ b/test/metabase/test/automagic_dashboards.clj
@@ -1,16 +1,17 @@
 (ns metabase.test.automagic-dashboards
   "Helper functions and macros for writing tests for automagic dashboards."
-  (:require [metabase.mbql
+  (:require [metabase
+             [models :refer [Card Collection Dashboard DashboardCard]]
+             [test :as mt]]
+            [metabase.mbql
              [normalize :as normalize]
              [schema :as mbql.s]]
-            [metabase.test.data.users :as test-users]
-            [metabase.test.util :as tu]
             [schema.core :as s]))
 
 (defmacro with-dashboard-cleanup
   "Execute body and cleanup all dashboard elements created."
   [& body]
-  `(tu/with-model-cleanup ['~'Card '~'Dashboard '~'Collection '~'DashboardCard]
+  `(mt/with-model-cleanup [Card Dashboard Collection DashboardCard]
      ~@body))
 
 (defn- collect-urls
@@ -26,8 +27,8 @@
   (->> dashboard
        collect-urls
        (every? (fn [url]
-                 ((test-users/user->client :rasta) :get 200 (format "automagic-dashboards/%s"
-                                                                    (subs url 16)))))))
+                 (mt/user-http-request :rasta :get 200 (format "automagic-dashboards/%s"
+                                                               (subs url 16)))))))
 
 (defn- valid-card? [{query :dataset_query}]
   (nil? (s/check mbql.s/Query (normalize/normalize query))))


### PR DESCRIPTION
1. Upgrade the test util `with-log-level` macro to support changing the log level of particular logger e.g.

   ```clj
   (with-log-level [metabase.query-processor :trace]
     ...)
   ```

2.  Rework test util `with-model-cleanup` macro to make it sane. Previously, the macro would delete *every* instance of a model after its body finished; this made it annoying to use from the REPL in some cases (it would wipe most of the stuff off your instance when you ran tests that used this macro) and impossible in others (it could destroy test DBs/Tables/Fields and mess up subsequent tests). I reworked this macro so now it only destroys *new* objects created by `body`. Now the macro is extremely useful and I expect it to find a lot of use in tests going forward.

3.  `metabase.api.card-test` was a bit of a mess. In #11817 we ran an automated tool to convert expectations-style tests to clojure.test ones; IMO this tool made things worse and gave us wacky tests with names like `---we-shouldn-t-be-able-to-if-we-don-t-have-permissions-for-the-collection`. I went in and fixed up a lot of these tests by hand and tried to combine things where possible 

4. In certain situations JUnit output would not be generated (if a test failed and the Exception included non-XML-friendly characters). I made some tweaks to our custom JUnit formatter to remove ANSI color escape sequences, character-encode any other ASCII control characters, and wrap the whole thing in `CDATA` so it stops exploding

5. Cleaned up `metabase.api.alert-test` and added additional tests.

6. Fixed a few bugs in the Metabase Alert API: 

   1.  `GET /api/alert` would fail with an error if any Alerts did not have Cards associated with them (AFAIK this would not normally affect day-to-day usage, since Cards normally get archived rather than actually deleted)

   1.  `PUT /api/alert/:id` would unset the Card associated with an Alert if it was not explicitly passed in. I couldn't find any GitHub issues that seemed to reference this, so I think the FE client may have always been passing it in.