### PR TITLE
Catch map errors on client, remove some server-side validation

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
@@ -52,12 +52,16 @@ export default class CustomGeoJSONWidget extends Component {
       delete value[id];
     }
 
-    await SettingsApi.put({
-      key: "custom-geojson",
-      value: value,
-    });
+    try {
+      await SettingsApi.put({
+        key: "custom-geojson",
+        value: value,
+      });
 
-    await this.props.reloadSettings();
+      await this.props.reloadSettings();
+    } catch (e) {
+      console.warn("Save failed: ", e);
+    }
   };
 
   _save = async () => {

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -1,10 +1,8 @@
 (ns metabase.api.geojson
-  (:require [cheshire.core :as json]
-            [clojure.java.io :as io]
+  (:require [clojure.java.io :as io]
             [compojure.core :refer [GET]]
             [metabase.api.common :as api]
             [metabase.models.setting :as setting :refer [defsetting]]
-            [metabase.util :as u]
             [metabase.util
              [i18n :as ui18n :refer [deferred-tru tru]]
              [schema :as su]]

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -10,76 +10,7 @@
              [schema :as su]]
             [ring.util.response :as rr]
             [schema.core :as s])
-  (:import com.fasterxml.jackson.core.JsonParseException
-           java.io.FileNotFoundException
-           [java.net ConnectException NoRouteToHostException UnknownHostException]
-           java.util.concurrent.TimeoutException
-           org.apache.commons.io.input.ReaderInputStream))
-
-(def ^:private ^:const ^Integer geojson-fetch-timeout-ms
-  "Number of milliseconds we have to fetch (and parse, if applicable) a GeoJSON file before we consider the request to
-  have timed out."
-  (int (* 60 1000)))
-
-(defn- valid-json?
-  "Does this `url-or-resource` point to valid JSON? `url-or-resource` should be something that can be passed to `slurp`,
-  like an HTTP URL or a `java.net.URL` (which is what `io/resource` returns below)."
-  [url-or-resource]
-  (try
-    (u/with-timeout geojson-fetch-timeout-ms
-      (with-open [reader (io/reader url-or-resource)]
-        (dorun (json/parse-stream reader))))
-    ;; `with-timeout` executes the body in a future. If an exception occurs, it will throw an ExcecutionException
-    ;; which isn't very useful. The cause of the ExcutionException is what we want to propagate as that is something
-    ;; that will be actionable by the user to fix
-    (catch java.util.concurrent.ExecutionException e
-      (throw (.getCause e))))
-  true)
-
-(defn- valid-json-resource-path-string?
-  "Does this `relative-path` point to a valid local JSON resource? (`relative-path` is something like
-  \"app/assets/geojson/us-states.json\".)"
-  [^String relative-path]
-  (when-let [^java.net.URI uri (u/ignore-exceptions (java.net.URI. relative-path))]
-    (when-not (.isAbsolute uri)
-      (let [relative-path-with-prefix (str "frontend_client/" uri)]
-        (if-let [resource (io/resource relative-path-with-prefix)]
-          (try
-            (valid-json? resource)
-            (catch JsonParseException e
-              (throw (Exception. (tru "Unable to parse resource `{0}` as JSON" relative-path-with-prefix) e))))
-          (throw (FileNotFoundException. (tru "Unable to find JSON via relative path `{0}`" relative-path-with-prefix))))))))
-
-(defn- valid-json-url-string?
-  "Is `url` a valid HTTP URL string and does it point to valid JSON?"
-  [^String url]
-  (when (u/url? url)
-    (try
-      (valid-json? url)
-      ;; There could be many reasons why we are not able to use a URL as a GeoJSON source. The various catch clauses
-      ;; below attempt to provide the user with more info around the failure so they can correct the issue and try
-      ;; again.
-      (catch TimeoutException e
-        (throw (Exception. (tru "Connection to host timed out for URL `{0}`" url) e)))
-      (catch UnknownHostException e
-        (throw (Exception. (tru "Unable to connect to unknown host at URL `{0}`" url) e)))
-      (catch NoRouteToHostException e
-        (throw (Exception. (tru "Unable to connect to host at URL `{0}`" url) e)))
-      (catch ConnectException e
-        (throw (Exception. (tru "Connection refused by host for URL `{0}`" url) e)))
-      (catch FileNotFoundException e
-        (throw (Exception. (tru "Unable to retrieve resource at URL `{0}`" url) e)))
-      (catch JsonParseException e
-        (throw (Exception. (tru "Unable to parse resource at URL `{0}` as JSON" url) e))))))
-
-(def ^:private ^{:arglists '([url-or-resource])} valid-json-url-or-resource?
-  "Check that remote URL points to a valid JSON file, or throw an exception. Since the remote file isn't likely to
-  change, this check isn't repeated for URLs that have already succeded; if the check fails, an exception is
-  thrown (thereby preventing memoization)."
-  (memoize (fn [url-or-resource-path]
-             (or (valid-json-url-string? url-or-resource-path)
-                 (valid-json-resource-path-string? url-or-resource-path)
-                 (throw (Exception. (tru "Invalid JSON URL or resource: {0}" url-or-resource-path)))))))
+  (:import org.apache.commons.io.input.ReaderInputStream))
 
 (def ^:private CustomGeoJSON
   {s/Keyword {:name                     s/Str
@@ -100,11 +31,6 @@
                      :region_name "NAME"
                      :builtin     true}})
 
-(defn- validate-custom-geo-json [geojson-value]
-  (s/validate CustomGeoJSON geojson-value)
-  (doseq [[_ {geo-url-or-uri :url}] geojson-value]
-    (valid-json-url-or-resource? geo-url-or-uri)))
-
 (defsetting custom-geojson
   (deferred-tru "JSON containing information about custom GeoJSON files for use in map visualizations instead of the default US State or World GeoJSON.")
   :type    :json
@@ -112,7 +38,7 @@
   :getter  (fn [] (merge (setting/get-json :custom-geojson) builtin-geojson))
   :setter  (fn [new-value]
              (when new-value
-               (validate-custom-geo-json new-value))
+               (s/validate CustomGeoJSON new-value))
              (setting/set-json! :custom-geojson new-value))
   :visibility :public)
 

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -19,35 +19,9 @@
                   :region_key  nil
                   :region_name nil}})
 
