### PR TITLE
resources/log4j2.xml: remove ansi formatting.

### DIFF
--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration>
   <Appenders>
     <Console name="STDOUT" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d %highlight{%p} %style{%c{2}}{bright} :: %m%n">
+      <PatternLayout pattern="%d %p %c{2} :: %m%n">
         <replace regex=":basic-auth \\[.*\\]" replacement=":basic-auth [redacted]"/>
       </PatternLayout>
     </Console>


### PR DESCRIPTION
Avoid ansi output from log4j2 so that the environment variable `NO_COLOR` behaves as expected.


Fixes #13538.