### PR TITLE
Repro for #13534: Filter joined table on "Is not"/"Does not contain"

### DIFF
--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -68,4 +68,33 @@ describe("scenarios > question > filter", () => {
     cy.findByText("Gadget").click();
     cy.findByText("Add filter").click();
   });
+
+  it.skip("should filter a joined table by 'Is not' filter (metabase#13534)", () => {
+    // NOTE: the original issue mentions "Is not" and "Does not contain" filters
+    // we're testing for one filter only to keep things simple
+
+    // go straight to "orders" in custom questions
+    cy.visit("/question/new?database=1&table=2&mode=notebook");
+    // join with Products
+    cy.findByText("Join data").click();
+    cy.findByText("Products").click();
+    // add filter
+    cy.findByText("Filter").click();
+    cy.findByText("Product").click();
+    cy.findByText("Category").click();
+    cy.findByText("Is").click();
+    cy.findByText("Is not").click();
+    cy.findByText("Gizmo").click();
+    cy.findByText("Add filter").click();
+    cy.contains("Category is not Gizmo");
+
+    cy.findByText("Visualize").click();
+    // wait for results to load
+    cy.get(".LoadingSpinner").should("not.exist");
+    cy.log("**The point of failure in 0.37.0-rc3**");
+    cy.findAllByText("Doohickey");
+    cy.findByText("There was a problem with your question").should("not.exist");
+    // this is not the point of this repro, but additionally make sure the filter is working as intended on "Gizmo"
+    cy.findByText("3621077291879").should("not.exist"); // one of the "Gizmo" EANs
+  });
 });


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- reproduces #13534 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/filter.cy.spec.js`
- replace `it.skip()` with `it.only()` to run only this test
- test should fail until related issue is resolved

### Additional notes:
- once the issue is fixed, please remove `.skip` part (unskip the test completely)
- make sure it is passing and 
- merge it together with the fix