-
-(deftest valid-url-test
-  (is (= true
-         (#'geojson-api/valid-json-url-string? test-geojson-url))))
-
-
-(deftest valid-resource-test
-  (is (= true
-         (#'geojson-api/valid-json-resource-path-string? "app/assets/geojson/us-states.json"))))
-
 (deftest geojson-schema-test
   (is (= true
          (boolean (s/validate @#'geojson-api/CustomGeoJSON test-custom-geojson)))))
-
-(deftest invalid-url-test
-  (testing "test that you're not allowed to set invalid URLs"
-    (is (thrown?
-         Exception
-         (geojson-api/custom-geojson {:name        "Middle Earth"
-                                      :url         "ABC"
-                                      :region_key  nil
-                                      :region_name nil})))
-
-    (is (thrown?
-         Exception
-         (geojson-api/custom-geojson {:name        "Middle Earth"
-                                      :url         "http://google.com"
-                                      :region_key  nil
-                                      :region_name nil})))))
 
 (deftest update-endpoint-test
   (testing "PUT /api/setting/custom-geojson"
@@ -59,29 +33,7 @@
                ;; stomping all over it
                (mt/with-temporary-setting-values [custom-geojson nil]
                  ((mt/user->client :crowberto) :put 204 "setting/custom-geojson" {:value test-custom-geojson})
-                 ((mt/user->client :crowberto) :get 200 "setting/custom-geojson"))))))
-
-    (testing "error conditions"
-      (letfn [(put-bad-url [url]
-                (mt/suppress-output
-                 ;; try this up to 3 times since Circle's outbound connections likes to randomly stop working
-                 (u/auto-retry 3
-                               ;; bind a temporary value so it will get set back to its old value here after the API calls are done
-                               ;; stomping all over it
-                               (mt/with-temporary-setting-values [custom-geojson nil]
-                                 (let [url (assoc-in test-custom-geojson [:middle-earth :url] url)]
-                                   (:message ((mt/user->client :crowberto) :put 500 "setting/custom-geojson" {:value url})))))))]
-        (testing "Test that a bad url will return a descriptive error message"
-          (is (re= #"^Unable to retrieve resource.*"
-                   (put-bad-url "https://raw.githubusercontent.com/metabase/metabase/master/test_resources/something-random"))))
-
-        (testing "Test that a bad host will return a connection refused error"
-          (is (re= #"^Unable to connect.*"
-                   (put-bad-url "https://somethingrandom.metabase.com"))))
-
-        (testing "Test out the error message for a relative path file we can't find"
-          (is (re= #"^Unable to find JSON via relative path.*"
-                   (put-bad-url "some/relative/path"))))))))
+                 ((mt/user->client :crowberto) :get 200 "setting/custom-geojson"))))))))
 
 (deftest proxy-endpoint-test
   (testing "GET /api/geojson/:key"


### PR DESCRIPTION
Fixes #12599 

The main freezing issue was due to an uncaught error. I caught this and logged it to the console. We could surface this through the UI, but I think the failure state when adding or editing a failed map does a good job.

Even with the freezing avoided, an invalid URL in any map would prevent updating other maps. The entire list of maps had to be valid to save an update. Two invalid map URLs would prevent any updates.

To fix that issue, I removed the server side validation that checks each link. We still validate the shape of the JSON, but the links go untested. I think that's fine. The UI prevents you from adding a new map until the map loads successfully. Also, as this issue shows, even if we validate them once when saving, it doesn't mean they'll remain valid.

