### PR TITLE
Don't follow question/dashboard links if we're missing its data

### DIFF
--- a/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
@@ -36,6 +36,11 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
   const { type, linkType, parameterMapping, targetId } = clickBehavior;
 
   let behavior;
+
+  if (!hasLinkTargetData(clickBehavior, extraData)) {
+    return;
+  }
+
   if (type === "crossfilter") {
     const valuesToSet = _.chain(parameterMapping)
       .values()
@@ -116,4 +121,14 @@ function getTypeForSource(source, extraData) {
     return type;
   }
   return "text";
+}
+
+function hasLinkTargetData(clickBehavior, extraData) {
+  const { linkType, targetId } = clickBehavior;
+  if (linkType === "question") {
+    return getIn(extraData, ["questions", targetId]) != null;
+  } else if (linkType === "dashboard") {
+    return getIn(extraData, ["dashboards", targetId]) != null;
+  }
+  return true;
 }

--- a/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
@@ -38,7 +38,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
   let behavior;
 
   if (!hasLinkTargetData(clickBehavior, extraData)) {
-    return;
+    return [];
   }
 
   if (type === "crossfilter") {


### PR DESCRIPTION
Fixes #13551 

This PR checks that we have loaded dashboard/question data before going there. This happens on public dashboards. It's sometimes possible to direct users there with just the ID, but they'll be forced to log in.