### PR TITLE
Disable color in log4j when NO_COLOR set

### DIFF
--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration>
+  <Properties>
+    <Property name="disableAnsi">${env:NO_COLOR:-false}</Property>
+  </Properties>
+
   <Appenders>
     <Console name="STDOUT" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d %highlight{%p} %style{%c{2}}{bright} :: %m%n">
+      <PatternLayout pattern="%d %highlight{%p} %style{%c{2}}{bright} :: %m%n" disableAnsi="${disableAnsi}">
         <replace regex=":basic-auth \\[.*\\]" replacement=":basic-auth [redacted]"/>
       </PatternLayout>
     </Console>


### PR DESCRIPTION
Disables ANSI escape sequences in log4j when NO_COLOR=true

Resolves #13538
