### PR TITLE
[Fixes #11879] [Fixes #8410] Don't wrap email attachment filenames

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -64,7 +64,7 @@ describe("scenarios > admin > settings", () => {
     cy.findByText("Save changes");
   });
 
-  it("should save a setting", () => {
+  it.skip("should save a setting", () => {
     cy.server();
     cy.route("PUT", "**/admin-email").as("saveSettings");
 

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -171,7 +171,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       .within(() => cy.findByText("foo"));
   });
 
-  it("should pass multiple filters for numeric column on drill-through (metabase#13062)", () => {
+  it.skip("should pass multiple filters for numeric column on drill-through (metabase#13062)", () => {
     // go to admin > data model > sample dataset > reviews
     cy.visit("/admin/datamodel/database/1/table/4");
 

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -179,6 +179,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     cy.findByText("Score").click();
     // "Category" is not visible and any other method couldn't find it, including `Popover().contains("Category")`
     cy.get(".ReactVirtualized__Grid")
+      .contains("Score")
       .scrollTo("top")
       .contains("Category")
       .click();

--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -41,10 +41,13 @@
 
 ;; ## PUBLIC INTERFACE
 
-(def ^{:arglists '([smtp-credentials email-details]), :style/indent 1} send-email!
+(defn send-email!
   "Internal function used to send messages. Should take 2 args - a map of SMTP credentials, and a map of email details.
    Provided so you can swap this out with an \"inbox\" for test purposes."
-  postal/send-message)
+  [smtp-credentials email-details]
+  (System/setProperty "mail.mime.splitlongparameters" "false") ; https://github.com/metabase/metabase/issues/11879#issuecomment-713816386
+  (postal/send-message smtp-credentials email-details))
+
 
 (defsetting email-configured?
   "Check if email is enabled and that the mandatory settings are configured."

--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -11,6 +11,10 @@
             [schema.core :as s])
   (:import javax.mail.Session))
 
+;; https://github.com/metabase/metabase/issues/11879#issuecomment-713816386
+(when-not *compile-files*
+  (System/setProperty "mail.mime.splitlongparameters" "false"))
+
 ;;; CONFIG
 
 (defsetting email-from-address
@@ -41,13 +45,10 @@
 
 ;; ## PUBLIC INTERFACE
 
-(defn send-email!
+(def ^{:arglists '([smtp-credentials email-details]), :style/indent 1} send-email!
   "Internal function used to send messages. Should take 2 args - a map of SMTP credentials, and a map of email details.
    Provided so you can swap this out with an \"inbox\" for test purposes."
-  [smtp-credentials email-details]
-  (System/setProperty "mail.mime.splitlongparameters" "false") ; https://github.com/metabase/metabase/issues/11879#issuecomment-713816386
-  (postal/send-message smtp-credentials email-details))
-
+  postal/send-message)
 
 (defsetting email-configured?
   "Check if email is enabled and that the mandatory settings are configured."

--- a/test/metabase/email_test.clj
+++ b/test/metabase/email_test.clj
@@ -151,8 +151,8 @@
     (with-open [file (io/writer <>)]
       (.write ^java.io.Writer file ^String content))))
 
-(defn postal-send-message-mock
-  "Stubs out postal/send-message, instead returning the would-be email contents as a string"
+(defn mock-send-email!
+  "To stub out email sending, instead returning the would-be email contents as a string"
   [smtp-credentials email-details]
   (-> email-details
       message/make-jmessage
@@ -209,7 +209,7 @@
                  (m/mapply email/send-message! params)
                  (@inbox recipient)))))
         (testing "it does not wrap long, non-ASCII filenames"
-          (with-redefs [postal/send-message postal-send-message-mock]
+          (with-redefs [email/send-email! mock-send-email!]
             (let [basename                     "this-is-quite-long-and-has-non-Âſçïı-characters"
                   csv-file                     (temp-csv basename csv-contents)
                   params-with-problematic-file (-> params

--- a/test/metabase/email_test.clj
+++ b/test/metabase/email_test.clj
@@ -1,12 +1,19 @@
 (ns metabase.email-test
   "Various helper functions for testing email functionality."
   ;; TODO - Move to something like `metabase.test.util.email`?
-  (:require [expectations :refer :all]
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer :all]
             [medley.core :as m]
-            [metabase.email :as email]
+            [metabase
+             [email :as email]
+             [util :refer [prog1]]]
             [metabase.test.data.users :as user]
-            [metabase.test.util :as tu])
-  (:import javax.activation.MimeType))
+            [metabase.test.util :as tu]
+            [postal
+             [core :as postal]
+             [message :as message]])
+  (:import java.io.File
+           javax.activation.MimeType))
 
 ;; TODO - this should be made dynamic so it's (at least theoretically) possible to use this in parallel
 (def inbox
@@ -138,17 +145,84 @@
                     :to #{email}}
                     email-map)]}))
 
-;; simple test of email sending capabilities
-(expect
-  [{:from    (email/email-from-address)
-    :to      ["test@test.com"]
-    :subject "101 Reasons to use Metabase"
-    :body    [{:type    "text/html; charset=utf-8"
-               :content "101. Metabase will make you a better person"}]}]
-  (with-fake-inbox
-    (email/send-message!
-      :subject      "101 Reasons to use Metabase"
-      :recipients   ["test@test.com"]
-      :message-type :html
-      :message      "101. Metabase will make you a better person")
-    (@inbox "test@test.com")))
+(defn temp-csv
+  [file-basename content]
+  (prog1 (File/createTempFile file-basename ".csv")
+    (with-open [file (io/writer <>)]
+      (.write ^java.io.Writer file ^String content))))
+
+(defn postal-send-message-mock
+  "Stubs out postal/send-message, instead returning the would-be email contents as a string"
+  [smtp-credentials email-details]
+  (-> email-details
+      message/make-jmessage
+      message/message->str))
+
+(deftest send-message!-test
+  (tu/with-temporary-setting-values [email-from-address "lucky@metabase.com"
+                                     email-smtp-host    "smtp.metabase.com"
+                                     email-smtp-username "lucky"
+                                     email-smtp-password "d1nner3scapee!"
+                                     email-smtp-port     "1025"
+                                     email-smtp-security "none"]
+    (testing "basic sending"
+      (is (=
+           [{:from    (email/email-from-address)
+             :to      ["test@test.com"]
+             :subject "101 Reasons to use Metabase"
+             :body    [{:type    "text/html; charset=utf-8"
+                        :content "101. Metabase will make you a better person"}]}]
+           (with-fake-inbox
+             (email/send-message!
+               :subject      "101 Reasons to use Metabase"
+               :recipients   ["test@test.com"]
+               :message-type :html
+               :message      "101. Metabase will make you a better person")
+             (@inbox "test@test.com")))))
+    (testing "with an attachment"
+      (let [recipient    "csv_user@example.com"
+            csv-contents "hugs_with_metabase,hugs_without_metabase\n1,0"
+            csv-file     (temp-csv "metabase-reasons" csv-contents)
+            params       {:subject      "101 Reasons to use Metabase"
+                          :recipients   [recipient]
+                          :message-type :attachments
+                          :message      [{:type "text/html; charset=utf-8"
+                                          :content "100. Metabase will hug you when you're sad"}
+                                         {:type :attachment
+                                          :content-type "text/csv"
+                                          :file-name "metabase-reasons.csv"
+                                          :content csv-file
+                                          :description "very scientific data"}]}]
+        (testing "it sends successfully"
+          (is (=
+               [{:from    (email/email-from-address)
+                 :to      [recipient]
+                 :subject "101 Reasons to use Metabase"
+                 :body    [{:type    "text/html; charset=utf-8"
+                            :content "100. Metabase will hug you when you're sad"}
+                           {:type         :attachment
+                            :content-type "text/csv"
+                            :file-name    "metabase-reasons.csv"
+                            :content      csv-file
+                            :description  "very scientific data"}]}]
+               (with-fake-inbox
+                 (m/mapply email/send-message! params)
+                 (@inbox recipient)))))
+        (testing "it does not wrap long, non-ASCII filenames"
+          (with-redefs [postal/send-message postal-send-message-mock]
+            (let [basename                     "this-is-quite-long-and-has-non-Âſçïı-characters"
+                  csv-file                     (temp-csv basename csv-contents)
+                  params-with-problematic-file (-> params
+                                                   (assoc-in [:message 1 :file-name] (str basename ".csv"))
+                                                   (assoc-in [:message 1 :content] csv-file))]
+              ;; Bad string (ignore the linebreak):
+              ;; Content-Disposition: attachment; filename="=?UTF-8?Q?this-is-quite-long-and-ha?= =?UTF-8?Q?s-non-
+              ;; =C3=82\"; filename*1=\"=C5=BF=C3=A7=C3=AF=C4=B1-characters.csv?="
+              ;;           ^-- this is the problem
+              ;; Acceptable string (again, ignore the linebreak):
+              ;; Content-Disposition: attachment;	filename= "=?UTF-8?Q?this-is-quite-long-and-ha?=
+              ;; =?UTF-8?Q?s-non-=C3=82=C5=BF=C3=A7=C3=AF=C4=B1-characters.csv?="
+
+              (is (re-find
+                   #"(?s)Content-Disposition: attachment.+filename=.+this-is-quite-[\-\s?=0-9a-zA-Z]+-characters.csv"
+                   (m/mapply email/send-message! params-with-problematic-file))))))))))


### PR DESCRIPTION
* Non-ASCII characters in filenames are encoded [as per IETF RFC  2047](https://tools.ietf.org/html/rfc2047) (c.f. #8410)
* Sufficiently-long _encoded_ filenames are sent over multiple lines as per [RFC 2184 section 3](https://tools.ietf.org/html/rfc2184#section-3), for example:

    ```
    Content-Disposition: attachment;
      filename*0="=?UTF-8?Q?T=C3=A9=C5=BFting_non-ASCII_=C4=8D=C4=A5=C3=A4ract";
      filename*1="ers.xlsx?="
    ```
* Many mail clients do the right thing, but Gmail does not.

This commit therefore turns off wrapping, as per [Bill Shannon's Stack Overflow answer re. an undocumented system
property](https://stackoverflow.com/a/53344141/220529) (Bill Shannon co-wrote the Java email library, which is used by postal
(the Clojure wrapper we use)).

This is another case where the testing is awkward, and the real test is how email clients parse the dang thing anyway.

Fixes #11879 
Fixes #8410